### PR TITLE
Check in WOW6432NODE for the Win8.1 SDK

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -155,6 +155,10 @@ def find_platform_sdk_dir():
                               r"SOFTWARE\Microsoft\Windows Kits\Installed Roots")
         installRoot = winreg.QueryValueEx(key, "KitsRoot81")[0]
     except EnvironmentError:
+        key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,
+                              r"SOFTWARE\WOW6432NODE\Microsoft\Windows Kits\Installed Roots")
+        installRoot = winreg.QueryValueEx(key, "KitsRoot81")[0]
+    except EnvironmentError:
         print("Can't find a windows 8.1 sdk")
         return None
 


### PR DESCRIPTION
If the Windows 8.1 Registry Key is not found in "SOFTWARE\Microsoft\Windows Kits\Installed Roots" check the WOW6432Node. Resolves issue #1293

Please keep in mind that I am an amateur and this may not be the best way to handle it. If there is indeed a better solution I'm all for it.