### PR TITLE
pywin32.pth: don't blindly append to PATH in case site is repeatedly reload()ed

### DIFF
--- a/pywin32.pth
+++ b/pywin32.pth
@@ -6,4 +6,4 @@ Pythonwin
 # isn't run, which would normally copy the pywin32 core DLL files to either
 # the top of the python directory.
 # We just stick the source of these DLLs directly on the PATH.
-import os;os.environ["PATH"]+=(';'+os.path.join(sitedir,"pywin32_system32"))
+import os;pywin32_system32=os.path.join(sitedir,"pywin32_system32");os.environ["PATH"]+=('' if pywin32_system32 in os.environ["PATH"] else (';'+pywin32_system32))


### PR DESCRIPTION
`pywin32.pth` appends to the `PATH` environment variable. When the `site` module is `reload()`ed, it re-evaluates `.pth` files. When an environment variable gets too long (~32k), `CreateProcess` fails.

This PR modifies `pywin32.pth` to append to PATH only if the entry is not already present.

POC:

    import os
    import subprocess
    import site


    for i in range(1000):
        old_path = os.environ['PATH']
        reload(site)
        if len(old_path) >= len(os.environ['PATH']):
            break
    print i

    subprocess.check_call('cmd /c set')

Output:

    c:\Python27\python test.py
    Error processing line 11 of c:\Python27\lib\site-packages\pywin32.pth:

      Traceback (most recent call last):
        File "c:\Python27\lib\site.py", line 152, in addpackage
          exec line
        File "<string>", line 1, in <module>
        File "c:\Python27\lib\os.py", line 422, in __setitem__
          putenv(key, item)
      ValueError: the environment variable is longer than 32767 bytes

    Remainder of file ignored
    660
    Traceback (most recent call last):
      File "test.py", line 13, in <module>
        subprocess.check_call('cmd /c set')
      File "c:\Python27\lib\subprocess.py", line 181, in check_call
        retcode = call(*popenargs, **kwargs)
      File "c:\Python27\lib\subprocess.py", line 168, in call
        return Popen(*popenargs, **kwargs).wait()
      File "c:\Python27\lib\subprocess.py", line 390, in __init__
        errread, errwrite)
      File "c:\Python27\lib\subprocess.py", line 640, in _execute_child
        startupinfo)
    WindowsError: [Error 8] Not enough memory resources are available to process this command