### PR TITLE
In _get_indexed_time_zone_keys, exclude keys that don't have that key.

### DIFF
--- a/win32/Lib/win32timezone.py
+++ b/win32/Lib/win32timezone.py
@@ -715,14 +715,22 @@ class TimeZoneInfo(datetime.tzinfo):
 	@staticmethod
 	def _get_indexed_time_zone_keys(index_key='Index'):
 		"""
-		Get the names of the registry keys indexed by a value in that key.
+		Get the names of the registry keys indexed by a value in that key,
+		ignoring any keys for which that value is empty or missing.
 		"""
 		key_names = list(TimeZoneInfo._get_time_zone_key_names())
+
 		def get_index_value(key_name):
 			key = TimeZoneInfo._get_time_zone_key(key_name)
-			return key[index_key]
+			return key.get(index_key)
+
 		values = map(get_index_value, key_names)
-		return zip(values, key_names)
+
+		return (
+			(value, key_name)
+			for value, key_name in zip(values, key_names)
+			if value
+		)
 
 	@staticmethod
 	def get_sorted_time_zone_names():


### PR DESCRIPTION
I've tested this change by replicating the environment reported in #1299, confirming the failure before the commit and verifying the correction in the fix. I haven't written a test for this behavior, as it feels obscure enough not to need one, and writing one would require monkeypatching or mocking.