### PR TITLE
Fixes Traceback when setting Sapi.SpVoice.Voice property

### DIFF
--- a/com/win32com/client/dynamic.py
+++ b/com/win32com/client/dynamic.py
@@ -120,7 +120,7 @@ def _GetDescInvokeType(entry, invoke_type):
 	if varkind == pythoncom.VAR_DISPATCH and invoke_type == pythoncom.INVOKE_PROPERTYGET:
 		return pythoncom.INVOKE_FUNC | invoke_type # DISPATCH_METHOD & DISPATCH_PROPERTYGET can be combined in IDispatch::Invoke
 	else:
-		return invoke_type
+		return varkind
 
 def Dispatch(IDispatch, userName = None, createClass = None, typeinfo = None, UnicodeToString=None, clsctx = pythoncom.CLSCTX_SERVER):
 	assert UnicodeToString is None, "this is deprecated and will go away"


### PR DESCRIPTION
This problem can be reproduced very easily. The code and Traceback are as follows.

Code:

    import win32com.client
    import pythoncom
    
    pythoncom.CoInitialize()
    tts = win32com.client.Dispatch("Sapi.SpVoice")
    tts.Voice = tts.GetVoices('Name=Microsoft Anna')[0]

Traceback:

    Traceback (most recent call last):
      File "", line 6, in <module>
        tts.Voice = tts.GetVoices('Name=Microsoft Anna')[0]
      File "\win32com\client\dynamic.py", line 565, in __setattr__
        self._oleobj_.Invoke(entry.dispid, 0, invoke_type, 0, value)
    pywintypes.com_error: (-2147352573, 'Member not found.', None, None)

I have not come across anything that this fix causes an issue with. Because of the broad scope of com I am not able to test everything. This may give some insight on where the problem may lie, Or it could be the solution.

Thanks.
Kevin