### PR TITLE
Enable exchange module for all builds

### DIFF
--- a/com/win32comext/mapi/emsabtags.py
+++ b/com/win32comext/mapi/emsabtags.py
@@ -1,15 +1,15 @@
 # Converted "manually" from EMSABTAG.H
-from mapitags import PT_UNSPECIFIED, PT_NULL, PT_I2, PT_LONG, PT_R4, \
-                     PT_DOUBLE, PT_CURRENCY, PT_APPTIME, PT_ERROR, \
-                     PT_BOOLEAN, PT_OBJECT, PT_I8, PT_STRING8, PT_UNICODE, \
-                     PT_SYSTIME, PT_CLSID, PT_BINARY, PT_SHORT, PT_I4, \
-                     PT_FLOAT, PT_DOUBLE, PT_LONGLONG, PT_TSTRING, \
-                     PT_MV_I2, PT_MV_LONG, PT_MV_R4, PT_MV_DOUBLE, \
-                     PT_MV_CURRENCY, PT_MV_APPTIME, PT_MV_SYSTIME, \
-                     PT_MV_STRING8, PT_MV_BINARY, PT_MV_UNICODE, \
-                     PT_MV_CLSID, PT_MV_I8, PT_MV_SHORT, PT_MV_I4, \
-                     PT_MV_FLOAT, PT_MV_R8, PT_MV_LONGLONG, PT_MV_TSTRING, \
-                     PROP_TAG
+from .mapitags import PT_UNSPECIFIED, PT_NULL, PT_I2, PT_LONG, PT_R4, \
+                      PT_DOUBLE, PT_CURRENCY, PT_APPTIME, PT_ERROR, \
+                      PT_BOOLEAN, PT_OBJECT, PT_I8, PT_STRING8, PT_UNICODE, \
+                      PT_SYSTIME, PT_CLSID, PT_BINARY, PT_SHORT, PT_I4, \
+                      PT_FLOAT, PT_DOUBLE, PT_LONGLONG, PT_TSTRING, \
+                      PT_MV_I2, PT_MV_LONG, PT_MV_R4, PT_MV_DOUBLE, \
+                      PT_MV_CURRENCY, PT_MV_APPTIME, PT_MV_SYSTIME, \
+                      PT_MV_STRING8, PT_MV_BINARY, PT_MV_UNICODE, \
+                      PT_MV_CLSID, PT_MV_I8, PT_MV_SHORT, PT_MV_I4, \
+                      PT_MV_FLOAT, PT_MV_R8, PT_MV_LONGLONG, PT_MV_TSTRING, \
+                      PROP_TAG
 
 
 AB_SHOW_PHANTOMS                      = 2

--- a/com/win32comext/mapi/mapiutil.py
+++ b/com/win32comext/mapi/mapiutil.py
@@ -5,7 +5,7 @@ ListType=list
 IntType=int
 from pywintypes import TimeType
 import pythoncom
-import mapi, mapitags
+from . import mapi, mapitags
 
 prTable = {}
 def GetPropTagName(pt):

--- a/com/win32comext/mapi/src/exchange.i
+++ b/com/win32comext/mapi/src/exchange.i
@@ -446,7 +446,9 @@ HRESULT MyHrMailboxLogon(
     OUT LPMDB           *lppMailboxMDB)            // ptr to mailbox message store ptr
 {
 #if defined(DONT_HAVE_MBLOGON)
+	PyGILState_STATE gstate = PyGILState_Ensure();
 	PyErr_Warn(PyExc_RuntimeWarning, "Not available with this version of the Exchange SDK");
+	PyGILState_Release(gstate);
 	return E_NOTIMPL;
 #else
 	return HrMailboxLogon(lplhSession, lpMDB, lpszMsgStoreDN, lpszMailboxDN, lppMailboxMDB);
@@ -467,7 +469,9 @@ HRESULT MyHrMailboxLogon(
 HRESULT MyHrMailboxLogoff(IMsgStore **pp)
 {
 #if defined(DONT_HAVE_MBLOGON)
+	PyGILState_STATE gstate = PyGILState_Ensure();
 	PyErr_Warn(PyExc_RuntimeWarning, "Not available with this version of the Exchange SDK");
+	PyGILState_Release(gstate);
 	return E_NOTIMPL;
 #else
 	return HrMailboxLogoff(pp);


### PR DESCRIPTION
The purpose of this patch is to expose `IID_IExchangeManageStore` and `IID_IExchangeManageStoreEx` for all builds. To minimize source changes, EdkSdk.lib now links for the 32-bit vs2015 builds as well.

However, we should consider deprecating and at some point finally removing all of the Exchange SDK library functions from the exchange module. This would also be the time to consider dropping the exchdapi module as well which is currently only building for 2.7 32-bit.

A separate commit was added to include an explicit relative import in mapiutil.py which for some reason lib2to3 was failing to process correctly. For consistency, emsabtags.py was also changed (but that _was_ being correctly processed.)