### PR TITLE
varkind and invoke_type

### DIFF
--- a/com/win32com/client/dynamic.py
+++ b/com/win32com/client/dynamic.py
@@ -120,7 +120,7 @@ def _GetDescInvokeType(entry, invoke_type):
 	if varkind == pythoncom.VAR_DISPATCH and invoke_type == pythoncom.INVOKE_PROPERTYGET:
 		return pythoncom.INVOKE_FUNC | invoke_type # DISPATCH_METHOD & DISPATCH_PROPERTYGET can be combined in IDispatch::Invoke
 	else:
-		return invoke_type
+		return varkind
 
 def Dispatch(IDispatch, userName = None, createClass = None, typeinfo = None, UnicodeToString=None, clsctx = pythoncom.CLSCTX_SERVER):
 	assert UnicodeToString is None, "this is deprecated and will go away"


### PR DESCRIPTION
Regarding this [commit](https://github.com/mhammond/pywin32/commit/a22ddedfd0d1a117c95876bf7e25e2dd4a419604#diff-f7b7ba0d109e33715b45f2165b6ba329)

Previous implementation was : 

<pre>
def _GetDescInvokeType(entry, default_invoke_type):
    if not entry or not entry.desc: return default_invoke_type
    return entry.desc[4]   # apparently varkind
</pre>

So this was always returning ```varkind``` when ```entry.desc``` was defined. The function name is consistent : we try to retrieve ```invoke_type``` from ```desc``` and return  ```default_invoke_type``` otherwise.

Regarding new implementation : 
<pre>
def _GetDescInvokeType(entry, invoke_type):
    # determine the wFlags argument passed as input to IDispatch::Invoke
    if not entry or not entry.desc: return invoke_type
    varkind = entry.desc[4] # from VARDESC struct returned by ITypeComp::Bind
    if varkind == pythoncom.VAR_DISPATCH and invoke_type == pythoncom.INVOKE_PROPERTYGET:
        return pythoncom.INVOKE_FUNC | invoke_type # DISPATCH_METHOD & DISPATCH_PROPERTYGET can be combined in IDispatch::Invoke
    else:
        return invoke_type
</pre>

The logic is totally different, we check ```varkind``` to possibly amend ```invoke_type```, but we never return ```varkind```.

In the related [issue](https://github.com/mhammond/pywin32/issues/1198) of this pull request, we found out that when setting  ```AdminQueueInfo``` member of an ```MSMQ.MSMQMessage``` , we call ```_GetDescInvokeType``` with an entry verifying ```entry.desc[4] = 8``` and an ```invoke_type = INVOKE_PROPERTYPUT```.
We should get a ```INVOKE_PROPERTYPUTREF (8)```, corresponding to ```entry.desc[4]```  but new function returns ```INVOKE_PROPERTYPUT``` and makes ```invoke``` crash.

The pull request is proposing  a mix between two implementations, but I'm still really confused, especially with  ```entry.desc[4]``` which apparently should correspond to ```varkind```. Looking to [documentation](https://msdn.microsoft.com/en-us/library/windows/desktop/ms221381(v=vs.85).aspx) 
```varkind``` values can only be 0,1,2,3. 

So what is really ```entry.desc[4]``` ?
 
