### PR TITLE
Always try to use ADO's parameter list

### DIFF
--- a/adodbapi/adodbapi.py
+++ b/adodbapi/adodbapi.py
@@ -757,21 +757,22 @@ class Cursor(object):
             parameters = []
 
         parameters_known = False
-        if sproc:  # needed only if we are calling a stored procedure
-            try: # attempt to use ADO's parameter list
-                self.cmd.Parameters.Refresh()
-                if verbose > 2:
-                    print 'ADO detected Params=', format_parameters(self.cmd.Parameters, True)
-                    print 'Program Parameters=', repr(parameters)
-                parameters_known = True
-            except api.Error:
-                if verbose:
-                    print 'ADO Parameter Refresh failed'
-                pass
-            else:
-                if len(parameters) != self.cmd.Parameters.Count - 1:
-                    raise api.ProgrammingError('You must supply %d parameters for this stored procedure' % \
-                                               (self.cmd.Parameters.Count - 1))
+        try: # attempt to use ADO's parameter list
+            self.cmd.Parameters.Refresh()
+            if verbose > 2:
+                print 'ADO detected Params=', format_parameters(self.cmd.Parameters, True)
+                print 'Program Parameters=', repr(parameters)
+            parameters_known = True
+        except api.Error:
+            if verbose:
+                print 'ADO Parameter Refresh failed'
+            pass
+        else:
+            expected = self.cmd.Parameters.Count
+            if sproc:
+                expected -= 1
+            if len(parameters) != expected:
+                raise api.ProgrammingError('You must supply %d parameters for this stored procedure' % expected)
         if sproc or parameters != []:
             i = 0
             if parameters_known:  # use ado parameter list


### PR DESCRIPTION
This pull request addresses https://github.com/mhammond/pywin32/issues/1119. The original implementation of `Cursor._buildADOparameterList()` had the comment "needed only if we are calling a stored procedure" above the code for trying to use ADO's parameter list, without explaining why that would be. Given the incorrect behavior behind this bug report, I'm inclined to think it would be needed for all paths. In any case, this change results in the desired behavior (an empty string passed as a parameter is stored correctly, instead of being replaced by an empty string).

This patch appears to fix another bug I hadn't gotten around to reporting. Without the patch:

```
>>> cursor.execute("CREATE TABLE #foo (i INT, t NTEXT NULL)")
>>> cursor.execute("INSERT INTO #foo VALUES(?, ?)", (42, None))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Python\lib\site-packages\adodbapi\adodbapi.py", line 885, in execute
    self._execute_command()
  File "C:\Python\lib\site-packages\adodbapi\adodbapi.py", line 697, in _execute_command
    self._raiseCursorError(klass, _message)
  File "C:\Python\lib\site-packages\adodbapi\adodbapi.py", line 570, in _raiseCursorError
    eh(self.connection, self, errorclass, errorvalue)
  File "C:\Python\lib\site-packages\adodbapi\apibase.py", line 53, in standardErrorHandler
    raise errorclass(errorvalue)
adodbapi.apibase.DatabaseError: (-2147352567, 'Exception occurred.', (0, u'Microsoft OLE DB Provider for SQL Server', u'Operand type clash: int is incompatible with ntext', None, 0, -2147217913), None)
Command:
INSERT INTO #foo VALUES(?, ?)
Parameters:
[Name: p0, Dir.: Input, Type: adInteger, Size: 0, Value: "42", Precision: 0, NumericScale: 0
Name: p1, Dir.: Input, Type: adInteger, Size: 0, Value: "None", Precision: 0, NumericScale: 0]
```

With the patch:

```
>>> cursor.execute("CREATE TABLE #foo (i INT, t NTEXT NULL)")
>>> cursor.execute("INSERT INTO #foo VALUES(?, ?)", (42, None))
>>> cursor.execute("SELECT * FROM #foo")
>>> [tuple(row) for row in cursor.fetchall()]
[(42, None)]
```