### PR TITLE
Handle index keys missing in registry

### DIFF
--- a/win32/Lib/win32timezone.py
+++ b/win32/Lib/win32timezone.py
@@ -720,7 +720,7 @@ class TimeZoneInfo(datetime.tzinfo):
 		key_names = list(TimeZoneInfo._get_time_zone_key_names())
 		def get_index_value(key_name):
 			key = TimeZoneInfo._get_time_zone_key(key_name)
-			return key[index_key]
+			return key.get(index_key, key_name)
 		values = map(get_index_value, key_names)
 		return zip(values, key_names)
 


### PR DESCRIPTION
When generating indexed time zone names from the registry, use the time zone
key name if the index key doesn't exist.

Closes #1299