### PR TITLE
Do not add pywin32_system32 to PATH if already in PATH

### DIFF
--- a/win32/Lib/pywin32_bootstrap.py
+++ b/win32/Lib/pywin32_bootstrap.py
@@ -26,6 +26,9 @@ for site_packages_dir in site_packages_dirs:
     if os.path.isdir(pywin32_system32):
         if hasattr(os, "add_dll_directory"):
             os.add_dll_directory(pywin32_system32)
-        else:
+        # This is to ensure the pywin32 path is in the beginning to find the
+        # pywin32 DLLs first and prevent other PATH entries to shadow them
+        elif not os.environ["PATH"].startswith(pywin32_system32):
+            os.environ["PATH"] = os.environ["PATH"].replace(os.pathsep + pywin32_system32, "")
             os.environ["PATH"] = pywin32_system32 + os.pathsep + os.environ["PATH"]
         break


### PR DESCRIPTION
**Problem description:**
We came across a problem with recursive python process (or repetitive `site` package loading). For Python version before 3.8 this will result in a growing `PATH` variable.

**How to reproduce:**
Create an example file here called `pywin32_path.py` with the following content:

```python
import sys
import subprocess
import os

i = int(sys.argv[1])

if len(sys.argv) < 3:
    depth = 0
else:
    depth = int(sys.argv[2])

print(f"Depth: {depth}")
print(f"PATH: {os.environ['PATH']}")

if depth < i:
    subprocess.run(["python", sys.argv[0], str(i-1), str(depth+1)])
```

Then execute this file with `python pywin32_path.py <num_iterations>` with `<num_iterations>` the number of iterations. You will then see the `PATH` growing.

**How the issue is addressed:**
I changed the `else` clause to `elif` only if it is not part of the `PATH`.

**Possible side effects:**
As the `pywin32_system32` is not always added to the front there might be other entries that shadow this.

Also if some subfolder of `pywin32_system32` was added to `PATH` then this will result in `pywin32_system32` not being added to `PATH`. But as this folder does not have subfolders the setup has to be very dirty to run into this problem.