### PR TITLE
Update tree control to support 64bit pointers

### DIFF
--- a/Pythonwin/win32ctrlTree.cpp
+++ b/Pythonwin/win32ctrlTree.cpp
@@ -355,7 +355,7 @@ MAKE_BOOL_ITEM_INT_ACTION(PyCTreeCtrl_Select, Select )
 PyObject *PyCTreeCtrl_GetItemImage( PyObject *self, PyObject *args ) 
 {
 	HTREEITEM item;
-	if (!PyArg_ParseTuple( args, "i:GetItemImage", &item))
+	if (!PyArg_ParseTuple( args, "O&:GetItemImage", PyWinObject_AsHANDLE, &item))
 		return NULL;
 	CTreeCtrl *pList = GetTreeCtrl(self);
 	if (!pList) return NULL;
@@ -374,7 +374,7 @@ PyObject *PyCTreeCtrl_GetItemImage( PyObject *self, PyObject *args )
 PyObject *PyCTreeCtrl_GetItemState( PyObject *self, PyObject *args ) 
 {
 	HTREEITEM item; UINT stateMask;
-	if (!PyArg_ParseTuple( args, "ii:GetItemState", &item, &stateMask))
+    if (!PyArg_ParseTuple( args, "O&i:GetItemState", PyWinObject_AsHANDLE, &item, &stateMask))
 		return NULL;
 	CTreeCtrl *pList = GetTreeCtrl(self);
 	if (!pList) return NULL;
@@ -552,7 +552,8 @@ PyObject *PyCTreeCtrl_GetItem( PyObject *self, PyObject *args )
 	HTREEITEM item;
 	UINT mask = TVIF_CHILDREN | TVIF_HANDLE | TVIF_IMAGE | TVIF_PARAM | TVIF_SELECTEDIMAGE | TVIF_STATE | TVIF_TEXT; 
 
-	if (!PyArg_ParseTuple( args, "i|i:GetItem", 
+	if (!PyArg_ParseTuple( args, "O&|i:GetItem", 
+                       PyWinObject_AsHANDLE,
 	                   &item, // @pyparm HTREEITEM|item||The item whose attributes are to be retrieved.
 					   &mask)) // @pyparm int|mask|(all flags set)|The requested attributes.
 		return NULL;
@@ -577,7 +578,8 @@ PyObject *PyCTreeCtrl_GetItem( PyObject *self, PyObject *args )
 PyObject *PyCTreeCtrl_GetItemText( PyObject *self, PyObject *args )
 {
 	HTREEITEM item;
-	if (!PyArg_ParseTuple( args, "i:GetItemText", 
+	if (!PyArg_ParseTuple( args, "O&:GetItemText", 
+                       PyWinObject_AsHANDLE,
 	                   &item)) // @pyparm HTREEITEM|item||The item whose text is to be retrieved.
 		return NULL;
 	CTreeCtrl *pList = GetTreeCtrl(self);
@@ -596,7 +598,8 @@ PyObject *PyCTreeCtrl_SetItemText( PyObject *self, PyObject *args )
 	HTREEITEM item;
 	TCHAR *text;
 	PyObject *obtext;
-	if (!PyArg_ParseTuple( args, "iO:SetItemText", 
+	if (!PyArg_ParseTuple( args, "O&O:SetItemText", 
+                       PyWinObject_AsHANDLE,
 	                   &item, // @pyparm HTREEITEM|item||The item whose text is to be retrieved.
 					   &obtext)) // @pyparm string|text||String that contains the new item text.
 
@@ -616,7 +619,8 @@ PyObject *PyCTreeCtrl_SetItemText( PyObject *self, PyObject *args )
 PyObject *PyCTreeCtrl_GetItemData( PyObject *self, PyObject *args )
 {
 	HTREEITEM item;
-	if (!PyArg_ParseTuple( args, "i:GetItemData", 
+	if (!PyArg_ParseTuple( args, "O&:GetItemData", 
+                       PyWinObject_AsHANDLE,
 	                   &item)) // @pyparm HTREEITEM|item||The index of the item whose data is to be retrieved.
 
 		return NULL;
@@ -635,7 +639,8 @@ PyObject *PyCTreeCtrl_SetItemData( PyObject *self, PyObject *args )
 	if (!pList) return NULL;
 	HTREEITEM item;
 	int data;
-	if (!PyArg_ParseTuple( args, "ii:SetItemData", 
+	if (!PyArg_ParseTuple( args, "O&i:SetItemData", 
+                           PyWinObject_AsHANDLE,
 		                   &item, // @pyparm HTREEITEM|item||The item whose Data is to be set.
 						   &data)) // @pyparm int|Data||New value for the data.
 		return NULL;
@@ -672,7 +677,8 @@ PyObject *PyCTreeCtrl_GetItemRect( PyObject *self, PyObject *args )
 	HTREEITEM item;
 	RECT rect;
 	BOOL bTextOnly;
-	if (!PyArg_ParseTuple( args, "ii:GetItemRect", 
+	if (!PyArg_ParseTuple( args, "O&i:GetItemRect", 
+                           PyWinObject_AsHANDLE,
 		                   &item, // @pyparm HTREEITEM|item||The item whose Data is to be set.
 						   &bTextOnly)) // @pyparm int|bTextOnly||f this parameter is nonzero, the bounding rectangle includes only the text of the item. Otherwise it includes the entire line that the item occupies in the tree view control.
 		return NULL;
@@ -706,7 +712,7 @@ PyObject *PyCTreeCtrl_EditLabel( PyObject *self, PyObject *args )
 	if (!pList) return NULL;
 	HTREEITEM item;
 	// @pyparm HTREEITEM|item||The item to edit.
-	if (!PyArg_ParseTuple( args, "i:EditLabel", &item))
+	if (!PyArg_ParseTuple( args, "O&:EditLabel", PyWinObject_AsHANDLE, &item))
 		return NULL;
 	GUI_BGN_SAVE;
 	CEdit *pEdit = pList->EditLabel(item);
@@ -723,7 +729,7 @@ PyObject *PyCTreeCtrl_EnsureVisible( PyObject *self, PyObject *args )
 	if (!pList) return NULL;
 	HTREEITEM item;
 	// @pyparm HTREEITEM|item||The item to edit.
-	if (!PyArg_ParseTuple( args, "i:EnsureVisible", &item))
+	if (!PyArg_ParseTuple( args, "O&:EnsureVisible", PyWinObject_AsHANDLE, &item))
 		return NULL;
 	GUI_BGN_SAVE;
 	BOOL ok = pList->EnsureVisible(item);
@@ -740,7 +746,7 @@ PyObject *PyCTreeCtrl_CreateDragImage( PyObject *self, PyObject *args )
 	if (!pList) return NULL;
 	HTREEITEM item;
 	// @pyparm HTREEITEM|item||The item to edit.
-	if (!PyArg_ParseTuple( args, "i:CreateDragImage", &item))
+	if (!PyArg_ParseTuple( args, "O&:CreateDragImage", PyWinObject_AsHANDLE, &item))
 		return NULL;
 	GUI_BGN_SAVE;
 	CImageList *pIL = pList->CreateDragImage(item);


### PR DESCRIPTION
The pointers to the tree control could be in range higher than signed 32bit. This change handles 32bit and 64bit compatibility.