### PR TITLE
win32com: server: Do type check against str

### DIFF
--- a/com/win32com/server/policy.py
+++ b/com/win32com/server/policy.py
@@ -233,7 +233,7 @@ class BasicWrapPolicy:
       self._com_interfaces_ = []
       # Allow interfaces to be specified by name.
       for i in ob._com_interfaces_:
-        if type(i) != pywintypes.IIDType:
+        if type(i) is str:
           # Prolly a string!
           if i[0] != "{":
             i = pythoncom.InterfaceNames[i]


### PR DESCRIPTION
The content inside the if-clause expects content as type(str).
Therefore let's check for str instead of !pywintypes.IIDType.
Otherwise content like int, floats or other types can go in.