### PR TITLE
Support for Python 3.8

### DIFF
--- a/pywin32.pth
+++ b/pywin32.pth
@@ -6,4 +6,4 @@ Pythonwin
 # isn't run, which would normally copy the pywin32 core DLL files to either
 # the top of the python directory.
 # We just stick the source of these DLLs directly on the PATH.
-import os;pywin32_system32=os.path.join(sitedir,"pywin32_system32");os.environ["PATH"]+=('' if pywin32_system32 in os.environ["PATH"] else (';'+pywin32_system32))
+import os;pywin32_system32=os.path.join(sitedir,"pywin32_system32");os.environ["PATH"]+=('' if pywin32_system32 in os.environ["PATH"] else (';'+pywin32_system32));getattr(os, "add_dll_directory", lambda x: None)(pywin32_system32)

--- a/pywin32.pth
+++ b/pywin32.pth
@@ -6,4 +6,4 @@ Pythonwin
 # isn't run, which would normally copy the pywin32 core DLL files to either
 # the top of the python directory.
 # We just stick the source of these DLLs directly on the PATH.
-import os;pywin32_system32=os.path.join(sitedir,"pywin32_system32");os.environ["PATH"]+=('' if pywin32_system32 in os.environ["PATH"] else (';'+pywin32_system32));getattr(os, "add_dll_directory", lambda x: None)(pywin32_system32)
+import os; pywin32_system32 = os.path.join(sitedir,"pywin32_system32"); os.environ["PATH"] += ("" if pywin32_system32 in os.environ["PATH"] else (";" + pywin32_system32)); getattr(os, "add_dll_directory", lambda x: None)(pywin32_system32)


### PR DESCRIPTION
Importing any of the modules fails:

    [cfati@CFATI-5510-0:C:\WINDOWS\system32]> "e:\Work\Dev\VEnvs\py_064_03.08.00_test0\Scripts\python.exe" -c "import win32api"
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
    ImportError: DLL load failed while importing win32api: The specified module could not be found.

Details are in [\[GitHub\]: mhammond/pywin32 - python 3.8](https://github.com/mhammond/pywin32/issues/1327).

**Note**: I consider this a **quick and dirty** fix, considering [\[Python.Bugs\]: Deprecate and remove pth files](https://bugs.python.org/issue33944).

Tested by manually replacing the *.pth* file on *Python* *3.8.0*, *3.7.3*, *3.6.8* and *2.7.15* *VEnv*s, and following the above procedure.
