### PR TITLE
Ensure a define happens before including wincrypt.h

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -316,6 +316,7 @@ class WinExt (Extension):
         define_macros.append(("DISTUTILS_BUILD", None))
         define_macros.append(("_CRT_SECURE_NO_WARNINGS", None))
         # CRYPT_DECRYPT_MESSAGE_PARA.dwflags is in an ifdef for some unknown reason
+	# See github PR #1444 for more details...
         define_macros.append(("CRYPT_DECRYPT_MESSAGE_PARA_HAS_EXTRA_FIELDS", None))
         self.pch_header = pch_header
         self.extra_swig_commands = extra_swig_commands or []

--- a/setup.py
+++ b/setup.py
@@ -316,7 +316,7 @@ class WinExt (Extension):
         define_macros.append(("DISTUTILS_BUILD", None))
         define_macros.append(("_CRT_SECURE_NO_WARNINGS", None))
         # CRYPT_DECRYPT_MESSAGE_PARA.dwflags is in an ifdef for some unknown reason
-	# See github PR #1444 for more details...
+        # See github PR #1444 for more details...
         define_macros.append(("CRYPT_DECRYPT_MESSAGE_PARA_HAS_EXTRA_FIELDS", None))
         self.pch_header = pch_header
         self.extra_swig_commands = extra_swig_commands or []

--- a/setup.py
+++ b/setup.py
@@ -315,6 +315,8 @@ class WinExt (Extension):
         define_macros = define_macros or []
         define_macros.append(("DISTUTILS_BUILD", None))
         define_macros.append(("_CRT_SECURE_NO_WARNINGS", None))
+        # CRYPT_DECRYPT_MESSAGE_PARA.dwflags is in an ifdef for some unknown reason
+        define_macros.append(("CRYPT_DECRYPT_MESSAGE_PARA_HAS_EXTRA_FIELDS", None))
         self.pch_header = pch_header
         self.extra_swig_commands = extra_swig_commands or []
         self.windows_h_version = windows_h_version

--- a/win32/src/win32crypt/win32crypt.h
+++ b/win32/src/win32crypt/win32crypt.h
@@ -1,8 +1,5 @@
 #define Py_USE_NEW_NAMES
 
-// CRYPT_DECRYPT_MESSAGE_PARA.dwflags is in an ifdef for some unknown reason
-#define CRYPT_DECRYPT_MESSAGE_PARA_HAS_EXTRA_FIELDS
-
 #define DllExport _declspec(dllexport)
 #include "windows.h"
 #include "Python.h"


### PR DESCRIPTION
The `CRYPT_DECRYPT_MESSAGE_PARA` struct is defined in `wincrypt.h`. The completeness of the struct definition is dependent on the `CRYPT_DECRYPT_MESSAGE_PARA_HAS_EXTRA_FIELDS` macro. However, `wincrypt.h` does not appear to be included explicitly, but via a transitive include.

Both VC++ and MinGW do this transitive include, but appear to do so in an inconsistent order. And in MinGW the include happens before the `CRYPT_DECRYPT_MESSAGE_PARA_HAS_EXTRA_FIELDS` macro definition. And the `CRYPT_DECRYPT_MESSAGE_PARA` ends up missing its `dwflags` field on MinGW.

This moves the macro definition to `setup.py` to guarantee it's defined before `wincrypt.h` is included.

P.S.
The test failures appear to be unrelated to the changes. They've been failing since https://github.com/mhammond/pywin32/pull/1400/commits/c157e25f0aabb195c1476d11005ff5967c13cfed.
