### PR TITLE
Fix VARIANT conversion from special sequences and numbers

### DIFF
--- a/com/win32com/src/oleargs.cpp
+++ b/com/win32com/src/oleargs.cpp
@@ -22,7 +22,7 @@ static PyObject *PyVariant_Type;
 #if (PY_VERSION_HEX < 0x03000000)
 #define PYWIN_BUFFER_CHECK PyBuffer_Check
 #else
-#define PYWIN_BUFFER_CHECK PyObject_CheckBuffer
+#define PYWIN_BUFFER_CHECK(obj) (PyBytes_Check(obj) || PyByteArray_Check(obj))
 #endif
 
 // A little helper just for this file
@@ -301,6 +301,12 @@ BOOL PyCom_VariantFromPyObject(PyObject *obj, VARIANT *var)
 		if (!PyObject_AsCurrency(obj, &V_CY(var)))
 			return FALSE;
 		V_VT(var) = VT_CY;
+	}
+	// Fallback for everything that can be converted to a double but where PyFloat_Check failed
+	else if (obj->ob_type->tp_as_number)
+	{
+		V_VT(var) = VT_R8;
+		V_R8(var) = PyFloat_AsDouble(obj);
 	}
 
 	if (V_VT(var) == VT_EMPTY && !bGoodEmpty) {

--- a/com/win32com/test/pippo.idl
+++ b/com/win32com/test/pippo.idl
@@ -21,7 +21,7 @@ import "ocidl.idl";
 	};
 	[
 		object,
-		uuid(F1A3CC2E-4B2A-4A81-992D-67862076949B),
+		uuid(618DB2A3-D5BD-4850-B66A-828727EB37E5),
 		dual,
 		helpstring("IPippo Interface"),
 		pointer_default(unique)
@@ -32,10 +32,12 @@ import "ocidl.idl";
 		[propget, id(2), helpstring("property MyProp1")] HRESULT MyProp1([out, retval] long *pVal);
 		[id(3), helpstring("method Method2")] HRESULT Method2([in] long in1, [in, out] long *inout1,
 		                                                      [out, retval] long *val);
+		[id(4), helpstring("method Method3")] HRESULT Method3([in] VARIANT in1,
+		                                                      [out, retval] VARIANT *val);
 	};
 
 [
-	uuid(41059C57-975F-4B36-8FF3-C5117426647A),
+	uuid(7783054E-9A20-4584-8C62-6ED2A08F6AC6),
 	version(1.0),
 	helpstring("TestServer 1.0 Type Library")
 ]
@@ -54,7 +56,7 @@ library TESTSERVERLib
 		[default] interface ITestServerApp;
 	};
 	[
-		uuid(E19C0A68-F61C-450B-A974-A7BA6957829C),
+		uuid(1F0F75D6-BD63-41B9-9F88-2D9D2E1AA5C3),
 		helpstring("Pippo Class")
 	]
 	coclass Pippo

--- a/com/win32com/test/pippo_server.py
+++ b/com/win32com/test/pippo_server.py
@@ -12,13 +12,13 @@ class CPippo:
     #
     # COM declarations    
     #
-    _reg_clsid_ = "{05AC1CCE-3F9B-4d9a-B0B5-DFE8BE45AFA8}"
+    _reg_clsid_ = "{1F0F75D6-BD63-41B9-9F88-2D9D2E1AA5C3}"
     _reg_desc_ = "Pippo Python test object"
     _reg_progid_ = "Python.Test.Pippo"
     #_reg_clsctx_ = pythoncom.CLSCTX_LOCAL_SERVER    
     ###
     ### Link to typelib
-    _typelib_guid_ = '{41059C57-975F-4B36-8FF3-C5117426647A}'
+    _typelib_guid_ = '{7783054E-9A20-4584-8C62-6ED2A08F6AC6}'
     _typelib_version_ = 1, 0
     _com_interfaces_ = ['IPippo']
 
@@ -31,13 +31,18 @@ class CPippo:
     def Method2(self, in1, inout1):
         return in1, inout1 * 2
 
+    def Method3(self, in1):
+        # in1 will be a tuple, not a list.
+        # Yet, we are not allowed to return a tuple, but need to convert it to a list first. (Bug?)
+        return list(in1)
+
 def BuildTypelib():
     from distutils.dep_util import newer
     this_dir = os.path.dirname(__file__)
     idl = os.path.abspath(os.path.join(this_dir, "pippo.idl"))
     tlb=os.path.splitext(idl)[0] + '.tlb'
     if newer(idl, tlb):
-        print "Compiling %s" % (idl,)
+        print("Compiling %s" % (idl,))
         rc = os.system ('midl "%s"' % (idl,))
         if rc:
             raise RuntimeError("Compiling MIDL failed!")
@@ -46,7 +51,7 @@ def BuildTypelib():
         for fname in "dlldata.c pippo_i.c pippo_p.c pippo.h".split():
             os.remove(os.path.join(this_dir, fname))
     
-    print "Registering %s" % (tlb,)
+    print("Registering %s" % (tlb,))
     tli=pythoncom.LoadTypeLib(tlb)
     pythoncom.RegisterTypeLib(tli,tlb)
 
@@ -58,8 +63,8 @@ def UnregisterTypelib():
                                     k._typelib_version_[1], 
                                     0, 
                                     pythoncom.SYS_WIN32)
-        print "Unregistered typelib"
-    except pythoncom.error, details:
+        print("Unregistered typelib")
+    except pythoncom.error as details:
         if details[0]==winerror.TYPE_E_REGISTRYACCESS:
             pass
         else:

--- a/com/win32com/test/testPippo.py
+++ b/com/win32com/test/testPippo.py
@@ -16,7 +16,7 @@ class PippoTester(unittest.TestCase):
         try:
             gtrc = sys.gettotalrefcount
         except AttributeError:
-            print "Please run this with python_d for leak tests"
+            print("Please run this with python_d for leak tests")
             gtrc = lambda: 0
         # note creating self.object() should have consumed our "one time" leaks
         self.object.Method1()
@@ -31,14 +31,37 @@ class PippoTester(unittest.TestCase):
 
     def testResults(self):
         rc, out1 = self.object.Method2(123, 111)
-        self.failUnlessEqual(rc, 123)
-        self.failUnlessEqual(out1, 222)
+        self.assertEqual(rc, 123)
+        self.assertEqual(out1, 222)
+
+    def testPythonArrays(self):
+        self._testArray([-3, -2, -1, 0, 1, 2, 3])
+        self._testArray([-3.14, -2, -.1, 0., 1.1, 2.5, 3])
+
+    def testNumpyArrays(self):
+        try:
+            import numpy
+        except:
+            print("Numpy test not possible because numpy module failed to import")
+            return
+        self._testArray(numpy.array([-3, -2, -1, 0, 1, 2, 3]))
+        self._testArray(numpy.array([-3.14, -2, -.1, 0., 1.1, 2.5, 3]))
+
+    def testByteArrays(self):
+        if 'bytes' in dir(__builtins__):
+            # Use eval to avoid compilation error in Python 2.
+            self._testArray(eval("b'abcdef'"))
+            self._testArray(eval("bytearray(b'abcdef')"))
+
+    def _testArray(self, inArray):
+        outArray = self.object.Method3(inArray)
+        self.assertEqual(list(outArray), list(inArray))
 
     def testLeaksGencache(self):
         try:
             gtrc = sys.gettotalrefcount
         except AttributeError:
-            print "Please run this with python_d for leak tests"
+            print("Please run this with python_d for leak tests")
             gtrc = lambda: 0
         # note creating self.object() should have consumed our "one time" leaks
         object = EnsureDispatch("Python.Test.Pippo")


### PR DESCRIPTION
Fixed behavior in PyCom_VariantFromPyObject for Python 3 in two cases:
1. Sequences that implement the buffer interface but are no buffers are now regarded as sequences instead of buffers
2. Support numeric types that fail both PyLong_Check and PyFloat_Check (e.g. numpy.int32)

Fixes #1346