### PR TITLE
setup.py: We are looking for headers not sources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -422,7 +422,7 @@ class WinExt (Extension):
                 else:
                     suffix = ""
                 self.extra_link_args.append("/IMPLIB:%s%s.lib" % (implib, suffix))
-            # Try and find the MFC source code, so we can reach inside for
+            # Try and find the MFC headers, so we can reach inside for
             # some of the ActiveX support we need.  We need to do this late, so
             # the environment is setup correctly.
             # Only used by the win32uiole extensions, but I can't be


### PR DESCRIPTION
The comment mentions, that we are looking for the MFC source code. I'm not an expert, but I doubt that Microsoft is sharing the source code of MFC on their Visual Studio releases. Therefore I'm correcting the comment to what we are looking for in the following code, that we are looking for headers.