### PR TITLE
Update some mingw-specific macros

### DIFF
--- a/com/win32com/src/include/PythonCOM.h
+++ b/com/win32com/src/include/PythonCOM.h
@@ -110,11 +110,7 @@
 
 #ifdef __MINGW32__
 // Special Mingw32 considerations.
-#define NO_PYCOM_IDISPATCHEX
-#define NO_PYCOM_IPROVIDECLASSINFO
-#define NO_PYCOM_ISERVICEPROVIDER
 #define NO_PYCOM_ENUMSTATPROPSTG
-#define NO_PYCOM_IPROPERTYSTORAGE
 #define __try try
 #define __except catch
 #include <olectl.h>


### PR DESCRIPTION
There is some old code (from 2003) which no longer reflects what MinGW's C library defines.

These are implemented now: [IDispatchEx](https://github.com/mirror/mingw-w64/blob/16151c441e89081fd398270bb888511ebef6fb35/mingw-w64-headers/include/dispex.idl#L76), [IProvideClassInfo](https://github.com/mirror/mingw-w64/blob/16151c441e89081fd398270bb888511ebef6fb35/mingw-w64-headers/include/ocidl.idl#L175), [IServiceProvider](https://github.com/mirror/mingw-w64/blob/16151c441e89081fd398270bb888511ebef6fb35/mingw-w64-headers/include/servprov.idl#L18), [IPropertyStorage](https://github.com/mirror/mingw-w64/blob/16151c441e89081fd398270bb888511ebef6fb35/mingw-w64-headers/include/propidl.idl#L306)