### PR TITLE
Fixes install by allowing any setuptools flags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,11 +80,12 @@ except ImportError:
 # The rest of our imports.
 from setuptools import setup
 from distutils.core import Extension
-from distutils.command.install import install
-from distutils.command.build_ext import build_ext
+from setuptools.command.install import install
+from setuptools.command.install_lib import install_lib
+from setuptools.command.build_ext import build_ext
+from setuptools.command.build_py import build_py
 from distutils.command.build import build
 from distutils.command.install_data import install_data
-from distutils.command.build_py import build_py
 from distutils.command.build_scripts import build_scripts
 
 try:


### PR DESCRIPTION
Flags normally available to setuptools commands -- such as
`--single-version-externally-managed` provided by
`setuptools.commands.install` -- were not being recognized. This change
fixes this behavior by preferring `setuptools.commands` over
`distutils.commands`.