### PR TITLE
Add MAPI IMsgServiceAdmin2 interface

### DIFF
--- a/com/win32comext/mapi/src/PyIMsgServiceAdmin2.i
+++ b/com/win32comext/mapi/src/PyIMsgServiceAdmin2.i
@@ -1,0 +1,79 @@
+/* File : PyIMsgServiceAdmin2.i */
+
+%module IMsgServiceAdmin2
+
+%include "typemaps.i"
+%include "pywin32.i"
+%include "pythoncom.i"
+%include "mapilib.i"
+
+%{
+
+#include "mapiaux.h"
+#include "PyIMsgServiceAdmin.h"
+#include "PyIMsgServiceAdmin2.h"
+
+PyIMsgServiceAdmin2::PyIMsgServiceAdmin2(IUnknown *pDisp) :
+	PyIMsgServiceAdmin(pDisp)
+{
+	ob_type = &type;
+}
+
+PyIMsgServiceAdmin2::~PyIMsgServiceAdmin2()
+{
+}
+
+/*static*/ IMsgServiceAdmin2 *PyIMsgServiceAdmin2::GetI(PyObject *self)
+{
+	return (IMsgServiceAdmin2 *)PyIUnknown::GetI(self);
+}
+
+
+%}
+
+%native(CreateMsgServiceEx) CreateMsgServiceEx;
+%{
+// @pyswig <o PyIID>|CreateMsgServiceEx|Creates a message service and returns the newly added service UID.
+PyObject *PyIMsgServiceAdmin2::CreateMsgServiceEx(PyObject *self, PyObject *args)
+{
+	PyObject *result = NULL;
+	HRESULT hRes;
+	PyObject *obService;
+	LPTSTR lpszService = NULL;
+	PyObject *obDisplayName;
+	LPTSTR lpszDisplayName = NULL;
+	ULONG ulUIParam = 0;
+	ULONG ulFlags = 0;
+	MAPIUID uidService = {0};
+
+	IMsgServiceAdmin2 *_swig_self;
+	if ((_swig_self=GetI(self))==NULL) return NULL;
+
+	if (!PyArg_ParseTuple(args, "OO|ll",
+		&obService, // @pyparm string|serviceName||The name of the service.
+		&obDisplayName, // @pyparm string|displayName||Display name of the service, or None
+		&ulUIParam, // @pyparm int|uiParam|0|A handle of the parent window for any dialog boxes or windows that this method displays.
+		&ulFlags)) // @pyparm int|flags||A bitmask of flags that controls how the message service is installed.
+		return NULL;
+
+	if (!PyWinObject_AsMAPIStr(obService, &lpszService, ulFlags & MAPI_UNICODE, FALSE))
+		goto done;
+	if (!PyWinObject_AsMAPIStr(obDisplayName, &lpszDisplayName, ulFlags & MAPI_UNICODE, TRUE))
+		goto done;
+
+	Py_BEGIN_ALLOW_THREADS
+		hRes = _swig_self->CreateMsgServiceEx(lpszService, lpszDisplayName, ulUIParam, ulFlags, &uidService);
+	Py_END_ALLOW_THREADS
+
+	if (FAILED(hRes))
+		result = OleSetOleError(hRes);
+	else
+		result = PyWinObject_FromIID(reinterpret_cast<GUID &>(uidService));
+
+done:
+	PyWinObject_FreeString(lpszService);
+	PyWinObject_FreeString(lpszDisplayName);
+
+	return result;
+}
+%}

--- a/com/win32comext/mapi/src/mapi.i
+++ b/com/win32comext/mapi/src/mapi.i
@@ -24,6 +24,8 @@
 %include "mapilib.i"
 
 %{
+#include "mapiaux.h"
+
 #include "PythonCOMServer.h"
 #include "PythonCOMRegister.h"
 #include <mapiutil.h>
@@ -43,6 +45,7 @@
 #include "PyIABContainer.h"
 #include "PyIProfSect.h"
 #include "PyIMsgServiceAdmin.h"
+#include "PyIMsgServiceAdmin2.h"
 #include "PyIProviderAdmin.h"
 #include "PyIMAPIAdviseSink.h"
 #include "IConverterSession.h"
@@ -175,6 +178,9 @@ static PyObject *PyMAPIUninitialize(PyObject *self, PyObject *args)
 
 	if ( PyCom_RegisterClientType(&PyIMsgServiceAdmin::type, &IID_IMsgServiceAdmin) != 0 ) return MODINIT_ERROR_RETURN;
 	ADD_IID(IID_IMsgServiceAdmin);
+
+	if ( PyCom_RegisterClientType(&PyIMsgServiceAdmin2::type, &IID_IMsgServiceAdmin2) != 0 ) return MODINIT_ERROR_RETURN;
+	ADD_IID(IID_IMsgServiceAdmin2);
 
 	if ( PyCom_RegisterClientType(&PyIProviderAdmin::type, &IID_IProviderAdmin) != 0 ) return MODINIT_ERROR_RETURN;
 	ADD_IID(IID_IProviderAdmin);

--- a/com/win32comext/mapi/src/mapiguids.cpp
+++ b/com/win32comext/mapi/src/mapiguids.cpp
@@ -31,3 +31,6 @@
 
 #include "windows.h"
 #include "mapiguid.h"
+
+#define USES_IID_IMsgServiceAdmin2
+#include "mapiaux.h"

--- a/com/win32comext/mapi/src/mapilib.i
+++ b/com/win32comext/mapi/src/mapilib.i
@@ -82,6 +82,10 @@ typedef unsigned long BOOKMARK;
 {
   $target = &temp;
 }
+%typemap(python,ignore) IMsgServiceAdmin2 **OUTPUT(IMsgServiceAdmin2 *temp)
+{
+  $target = &temp;
+}
 %typemap(python,ignore) IStream **OUTPUT(IStream *temp)
 {
   $target = &temp;
@@ -130,6 +134,9 @@ typedef unsigned long BOOKMARK;
 %typemap(python,argout) IMsgServiceAdmin **OUTPUT {
 	MAKE_OUTPUT_INTERFACE($source, $target, IID_IMsgServiceAdmin)
 }
+%typemap(python,argout) IMsgServiceAdmin2 **OUTPUT {
+	MAKE_OUTPUT_INTERFACE($source, $target, IID_IMsgServiceAdmin2)
+}
 %typemap(python,argout) IStream **OUTPUT {
 	MAKE_OUTPUT_INTERFACE($source, $target, IID_IStream)
 }
@@ -163,6 +170,8 @@ typedef unsigned long BOOKMARK;
 						 IAddrBook *INPUT_NULLOK,
 						 IMsgServiceAdmin *INPUT,
 						 IMsgServiceAdmin *INPUT_NULLOK,
+						 IMsgServiceAdmin2 *INPUT,
+						 IMsgServiceAdmin2 *INPUT_NULLOK,
 						 IStream *INPUT,
 						 IStream *INPUT_NULLOK
 {
@@ -294,6 +303,17 @@ typedef unsigned long BOOKMARK;
 	if (!PyCom_InterfaceFromPyInstanceOrObject($source, IID_IMsgServiceAdmin, (void **)&$target, 1))
 		return NULL;
 }
+
+%typemap(python,in) IMsgServiceAdmin2 *INPUT {
+	if (!PyCom_InterfaceFromPyInstanceOrObject($source, IID_IMsgServiceAdmin2, (void **)&$target, 0))
+		return NULL;
+}
+
+%typemap(python,in) IMsgServiceAdmin2 *INPUT_NULLOK {
+	if (!PyCom_InterfaceFromPyInstanceOrObject($source, IID_IMsgServiceAdmin2, (void **)&$target, 1))
+		return NULL;
+}
+
 %typemap(python,in) IStream *INPUT {
 	if (!PyCom_InterfaceFromPyInstanceOrObject($source, IID_IStream, (void **)&$target, 0))
 		return NULL;

--- a/setup.py
+++ b/setup.py
@@ -1924,6 +1924,7 @@ com_extensions += [
                         %(mapi)s/PyIMAPITable.i         %(mapi)s/PyIMAPITable.cpp
                         %(mapi)s/PyIMessage.i           %(mapi)s/PyIMessage.cpp
                         %(mapi)s/PyIMsgServiceAdmin.i   %(mapi)s/PyIMsgServiceAdmin.cpp
+                        %(mapi)s/PyIMsgServiceAdmin2.i  %(mapi)s/PyIMsgServiceAdmin2.cpp
                         %(mapi)s/PyIProviderAdmin.i     %(mapi)s/PyIProviderAdmin.cpp
                         %(mapi)s/PyIMsgStore.i          %(mapi)s/PyIMsgStore.cpp
                         %(mapi)s/PyIProfAdmin.i         %(mapi)s/PyIProfAdmin.cpp
@@ -2307,6 +2308,7 @@ swig_interface_parents = {
     'PyIMAPITable':         '',
     'PyIMessage':           'IMAPIProp',
     'PyIMsgServiceAdmin':   '',
+    'PyIMsgServiceAdmin2':  'IMsgServiceAdmin',
     'PyIProviderAdmin':     '',
     'PyIMsgStore':          'IMAPIProp',
     'PyIProfAdmin':         '',


### PR DESCRIPTION
Only difference is CreateMsgServiceEx returns the newly created uid.
This PR is mostly a modified copy of the existing IMsgServiceAdmin::CreateMsgService.
