### PR TITLE
Add the offset to win32timezone tests.

### DIFF
--- a/win32/Lib/win32timezone.py
+++ b/win32/Lib/win32timezone.py
@@ -60,7 +60,7 @@ registry.
 
 >>> gmt = win32timezone.TimeZoneInfo('GMT Standard Time', True)
 >>> str(gmt.displayName)
-'(UTC) Dublin, Edinburgh, Lisbon, London'
+'(UTC+00:00) Dublin, Edinburgh, Lisbon, London'
 
 To get the complete list of available time zone keys,
 >>> zones = win32timezone.TimeZoneInfo.get_all_time_zones()


### PR DESCRIPTION
For some reason this test is failing everywhere with:

```
Failed example:
    str(gmt.displayName)
Expected:
    '(UTC) Dublin, Edinburgh, Lisbon, London'
Got:
    '(UTC+00:00) Dublin, Edinburgh, Lisbon, London'
```

I don't understand why it apparently didn't fail with that error
forever, but given other tests near it include an offset (eg,

```
>>> str(est.displayName)
'(UTC-05:00) Eastern Time (US & Canada)'
```
It seems like a reasonable fix.

(