### PR TITLE
Fixes GetServiceClassString for py files in zip/exe #642

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,10 @@ Since build 223:
   creep in, so it should be explicitly called out as a change.
   On the plus side, this makes building the extensions far simpler.
 
+* win32serviceutil - in GetServiceClassString, skip rewrite of file name (fname)
+  when win32api.FindFiles returns an empty list, e.g., if the service has been
+  packaged in a zip or exe. (fixes issue #642)
+
 Since build 222:
 ----------------
 * pywin32.pth now arranges for the pywin32_system32 directory to be on

--- a/win32/Lib/win32serviceutil.py
+++ b/win32/Lib/win32serviceutil.py
@@ -484,7 +484,7 @@ def GetServiceClassString(cls, argv = None):
             filelist = win32api.FindFiles(fname)
             # win32api.FindFiles will not detect files in a zip or exe. If list is empty,
             # skip the test and hope the file really exists. 
-            if len(filelist) is not 0:
+            if len(filelist) != 0:
                 # Get the long name
                 fname = os.path.join(path, filelist[0][8])
         except win32api.error:

--- a/win32/Lib/win32serviceutil.py
+++ b/win32/Lib/win32serviceutil.py
@@ -481,8 +481,12 @@ def GetServiceClassString(cls, argv = None):
             path = os.path.split(fname)[0]
             # Eaaaahhhh - sometimes this will be a short filename, which causes
             # problems with 1.5.1 and the silly filename case rule.
-            # Get the long name
-            fname = os.path.join(path, win32api.FindFiles(fname)[0][8])
+            filelist = win32api.FindFiles(fname)
+            # win32api.FindFiles will not detect files in a zip or exe. If list is empty,
+            # skip the test and hope the file really exists. 
+            if len(filelist) is not 0:
+                # Get the long name
+                fname = os.path.join(path, filelist[0][8])
         except win32api.error:
             raise error("Could not resolve the path name '%s' to a full path" % (argv[0]))
         modName = os.path.splitext(fname)[0]


### PR DESCRIPTION
Resolves #642 when executing GetServiceClassString against a class within a module stored in an exe or zip file. Workaround is mutually exclusive with existing short file name workaround. 