### PR TITLE
CI: Adding WinSxS fallback for MFC lookup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -956,7 +956,7 @@ class my_build_ext(build_ext):
                                0,
                                access,
                                )
-        val, val_typ = winreg.QueryValueEx(vckey, "ProductDir")
+        val = winreg.QueryValueEx(vckey, "ProductDir")[0]
         mfc_dir = os.path.join(val, "redist", plat_dir, mfc_dir)
         if os.path.isdir(mfc_dir):
             # Ensuring absolute paths
@@ -1410,8 +1410,13 @@ class my_compiler(base_compiler):
         except ImportError:
             ok = False
         if ok:
-            stamp_script = os.path.join(sys.prefix, "Lib", "site-packages",
-                                        "win32", "lib", "win32verstamp.py")
+            stamp_script = os.path.join(sys.prefix,
+                                        "Lib",
+                                        "site-packages",
+                                        "win32",
+                                        "lib",
+                                        "win32verstamp.py",
+                                        )
             ok = os.path.isfile(stamp_script)
         if ok:
             args = [sys.executable]

--- a/setup.py
+++ b/setup.py
@@ -970,7 +970,7 @@ class my_build_ext(build_ext):
                 mfc_files = []
                 windows_dir = os.getenv("windir", "C:\\Windows")
                 if os.path.isdir(windows_dir):
-                    winsxs_path = os.path.join(os.environ["windir"], "WinSxS")
+                    winsxs_path = os.path.join(windows_dir, "WinSxS")
                     if os.path.isdir(winsxs_path):
                         mfc_redist_path = None
                         winsxs_listdir = os.listdir(winsxs_path)

--- a/setup.py
+++ b/setup.py
@@ -174,7 +174,6 @@ def find_platform_sdk_dir():
 # http://bugs.python.org/issue7833 (which has landed for Python 2.7 and on 3.2
 # and later, which are all we care about currently)
 if sys.version_info > (2,6):
-    from distutils.spawn import spawn
     from distutils.msvc9compiler import MSVCCompiler
     MSVCCompiler._orig_spawn = MSVCCompiler.spawn
     MSVCCompiler._orig_link = MSVCCompiler.link
@@ -1407,7 +1406,6 @@ class my_compiler(base_compiler):
         # modules needed by this process, and which we will soon try and
         # update.
         try:
-            import optparse # win32verstamp will not work without this!
             ok = True
         except ImportError:
             ok = False

--- a/setup.py
+++ b/setup.py
@@ -1005,7 +1005,7 @@ class my_build_ext(build_ext):
         mfc_contents = self.lookupMfcInVisualStudio(mfc_version, mfc_libraries)
         if not mfc_contents:
             print("Can't find MFC contents in VisualStudio. Looking into WinSxS now..")
-            self.lookupMfcInWinSxS(mfc_version, mfc_libraries)
+            mfc_contents = self.lookupMfcInWinSxS(mfc_version, mfc_libraries)
 
         if not mfc_contents:
             raise RuntimeError("No MFC files found!")

--- a/setup.py
+++ b/setup.py
@@ -1003,9 +1003,9 @@ class my_build_ext(build_ext):
                 raise RuntimeError("No MFC files found!")
 
             for mfc_file_absolute in mfc_files:
-                shutil.copy(mfc_file_absolute,
-                            target_dir,
-                            )
+                shutil.copyfile(mfc_file_absolute,
+                                os.path.join(target_dir, os.path.split(mfc_file_absolute)[1]),
+                                )
 
 
     def build_exefile(self, ext):

--- a/setup.py
+++ b/setup.py
@@ -173,74 +173,74 @@ def find_platform_sdk_dir():
 # to prevent the extension from loading.  For more details, see
 # http://bugs.python.org/issue7833 (which has landed for Python 2.7 and on 3.2
 # and later, which are all we care about currently)
-if sys.version_info > (2,6):
-    from distutils.msvc9compiler import MSVCCompiler
-    MSVCCompiler._orig_spawn = MSVCCompiler.spawn
-    MSVCCompiler._orig_link = MSVCCompiler.link
+from distutils.msvc9compiler import MSVCCompiler
+MSVCCompiler._orig_spawn = MSVCCompiler.spawn
+MSVCCompiler._orig_link = MSVCCompiler.link
 
-    # We need to override this method for versions where issue7833 *has* landed
-    # (ie, 2.7 and 3.2+)
-    def manifest_get_embed_info(self, target_desc, ld_args):
-        _want_assembly_kept = getattr(self, '_want_assembly_kept', False)
-        if not _want_assembly_kept:
-            return None
-        for arg in ld_args:
-            if arg.startswith("/MANIFESTFILE:"):
-                orig_manifest = arg.split(":", 1)[1]
-                if target_desc==self.EXECUTABLE:
-                    rid = 1
-                else:
-                    rid = 2
-                return orig_manifest, rid
+# We need to override this method for versions where issue7833 *has* landed
+# (ie, 2.7 and 3.2+)
+def manifest_get_embed_info(self, target_desc, ld_args):
+    _want_assembly_kept = getattr(self, '_want_assembly_kept', False)
+    if not _want_assembly_kept:
         return None
-    # always monkeypatch it in even though it will only be called in 2.7
-    # and 3.2+.
-    MSVCCompiler.manifest_get_embed_info = manifest_get_embed_info
+    for arg in ld_args:
+        if arg.startswith("/MANIFESTFILE:"):
+            orig_manifest = arg.split(":", 1)[1]
+            if target_desc==self.EXECUTABLE:
+                rid = 1
+            else:
+                rid = 2
+            return orig_manifest, rid
+    return None
 
-    def monkeypatched_spawn(self, cmd):
-        is_link = cmd[0].endswith("link.exe") or cmd[0].endswith('"link.exe"')
-        is_mt = cmd[0].endswith("mt.exe") or cmd[0].endswith('"mt.exe"')
-        _want_assembly_kept = getattr(self, '_want_assembly_kept', False)
-        if not _want_assembly_kept and is_mt:
-            # We don't want mt.exe run...
-            return
-        if not _want_assembly_kept and is_link:
-            # remove /MANIFESTFILE:... and add MANIFEST:NO
-            # (but note that for winxpgui, which specifies a manifest via a
-            # .rc file, this is ignored by the linker - the manifest specified
-            # in the .rc file is still added)
-            for i in range(len(cmd)):
-                if cmd[i].startswith("/MANIFESTFILE:"):
-                    cmd[i] = "/MANIFEST:NO"
-                    break
-        if _want_assembly_kept and is_mt:
-            # We want mt.exe run with the original manifest
-            for i in range(len(cmd)):
-                if cmd[i] == "-manifest":
-                    cmd[i+1] = cmd[i+1] + ".orig"
-                    break
-        self._orig_spawn(cmd)
-        if _want_assembly_kept and is_link:
-            # We want a copy of the original manifest so we can use it later.
-            for i in range(len(cmd)):
-                if cmd[i].startswith("/MANIFESTFILE:"):
-                    mfname = cmd[i][14:]
-                    shutil.copyfile(mfname, mfname + ".orig")
-                    break
+# always monkeypatch it in even though it will only be called in 2.7
+# and 3.2+.
+MSVCCompiler.manifest_get_embed_info = manifest_get_embed_info
 
-    def monkeypatched_link(self, target_desc, objects, output_filename, *args, **kw):
-        # no manifests for 3.3+
-        self._want_assembly_kept = sys.version_info < (3,3) and \
-                                   (os.path.basename(output_filename).startswith("PyISAPI_loader.dll") or \
-                                    os.path.basename(output_filename).startswith("perfmondata.dll") or \
-                                    os.path.basename(output_filename).startswith("win32ui.pyd") or \
-                                    target_desc==self.EXECUTABLE)
-        try:
-            return self._orig_link(target_desc, objects, output_filename, *args, **kw)
-        finally:
-            delattr(self, '_want_assembly_kept')
-    MSVCCompiler.spawn = monkeypatched_spawn
-    MSVCCompiler.link = monkeypatched_link
+def monkeypatched_spawn(self, cmd):
+    is_link = cmd[0].endswith("link.exe") or cmd[0].endswith('"link.exe"')
+    is_mt = cmd[0].endswith("mt.exe") or cmd[0].endswith('"mt.exe"')
+    _want_assembly_kept = getattr(self, '_want_assembly_kept', False)
+    if not _want_assembly_kept and is_mt:
+        # We don't want mt.exe run...
+        return
+    if not _want_assembly_kept and is_link:
+        # remove /MANIFESTFILE:... and add MANIFEST:NO
+        # (but note that for winxpgui, which specifies a manifest via a
+        # .rc file, this is ignored by the linker - the manifest specified
+        # in the .rc file is still added)
+        for i in range(len(cmd)):
+            if cmd[i].startswith("/MANIFESTFILE:"):
+                cmd[i] = "/MANIFEST:NO"
+                break
+    if _want_assembly_kept and is_mt:
+        # We want mt.exe run with the original manifest
+        for i in range(len(cmd)):
+            if cmd[i] == "-manifest":
+                cmd[i+1] = cmd[i+1] + ".orig"
+                break
+    self._orig_spawn(cmd)
+    if _want_assembly_kept and is_link:
+        # We want a copy of the original manifest so we can use it later.
+        for i in range(len(cmd)):
+            if cmd[i].startswith("/MANIFESTFILE:"):
+                mfname = cmd[i][14:]
+                shutil.copyfile(mfname, mfname + ".orig")
+                break
+
+def monkeypatched_link(self, target_desc, objects, output_filename, *args, **kw):
+    # no manifests for 3.3+
+    self._want_assembly_kept = sys.version_info < (3,3) and \
+                               (os.path.basename(output_filename).startswith("PyISAPI_loader.dll") or \
+                                os.path.basename(output_filename).startswith("perfmondata.dll") or \
+                                os.path.basename(output_filename).startswith("win32ui.pyd") or \
+                                target_desc==self.EXECUTABLE)
+    try:
+        return self._orig_link(target_desc, objects, output_filename, *args, **kw)
+    finally:
+        delattr(self, '_want_assembly_kept')
+MSVCCompiler.spawn = monkeypatched_spawn
+MSVCCompiler.link = monkeypatched_link
 
 
 sdk_info = find_platform_sdk_dir()

--- a/setup.py
+++ b/setup.py
@@ -975,7 +975,6 @@ class my_build_ext(build_ext):
                     winsxs_listdir.sort()
                     for entry in winsxs_listdir:
                         if entry.startswith("{}_microsoft.{}.mfc_".format(platform.machine().lower(), mfc_version)) and os.path.isdir(os.path.join(winsxs_path, entry)):
-                            all_files_available = True
                             for mfc_libary in mfc_libraries:
                                 if not os.path.isfile(os.path.join(winsxs_path, entry, mfc_libary)):
                                     continue

--- a/setup.py
+++ b/setup.py
@@ -913,11 +913,11 @@ class my_build_ext(build_ext):
         target_dir = os.path.join(self.build_lib, "pythonwin")
 
         # Common values for the MFC lookup over the Visual Studio installation and redist installation.
-        if sys.hexversion < 0x3030000:
+        if sys.version_info < (3, 3):
             mfc_version = "vc90"
             mfc_libraries = ["mfc90.dll", "mfc90u.dll", "mfcm90.dll", "mfcm90u.dll"]
         # 3.3 and 3.4 use(d) vs2010 (compiler version 1600, crt=10)
-        elif sys.hexversion < 0x3050000:
+        elif sys.version_info < (3, 5):
             mfc_version = "vc100"
             mfc_libraries = ["mfc100u.dll", "mfcm100u.dll"]
         # 3.5 and later on vs2015 (compiler version 1900, crt=14)
@@ -929,15 +929,15 @@ class my_build_ext(build_ext):
         plat_dir_64 = "x64"
         mfc_dir = "Microsoft.{}.MFC".format(mfc_version.upper())
         # 2.7, 3.0, 3.1 and 3.2 all use(d) vs2008 (compiler version 1500)
-        if sys.hexversion < 0x3050000:
-            product_key = r"SOFTWARE\Microsoft\VisualStudio\10.0\Setup\VC"
-            mfc_files = mfc_libraries
-        # 3.5 and later on vs2015 (compiler version 1900, crt=14)
-        elif sys.hexversion < 0x3030000:
+        if sys.version_info < (3, 3):
             product_key = r"SOFTWARE\Microsoft\VisualStudio\9.0\Setup\VC"
             plat_dir_64 = "amd64"
             mfc_files = mfc_libraries + ["Microsoft.VC90.MFC.manifest", ]
         # 3.3 and 3.4 use(d) vs2010 (compiler version 1600, crt=10)
+        elif sys.version_info < (3, 5):
+            product_key = r"SOFTWARE\Microsoft\VisualStudio\10.0\Setup\VC"
+            mfc_files = mfc_libraries
+        # 3.5 and later on vs2015 (compiler version 1900, crt=14)
         else:
             product_key = r"SOFTWARE\Microsoft\VisualStudio\14.0\Setup\VC"
             mfc_files = mfc_libraries

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ static_crt_modules = ["winxpgui"]
 from distutils.dep_util import newer_group
 from distutils.sysconfig import get_config_vars
 from distutils.filelist import FileList
-from distutils.errors import DistutilsExecError
+from distutils.errors import DistutilsExecError, DistutilsSetupError
 import distutils.util
 
 # prevent the new in 3.5 suffix of "cpXX-win32" from being added.

--- a/setup.py
+++ b/setup.py
@@ -61,8 +61,10 @@ The "wheel" packages are uploaded to pypi using `twine upload dist/path-to.whl`
 
 """
 # Originally by Thomas Heller, started in 2000 or so.
-import os, string, sys
-import types, glob
+import os
+import string
+import sys
+import glob
 import re
 from tempfile import gettempdir
 import platform
@@ -77,9 +79,8 @@ except ImportError:
 
 # The rest of our imports.
 from setuptools import setup
-from distutils.core import Extension, Command
+from distutils.core import Extension
 from distutils.command.install import install
-from distutils.command.install_lib import install_lib
 from distutils.command.build_ext import build_ext
 from distutils.command.build import build
 from distutils.command.install_data import install_data
@@ -100,9 +101,8 @@ from distutils import log
 static_crt_modules = ["winxpgui"]
 
 
-from distutils.dep_util import newer_group, newer
-from distutils import dir_util, file_util
-from distutils.sysconfig import get_python_lib, get_config_vars
+from distutils.dep_util import newer_group
+from distutils.sysconfig import get_config_vars
 from distutils.filelist import FileList
 from distutils.errors import DistutilsExecError
 import distutils.util

--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,7 @@ def find_platform_sdk_dir():
     try:
         key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,
                               r"SOFTWARE\Microsoft\Windows Kits\Installed Roots")
-        installRoot, ignore = winreg.QueryValueEx(key, "KitsRoot81")
+        installRoot = winreg.QueryValueEx(key, "KitsRoot81")[0]
     except EnvironmentError:
         print("Can't find a windows 8.1 sdk")
         return None
@@ -285,7 +285,7 @@ class WinExt (Extension):
                   implib_name=None,
                   delay_load_libraries="",
                  ):
-        libary_dirs = library_dirs,
+        _ = library_dirs,
         include_dirs = ['com/win32com/src/include',
                         'win32/src'] + include_dirs
         libraries=libraries.split()

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ import os, string, sys
 import types, glob
 import re
 from tempfile import gettempdir
+import platform
 import shutil
 
 is_py3k = sys.version_info > (3,) # get this out of the way early on...

--- a/setup.py
+++ b/setup.py
@@ -968,7 +968,8 @@ class my_build_ext(build_ext):
                 print("Can't find the redist dir at %r. Looking into WinSxS now.." % (mfc_dir))
 
                 mfc_files = []
-                if "windir" in os.environ.keys():
+                windows_dir = os.getenv("windir", "C:\\Windows")
+                if os.path.isdir(windows_dir):
                     winsxs_path = os.path.join(os.environ["windir"], "WinSxS")
                     if os.path.isdir(winsxs_path):
                         mfc_redist_path = None
@@ -993,6 +994,8 @@ class my_build_ext(build_ext):
                             print("Could not find any redist libraries in WinSxS!")
                     else:
                         print("Could not find WinSxS directory in %WINDIR%.")
+                else:
+                    print("Windows directory not found!")
             else:
                 mfc_files = [os.path.join(mfc_dir, mfc_file) for mfc_file in mfc_files]
 

--- a/setup.py
+++ b/setup.py
@@ -245,14 +245,14 @@ if sys.version_info > (2,6):
 
 sdk_info = find_platform_sdk_dir()
 if not sdk_info:
-  print()
-  print("It looks like you are trying to build pywin32 in an environment without")
-  print("the necessary tools installed. It's much easier to grab binaries!")
-  print()
-  print("Please read the docstring at the top of this file, or read README.md")
-  print("for more information.")
-  print()
-  raise RuntimeError("Can't find the Windows SDK")
+    print()
+    print("It looks like you are trying to build pywin32 in an environment without")
+    print("the necessary tools installed. It's much easier to grab binaries!")
+    print()
+    print("Please read the docstring at the top of this file, or read README.md")
+    print("for more information.")
+    print()
+    raise RuntimeError("Can't find the Windows SDK")
 
 class WinExt (Extension):
     # Base class for all win32 extensions, with some predefined

--- a/setup.py
+++ b/setup.py
@@ -761,8 +761,8 @@ class my_build_ext(build_ext):
         return None # no reason - it can be built!
 
     def _build_scintilla(self):
-        path = 'pythonwin\\Scintilla'
-        makefile = 'makefile_pythonwin'
+        path = "pythonwin\\Scintilla"
+        makefile = "makefile_pythonwin"
         makeargs = []
 
         if self.debug:
@@ -814,7 +814,7 @@ class my_build_ext(build_ext):
         suffix = "%d%d" % (sys.version_info[0], sys.version_info[1])
         if self.debug:
             suffix += '_d'
-        src = r"com\win32com\src\PythonCOMLoader.cpp"
+        src = "com\\win32com\\src\\PythonCOMLoader.cpp"
         build_temp = os.path.abspath(self.build_temp)
         obj = os.path.join(build_temp, os.path.splitext(src)[0]+".obj")
         dll = os.path.join(self.build_lib, "pywin32_system32", "pythoncomloader"+suffix+".dll")
@@ -829,7 +829,7 @@ class my_build_ext(build_ext):
             ccargs.append('/DDLL_DELEGATE=\\"pythoncom%s.dll\\"' % (suffix,))
             self.spawn(ccargs)
 
-        deffile = r"com\win32com\src\PythonCOMLoader.def"
+        deffile = "com\\win32com\\src\\PythonCOMLoader.def"
         if self.force or newer_group([obj, deffile], dll, 'newer'):
             largs = [self.compiler.linker, '/DLL', '/nologo', '/incremental:no']
             if self.debug:
@@ -930,16 +930,16 @@ class my_build_ext(build_ext):
         mfc_dir = "Microsoft.{}.MFC".format(mfc_version.upper())
         # 2.7, 3.0, 3.1 and 3.2 all use(d) vs2008 (compiler version 1500)
         if sys.version_info < (3, 3):
-            product_key = r"SOFTWARE\Microsoft\VisualStudio\9.0\Setup\VC"
+            product_key = "SOFTWARE\\Microsoft\\VisualStudio\\9.0\\Setup\\VC"
             plat_dir_64 = "amd64"
             mfc_files = mfc_libraries + ["Microsoft.VC90.MFC.manifest", ]
         # 3.3 and 3.4 use(d) vs2010 (compiler version 1600, crt=10)
         elif sys.version_info < (3, 5):
-            product_key = r"SOFTWARE\Microsoft\VisualStudio\10.0\Setup\VC"
+            product_key = "SOFTWARE\\Microsoft\\VisualStudio\\10.0\\Setup\\VC"
             mfc_files = mfc_libraries
         # 3.5 and later on vs2015 (compiler version 1900, crt=14)
         else:
-            product_key = r"SOFTWARE\Microsoft\VisualStudio\14.0\Setup\VC"
+            product_key = "SOFTWARE\\Microsoft\\VisualStudio\\14.0\\Setup\\VC"
             mfc_files = mfc_libraries
 
         # On a 64bit host, the value we are looking for is actually in
@@ -952,11 +952,17 @@ class my_build_ext(build_ext):
         else:
             plat_dir = "x86"
         # Find the redist directory.
-        vckey = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, product_key,
-                                0, access)
+        vckey = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,
+                               product_key,
+                               0,
+                               access,
+                               )
         val, val_typ = winreg.QueryValueEx(vckey, "ProductDir")
         mfc_dir = os.path.join(val, "redist", plat_dir, mfc_dir)
-        if not os.path.isdir(mfc_dir):
+        if os.path.isdir(mfc_dir):
+            # Ensuring absolute paths
+            mfc_files = [os.path.join(mfc_dir, mfc_file) for mfc_file in mfc_files]
+        else:
             print("Can't find the redist dir at %r. Looking into WinSxS now.." % (mfc_dir))
 
             mfc_files = []
@@ -988,8 +994,6 @@ class my_build_ext(build_ext):
                     print("Could not find WinSxS directory in %WINDIR%.")
             else:
                 print("Windows directory not found!")
-        else:
-            mfc_files = [os.path.join(mfc_dir, mfc_file) for mfc_file in mfc_files]
 
         if not mfc_files:
             raise RuntimeError("No MFC files found!")
@@ -1196,25 +1200,25 @@ class my_build_ext(build_ext):
 
         # The pre 3.1 pywintypes
         if name == "pywin32_system32.pywintypes":
-            return r"pywin32_system32\pywintypes%d%d%s" % (sys.version_info[0], sys.version_info[1], extra_dll)
+            return "pywin32_system32\\pywintypes%d%d%s" % (sys.version_info[0], sys.version_info[1], extra_dll)
         # 3.1+ pywintypes
         elif name == "pywintypes":
-            return r"pywintypes%d%d%s" % (sys.version_info[0], sys.version_info[1], extra_dll)
+            return "pywintypes%d%d%s" % (sys.version_info[0], sys.version_info[1], extra_dll)
         # pre 3.1 pythoncom
         elif name == "pywin32_system32.pythoncom":
-            return r"pywin32_system32\pythoncom%d%d%s" % (sys.version_info[0], sys.version_info[1], extra_dll)
+            return "pywin32_system32\\pythoncom%d%d%s" % (sys.version_info[0], sys.version_info[1], extra_dll)
         # 3.1+ pythoncom
         elif name == "pythoncom":
-            return r"pythoncom%d%d%s" % (sys.version_info[0], sys.version_info[1], extra_dll)
+            return "pythoncom%d%d%s" % (sys.version_info[0], sys.version_info[1], extra_dll)
         # Pre 3.1 rest.
         elif name.endswith("win32.perfmondata"):
-            return r"win32\perfmondata" + extra_dll
+            return "win32\\perfmondata" + extra_dll
         elif name.endswith("win32.pythonservice"):
-            return r"win32\pythonservice" + extra_exe
+            return "win32\\pythonservice" + extra_exe
         elif name.endswith("pythonwin.Pythonwin"):
-            return r"pythonwin\Pythonwin" + extra_exe
+            return "pythonwin\\Pythonwin" + extra_exe
         elif name.endswith("isapi.PyISAPI_loader"):
-            return r"isapi\PyISAPI_loader" + extra_dll
+            return "isapi\\PyISAPI_loader" + extra_dll
         # The post 3.1 rest
         elif name in ['perfmondata', 'PyISAPI_loader']:
             return name + extra_dll
@@ -1233,7 +1237,7 @@ class my_build_ext(build_ext):
             swig = os.environ["SWIG"]
         else:
             # We know where our swig is
-            swig = os.path.abspath(r"swig\swig.exe")
+            swig = os.path.abspath("swig\\swig.exe")
         lib = os.path.join(os.path.dirname(swig), "swig_lib")
         os.environ["SWIG_LIB"] = lib
         return swig
@@ -1711,30 +1715,30 @@ pythoncom = WinExt_system32('pythoncom',
                         %(win32com)s/extensions/PyIEnumContextProps.cpp     %(win32com)s/extensions/PyIClientSecurity.cpp
                         %(win32com)s/extensions/PyIServerSecurity.cpp
                         """ % dirs).split(),
-                   depends=(r"""
-                        %(win32com)s/include\propbag.h          %(win32com)s/include\PyComTypeObjects.h
-                        %(win32com)s/include\PyFactory.h        %(win32com)s/include\PyGConnectionPoint.h
-                        %(win32com)s/include\PyGConnectionPointContainer.h
-                        %(win32com)s/include\PyGPersistStorage.h %(win32com)s/include\PyIBindCtx.h
-                        %(win32com)s/include\PyICatInformation.h %(win32com)s/include\PyICatRegister.h
-                        %(win32com)s/include\PyIDataObject.h    %(win32com)s/include\PyIDropSource.h
-                        %(win32com)s/include\PyIDropTarget.h    %(win32com)s/include\PyIEnumConnectionPoints.h
-                        %(win32com)s/include\PyIEnumConnections.h %(win32com)s/include\PyIEnumFORMATETC.h
-                        %(win32com)s/include\PyIEnumGUID.h      %(win32com)s/include\PyIEnumSTATPROPSETSTG.h
-                        %(win32com)s/include\PyIEnumSTATSTG.h   %(win32com)s/include\PyIEnumString.h
-                        %(win32com)s/include\PyIEnumVARIANT.h   %(win32com)s/include\PyIExternalConnection.h
-                        %(win32com)s/include\PyIGlobalInterfaceTable.h %(win32com)s/include\PyILockBytes.h
-                        %(win32com)s/include\PyIMoniker.h       %(win32com)s/include\PyIOleWindow.h
-                        %(win32com)s/include\PyIPersist.h       %(win32com)s/include\PyIPersistFile.h
-                        %(win32com)s/include\PyIPersistStorage.h %(win32com)s/include\PyIPersistStream.h
-                        %(win32com)s/include\PyIPersistStreamInit.h %(win32com)s/include\PyIRunningObjectTable.h
-                        %(win32com)s/include\PyIStorage.h       %(win32com)s/include\PyIStream.h
-                        %(win32com)s/include\PythonCOM.h        %(win32com)s/include\PythonCOMRegister.h
-                        %(win32com)s/include\PythonCOMServer.h  %(win32com)s/include\stdafx.h
-                        %(win32com)s/include\univgw_dataconv.h
-                        %(win32com)s/include/PyICancelMethodCalls.h    %(win32com)s/include/PyIContext.h
-                        %(win32com)s/include/PyIEnumContextProps.h     %(win32com)s/include/PyIClientSecurity.h
-                        %(win32com)s/include/PyIServerSecurity.h
+                   depends=("""
+                        %(win32com)s/include\\propbag.h          %(win32com)s/include\\PyComTypeObjects.h
+                        %(win32com)s/include\\PyFactory.h        %(win32com)s/include\\PyGConnectionPoint.h
+                        %(win32com)s/include\\PyGConnectionPointContainer.h
+                        %(win32com)s/include\\PyGPersistStorage.h %(win32com)s/include\\PyIBindCtx.h
+                        %(win32com)s/include\\PyICatInformation.h %(win32com)s/include\\PyICatRegister.h
+                        %(win32com)s/include\\PyIDataObject.h    %(win32com)s/include\\PyIDropSource.h
+                        %(win32com)s/include\\PyIDropTarget.h    %(win32com)s/include\\PyIEnumConnectionPoints.h
+                        %(win32com)s/include\\PyIEnumConnections.h %(win32com)s/include\\PyIEnumFORMATETC.h
+                        %(win32com)s/include\\PyIEnumGUID.h      %(win32com)s/include\\PyIEnumSTATPROPSETSTG.h
+                        %(win32com)s/include\\PyIEnumSTATSTG.h   %(win32com)s/include\\PyIEnumString.h
+                        %(win32com)s/include\\PyIEnumVARIANT.h   %(win32com)s/include\\PyIExternalConnection.h
+                        %(win32com)s/include\\PyIGlobalInterfaceTable.h %(win32com)s/include\\PyILockBytes.h
+                        %(win32com)s/include\\PyIMoniker.h       %(win32com)s/include\\PyIOleWindow.h
+                        %(win32com)s/include\\PyIPersist.h       %(win32com)s/include\\PyIPersistFile.h
+                        %(win32com)s/include\\PyIPersistStorage.h %(win32com)s/include\\PyIPersistStream.h
+                        %(win32com)s/include\\PyIPersistStreamInit.h %(win32com)s/include\\PyIRunningObjectTable.h
+                        %(win32com)s/include\\PyIStorage.h       %(win32com)s/include\\PyIStream.h
+                        %(win32com)s/include\\PythonCOM.h        %(win32com)s/include\\PythonCOMRegister.h
+                        %(win32com)s/include\\PythonCOMServer.h  %(win32com)s/include\\stdafx.h
+                        %(win32com)s/include\\univgw_dataconv.h
+                        %(win32com)s/include\\PyICancelMethodCalls.h    %(win32com)s/include\\PyIContext.h
+                        %(win32com)s/include\\PyIEnumContextProps.h     %(win32com)s/include\\PyIClientSecurity.h
+                        %(win32com)s/include\\PyIServerSecurity.h
                         """ % dirs).split(),
                    libraries = "oleaut32 ole32 user32 urlmon",
                    export_symbol_file = 'com/win32com/src/PythonCOM.def',


### PR DESCRIPTION
These corrections allow to look into %WINDIR%/WinSxS for the MFC libraries and take them from there if they couldn't be found in the Visual Studio installation. That can happen when building for Python 2.7 and using the Express version of Visual Studio.

With these changes, all builds can pass now.
More importantly: We can deploy the resulting wheel files and installers directly here to Github.