### PR TITLE
Fix PythonWin startup crash when keyboard layout is non-English

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,10 @@ Generally created by hand after running:
    hg log -rb2xx: > log.out
 However contributors are encouraged to add their own entries for their work.
 
+Since build 224:
+----------------
+* PythonWin is now able to start with non-English active keyboard layout.
+
 Since build 223:
 ----------------
 * Built with a released version of Python 3.7, which fixes various date related

--- a/Pythonwin/pywin/scintilla/keycodes.py
+++ b/Pythonwin/pywin/scintilla/keycodes.py
@@ -35,7 +35,9 @@ def get_vk(chardesc):
         # it is a character.
         info = win32api.VkKeyScan(chardesc)
         if info==-1:
-            return None, None
+            # Note: returning None, None causes an error when keyboard layout is non-English, see the report below
+            # https://stackoverflow.com/questions/45138084/pythonwin-occasionally-gives-an-error-on-opening
+            return 0, 0
         vk = win32api.LOBYTE(info)
         state = win32api.HIBYTE(info)
         modifiers = 0


### PR DESCRIPTION
This is a long living issue I found few years ago. Now it's time to fix it.

Detailed report is here:
 * https://stackoverflow.com/questions/45138084/pythonwin-occasionally-gives-an-error-on-opening

Workaround was to switch keyboard layout back to English.