### PR TITLE
Moved Adodbapi PR changelog entry to correct section

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,12 +4,14 @@ Generally created by hand after running:
    hg log -rb2xx: > log.out
 However contributors are encouraged to add their own entries for their work.
 
-Since build 226:
+Since build 227:
 ----------------
 * Adodbapi corrected and updated to version 2.6.2. With this change the pywin32
   repo will become the definitive source code for adodbapi, so files should never
   be missing again. Includes bug fix for 'named' paramstyle SF#28.
 
+Since build 226:
+----------------
 * Improved the search for pywin32 system DLLs logic. Useful when installed
   in virtual environments (#1442, @CristiFati)
 


### PR DESCRIPTION
Put the Adodbapi changelog entry in the "Since build 227" section.