### PR TITLE
Added repr to SecBuffer classes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,7 @@ Since build 227:
 * Adodbapi corrected and updated to version 2.6.2. With this change the pywin32
   repo will become the definitive source code for adodbapi, so files should never
   be missing again. Includes bug fix for 'named' paramstyle SF#28.
+* Added a __repr__ implementation for PySecBufferDesc and PySecBuffer.
 
 Since build 226:
 ----------------

--- a/win32/src/win32security_sspi.cpp
+++ b/win32/src/win32security_sspi.cpp
@@ -89,7 +89,7 @@ PyTypeObject PySecBufferDescType = {
     0,                                         // tp_getattr
     0,                                         // tp_setattr
     0,                                         // tp_compare
-    0,                                         // tp_repr
+    (reprfunc)PySecBufferDesc::tp_repr,        // tp_repr
     0,                                         // PyNumberMethods *tp_as_number
     &PySecBufferDesc_sequencemethods,          // PySequenceMethods *tp_as_sequence
     0,                                         // PyMappingMethods *tp_as_mapping
@@ -190,6 +190,13 @@ PyObject *PySecBufferDesc::tp_new(PyTypeObject *typ, PyObject *args, PyObject *k
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|l:PySecBufferDescType", keywords, &ulVersion))
         return NULL;
     return new PySecBufferDesc(ulVersion);
+}
+
+PyObject * PySecBufferDesc::tp_repr(PyObject * obj)
+{
+    PSecBufferDesc psecbufferdesc = ((PySecBufferDesc *)obj)->GetSecBufferDesc();
+    return PyUnicode_FromFormat("PySecBufferDesc(ulVersion: %i | cBuffers: %i | pBuffers: %p)",
+        psecbufferdesc->ulVersion, psecbufferdesc->cBuffers, psecbufferdesc->pBuffers);
 }
 
 BOOL PyWinObject_AsSecBufferDesc(PyObject *ob, PSecBufferDesc *ppSecBufferDesc, BOOL bNoneOk)
@@ -304,7 +311,7 @@ PyTypeObject PySecBufferType = {
     0,                                         // tp_getattr
     0,                                         // tp_setattr
     0,                                         // tp_compare
-    0,                                         // tp_repr
+    (reprfunc)PySecBuffer::tp_repr,            // tp_repr
     0,                                         // PyNumberMethods *tp_as_number
     0,                                         // PySequenceMethods *tp_as_sequence
     0,                                         // PyMappingMethods *tp_as_mapping
@@ -430,6 +437,13 @@ PyObject *PySecBuffer::tp_new(PyTypeObject *typ, PyObject *args, PyObject *kwarg
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "ll", keywords, &cbBuffer, &BufferType))
         return NULL;
     return new PySecBuffer(cbBuffer, BufferType);
+}
+
+PyObject * PySecBuffer::tp_repr(PyObject * obj)
+{
+    PSecBuffer psecbuffer = ((PySecBuffer *)obj)->GetSecBuffer();
+    return PyUnicode_FromFormat("PySecBuffer(cbBuffer: %i | BufferType: %i | pvBuffer: %p)", psecbuffer->cbBuffer,
+        psecbuffer->BufferType, psecbuffer->pvBuffer);
 }
 
 // @pymethod |PySecBuffer|Clear|Resets the buffer to all NULL's, and set the current size to maximum

--- a/win32/src/win32security_sspi.cpp
+++ b/win32/src/win32security_sspi.cpp
@@ -89,7 +89,7 @@ PyTypeObject PySecBufferDescType = {
     0,                                         // tp_getattr
     0,                                         // tp_setattr
     0,                                         // tp_compare
-    (reprfunc)PySecBufferDesc::tp_repr,        // tp_repr
+    PySecBufferDesc::tp_repr,                  // tp_repr
     0,                                         // PyNumberMethods *tp_as_number
     &PySecBufferDesc_sequencemethods,          // PySequenceMethods *tp_as_sequence
     0,                                         // PyMappingMethods *tp_as_mapping
@@ -311,7 +311,7 @@ PyTypeObject PySecBufferType = {
     0,                                         // tp_getattr
     0,                                         // tp_setattr
     0,                                         // tp_compare
-    (reprfunc)PySecBuffer::tp_repr,            // tp_repr
+    PySecBuffer::tp_repr,                      // tp_repr
     0,                                         // PyNumberMethods *tp_as_number
     0,                                         // PySequenceMethods *tp_as_sequence
     0,                                         // PyMappingMethods *tp_as_mapping

--- a/win32/src/win32security_sspi.h
+++ b/win32/src/win32security_sspi.h
@@ -51,6 +51,7 @@ class PySecBuffer : public PyObject {
     static PyObject *getattro(PyObject *self, PyObject *name);
     static int setattro(PyObject *self, PyObject *obname, PyObject *obvalue);
     static PyObject *tp_new(PyTypeObject *, PyObject *, PyObject *);
+    static PyObject *tp_repr(PyObject * obj);
     static PyObject *Clear(PyObject *self, PyObject *args);
 
     PSecBuffer GetSecBuffer(void);
@@ -81,6 +82,7 @@ class PySecBufferDesc : public PyObject {
     static PyObject *getattro(PyObject *self, PyObject *name);
     static int setattro(PyObject *self, PyObject *obname, PyObject *obvalue);
     static PyObject *tp_new(PyTypeObject *, PyObject *, PyObject *);
+    static PyObject *tp_repr(PyObject * obj);
     static PySequenceMethods sequencemethods;
     PSecBufferDesc GetSecBufferDesc(void);
     PyObject **obBuffers;

--- a/win32/test/test_sspi.py
+++ b/win32/test/test_sspi.py
@@ -1,6 +1,7 @@
 # Some tests of the win32security sspi functions.
 # Stolen from Roger's original test_sspi.c, a version of which is in "Demos"
 # See also the other SSPI demos.
+import re
 import win32security, sspi, sspicon, win32api
 from pywin32_testutil import TestSkipped, testmain, str2bytes
 import unittest
@@ -136,6 +137,23 @@ class TestSSPI(unittest.TestCase):
 
     def testSequenceEncrypt(self):
         applyHandlingSkips(self._testSequenceEncrypt)
+
+    def testSecBufferRepr(self):
+        desc = win32security.PySecBufferDescType()
+        assert re.match('PySecBufferDesc\(ulVersion: 0 \| cBuffers: 0 \| pBuffers: 0x[\da-fA-F]{8,16}\)', repr(desc))
+
+        buffer1 = win32security.PySecBufferType(0, sspicon.SECBUFFER_TOKEN)
+        assert re.match('PySecBuffer\(cbBuffer: 0 \| BufferType: 2 \| pvBuffer: 0x[\da-fA-F]{8,16}\)', repr(buffer1))
+        'PySecBuffer(cbBuffer: 0 | BufferType: 2 | pvBuffer: 0x000001B8CC6D8020)'
+        desc.append(buffer1)
+
+        assert re.match('PySecBufferDesc\(ulVersion: 0 \| cBuffers: 1 \| pBuffers: 0x[\da-fA-F]{8,16}\)', repr(desc))
+
+        buffer2 = win32security.PySecBufferType(4, sspicon.SECBUFFER_DATA)
+        assert re.match('PySecBuffer\(cbBuffer: 4 \| BufferType: 1 \| pvBuffer: 0x[\da-fA-F]{8,16}\)', repr(buffer2))
+        desc.append(buffer2)
+
+        assert re.match('PySecBufferDesc\(ulVersion: 0 \| cBuffers: 2 \| pBuffers: 0x[\da-fA-F]{8,16}\)', repr(desc))
 
 if __name__=='__main__':
     testmain()


### PR DESCRIPTION
Added the `__repr__` method for `PySecBufferDesc` and `PySecBuffer` to make it easier to debug the actual C struct.