### PR TITLE
BUILD: End `bdist_wininst` support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,6 @@ jobs:
     - name: Build wheels
       run: |
         python setup.py bdist_wheel --skip-build
-        python setup.py bdist_wininst --skip-build --target-version=${{ matrix.python-version }}
 
     - uses: actions/upload-artifact@v2
       if: ${{ always() }}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -76,7 +76,6 @@ after_test:
   # interpreter
   - if "%PYTHON_MAJOR%"=="2" if "%PYTHON_MINOR%"=="7" python setup.py sdist
   - python setup.py bdist_wheel --skip-build
-  - python setup.py bdist_wininst --skip-build --target-version=%PYTHON_MAJOR%.%PYTHON_MINOR%
 
 #artifacts:
   # bdist_wheel puts your built wheel in the dist directory

--- a/make_all.bat
+++ b/make_all.bat
@@ -15,9 +15,7 @@ rem Now the binaries.
 rem Yuck - 2to3 hackery - must nuke bdist dirs as it may hold py3x syntax.
 if exist build/bdist.win32/. rd /s/q build\bdist.win32
 if exist build/bdist.win-amd64/. rd /s/q build\bdist.win-amd64
-py -2.7-32 setup.py -q bdist_wininst --target-version=2.7 --skip-build
 py -2.7-32 setup.py -q bdist_wheel --skip-build
-py -2.7 setup.py -q bdist_wininst --target-version=2.7 --skip-build
 py -2.7 setup.py -q bdist_wheel --skip-build
 
 rem Just incase - re-nuke bdist dirs so 2to3 always runs.
@@ -29,40 +27,24 @@ rem due to the mfc DLLs - but the dir can be removed manually.
 rem I've excluded the possibility of anti-virus or the indexer.
 rem So manually nuke them before builds.
 rem @if exist build\bdist.win32 rd /s/q build\bdist.win32 & @if exist build\bdist.amd64 rd /s/q build\bdist.amd64
-py -3.5-32 setup.py -q bdist_wininst --skip-build --target-version=3.5
-rem @if exist build\bdist.win32 rd /s/q build\bdist.win32 & @if exist build\bdist.amd64 rd /s/q build\bdist.amd64
 py -3.5-32 setup.py -q bdist_wheel --skip-build
-rem @if exist build\bdist.win32 rd /s/q build\bdist.win32 & @if exist build\bdist.amd64 rd /s/q build\bdist.amd64
-py -3.5 setup.py -q bdist_wininst --skip-build --target-version=3.5
 rem @if exist build\bdist.win32 rd /s/q build\bdist.win32 & @if exist build\bdist.amd64 rd /s/q build\bdist.amd64
 py -3.5 setup.py -q bdist_wheel --skip-build
 
 rem @if exist build\bdist.win32 rd /s/q build\bdist.win32 & @if exist build\bdist.amd64 rd /s/q build\bdist.amd64
-py -3.6-32 setup.py -q bdist_wininst --skip-build --target-version=3.6
-rem @if exist build\bdist.win32 rd /s/q build\bdist.win32 & @if exist build\bdist.amd64 rd /s/q build\bdist.amd64
 py -3.6-32 setup.py -q bdist_wheel --skip-build
-rem @if exist build\bdist.win32 rd /s/q build\bdist.win32 & @if exist build\bdist.amd64 rd /s/q build\bdist.amd64
-py -3.6 setup.py -q bdist_wininst --skip-build --target-version=3.6
 rem @if exist build\bdist.win32 rd /s/q build\bdist.win32 & @if exist build\bdist.amd64 rd /s/q build\bdist.amd64
 py -3.6 setup.py -q bdist_wheel --skip-build
 
 rem @if exist build\bdist.win32 rd /s/q build\bdist.win32 & @if exist build\bdist.amd64 rd /s/q build\bdist.amd64
-py -3.7-32 setup.py -q bdist_wininst --skip-build --target-version=3.7
-rem @if exist build\bdist.win32 rd /s/q build\bdist.win32 & @if exist build\bdist.amd64 rd /s/q build\bdist.amd64
 py -3.7-32 setup.py -q bdist_wheel --skip-build
-rem @if exist build\bdist.win32 rd /s/q build\bdist.win32 & @if exist build\bdist.amd64 rd /s/q build\bdist.amd64
-py -3.7 setup.py -q bdist_wininst --skip-build --target-version=3.7
 rem @if exist build\bdist.win32 rd /s/q build\bdist.win32 & @if exist build\bdist.amd64 rd /s/q build\bdist.amd64
 py -3.7 setup.py -q bdist_wheel --skip-build
 
-py -3.8-32 setup.py -q bdist_wininst --skip-build --target-version=3.8
 py -3.8-32 setup.py -q bdist_wheel --skip-build
-py -3.8 setup.py -q bdist_wininst --skip-build --target-version=3.8
 py -3.8 setup.py -q bdist_wheel --skip-build
 
-py -3.9-32 setup.py -q bdist_wininst --skip-build --target-version=3.9
 py -3.9-32 setup.py -q bdist_wheel --skip-build
-py -3.9 setup.py -q bdist_wininst --skip-build --target-version=3.9
 py -3.9 setup.py -q bdist_wheel --skip-build
 
 rem And nuke the dirs one more time :)

--- a/setup.py
+++ b/setup.py
@@ -922,7 +922,7 @@ class my_build_ext(build_ext):
             # Should have the same length - if not we lost a file!
             if len(mfc_files) is not len(mfc_contents):
                 mfc_contents = []
-        
+
         return mfc_contents
 
     def lookupMfcInWinSxS(self, mfc_version, mfc_libraries):
@@ -954,7 +954,7 @@ class my_build_ext(build_ext):
                 print("Could not find WinSxS directory in %WINDIR%.")
         else:
             print("Windows directory not found!")
-        
+
         return mfc_contents
 
     def build_extensions(self):
@@ -1384,8 +1384,7 @@ class my_build_ext(build_ext):
 class my_install(install):
     def run(self):
         install.run(self)
-        # Custom script we run at the end of installing - this is the same script
-        # run by bdist_wininst
+        # Custom script we run at the end of installing
         # This child process won't be able to install the system DLLs until our
         # process has terminated (as distutils imports win32api!), so we must use
         # some 'no wait' executor - spawn seems fine!  We pass the PID of this
@@ -1393,9 +1392,8 @@ class my_install(install):
         # XXX - hmm - a closer look at distutils shows it only uses win32api
         # if _winreg fails - and this never should.  Need to revisit this!
         # If self.root has a value, it means we are being "installed" into
-        # some other directory than Python itself (eg, into a temp directory
-        # for bdist_wininst to use) - in which case we must *not* run our
-        # installer
+        # some other directory than Python itself (eg, into a temp directory)
+        # - in which case we must *not* run our installer
         if not self.dry_run and not self.root:
             # We must run the script we just installed into Scripts, as it
             # may have had 2to3 run over it.
@@ -2488,12 +2486,7 @@ dist = setup(name="pywin32",
       license="PSF",
       classifiers = classifiers,
       cmdclass = cmdclass,
-      options = {"bdist_wininst":
-                    {"install_script": "pywin32_postinstall.py",
-                     "title": "pywin32-%s" % (build_id,),
-                     "user_access_control": "auto",
-                    },
-                 "bdist_msi":
+      options = {"bdist_msi":
                     {"install_script": "pywin32_postinstall.py",
                     },
                 },


### PR DESCRIPTION
Ref enthought/comtypes#191
Ref enthought/comtypes#196
Ref enthought/comtypes#199
Ref enthought/comtypes#214 (basically the same as this commit)
Ref indygreg/PyOxidizer#202

I'll start with the post hoc justification for this change: `bdist_wininst` has been deprecated starting in Python 3.8. See

- notice:      https://docs.python.org/3/whatsnew/3.8.html#deprecated
- discussion:  https://discuss.python.org/t/deprecate-bdist-wininst/1929
- bug tracker: https://bugs.python.org/issue37481

The real reason for this change is that Pip fails to build pywin32 when run from PyOxidizer's packaging system using PyOxidizer's `dist.pip_install` Skylark function. Pip issues the following error (after 8 minutes of compiling...):

```
error in setup script: command 'bdist_wininst' has no such option 'install_script'
```

Upgrading Wheel to the latest version solves this problem for me in  regular virtual environment, but requiring the most recent Wheel version in my `pyproject.toml`'s `build-system.requires` list doesn't solve it when building with PyOxidizer. (Verbose output from Pip confirms the latest Wheel version is indeed installed.)

So removing `bdist_wininst` support solves my very niche problem, but because `bdist_wininst` is so rarely used and is deprecated anyway, I figure there's little harm to anyone else in removing it from pywin32.