### PR TITLE
Add ability to avoid freeing a PySecBufferType buffer

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,10 @@ Since build 227:
   be missing again. Includes bug fix for 'named' paramstyle SF#28.
 * Added a __repr__ implementation for PySecBufferDesc and PySecBuffer.
 
+* Fix bug when trying to free a PySecBuffer object when the buffer was not
+  allocated by the caller. This can occur when decrypting a message with a
+  SECBUFFER_STREAM and SECBUFFER_DATA buffer when calling DecryptMessage().
+
 Since build 226:
 ----------------
 * Improved the search for pywin32 system DLLs logic. Useful when installed

--- a/win32/src/win32security_sspi.h
+++ b/win32/src/win32security_sspi.h
@@ -62,6 +62,7 @@ class PySecBuffer : public PyObject {
 
    protected:
     SecBuffer secbuffer;
+    void *allocBuffer;
 };
 
 class PySecBufferDesc : public PyObject {


### PR DESCRIPTION
Add in the ability to pass in an optional boolean to `PySecBufferType` that controls whether the pvBuffer is freed or not when discarded. Controlling this behaviour is required when SSPI sets that buffer to an address in an existing buffer in the `PySecBufferDescType` list. By freeing the memory twice it causes a heap corruption that brings down the process.

I'm not sure if you would like to go a different direction but happy to adjust the PR in whatever way you desire.

Fixes https://github.com/mhammond/pywin32/issues/1498