### PR TITLE
Fix gcc/mingw errors for PyWinObject_From(LARGE|ULARGE)_INTEGER

### DIFF
--- a/win32/src/PyLARGE_INTEGER.cpp
+++ b/win32/src/PyLARGE_INTEGER.cpp
@@ -77,12 +77,12 @@ BOOL PyWinObject_AsULARGE_INTEGER(PyObject *ob, ULARGE_INTEGER *pResult)
 	return TRUE;
 }
 
-PyObject *PyWinObject_FromLARGE_INTEGER(LARGE_INTEGER &val)
+PYWINTYPES_EXPORT PyObject *PyWinObject_FromLARGE_INTEGER(const LARGE_INTEGER &val)
 {
 	return PyLong_FromLongLong(val.QuadPart);
 }
 
-PyObject *PyWinObject_FromULARGE_INTEGER(ULARGE_INTEGER &val)
+PYWINTYPES_EXPORT PyObject *PyWinObject_FromULARGE_INTEGER(const ULARGE_INTEGER &val)
 {
 	return PyLong_FromUnsignedLongLong(val.QuadPart);
 }

--- a/win32/src/PyWinTypes.h
+++ b/win32/src/PyWinTypes.h
@@ -385,8 +385,8 @@ PYWINTYPES_EXPORT PyObject *PyWinLong_FromVoidPtr(const void *ptr);
 //AsLARGE_INTEGER takes either int or long
 PYWINTYPES_EXPORT BOOL PyWinObject_AsLARGE_INTEGER(PyObject *ob, LARGE_INTEGER *pResult);
 PYWINTYPES_EXPORT BOOL PyWinObject_AsULARGE_INTEGER(PyObject *ob, ULARGE_INTEGER *pResult);
-PYWINTYPES_EXPORT PyObject *PyWinObject_FromLARGE_INTEGER(LARGE_INTEGER &val);
-PYWINTYPES_EXPORT PyObject *PyWinObject_FromULARGE_INTEGER(ULARGE_INTEGER &val);
+PYWINTYPES_EXPORT PyObject *PyWinObject_FromLARGE_INTEGER(const LARGE_INTEGER &val);
+PYWINTYPES_EXPORT PyObject *PyWinObject_FromULARGE_INTEGER(const ULARGE_INTEGER &val);
 // Helpers that take a Py_LONG_LONG, but (a) have pywin32 consistent signatures
 // and (b) handle int *and* long (where Python only starts doing that in the
 // PyLong_* APIs post 2.4)


### PR DESCRIPTION
When compiling under MinGW I get these errors:

```
win32/src/PyWinTypes.h:396:73: error: cannot bind non-const lvalue reference of type 'LARGE_INTEGER&' {aka '_LARGE_INTEGER&'} to an rvalue of type '_LARGE_INTEGER'
  396 | #define PyWinObject_FromPY_LONG_LONG(val) PyWinObject_FromLARGE_INTEGER((LARGE_INTEGER)val)
com/win32com/src/oleargs.cpp:826:14: note: in expansion of macro 'PyWinObject_FromPY_LONG_LONG'
  826 |    subitem = PyWinObject_FromPY_LONG_LONG(ll);
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
win32/src/PyWinTypes.h:388:74: note:   initializing argument 1 of 'PyObject* PyWinObject_FromLARGE_INTEGER(LARGE_INTEGER&)'
  388 | PYWINTYPES_EXPORT PyObject *PyWinObject_FromLARGE_INTEGER(LARGE_INTEGER &val);
      |                                                           ~~~~~~~~~~~~~~~^~~
win32/src/PyWinTypes.h:397:75: error: cannot bind non-const lvalue reference of type 'ULARGE_INTEGER&' {aka '_ULARGE_INTEGER&'} to an rvalue of type '_ULARGE_INTEGER'
  397 | #define PyWinObject_FromUPY_LONG_LONG(val) PyWinObject_FromULARGE_INTEGER((ULARGE_INTEGER)val)
com/win32com/src/oleargs.cpp:924:14: note: in expansion of macro 'PyWinObject_FromUPY_LONG_LONG'
  924 |    subitem = PyWinObject_FromUPY_LONG_LONG(ll);
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
win32/src/PyWinTypes.h:389:76: note:   initializing argument 1 of 'PyObject* PyWinObject_FromULARGE_INTEGER(ULARGE_INTEGER&)'
  389 | PYWINTYPES_EXPORT PyObject *PyWinObject_FromULARGE_INTEGER(ULARGE_INTEGER &val);
      |                                                            ~~~~~~~~~~~~~~~~^~~
error: command 'C:\\dev\\msys64\\mingw64\\bin/x86_64-w64-mingw32-gcc.exe' failed with exit status 1
```

This is resolved by adding `const`s to the argument references of these two functions.

Additionally after fixing these there are some linker errors caused by the functions not being exported correctly in MinGW. This PR fixes this too.
