### PR TITLE
Workaround for virtual environments (VirtualEnv)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,11 @@ Generally created by hand after running:
    hg log -rb2xx: > log.out
 However contributors are encouraged to add their own entries for their work.
 
+Since build 227:
+----------------
+* Improved the search for pywin32 system DLLs logic. Useful when installed
+  in virtual environments (#1442, @CristiFati)
+
 Since build 225:
 ----------------
 * The directory with the pywin32 system DLLs is now added to the start of PATH

--- a/win32/Lib/pywin32_bootstrap.py
+++ b/win32/Lib/pywin32_bootstrap.py
@@ -8,14 +8,15 @@
 # Otherwise, we add this path to PATH.
 import os
 import site
-import sys
 
 # The directory should be installed under site-packages.
-for maybe in site.getsitepackages():
-	pywin32_system32=os.path.join(maybe,"pywin32_system32")
-	if os.path.isdir(pywin32_system32):
-		if hasattr(os, "add_dll_directory"):
-			os.add_dll_directory(pywin32_system32)
-		else:
-			os.environ["PATH"] = pywin32_system32 + ";" + os.environ["PATH"]
 
+dirname = os.path.dirname
+
+for site_dir in getattr(site, "getsitepackages", lambda: [dirname(dirname(dirname(__file__)))])():
+    pywin32_system32 = os.path.join(site_dir, "pywin32_system32")
+    if os.path.isdir(pywin32_system32):
+        if hasattr(os, "add_dll_directory"):
+            os.add_dll_directory(pywin32_system32)
+        else:
+            os.environ["PATH"] = pywin32_system32 + os.pathsep + os.environ["PATH"]

--- a/win32/Lib/pywin32_bootstrap.py
+++ b/win32/Lib/pywin32_bootstrap.py
@@ -12,6 +12,9 @@ import site
 # The directory should be installed under site-packages.
 
 dirname = os.path.dirname
+# This is to get the "...\Lib\site-packages" directory
+# out of this file name: "...\Lib\site-packages\win32\Lib\pywin32_bootstrap.py".
+# It needs to be searched when installed in VirtualEnv or Python's venv.
 level3_up_dir = dirname(dirname(dirname(__file__)))
 
 site_packages_dirs = getattr(site, "getsitepackages", lambda: [level3_up_dir])()

--- a/win32/Lib/pywin32_bootstrap.py
+++ b/win32/Lib/pywin32_bootstrap.py
@@ -14,12 +14,12 @@ import site
 dirname = os.path.dirname
 # This is to get the "...\Lib\site-packages" directory
 # out of this file name: "...\Lib\site-packages\win32\Lib\pywin32_bootstrap.py".
-# It needs to be searched when installed in VirtualEnv or Python's venv.
+# It needs to be searched when installed in virtual environments.
 level3_up_dir = dirname(dirname(dirname(__file__)))
 
-site_packages_dirs = getattr(site, "getsitepackages", lambda: [level3_up_dir])()
+site_packages_dirs = getattr(site, "getsitepackages", lambda: [])()
 if level3_up_dir not in site_packages_dirs:
-    site_packages_dirs.append(level3_up_dir)
+    site_packages_dirs.insert(0, level3_up_dir)
 
 for site_packages_dir in site_packages_dirs:
     pywin32_system32 = os.path.join(site_packages_dir, "pywin32_system32")
@@ -28,3 +28,4 @@ for site_packages_dir in site_packages_dirs:
             os.add_dll_directory(pywin32_system32)
         else:
             os.environ["PATH"] = pywin32_system32 + os.pathsep + os.environ["PATH"]
+        break

--- a/win32/Lib/pywin32_bootstrap.py
+++ b/win32/Lib/pywin32_bootstrap.py
@@ -12,9 +12,14 @@ import site
 # The directory should be installed under site-packages.
 
 dirname = os.path.dirname
+level3_up_dir = dirname(dirname(dirname(__file__)))
 
-for site_dir in getattr(site, "getsitepackages", lambda: [dirname(dirname(dirname(__file__)))])():
-    pywin32_system32 = os.path.join(site_dir, "pywin32_system32")
+site_packages_dirs = getattr(site, "getsitepackages", lambda: [level3_up_dir])()
+if level3_up_dir not in site_packages_dirs:
+    site_packages_dirs.append(level3_up_dir)
+
+for site_packages_dir in site_packages_dirs:
+    pywin32_system32 = os.path.join(site_packages_dir, "pywin32_system32")
     if os.path.isdir(pywin32_system32):
         if hasattr(os, "add_dll_directory"):
             os.add_dll_directory(pywin32_system32)


### PR DESCRIPTION
`pip install`ing *v226* in a (*VirtualEnv* based) virtual environment (not sure f this is an officially supported configuration) makes it unusable:

```batch
[prompt]> ".\venv_py_064_030800\Scripts\python.exe" -m pip list
Fatal Python error: init_import_size: Failed to import the site module
Python runtime state: initialized
Traceback (most recent call last):
  File "e:\Work\Dev\StackOverflow\q058805040\venv_py_064_030800\lib\site.py", line 769, in <module>
    main()
  File "e:\Work\Dev\StackOverflow\q058805040\venv_py_064_030800\lib\site.py", line 746, in main
    paths_in_sys = addsitepackages(paths_in_sys)
  File "e:\Work\Dev\StackOverflow\q058805040\venv_py_064_030800\lib\site.py", line 279, in addsitepackages
    addsitedir(sitedir, known_paths)
  File "e:\Work\Dev\StackOverflow\q058805040\venv_py_064_030800\lib\site.py", line 202, in addsitedir
    addpackage(sitedir, name, known_paths)
  File "e:\Work\Dev\StackOverflow\q058805040\venv_py_064_030800\lib\site.py", line 170, in addpackage
    exec(line)
  File "<string>", line 1, in <module>
  File "e:\Work\Dev\StackOverflow\q058805040\venv_py_064_030800\lib\site-packages\win32\lib\pywin32_bootstrap.py", line 14, in <module>
    for maybe in site.getsitepackages():
AttributeError: partially initialized module 'site' has no attribute 'getsitepackages' (most likely due to a circular import)
```

**Just to make things clear: there's nothing wrong with *PyWin32*, it's just a fix applied on *PyWin32*'s side to work around a *VirtualEnv* bug**.

More details on [[SO]: PyWin32 (226) and virtual environments (@CristiFati's answer)](https://stackoverflow.com/questions/58805040/pywin32-226-and-virtual-environments/58805300#58805300).
