### PR TITLE
add flag to allow creation of symbolic links when the process is not elevated

### DIFF
--- a/win32/src/win32file.i
+++ b/win32/src/win32file.i
@@ -3286,7 +3286,7 @@ static PyObject *py_CreateSymbolicLink(PyObject *self, PyObject *args, PyObject 
 	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|kO:CreateSymbolicLink", keywords,
 		&oblinkname,	// @pyparm <o PyUnicode>|SymlinkFileName||Path of the symbolic link to be created
 		&obtargetname,	// @pyparm <o PyUnicode>|TargetFileName||The name of file to which link will point
-		&flags,			// @pyparm int|Flags|0|SYMBOLIC_LINK_FLAG_DIRECTORY is only defined flag
+		&flags,			// @pyparm int|Flags|0|SYMBOLIC_LINK_FLAG_DIRECTORY and SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE are the only defined flags
 		&obtrans))		// @pyparm <o PyHANDLE>|Transaction|None|Handle to a transaction, as returned by <om win32transaction.CreateTransaction>
 		return NULL;
 	if (!PyWinObject_AsHANDLE(obtrans, &htrans))

--- a/win32/src/win32file.i
+++ b/win32/src/win32file.i
@@ -6227,6 +6227,7 @@ PyCFunction pfnpy_OpenFileById=(PyCFunction)py_OpenFileById;
 
 // Flags for CreateSymbolicLink/CreateSymbolicLinkTransacted
 #define SYMBOLIC_LINK_FLAG_DIRECTORY 1
+#define SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE 2
 
 // FILE_INFO_BY_HANDLE_CLASS used with GetFileInformationByHandleEx
 #define FileBasicInfo FileBasicInfo


### PR DESCRIPTION
just added the definition taken from the official Windows API documentation (https://msdn.microsoft.com/en-us/library/windows/desktop/aa363866(v=vs.85).aspx)