### PR TITLE
Use add_dll_directory() for Python 3.8.

### DIFF
--- a/pywin32_38.pth
+++ b/pywin32_38.pth
@@ -1,0 +1,9 @@
+# .pth file for the PyWin32 extensions
+win32
+win32\lib
+Pythonwin
+# Entries needed for a "portable" installations, where the post_install script
+# isn't run, which would normally copy the pywin32 core DLL files to either
+# %windir%\system32 or the top of the python directory.
+# Add the source of these DLLs to the DLL search path.
+import os;os.add_dll_directory(os.path.join(sitedir,"pywin32_system32"))

--- a/setup.py
+++ b/setup.py
@@ -2473,6 +2473,11 @@ classifiers = [ 'Environment :: Win32 (MS Windows)',
 	            'Programming Language :: Python :: Implementation :: CPython',
 	          ]
 
+if sys.version_info >= (3, 8, 0):
+    pywin32_pth = 'pywin32_38.pth'
+else:
+    pywin32_pth = 'pywin32.pth'
+
 dist = setup(name="pywin32",
       version=str(build_id),
       description="Python for Window Extensions",
@@ -2578,7 +2583,7 @@ dist = setup(name="pywin32",
                     # pythoncom.py doesn't quite fit anywhere else.
                     # Note we don't get an auto .pyc - but who cares?
                     ('', ('com/pythoncom.py',)),
-                    ('', ('pywin32.pth',)),
+                    ('', (pywin32_pth,)),
                 ],
       )
 


### PR DESCRIPTION
When I install pywin32 build 225 with PIP in Python 3.8.0b4, I can't `import win32api`.  I think this is a result of [bpo-36085](https://bugs.python.org/issue36085). This PR fixes my problem.

I'm not thrilled with the new file name, `pywin32_38.pth`.  Comments welcome.