### PR TITLE
setup.py: Allow user installations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1370,7 +1370,7 @@ class my_install(install):
         if not self.dry_run and not self.root:
             # We must run the script we just installed into Scripts, as it
             # may have had 2to3 run over it.
-            filename = os.path.join(self.prefix, "Scripts", "pywin32_postinstall.py")
+            filename = os.path.join(self.install_scripts, "pywin32_postinstall.py")
             if not os.path.isfile(filename):
                 raise RuntimeError("Can't find '%s'" % (filename,))
             print("Executing post install script...")


### PR DESCRIPTION
When executing python setup.py --user, self.prefix will be set to None. Of course, you will get an error that None can't be os.join'd.
Therefore, using distutils' own variable, which has the script install directory already resolved.

PS: Found while working on #1391 