### PR TITLE
Switch to GitHub Actions for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,62 @@
+name: build
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test:
+    runs-on: windows-2019
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.5', '3.6', '3.7', '3.8']
+        architecture: ['x64', 'x86']
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: ${{ matrix.architecture }}
+
+    - name: Show runner information
+      run: |
+        python --version
+        pip --version
+
+    - name: Set Python user directory
+      run: echo "::set-env name=USER_DIR::$(python -c 'import os,site;print(os.path.dirname(site.USER_SITE))', end='')"
+
+    - name: Install Windows 8.1 SDK
+      run: choco install windows-sdk-8.1
+
+    - name: Install Windows 10 SDK for Python 3.5
+      if: matrix.python-version == '3.5'
+      run: choco install windows-sdk-10.0
+
+    - name: Build package
+      run: python setup.py build
+
+    - name: Install package
+      run: python setup.py install --user
+
+    - name: Run tests
+      run: python ${env:USER_DIR}\Scripts\pywin32_testall.py -no-user-interaction
+
+    - name: Build wheels
+      run: |
+        python setup.py bdist_wheel --skip-build
+        python setup.py bdist_wininst --skip-build --target-version=${{ matrix.python-version }}
+
+    - uses: actions/upload-artifact@v2
+      if: ${{ always() }}
+      with:
+        name: wheels
+        path: dist/*.whl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: build
+name: CI
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # pywin32
 
+[![CI - Build](https://github.com/mhammond/pywin32/workflows/build/badge.svg)](https://github.com/mhammond/pywin32/actions?query=workflow%3Abuild)
+[![PyPI - Version](https://img.shields.io/pypi/v/pywin32.svg)](https://pypi.org/project/pywin32)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pywin32.svg)](https://pypi.org/project/pywin32)
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/pywin32.svg)](https://pypi.org/project/pywin32)
+[![License - PSF-2.0](https://img.shields.io/badge/license-PSF--2.0-9400d3.svg)](https://spdx.org/licenses/PSF-2.0.html)
+
+-----
+
 This is the readme for the Python for Win32 (pywin32) extensions, which provides access to many of the Windows APIs from Python.
 
 See [CHANGES.txt](https://github.com/mhammond/pywin32/blob/master/CHANGES.txt) for recent notable changes.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pywin32
 
-[![CI - Build](https://github.com/mhammond/pywin32/workflows/build/badge.svg)](https://github.com/mhammond/pywin32/actions?query=workflow%3Abuild)
+[![CI](https://github.com/mhammond/pywin32/workflows/CI/badge.svg)](https://github.com/mhammond/pywin32/actions?query=workflow%3ACI)
 [![PyPI - Version](https://img.shields.io/pypi/v/pywin32.svg)](https://pypi.org/project/pywin32)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pywin32.svg)](https://pypi.org/project/pywin32)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/pywin32.svg)](https://pypi.org/project/pywin32)


### PR DESCRIPTION
So we can run more than one job at a time (10 to be exact)

This does a few things:

- moves all current Python 3 jobs to GitHub Actions
- adds Python 3.8 (x64 & x86)
- uploads all built wheels as artifacts so anyone can download them from the UI and try them out
- makes the readme prettier by adding badges

Notes:

- I couldn't get Python 2 to work, mostly because sdk 9.0 wasn't on Chocolatey & I figure it's EOL anyway
- for convenience the upload artifact step is set to always occur even if tests fail. however, the wheel packaging step happens after the tests instead of at build time. is there a reason for that?
- master is still failing the same as on appveyor

cc @mhammond @zooba 😄 