### PR TITLE
Fix memset arguments in PyICreateTypeInfo

### DIFF
--- a/com/win32com/src/extensions/PyICreateTypeInfo.cpp
+++ b/com/win32com/src/extensions/PyICreateTypeInfo.cpp
@@ -352,7 +352,7 @@ PyObject *PyICreateTypeInfo::SetFuncAndParamNames(PyObject *self, PyObject *args
     }
     UINT cNames = PySequence_Length(obrgszNames);
     OLECHAR **pNames = new OLECHAR *[cNames];
-    memset(pNames, sizeof(OLECHAR *) * cNames, 0);
+    memset(pNames, 0, sizeof(OLECHAR *) * cNames);
     UINT i;
     for (i = 0; bPythonIsHappy && i < cNames; i++) {
         PyObject *item = PySequence_GetItem(obrgszNames, i);


### PR DESCRIPTION
The `void *memset(void *s, int c, size_t n)` function takes the value to fill in its 2nd argument and the number of byte to fill in in 3rd.

This commit fixes an invalid use of `memset` which had the two arguments swapped and it did not set any memory at all in the end due to that.