### PR TITLE
Extensions, Improvements and Fixes to the PythonWIN IDE ( Python part in pywin.* )

### DIFF
--- a/Pythonwin/pywin/Demos/app/basictimerapp.py
+++ b/Pythonwin/pywin/Demos/app/basictimerapp.py
@@ -1,6 +1,8 @@
 # basictimerapp - a really simple timer application.
 # This should be run using the command line:
 # pythonwin /app demos\basictimerapp.py
+from __future__ import absolute_import
+from __future__ import print_function
 import win32ui
 import win32api
 import win32con
@@ -9,6 +11,7 @@ from pywin.framework import app, cmdline, dlgappcore, cmdline
 import timer
 import time
 import string
+from pywin.xtypes.moves import range
 
 class TimerAppDialog(dlgappcore.AppDialog):
 	softspace=1

--- a/Pythonwin/pywin/Demos/app/customprint.py
+++ b/Pythonwin/pywin/Demos/app/customprint.py
@@ -5,6 +5,7 @@
 
 # This sample was contributed by Roger Burnham.
 
+from __future__ import absolute_import
 from pywin.mfc import docview, dialog, afxres
 from pywin.framework import app
 

--- a/Pythonwin/pywin/Demos/app/demoutils.py
+++ b/Pythonwin/pywin/Demos/app/demoutils.py
@@ -1,5 +1,6 @@
 # Utilities for the demos
 
+from __future__ import absolute_import
 import sys, win32api, win32con, win32ui
 
 NotScriptMsg = """\

--- a/Pythonwin/pywin/Demos/app/dlgappdemo.py
+++ b/Pythonwin/pywin/Demos/app/dlgappdemo.py
@@ -6,6 +6,8 @@
 # This module must be specified on the commandline to PythonWin only.
 # eg, PythonWin /app dlgappdemo.py
 
+from __future__ import absolute_import
+from __future__ import print_function
 from pywin.framework import dlgappcore, app
 import win32ui
 import sys

--- a/Pythonwin/pywin/Demos/app/dojobapp.py
+++ b/Pythonwin/pywin/Demos/app/dojobapp.py
@@ -5,6 +5,7 @@
 # This should be run using the command line:
 # pythonwin /app demos\dojobapp.py
 
+from __future__ import absolute_import
 import win32ui
 import win32api
 import win32con

--- a/Pythonwin/pywin/Demos/app/helloapp.py
+++ b/Pythonwin/pywin/Demos/app/helloapp.py
@@ -12,6 +12,7 @@
 ## Originally by Willy Heineman <wheineman@uconect.net>
 
 
+from __future__ import absolute_import
 import win32con
 import win32ui
 from pywin.mfc import window, dialog, afxres

--- a/Pythonwin/pywin/Demos/cmdserver.py
+++ b/Pythonwin/pywin/Demos/cmdserver.py
@@ -2,11 +2,13 @@
 
 # Demo code that is not Pythonwin related, but too good to throw away...
 
+from __future__ import absolute_import
+from __future__ import print_function
 import win32api
 import sys
 from pywin.framework import winout
 
-import _thread, sys
+from pywin.xtypes.moves import _thread
 
 import traceback
 

--- a/Pythonwin/pywin/Demos/createwin.py
+++ b/Pythonwin/pywin/Demos/createwin.py
@@ -7,6 +7,7 @@
 #	the parameters to OnPaint are.
 #
 
+from __future__ import absolute_import
 from pywin.mfc import dialog, window
 import win32ui
 import win32con

--- a/Pythonwin/pywin/Demos/demoutils.py
+++ b/Pythonwin/pywin/Demos/demoutils.py
@@ -1,5 +1,6 @@
 # Utilities for the demos
 
+from __future__ import absolute_import
 import sys, win32api, win32con, win32ui
 
 NotScriptMsg = """\

--- a/Pythonwin/pywin/Demos/dibdemo.py
+++ b/Pythonwin/pywin/Demos/dibdemo.py
@@ -1,6 +1,8 @@
 # A demo which creates a view and a frame which displays a PPM format bitmap
 #
 # This hasnnt been run in a while, as I dont have many of that format around!
+from __future__ import absolute_import
+from __future__ import print_function
 import win32ui
 import win32con
 import win32api

--- a/Pythonwin/pywin/Demos/dlgtest.py
+++ b/Pythonwin/pywin/Demos/dlgtest.py
@@ -7,6 +7,8 @@
 #
 # ID's for the tabstop dialog - out test.
 #
+from __future__ import absolute_import
+from __future__ import print_function
 from win32ui import IDD_SET_TABSTOPS
 from win32ui import IDC_EDIT_TABS
 from win32ui import IDC_PROMPT_TABS

--- a/Pythonwin/pywin/Demos/dyndlg.py
+++ b/Pythonwin/pywin/Demos/dyndlg.py
@@ -19,6 +19,7 @@
 #	Parameter 6 - Extra data
 
 
+from __future__ import absolute_import
 import win32ui
 import win32con
 from pywin.mfc import dialog, window

--- a/Pythonwin/pywin/Demos/fontdemo.py
+++ b/Pythonwin/pywin/Demos/fontdemo.py
@@ -10,6 +10,7 @@
 # >>> f2 = {'name':'Courier New', 'height':24, 'italic':1}
 # >>> d.SetFont (f2)
 
+from __future__ import absolute_import
 import win32ui
 import win32con
 import win32api

--- a/Pythonwin/pywin/Demos/guidemo.py
+++ b/Pythonwin/pywin/Demos/guidemo.py
@@ -1,4 +1,6 @@
 # GUI Demo - just a worker script to invoke all the other demo/test scripts.
+from __future__ import absolute_import
+from __future__ import print_function
 import win32ui
 import __main__
 import sys

--- a/Pythonwin/pywin/Demos/hiertest.py
+++ b/Pythonwin/pywin/Demos/hiertest.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import win32ui
 import os
 import commctrl

--- a/Pythonwin/pywin/Demos/menutest.py
+++ b/Pythonwin/pywin/Demos/menutest.py
@@ -1,4 +1,6 @@
 # Run this as a python script, to gray "close" off the edit window system menu.
+from __future__ import absolute_import
+from __future__ import print_function
 from pywin.framework import interact
 import win32con
 

--- a/Pythonwin/pywin/Demos/objdoc.py
+++ b/Pythonwin/pywin/Demos/objdoc.py
@@ -5,6 +5,8 @@
 # In the example below, the OpenObject() method is used instead of OpenDocumentFile,
 # and all the core MFC document open functionality is retained.
 
+from __future__ import absolute_import
+from __future__ import print_function
 import win32ui
 from pywin.mfc import docview
 

--- a/Pythonwin/pywin/Demos/ocx/demoutils.py
+++ b/Pythonwin/pywin/Demos/ocx/demoutils.py
@@ -1,5 +1,6 @@
 # Utilities for the demos
 
+from __future__ import absolute_import
 import sys, win32api, win32con, win32ui
 
 NotScriptMsg = """\

--- a/Pythonwin/pywin/Demos/ocx/flash.py
+++ b/Pythonwin/pywin/Demos/ocx/flash.py
@@ -5,6 +5,8 @@
 # http://pages.cpsc.ucalgary.ca/~saul/vb_examples/tutorial12/
 
 # Update to the path of the .swf file (note it could be a true URL)
+from __future__ import absolute_import
+from __future__ import print_function
 flash_url = "c:\\bounce.swf"
 
 import win32ui, win32con, win32api, regutil

--- a/Pythonwin/pywin/Demos/ocx/msoffice.py
+++ b/Pythonwin/pywin/Demos/ocx/msoffice.py
@@ -4,6 +4,7 @@
 # It is not comlpete yet, but it _does_ show an Excel spreadsheet in a frame!
 #
 
+from __future__ import absolute_import
 import win32ui, win32uiole, win32con, regutil
 from pywin.mfc import window, activex, object, docview
 from win32com.client import gencache

--- a/Pythonwin/pywin/Demos/ocx/ocxserialtest.py
+++ b/Pythonwin/pywin/Demos/ocx/ocxserialtest.py
@@ -5,6 +5,8 @@
 
 # Very simple -  queries a modem for ATI responses
 
+from __future__ import absolute_import
+from __future__ import print_function
 import win32ui, win32uiole
 import win32con
 from pywin.mfc import dialog, activex

--- a/Pythonwin/pywin/Demos/ocx/ocxtest.py
+++ b/Pythonwin/pywin/Demos/ocx/ocxtest.py
@@ -5,6 +5,8 @@
 #
 # The .py files behind the OCXs will be automatically generated and imported.
 
+from __future__ import absolute_import
+from __future__ import print_function
 from pywin.mfc import dialog, window, activex
 import win32ui, win32uiole
 import win32con

--- a/Pythonwin/pywin/Demos/ocx/webbrowser.py
+++ b/Pythonwin/pywin/Demos/ocx/webbrowser.py
@@ -3,6 +3,7 @@
 # It catches an "OnNavigate" event, and updates the frame title.
 # (event stuff by Neil Hodgson)
 
+from __future__ import absolute_import
 import win32ui, win32con, win32api, regutil
 from pywin.mfc import window, activex
 from win32com.client import gencache

--- a/Pythonwin/pywin/Demos/openGLDemo.py
+++ b/Pythonwin/pywin/Demos/openGLDemo.py
@@ -1,7 +1,10 @@
 # Ported from the win32 and MFC OpenGL Samples.
 
+from __future__ import absolute_import
+from __future__ import print_function
 from pywin.mfc import docview
 import sys
+from pywin.xtypes.moves import range
 try:
 	from OpenGL.GL import *
 	from OpenGL.GLU import *

--- a/Pythonwin/pywin/Demos/progressbar.py
+++ b/Pythonwin/pywin/Demos/progressbar.py
@@ -17,6 +17,7 @@
 # Example and progress bar code courtesy of KDL Technologies, Ltd., Hong Kong SAR, China.
 #
 
+from __future__ import absolute_import
 from pywin.mfc import dialog
 import win32ui
 import win32con

--- a/Pythonwin/pywin/Demos/sliderdemo.py
+++ b/Pythonwin/pywin/Demos/sliderdemo.py
@@ -1,6 +1,8 @@
 # sliderdemo.py
 # Demo of the slider control courtesy of Mike Fletcher.
 
+from __future__ import absolute_import
+from __future__ import print_function
 import win32con, win32ui
 from pywin.mfc import dialog
 

--- a/Pythonwin/pywin/Demos/splittst.py
+++ b/Pythonwin/pywin/Demos/splittst.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import win32ui
 import win32con
 import fontdemo

--- a/Pythonwin/pywin/Demos/threadedgui.py
+++ b/Pythonwin/pywin/Demos/threadedgui.py
@@ -2,6 +2,7 @@
 
 # Also demo of a GUI thread, pretty much direct from the MFC C++ sample MTMDI.
 
+from __future__ import absolute_import
 import win32ui
 import win32con
 import win32api
@@ -9,6 +10,7 @@ import timer
 
 from pywin.mfc import window, docview, thread
 from pywin.mfc.thread import WinThread
+from pywin.xtypes.moves import range
 
 
 WM_USER_PREPARE_TO_CLOSE = win32con.WM_USER + 32

--- a/Pythonwin/pywin/Demos/toolbar.py
+++ b/Pythonwin/pywin/Demos/toolbar.py
@@ -3,6 +3,8 @@
 # Shows the toolbar control.
 # Demos how to make custom tooltips, etc.
 
+from __future__ import absolute_import
+from __future__ import print_function
 import win32ui
 import win32con
 import win32api

--- a/Pythonwin/pywin/debugger/__init__.py
+++ b/Pythonwin/pywin/debugger/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import sys
 
 # Some cruft to deal with the Pythonwin GUI booting up from a non GUI app.
@@ -12,7 +14,7 @@ def _CheckNeedGUI():
 		isInprocApp = win32ui.GetApp().IsInproc()
 	if isInprocApp:
 		# MAY Need it - may already have one
-		need = "pywin.debugger.dbgpyapp" not in sys.modules
+		need = "pywin.framework.app" not in sys.modules
 	else:
 		need = 0
 	if need:
@@ -65,7 +67,7 @@ def runeval(expression, globals=None, locals=None):
 def runcall(*args):
 	return _GetCurrentDebugger().runcall(*args)
 
-def set_trace():
+def set_trace(frame=None):
 	import sys
 	d = _GetCurrentDebugger()
 
@@ -75,16 +77,14 @@ def set_trace():
 		# If im not "running"
 		return
 
-	sys.settrace(None) # May be hooked
-	d.reset()
-	d.set_trace()
+	d.set_trace(frame or sys._getframe().f_back)
 
 # "brk" is an alias for "set_trace" ("break" is a reserved word :-(
 brk = set_trace
 
 # Post-Mortem interface
 
-def post_mortem(t=None):
+def post_mortem(t=None, frame=None):
 	if t is None:
 		t = sys.exc_info()[2] # Will be valid if we are called from an except handler.
 	if t is None:
@@ -103,11 +103,11 @@ def post_mortem(t=None):
 	p.bAtPostMortem = 1
 	p.prep_run(None)
 	try:
-		p.interaction(t.tb_frame, t)
+		p.interaction(frame or t.tb_frame, t)
 	finally:
 		t = None
 		p.bAtPostMortem = 0
 		p.done_run()
 
-def pm(t=None):
-	post_mortem(t)
+def pm(t=None, frame=None):
+	post_mortem(t, frame)

--- a/Pythonwin/pywin/debugger/configui.py
+++ b/Pythonwin/pywin/debugger/configui.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from . import dbgcon
 from pywin.mfc import dialog
 import win32ui

--- a/Pythonwin/pywin/debugger/dbgcon.py
+++ b/Pythonwin/pywin/debugger/dbgcon.py
@@ -1,9 +1,11 @@
 # General constants for the debugger
 
+from __future__ import absolute_import
 DBGSTATE_NOT_DEBUGGING = 0
 DBGSTATE_RUNNING = 1
 DBGSTATE_BREAK = 2
 DBGSTATE_QUITTING = 3 # Attempting to back out of the debug session.
+DBGSTATE_FREETRACING = 4
 
 LINESTATE_CURRENT    = 0x1 # This line is where we are stopped
 LINESTATE_BREAKPOINT = 0x2 # This line is a breakpoint

--- a/Pythonwin/pywin/debugger/dbgpyapp.py
+++ b/Pythonwin/pywin/debugger/dbgpyapp.py
@@ -1,5 +1,6 @@
 # dbgpyapp.py  - Debugger Python application class
 #
+from __future__ import absolute_import
 import win32con
 import win32ui
 import sys

--- a/Pythonwin/pywin/debugger/fail.py
+++ b/Pythonwin/pywin/debugger/fail.py
@@ -5,6 +5,7 @@
 
 # It does nothing useful, and it even doesnt do that!
 
+from __future__ import absolute_import
 import pywin.debugger, sys, time
 import traceback
 

--- a/Pythonwin/pywin/default.cfg
+++ b/Pythonwin/pywin/default.cfg
@@ -8,7 +8,7 @@
 # NOTE:  You should not need to modify this file.
 # Simply create a new .CFG file, and add an entry:
 # [General]
-# BasedOn = Default
+# Based On = Default
 #
 # and add your customisations.  Then select your new configuration 
 # from the Pythonwin View/Options/Editor dialog.
@@ -16,7 +16,7 @@
 # but still take advantage of changes to the default
 # configuration in new releases.
 
-# See IDLE.cfg for an example extension configuration.
+# See user.cfg and IDLE.cfg for an example extension configuration.
 #
 ##########################################################################
 
@@ -62,22 +62,57 @@ F5                = DbgGo
 Shift+F5          = DbgClose
 F11               = DbgStep
 F10               = DbgStepOver
+Shift+F10         = DbgStepUntil
 Shift+F11         = DbgStepOut
 
 Ctrl+F3           = AutoFindNext
+Shift+F3          = FindPrev
+Ctrl+Shift+F3     = AutoFindPrev
 
+# Context help keys: they go to a default URL (defined in CtxHelp()
+# here in this file) or to CHM help, when the CHM help file is defined in
+# the registry at e.g.
+# "HKxx\Software\Python\PythonCore\V.v\Help\HelpNumpy" in the same way as
+# "HKxx\Software\Python\PythonCore\V.v\Help\Main Python Documentation"
+F1               = HelpPy
+Ctrl+F1          = HelpPyWin
+Alt+F1           = HelpMSDN
+Shift+F1         = HelpWXPY
+Shift+Alt+F1     = HelpWX
+
+F12              = HelpNumpy
+Shift+F12        = HelpScipy
+Ctrl+F12         = HelpPandas
+Alt+Shift+F12    = HelpSklearn
+Ctrl+Shift+F12   = HelpTensorflow
+
+Alt+F12          = HelpGoogle
+
+# reload this or user config
+Alt+R             = ReloadConfig
 
 [Keys:Editor]
 # Key bindings specific to the editor
 F2                = GotoNextBookmark
+Shift+F2          = GotoPrevBookmark
 Ctrl+F2           = ToggleBookmark
 Ctrl+G            = GotoLine
+
+# Ctrl+L            = LocateObject  # hardwired in Menu/File/Locate
+Alt+L             = GotoLastPos  # order of creation
+Shift+Alt+L       = GotoFollowingPos  # order of creation
+Ctrl+Shift+L      = GotoPrevPos  # position
+Ctrl+Shift+Alt+L  = GotoNextPos  # position
+Ctrl+Alt+L        = AddLastPos  # also toggle-removes
+Ctrl+Home         = GotoStartOfFile  # remembers last pos when far
+Ctrl+End          = GotoEndOfFile  # remembers last pos when far
 
 Alt+I             = ShowInteractiveWindow
 Alt-B             = AddBanner # A sample Event defined in this file.
 
 # Block operations
 Alt+3             = <<comment-region>>
+Ctrl+Q            = <<comment-region>>
 Shift+Alt+3       = <<uncomment-region>>
 Alt+4             = <<uncomment-region>> # IDLE default.
 Alt+5             = <<tabify-region>>
@@ -85,7 +120,7 @@ Alt+6             = <<untabify-region>>
 
 # Tabs and other indent features
 Back              = <<smart-backspace>>
-Ctrl+T            = <<toggle-tabs>>
+Ctrl+Shift+T      = <<toggle-tabs>>
 Alt+U             = <<change-indentwidth>>
 Enter             = EnterKey
 Tab               = TabKey
@@ -100,15 +135,21 @@ Alt+Subtract      = FoldCollapseAll
 Shift+Subtract    = FoldCollapseSecondLevel
 Multiply          = FoldTopLevel
 
+# Interact with selected lines
+Ctrl+K            = InteractSelectedLines
+Ctrl+Shift+K      = ExecSelectedLines
+
 [Keys:Interactive]
 # Key bindings specific to the interactive window.
 # History for the interactive window
 Ctrl+Up           = <<history-previous>>
 Ctrl+Down         = <<history-next>>
 Enter             = ProcessEnter
-Ctrl+Enter        = ProcessEnter
-Shift+Enter       = ProcessEnter
+Ctrl+Enter        = DebugStatement
+Shift+Enter       = EnterIndent
 Esc               = ProcessEsc
+##Back              = ProcessBack # doesn't stop auto-complete show when hitting dot again
+Back              = <<smart-backspace>>  # doesn't stop auto-complete show + more
 Alt+I             = WindowBack # Toggle back to previous window.
 Home              = InteractiveHome # A sample Event defined in this file.
 Shift+Home        = InteractiveHomeExtend # A sample Event defined in this file.
@@ -131,6 +172,11 @@ Ctrl+Shift+Tab    = MDIPrev
 # events.
 # Note that we bind keystrokes to these events in the various
 # [Keys] sections.
+
+# Note: This code executed from config.py/ConfigManager.configure
+# via SyntEditView.OnInitialUpdate > ... > DoConfigChange
+# upon EACH creation of a new editor view.
+# Its (re-)compiled upon import/reload of pywin.scintilla.view
 
 # Add a simple file/class/function simple banner
 def AddBanner(editor_window, event):
@@ -176,7 +222,9 @@ def _DoInteractiveHome(text, extend):
 	text.tag_add("sel", start, end)
 
 # From Niki Spahie
-def AutoFindNext(editor_window, event):
+def AutoFindPrev(editor_window, event):
+    return AutoFindNext(editor_window, event, prev=True)
+def AutoFindNext(editor_window, event, prev=False):
     "find selected text or word under cursor"
 
     from pywin.scintilla import find
@@ -199,8 +247,24 @@ def AutoFindNext(editor_window, event):
     except Exception:
         import traceback
         traceback.print_exc()
-    find.FindNext()
+    if prev:
+        FindPrev(editor_window, event)
+    else:
+        find.FindNext()
 
+def FindPrev(editor_window, event=None):
+    "find selected text or word under cursor"
+    from pywin.scintilla import find
+    sci = editor_window.edit
+    a, b = sci.GetSel()
+    rgn_end = max(a, b) - 1
+    # do like find.FindNext()
+    params = find.SearchParams(find.lastSearch)
+    params.sel = (rgn_end, 0)   # -> search in reverse direction
+    if not params.findText:
+        ShowFindDialog()
+    else:
+        return find._FindIt(sci, params)
 
 # A couple of generic events.
 def Beep(editor_window, event):
@@ -213,3 +277,176 @@ def ContinueEvent(editor_window, event):
 	# Almost an "unbind" - allows Pythonwin/MFC to handle the keystroke
 	return 1
 
+# Context Help (F1 and related keys in the editor at a word)
+
+_help_table = {
+	# doc_id : registry_CHM_help_name (None->doc_id), CHM_index_template, URL_template
+	'HelpPy' : ('Main Python Documentation', '%s', 'http://www.google.com/search?q=python+%s'),  # F1
+	'HelpPyWin' : ("Pythonwin Reference", '%s', 'http://www.google.com/search?q=pywin32+%s'), # Ctrl+F1
+	'HelpMSDN' : (None, '%s', 'http://social.msdn.microsoft.com/Search/en-US/?Query=%s'), # Alt+F1
+	'HelpWXPY' : (None, '%s', 'https://docs.wxpython.org/search.html?q=%s&check_keywords=yes'), # Shift+F1
+	'HelpWX'  : (None, 'wx%s', 'https://docs.wxwidgets.org/trunk/search.php?query=wx%s'), # Shift+Alt+F1
+
+	'HelpNumpy' : (None, '%s', 'https://numpy.org/doc/stable/search.html?q=%s&check_keywords=yes'), # F12
+	'HelpScipy' : (None, '%s', 'https://docs.scipy.org/doc/scipy/reference/search.html?q=%s&check_keywords=yes'), # Shift+F12
+	'HelpPandas' : (None, '%s', 'https://pandas.pydata.org/pandas-docs/stable/search.html?q=%s'),  # Ctrl+F12
+	'HelpSklearn' : (None, '%s', 'https://scikit-learn.org/stable/search.html?q=%s'), # Alt+Shift+F12
+	'HelpTensorflow' : (None, '%s', 'https://www.tensorflow.org/s/results?q=%s'),  # Ctrl+Shift+F12
+
+	'HelpGoogle' : (None, '%s', 'https://www.google.com/search?q=%s'), # Alt+F12
+	}
+for _k in _help_table:
+	exec("def %s(ed, event): CtxHelp(ed, event)" % _k)
+
+def CtxHelp(editor_window, event=None, return_word=False, hf_url=None):
+	"""launch context sensitive help for relevant word near cursor position
+	"""
+	import sys, os, re, pywin, traceback
+	
+	self = editor_window.edit
+	
+	start, end = self.GetSel()
+	if start != end:
+		word = self.GetSelText()
+	else:
+		# find the relevant word at or left of cursor ..
+		iline = self.LineFromChar(start)
+		linestart = self.LineIndex(iline)
+		line = self.GetLine(iline)
+		curpos = start - linestart
+		word = ''
+		for m in re.finditer(r'\b[A-Za-z_]\w+', line):   # min 2 lettered words
+			if m.start() > curpos:
+				break
+			w = m.group()
+			if w in ('self', 'this',  'and', 'or', 'not', 'in', 'if', 'else', 'None'):
+			## if keyword.iskeyword(w):
+				continue   # ignore names too trivial & frequently near symbols
+			word = w
+
+	if return_word:
+		return word
+
+	if not word:
+		return
+	
+	import win32help, regutil, win32ui, webbrowser
+	PY3 = sys.version_info[0] > 2
+	if PY3: from urllib.parse import quote
+	else:   from urllib       import quote            
+	
+	hwnd = None
+	hstr = PY3 and (lambda x:x) or (lambda x:x.encode('mbcs'))
+	
+	doc_id = sys._getframe(1).f_code.co_name  # caller name, e.g. 'HelpPyWin'
+	if not hf_url:
+		hf_url = _help_table.get(doc_id)
+	if not hf_url:
+		sys.stdout.write("-- default.cfg/CtxHelp(): unknown help doc_id %s --\r\n" % doc_id)
+		return
+	hf_name, hf_template, url_template = hf_url
+	hf = regutil.GetRegisteredHelpFile(hf_name or doc_id)  
+	if hf:
+		win32help.HtmlHelp(hwnd, hf, win32help.HH_DISPLAY_INDEX, hstr(hf_template % word))
+	else:
+		webbrowser.open(url_template % (word))                                                
+
+def InteractSelectedLines(editor_window,event):
+	ExecSelectedLines(editor_window,event, mode='interact')
+def ExecSelectedLines(editor_window, event, mode=''):
+	"""Execute selected lines in global namespace (auto-unindented)"""
+	import sys, string, re, pywin
+	write = sys.stdout.write
+	
+	self = editor_window.edit
+	startpos, endpos = self.GetSel()
+	if endpos > startpos: 
+		endpos = endpos - 1
+	start, end = map(self.LineFromChar, (startpos, endpos))
+	code=''
+
+	# get selected lines & compute minimal leading whitespace
+	l = []          # accumulated lines
+	baselines = 1   # counts lines which have minimal leading whitespace
+	minw = 0        # minimal leading whitespace of the lines
+	if start == end and startpos != endpos:
+		l = [self.GetSelText().lstrip()]
+	else:
+		minw = 10000
+		linecount = self.GetLineCount()
+		for i in range(start, end + 1):
+			line = self.GetLine(i)
+			white = len(line) - len(line.lstrip())
+			if white < minw:
+				minw = white
+				baselines = 1
+			elif white == minw:
+				baselines += baselines + 1
+			l.append(line)
+
+		# fetch indented lines of open statments (todo: use interpreter intelligence)
+		if line.strip().endswith(':'): 
+			white1 = len(line) - len(line.lstrip())
+			while i < linecount:
+				i = i+1
+				line = self.GetLine(i)
+				xline = line.lstrip()
+				if not xline or xline.startswith('#'):
+					continue
+				white = len(line) - len(xline)
+				if white == minw and sum([xline.startswith(x)
+										  for x in ('else:','except:','finally:')]): # sum='any'
+					pass
+				elif white <= minw:
+					break
+				l.append(line)
+
+	# print first to last line when executing snippet 
+	if mode != 'interact':
+		write('\r\n' + sys.ps2)
+		write(re.sub('\r|\n', '', l[0][minw:]) + '\r\n')
+		if len(l) > 1:
+			if len(l) > 2:
+				write('..\r\n')
+			write(sys.ps2 + re.sub('\r|\n', '', l[-1][minw:]) + '\r\n')
+
+	# .. or put snippet lines for interaction
+	i = 0
+	if mode == 'interact' and baselines > 1:
+		write('\r\n' + sys.ps2 + 'if 1:')
+	for line in l:
+		code = code + line[minw:]
+		if mode == 'interact':
+			write('\r\n' + sys.ps2)
+			if baselines > 1:
+				write('    ')  # indent of "if 1:"
+			write(re.sub('\r|\n', '', line[minw:]))
+		i = i + 1
+
+	from pywin.framework import interact
+	interact.edit.currentView.SetSel(-1)
+	if mode == 'interact':
+		interact.ShowInteractiveWindow()
+		return 0
+
+	#execute snippet lines  
+	write('-- executing lines in interactive context ... --\r\n')
+	interp = interact.edit.currentView.interp
+	try:
+		exec(code.replace('\r\n', '\n'), interp.globals, interp.locals)
+		if interp.curframe:
+			 # transfer locals dict -> fast locals
+			interact.save_locals(interp.curframe)
+	except:
+		import traceback
+		traceback.print_exc()
+	write('-- lines executed --\n' + sys.ps1)
+	return 0
+
+def ReloadConfig(editor_window, event):
+	# note: similarly by Opening & OK of PythonWin options dialog
+	import sys, win32ui, win32con, pywin.scintilla.view
+	pywin.scintilla.view.LoadConfiguration()
+	win32ui.GetMainFrame().SendMessageToDescendants(win32con.WM_WININICHANGE, 0, 0)
+	sys.stdout.write("-- ReloadConfig done.\n")
+	

--- a/Pythonwin/pywin/dialogs/ideoptions.py
+++ b/Pythonwin/pywin/dialogs/ideoptions.py
@@ -1,5 +1,6 @@
 # The property page to define generic IDE options for Pythonwin
 
+from __future__ import absolute_import
 from pywin.mfc import dialog
 from pywin.framework import interact
 import win32ui

--- a/Pythonwin/pywin/dialogs/list.py
+++ b/Pythonwin/pywin/dialogs/list.py
@@ -1,5 +1,8 @@
+from __future__ import absolute_import
+from __future__ import print_function
 from pywin.mfc import dialog
 import win32ui, win32con, commctrl, win32api
+from pywin.xtypes.moves import range
 
 class ListDialog (dialog.Dialog):
 	

--- a/Pythonwin/pywin/dialogs/login.py
+++ b/Pythonwin/pywin/dialogs/login.py
@@ -23,6 +23,8 @@ Jim Eggleston, 28 August 1996
 Merged with dlgpass and moved to pywin.dialogs by Mark Hammond Jan 1998.
 '''
 
+from __future__ import absolute_import
+from __future__ import print_function
 import win32ui
 import win32api
 import win32con

--- a/Pythonwin/pywin/dialogs/status.py
+++ b/Pythonwin/pywin/dialogs/status.py
@@ -1,5 +1,6 @@
 # No cancel button.
 
+from __future__ import absolute_import
 from pywin.mfc import dialog
 from pywin.mfc.thread import WinThread
 import threading
@@ -7,6 +8,7 @@ import win32ui
 import win32con
 import win32api
 import time
+from pywin.xtypes.moves import range
 
 def MakeProgressDlgTemplate(caption, staticText = ""):
     style = (win32con.DS_MODALFRAME |

--- a/Pythonwin/pywin/docking/DockingBar.py
+++ b/Pythonwin/pywin/docking/DockingBar.py
@@ -6,6 +6,7 @@
 # Currently we support only one child per DockingBar.  Later we need to add
 # support for multiple children.
 
+from __future__ import absolute_import
 import win32api, win32con, win32ui
 from pywin.mfc import afxres, window
 import struct

--- a/Pythonwin/pywin/framework/bitmap.py
+++ b/Pythonwin/pywin/framework/bitmap.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import win32ui
 import win32con
 import win32api

--- a/Pythonwin/pywin/framework/cmdline.py
+++ b/Pythonwin/pywin/framework/cmdline.py
@@ -1,4 +1,5 @@
 # cmdline - command line utilities.
+from __future__ import absolute_import
 import sys
 import win32ui
 import string

--- a/Pythonwin/pywin/framework/dlgappcore.py
+++ b/Pythonwin/pywin/framework/dlgappcore.py
@@ -2,6 +2,7 @@
 #
 # base classes for dialog based apps.
 
+from __future__ import absolute_import
 from . import app
 import win32ui
 import win32con

--- a/Pythonwin/pywin/framework/editor/ModuleBrowser.py
+++ b/Pythonwin/pywin/framework/editor/ModuleBrowser.py
@@ -1,4 +1,5 @@
 # ModuleBrowser.py - A view that provides a module browser for an editor document.
+from __future__ import absolute_import
 import pywin.mfc.docview
 import win32ui
 import win32con

--- a/Pythonwin/pywin/framework/editor/__init__.py
+++ b/Pythonwin/pywin/framework/editor/__init__.py
@@ -5,6 +5,8 @@
 # This really isnt necessary with Scintilla, and scintilla
 # is getting so deeply embedded that it was too much work.
 
+from __future__ import absolute_import
+from __future__ import print_function
 import win32ui, sys, win32con
 
 defaultCharacterFormat = (-402653169, 0, 200, 0, 0, 0, 49, 'Courier New')

--- a/Pythonwin/pywin/framework/editor/configui.py
+++ b/Pythonwin/pywin/framework/editor/configui.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from pywin.mfc import dialog
 from . import document
 import win32ui
@@ -6,6 +7,7 @@ import win32api
 
 from pywin.framework.editor import GetEditorOption, SetEditorOption, DeleteEditorOption, GetEditorFontOption, SetEditorFontOption, defaultCharacterFormat, editorTemplate
 import pywin.scintilla.config
+from pywin.xtypes.moves import range
 
 # The standard 16 color VGA palette should always be possible    
 paletteVGA = ( ("Black",0,0,0), ("Navy",0,0,128), ("Green",0,128,0), ("Cyan",0,128,128), 

--- a/Pythonwin/pywin/framework/editor/document.py
+++ b/Pythonwin/pywin/framework/editor/document.py
@@ -1,5 +1,7 @@
 # We no longer support the old, non-colour editor!
 
+from __future__ import absolute_import
+from __future__ import print_function
 from pywin.mfc import docview, object
 from pywin.framework.editor import GetEditorOption
 import win32ui
@@ -9,6 +11,7 @@ import string
 import traceback
 import win32api
 import shutil
+from pywin.xtypes.moves import zip
 
 BAK_NONE=0
 BAK_DOT_BAK=1

--- a/Pythonwin/pywin/framework/editor/editor.py
+++ b/Pythonwin/pywin/framework/editor/editor.py
@@ -17,6 +17,7 @@
 # Note that it will _always_ prompt you if the file in the editor has been modified.
 
 
+from __future__ import absolute_import
 import win32ui
 import win32api
 import win32con
@@ -28,6 +29,7 @@ import traceback
 from pywin.mfc import docview, dialog, afxres
 
 from pywin.framework.editor import GetEditorOption, SetEditorOption, GetEditorFontOption, SetEditorFontOption, defaultCharacterFormat
+from pywin.xtypes.moves import range, input
 
 patImport=regex.symcomp('import \(<name>.*\)')
 patIndent=regex.compile('^\\([ \t]*[~ \t]\\)')

--- a/Pythonwin/pywin/framework/editor/frame.py
+++ b/Pythonwin/pywin/framework/editor/frame.py
@@ -1,4 +1,5 @@
 # frame.py - The MDI frame window for an editor.
+from __future__ import absolute_import
 import pywin.framework.window
 import win32ui
 import win32con

--- a/Pythonwin/pywin/framework/editor/template.py
+++ b/Pythonwin/pywin/framework/editor/template.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import string
 import win32ui
 import win32api

--- a/Pythonwin/pywin/framework/editor/vss.py
+++ b/Pythonwin/pywin/framework/editor/vss.py
@@ -16,6 +16,7 @@
 # Database=??
 
 
+from __future__ import absolute_import
 import win32ui, win32api, win32con, os, string, sys
 
 import traceback

--- a/Pythonwin/pywin/framework/help.py
+++ b/Pythonwin/pywin/framework/help.py
@@ -1,4 +1,6 @@
  # help.py - help utilities for PythonWin.
+from __future__ import absolute_import
+from __future__ import print_function
 import win32api
 import win32con
 import win32ui
@@ -146,6 +148,25 @@ def SetHelpMenuOtherHelp(mainMenu):
 			otherMenu.AppendMenu(win32con.MF_ENABLED|win32con.MF_STRING,id, desc)
 	else:
 		helpMenu.EnableMenuItem(otherHelpMenuPos, win32con.MF_BYPOSITION | win32con.MF_GRAYED)
-		
+
+	# insert opener for default.cfg & user.cfg keyboard configuration
+	cmdID = win32ui.ID_HELP_OTHER + 20
+	pos = 3
+	helpMenu.InsertMenu(pos, win32con.MF_ENABLED|win32con.MF_STRING|win32con.MF_BYPOSITION, cmdID, 'Keyboard &default.cfg')
+	win32ui.GetMainFrame().HookCommand(HandleHelpCfg, cmdID)
+	cmdID += 1
+	helpMenu.InsertMenu(pos, win32con.MF_ENABLED|win32con.MF_STRING|win32con.MF_BYPOSITION, cmdID, 'Keyboard &user.cfg')
+	win32ui.GetMainFrame().HookCommand(HandleHelpUserCfg, cmdID)
+	cmdID += 1
+	helpMenu.InsertMenu(pos, win32con.MF_SEPARATOR|win32con.MF_BYPOSITION)
+
+from . import scriptutils
+import pywin
+
+def HandleHelpCfg(cmd, code):
+	scriptutils.JumpToDocument(os.path.join(pywin.__path__[0], 'default.cfg'))
+def HandleHelpUserCfg(cmd, code):
+	scriptutils.JumpToDocument(os.path.join(pywin.__path__[0], 'user.cfg'))
+
 def HandleHelpOtherCommand(cmd, code):
 	OpenHelpFile(helpIDMap[cmd][1])

--- a/Pythonwin/pywin/framework/intpydde.py
+++ b/Pythonwin/pywin/framework/intpydde.py
@@ -5,6 +5,8 @@
 # is open.  Strange, but true.  If you have problems with this, close all Command Prompts!
 
 
+from __future__ import absolute_import
+from __future__ import print_function
 import win32ui
 import win32api, win32con
 from pywin.mfc import object

--- a/Pythonwin/pywin/framework/mdi_pychecker.py
+++ b/Pythonwin/pywin/framework/mdi_pychecker.py
@@ -33,12 +33,17 @@
 ## 
 ######################################################################
 
+from __future__ import absolute_import
+from __future__ import print_function
 import win32ui
 import win32api
 from pywin.mfc import docview, dialog, window
 import win32con
 import sys, string, re, glob, os, stat, time
 from . import scriptutils
+from pywin.xtypes.moves import map
+from pywin.xtypes.moves import range
+from functools import reduce
 
 def getsubdirs(d):
     dlist = []
@@ -275,7 +280,7 @@ class TheDocument(docview.RichEditDoc):
         self.result=None
         old=win32api.SetCursor(win32api.LoadCursor(0, win32con.IDC_APPSTARTING))
         win32ui.GetApp().AddIdleHandler(self.idleHandler)
-        import _thread
+        from pywin.xtypes.moves import _thread
         _thread.start_new(self.threadPycheckerRun,())
         ##win32api.SetCursor(old)
     def threadPycheckerRun(self):

--- a/Pythonwin/pywin/framework/mdi_runtool.py
+++ b/Pythonwin/pywin/framework/mdi_runtool.py
@@ -1,0 +1,806 @@
+#####################################################################
+#
+# RunTool by kxrob - MDI-Plugin in the style of sgrepmdi.py / mdi_pychecker
+#
+# Runs external command-line tools (e.g. pyflakes/flake8, diff/git, test &
+# build jobs, cython, grep), collects their standard & error output, and allows to
+# comfortably jump to target lines or to add (noqa) ignore comments. The
+# target parser currently detects: standard compiler and
+# checker error formats, Python tracebacks, unified diff positions, `grep
+# -nH` output. Reads non-blocking from external process via thread. Multiple
+# instances with separate settings stores are exposed in Menu/File/New.
+# ( HKCU\SOFTWARE\Python V.v\Python for Win32\RunTool\num_instances )
+#
+# REQ: extra right-click "jump to diff old source location" (--- vs
+# default new +++ locations)
+#
+#####################################################################
+
+from __future__ import absolute_import
+from __future__ import print_function
+import sys
+import os
+import time
+import re
+import traceback
+
+import win32ui
+import win32api
+from pywin.mfc import docview, dialog, window
+import win32con
+from . import scriptutils
+from pywin.xtypes.moves import range
+
+# group(1) is the filename, group(2) is the lineno, group(3) is column, group(4) is errtext
+reError = re.compile(r"^([^+-]..[^\(:]+)?[\(:](\d+)[\):](?:(\d*):?)?\s*(.*)")
+reTraceback = re.compile(r'["(]([^",]+)"?[,\s]+line (\d+)()()')
+# example: File "C:\Python27\Lib\site-packages\pychecker\warn.py", line 242, in _checkFunction
+# example: SyntaxError: invalid syntax (C:\path\to\somemod.py, line 240)
+
+# these are the atom numbers defined by Windows for basic dialog controls
+BUTTON = 0x80
+EDIT = 0x81
+STATIC = 0x82
+LISTBOX = 0x83
+SCROLLBAR = 0x84
+COMBOBOX = 0x85
+
+class RTTemplate(docview.RichEditDocTemplate):
+
+    def __init__(self, tname='RunTool'):
+        self.tname = tname
+        docview.RichEditDocTemplate.__init__(
+            self, win32ui.IDR_TEXTTYPE, RTDocument, RTFrame, RTView)
+        self.SetDocStrings("\n%(tname)s\n%(tname)s\nRunTool params (*.pywruntool)\n.pywruntool\n\n\n" % locals())
+        win32ui.GetApp().AddDocTemplate(self)
+        self.docparams = None
+
+    def MatchDocType(self, fileName, _fileType):
+        doc = self.FindOpenDocument(fileName)
+        if doc:
+            return doc
+        ext = os.path.splitext(fileName)[1].lower()
+        if ext == '.runtool':
+            return win32ui.CDocTemplate_Confidence_yesAttemptNative
+        return win32ui.CDocTemplate_Confidence_noAttempt
+
+    def SetParams(self, params):
+        self.docparams = params
+
+    def ReadParams(self):
+        tmp = self.docparams
+        self.docparams = None
+        return tmp
+
+class RTFrame(window.MDIChildWnd):
+    # The template and doc params will one day be removed.
+    def __init__(self, wnd=None):
+        window.MDIChildWnd.__init__(self, wnd)
+
+def str2int(s, default=0):
+    try: return int(s)
+    except ValueError:
+        return default
+
+
+class RTParams:
+    filpattern = ''
+    dirpattern = ''
+    remember = 0
+    use_file = 1
+    preset_prj_root = 0
+    def GetParams(self, nc=0):
+        l = [self.dirpattern, self.filpattern, self.toolcmd, str(int(self.use_file)), str(int(self.preset_prj_root))]
+        for i in range(nc):
+            l[i] = ''
+        return '\t'.join(l)
+    def SetParams(self, paramstr):
+        params = paramstr.split('\t') + [''] * 5
+        self.dirpattern = params[0]
+        self.filpattern = params[1]
+        self.toolcmd = params[2] or self.toolcmd
+        self.use_file = str2int(params[3], default=1)
+        self.preset_prj_root = str2int(params[4])
+
+
+##DocBase = docview.RichEditDoc
+##ViewBase = docview.RichEditView
+##from pywin.scintilla.view import CScintillaView as ViewBase
+from pywin.scintilla.document import CScintillaDocument as DocBase
+from pywin.framework.editor.color.coloreditor import SyntEditView as ViewBase
+
+class RTDocument(RTParams, DocBase):
+    result = None
+    toolcmd = ''
+    def __init__(self, template):
+        self.template = template
+        self.tname = template.tname
+        DocBase.__init__(self, template)
+
+    def CheckExternalDocumentUpdated(self): 
+        return False  # required by SyntEditView
+    
+    def OnOpenDocument(self, fnm):
+        #this bizarre stuff with params is so right clicking in a result window
+        #and starting a new run can communicate the default parameters
+        try:
+            params = open(fnm, 'r').read()
+        except EnvironmentError:
+            params = None
+        self.SetInitParams(params)
+        return self.OnNewDocument()
+    
+    kill_cnt = 0
+    def OnCloseDocument(self):
+        try:
+            win32ui.GetApp().DeleteIdleHandler(self.IdleHandler)
+        except ValueError:
+            pass
+        p = self.process
+        if p and p.poll() is None:
+            self.kill_cnt += 1
+            msg = "-- terminating child process %s (%s) --\n" % (p.pid, self.cmd)
+            self.GetFirstView().Append(msg)
+            sys.stderr.write(msg)
+            ##p.terminate()  # doesn't kill childs when shell=1
+            os.popen('TASKKILL /T /PID %s /F' % p.pid).read()
+            if self.kill_cnt <= 2:
+                return 1
+            time.sleep(0.7)
+        return self._obj_.OnCloseDocument()
+
+    def SaveInitParams(self):
+        if self.remember:
+            paramstr = self.GetParams(nc=2)
+            win32ui.WriteProfileVal(self.tname, 'Params', paramstr)
+
+    num_instances = 2
+    def SetInitParams(self, paramstr=None):
+        if paramstr is None:
+            paramstr = win32ui.GetProfileVal(self.tname, 'Params', '')
+        self.SetParams(paramstr)
+        
+        # setup some reasonable defaults.
+        if not self.filpattern:
+            try:
+                editor = win32ui.GetMainFrame().MDIGetActive()[0].GetEditorView()
+                self.filpattern = os.path.basename(editor.GetDocument().GetPathName())
+            except (AttributeError, win32ui.error):
+                self.filpattern = '*.py'
+
+        if not self.dirpattern:
+            try:
+                editor = win32ui.GetMainFrame().MDIGetActive()[0].GetEditorView()
+                self.dirpattern = os.path.abspath(
+                    os.path.dirname(editor.GetDocument().GetPathName()))
+            except (AttributeError, win32ui.error):
+                self.dirpattern = os.getcwd()
+
+        if self.preset_prj_root:
+            prjroot = find_prj_root(self.dirpattern)
+            if prjroot:
+                self.dirpattern = prjroot
+
+    def FindRunableModuleOrProgCmd(self, name='flake8'):
+        py = os.path.join(sys.prefix, 'python.exe')
+        if not os.path.isfile(py):
+            if "64 bit" in sys.version:
+                py = os.path.join(sys.prefix, 'PCBuild', 'amd64', 'python.exe')
+            else:
+                py = os.path.join(sys.prefix, 'PCBuild', 'python.exe')
+        try:
+            py = win32api.GetShortPathName(py)
+        except win32api.error:
+            py = ""
+            
+        # check if that package supports -m 
+        from distutils.sysconfig import get_python_lib
+        mainscript = os.path.join(get_python_lib(), name, '__main__.py')
+        err = None
+        # default command examples
+        if name == '4.RunTool':
+            name = 'cython'
+        cmd = py + ' -m ' + name
+        if name == 'flake8':
+            cmd += ' --ignore W,E'  # non pep warnings by default
+        elif name == '2.RunTool':
+            cmd = os.path.join(sys.exec_prefix, 'python setup.py --help')
+            self.use_file = 0
+        elif name == '3.RunTool':
+            cmd = 'git diff'
+            self.use_file = 0
+        elif 'RunTool' in name:
+            cmd = 'make --help'
+            self.use_file = 0
+        if not os.path.isfile(py):
+            if sys.version > '3.3':
+                import shutil
+                py = shutil.which("python")
+            else:
+                py = 'python'
+            return cmd, "Can't find python.exe! (at %s)\n" % py
+        elif not os.path.isfile(mainscript):
+            if sys.version > '3.3':
+                import shutil
+                if shutil.which(name):
+                    return name, None
+                return cmd, "%s not installed as runnable Python module or on PATH?" % (name)
+            return cmd, "Can't find %s as runnable Python module" % (name)
+        return cmd, err
+
+    warncmd = None
+    def OnNewDocument(self):
+        if self.dirpattern == '':
+            self.SetInitParams(thetemplate.ReadParams())
+            
+        if not self.toolcmd.strip():
+            self.toolcmd, self.warncmd = self.FindRunableModuleOrProgCmd(self.tname)
+
+        d = RTDialog(self, name=self.tname)
+        if d.DoModal() == win32con.IDOK:
+            for name in list(d.keys()):
+                setattr(self, name, d[name])
+            if not self.toolcmd.strip():
+                self.toolcmd, self.warncmd = self.FindRunableModuleOrProgCmd(self.tname)
+            self.DoRun()
+            self.SaveInitParams()
+            return 1
+        return 0  # cancelled - return zero to stop frame creation.
+
+    def DoRun(self):
+        self.SetTitle("Run '%s' in '%s'" % (self.toolcmd, self.dirpattern))
+        #self.text = []
+        Append = self.GetFirstView().Append
+        Append("# Run in " + self.dirpattern + " at %s\n" % time.asctime())
+        Append("# Files:   " + self.filpattern + '\n')
+        if not os.path.isdir(self.dirpattern):
+            Append("# ERROR: directory '%s' doesn't exist " % self.dirpattern)
+            self.SetModifiedFlag(0)
+            return
+
+        files = self.use_file and self.filpattern or ''
+        if re.search(r'\b(pyflakes|flake\d)\b', self.toolcmd):
+            # pre-expand  ( pyflakes issue #566 )
+            import glob, shlex
+            dn = self.dirpattern
+            try:
+                cwd = os.getcwd()
+                if os.path.isdir(dn):
+                    os.chdir(dn)
+                l = sum([glob.glob(x) or [x] for x in shlex.split(files)], [])
+                files = ' '.join([' ' in x and '"%s"' % x or x for x in l])
+            finally:
+                os.chdir(cwd)
+        
+        self.cmd = '%s %s' % (self.toolcmd, files)
+        Append("# Command: %s\n" % self.cmd)
+        win32ui.SetStatusText("Running ...", 0)
+        self.StartRun()
+
+    def StartRun(self):
+        self.result = None
+        win32api.SetCursor(win32api.LoadCursor(0, win32con.IDC_APPSTARTING))
+        from pywin.xtypes.moves import _thread
+        ##self.ThreadRun()  # in main thread for debugging
+        _thread.start_new(self.ThreadRun, ())
+
+    process = None
+    def ThreadRun(self):
+        import sys
+        result = ''
+        Append = self.GetFirstView().Append        
+        try:
+            import subprocess
+            t0 = time.time()
+            p = self.process = subprocess.Popen(
+                self.cmd,  # [self.toolcmd, self.tooloptions, files],
+                shell=1,
+                bufsize=1,  # 0=unbuffered, 1=line buffered, -1=system default
+                cwd=self.dirpattern,
+                stdout=subprocess.PIPE, stderr=subprocess.STDOUT,   # STDOUT : stderr goes to same pipe as stdout
+            )
+            Append("# == Process %s running ... ==\n\n" % p.pid)
+            
+            enc = getattr(p.stdout, 'encoding', None)
+            if not enc:
+                from pywin.xtypes.moves import winreg
+                k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r'SYSTEM\CurrentControlSet\Control\Nls\CodePage')
+                enc = 'cp' + winreg.QueryValueEx(k, 'OEMCP')[0]
+                k.Close()
+                try: u''.encode(enc)
+                except LookupError:
+                    sys.stdout.write("-- unknown console code page: %s\n" % enc)
+                    enc = 'ascii'
+
+            ##result = p.stdout.read()
+            lines = []
+            new = []
+            t_last = t0
+            ##for line in p.stdout:
+            while 1:
+                line = p.stdout.readline()
+                new.append(line)
+                if time.time() - t_last > 1 or not line:
+                    t_last = time.time()
+                    s = (b''.join(new)).decode(enc, 'replace')
+                    Append(s)
+                    lines.append(s)
+                if not line:
+                    break
+            p.stdout.close()
+            t1 = time.time()
+            result = ''.join(lines)
+            ##Append(result)
+            
+            msg = "# == %s run finished after %.1fs ==" % (self.tname, t1 - t0)
+            sys.stdout.write(msg + '\r\n')
+            Append('\n' + msg + "\n# (Double-click on warning lines to jump to source. Right-click for more)")
+            self.SetModifiedFlag(0)
+        except Exception:
+            global _exc
+            _exc = self._exc = sys.exc_info()
+            msg = "# == %s ENDs with exception ==\n%s" % (
+                self.tname, ''.join(traceback.format_exception_only(*_exc[:2])))
+            traceback.print_exc()
+            sys.stdout.write(msg)
+            Append('\n' + msg)
+            self.SetModifiedFlag(0)
+        self.result = result
+
+    def IdleHandler(self, _handler, _count):
+        time.sleep(0.001)
+        if self.result != None:
+            win32ui.GetApp().DeleteIdleHandler(self.IdleHandler)
+            return 0
+        return 1  # more
+
+    def OnSaveDocument(self, filename):
+        savefile = open(filename, 'wb')
+        txt = self.GetParams() + '\n'
+        savefile.write(txt)
+        savefile.close()
+        self.SetModifiedFlag(0)
+        return 1
+    # end of RTDocument
+
+
+def find_prj_root(dn):
+    while 1:
+        for x in ('.git', '.svn', 'Makefile', 'setup.py'):
+            if os.path.exists(os.path.join(dn, x)):
+                return dn
+        old = dn
+        dn = os.path.dirname(dn)
+        if dn != old:
+            continue
+        # no project root found
+        return None
+
+
+ID_OPEN_FILE = 0xe500
+ID_SAVERESULTS = 0x502
+ID_TRYAGAIN = 0x503
+ID_NUMINSTANCES = 0x510
+ID_ADDCOMMENT = 0x504
+
+class RTView(ViewBase, object):
+    def __init__(self, doc):
+        self.doc = doc
+        ViewBase.__init__(self, doc)
+        ##self.SetWordWrap(win32ui.CRichEditView_WrapNone)
+    def OnInitialUpdate(self):
+        ##self.HookHandlers()
+        rc = ViewBase.OnInitialUpdate(self)  # includes HookHandlers()
+        ##fmt = (-402653169, 0, 200, 0, 0, 0, 49, 'Courier New')
+        ##self.SetDefaultCharFormat(fmt)
+        return rc
+    def _on_reclass(self):
+        # smart reloader post fix for fast debugging
+        print("RTView._on_reclass")
+        self.HookHandlers()
+    def HookHandlers(self):
+        ViewBase.HookHandlers(self)
+        self.HookMessage(self.OnRClick, win32con.WM_RBUTTONDOWN)
+        self.HookCommand(self.OnCmdOpenFile, ID_OPEN_FILE)
+        self.HookCommand(self.OnCmdOpenFile, ID_OPEN_FILE + 1)
+        self.HookCommand(self.OnCmdSave, ID_SAVERESULTS)
+        self.HookCommand(self.OnTryAgain, ID_TRYAGAIN)
+        self.HookCommandRange(self.OnAddComment, ID_ADDCOMMENT, ID_ADDCOMMENT + 4)
+        self.HookMessage(self.OnLDblClick, win32con.WM_LBUTTONDBLCLK)
+        self.HookMessage(self.OnLButtonUp, win32con.WM_LBUTTONUP)
+
+    lbu_action = None
+    def OnLButtonUp(self, *args):
+        if self.lbu_action:
+            try:
+                ##self.lbu_action()
+                app.CallAfter(self.lbu_action)
+            finally:
+                self.lbu_action = None
+            return 1
+        return 1
+
+    def FindTarget(self, line=None):
+        """Detects jump target file & lineno (&col) of: standard warning /
+        error formats, python tracebacks, diff / git diff output, grep -nH
+        """
+
+        lnno = None
+        if line is None:
+            lnno = self.LineFromChar(-1)  # selection or current line
+            line = self.GetLine(lnno)
+            
+        # check standard warning / error lines and Python tracebacks
+        
+        m = reError.match(line) or \
+            reTraceback.search(line) or \
+            (lnno and reTraceback.search(self.GetLine(lnno - 1)))  # python traceback style
+        if m:
+            col = m.group(3)
+            col = col and int(col) or 0
+            return scriptutils.DictObj(
+                fname=m.group(1),
+                lineno=int(m.group(2)),
+                col=col,
+                errtext=m.group(4))
+        
+        # check for diff / git diff output
+        
+        _a, end = self.GetSel()
+        lnno = self.LineFromChar(end)
+        ##lnno = self.GetCurLineNumber()
+        linestart = self.LineIndex(lnno)
+        lineend = self.LineIndex(lnno + 1)
+        col = end - linestart
+        lineno = lineno_old = 0  # of jump target
+        s = self.GetTextRange(0, lineend)
+        l = list(re.finditer(r'(?m)^\+\+\+ ("[^"]+"|\S+)', s))
+        if l:
+            
+            # found diff new file signature
+            
+            m = l[-1]
+            fname = m.group(1)
+            if fname[:2] in ('b/', 'a/'):
+                fname = './' + fname[2:]
+            fn1 = fname
+            root = self.doc.dirpattern
+            if not os.path.isabs(fname):
+                fname = os.path.normpath(os.path.join(root, fname))
+            if not os.path.isfile(fname):
+                prjroot = find_prj_root(root)
+                if prjroot:
+                    root = prjroot
+                    fname = os.path.normpath(os.path.join(root, fn1))
+            if not os.path.isfile(fname):
+                print("-- file '%s' not found --" % fname)
+                return None
+            l = list(re.compile(r'(?m)^@@ -(\d+),\d+ \+(\d+),\d+ @@').finditer(s, m.start()))
+            if l:
+                # hunk start found
+                m = l[-1]
+                lineno_old = int(m.group(1))
+                lineno = int(m.group(2))
+                hunklines = s[m.start():]
+                for line in hunklines.split('\n')[2:]:
+                    if line[:1] in (' ', '+'):
+                        lineno += 1
+                    if line[:1] in (' ', '-'):
+                        lineno_old += 1
+            ##print "-- found: '%(fname)s' line %(lineno)s:%(col)s' --" % locals()
+            o = scriptutils.DictObj(
+                fname=fname,
+                lineno=lineno,
+                col=col,
+                errtext='')
+            l_oldfile = list(re.finditer(r'(?m)^--- ("[^"]+"|\S+)', s))
+            if l_oldfile:
+                m = l_oldfile[-1]
+                o.fname_old = m.group(1)
+                if not os.path.isabs(o.fname_old):
+                    o.fname_old = os.path.normpath(os.path.join(root, o.fname_old))
+                o.lineno_old = lineno_old
+            return o
+        
+        return None
+
+    def OnLDblClick(self, _params=None, delay_action=True, ft=None):
+        ft = ft or self.FindTarget()
+        if ft:
+            if not os.path.dirname(ft.fname):
+                ft.fname = os.path.normpath(os.path.join(self.doc.dirpattern, ft.fname))
+            def action():
+                view = scriptutils.JumpToDocument(ft.fname, ft.lineno, ft.col)
+                if view:
+                    view.AddLastPosEvent()
+            ##app.CallAfter(_action)
+            if delay_action:
+                self.lbu_action = action  # delayed action or dbl click will mess mark/sel
+            else:
+                action()
+            return 0    # done
+        return 1    # pass it on by default.
+
+    def OnCmdOpenFile(self, cmd, _code):
+        ft = self.ft
+        if cmd == ID_OPEN_FILE + 1:
+            ft.fname = ft.fname_old
+            ft.lineno = ft.lineno_old
+        return self.OnLDblClick(delay_action=False, ft=ft)
+
+    def OnRClick(self, params):
+        menu = win32ui.CreatePopupMenu()
+        flags = win32con.MF_STRING | win32con.MF_ENABLED
+        self.ft = ft = self.FindTarget()
+        if ft:
+            menu.AppendMenu(flags | win32con.MF_DEFAULT, ID_OPEN_FILE, "&Jump to %s:%s" % (
+                os.path.basename(ft.fname), ft.lineno))
+            if hasattr(ft, 'lineno_old'):
+                menu.AppendMenu(flags | win32con.MF_DEFAULT, ID_OPEN_FILE + 1, "&Jump to --- %s:%s" % (
+                    os.path.basename(ft.fname_old), ft.lineno_old))
+            menu.AppendMenu(flags, ID_ADDCOMMENT + 0, "&Add to source: # noqa")
+            menu.AppendMenu(flags, ID_ADDCOMMENT + 1, "&Add to source: # noqa:<WARNCODE>")
+            menu.AppendMenu(flags, ID_ADDCOMMENT + 2, "&Add to source: # noqa=<WARNREGEX>")
+            menu.AppendMenu(flags, ID_ADDCOMMENT + 3, "&Add to source: #pylint:disable=W")
+            menu.AppendMenu(flags, ID_ADDCOMMENT + 4, "&Add to source: #pylint:disable=<WARNCODE>")
+            menu.AppendMenu(win32con.MF_SEPARATOR)
+        menu.AppendMenu(flags, ID_TRYAGAIN, "&Try Again")
+        menu.AppendMenu(flags, win32con.MF_SEPARATOR)
+        menu.AppendMenu(flags, win32ui.ID_EDIT_CUT, "Cu&t")
+        menu.AppendMenu(flags, win32ui.ID_EDIT_COPY, "&Copy")
+        menu.AppendMenu(flags, win32ui.ID_EDIT_PASTE, "&Paste")
+        menu.AppendMenu(flags, win32con.MF_SEPARATOR)
+        menu.AppendMenu(flags, win32ui.ID_EDIT_SELECT_ALL, "&Select all")
+        menu.AppendMenu(flags, win32con.MF_SEPARATOR)
+        menu.AppendMenu(flags, ID_SAVERESULTS, "Sa&ve results")
+        menu.TrackPopupMenu(params[5])
+        return 0
+
+    def OnAddComment(self, cmd, _code):
+        icm = cmd - ID_ADDCOMMENT
+        lcm = [
+            '# noqa',
+            '# noqa:<WARNCODE>',
+            '# noqa=<WARNREGEX>',
+            '#pylint:disable=W',
+            '#pylint:disable=<WARNCODE>',
+        ]
+        cm = lcm[icm]
+        addspecific = cmd & 1
+        sel = list(self.GetSel())
+        sel.sort()
+        start, end = sel
+        line_start, line_end = self.LineFromChar(start), self.LineFromChar(end)
+        first = 1
+        for i in range(line_start, line_end + 1):
+            line = self.GetLine(i)
+            ft = self.FindTarget(line)
+            if ft:
+                if not os.path.dirname(ft.fname):
+                    ft.fname = os.path.join(self.doc.dirpattern, ft.fname)
+                view = scriptutils.JumpToDocument(ft.fname, ft.lineno)
+                pos = view.LineIndex(ft.lineno) - 1
+                if view.GetTextRange(pos - 1, pos) in ('\r', '\n'):
+                    pos -= 1
+                view.SetSel(pos, pos)
+                errtext = ft.errtext.strip()
+                errcode = 'W'
+                m = re.search(r'([A-Z]\d\d\d\d?\b)', errtext)
+                if m:
+                    errcode = m.group(1)
+                if start != end and line_start == line_end:
+                    errcode = self.GetSelText()
+                errcode = re.escape(errcode).replace('\ ', ' ')
+                cmnt = cm.replace('<WARNREGEX>', repr(
+                    re.escape(errtext).replace('\ ', ' ')))
+                cmnt = cmnt.replace('<WARNCODE>', errcode)
+                ##if cmnt != cm:
+                ##    cmnt = dialog.GetSimpleInput("Add", cmnt)
+                if not cmnt:
+                    return 0
+
+                cmnt = cmnt % locals()
+                view.ReplaceSel('  ' + cmnt)
+        return 0
+
+    def OnTryAgain(self, _cmd, _code):
+        thetemplate.SetParams(self.GetDocument().GetParams())
+        thetemplate.OpenDocumentFile()
+        return 0
+
+    def OnCmdSave(self, _cmd, _code):
+        flags = win32con.OFN_OVERWRITEPROMPT
+        dlg = win32ui.CreateFileDialog(0, None, None, flags, "Text Files (*.txt)|*.txt||", self)
+        dlg.SetOFNTitle("Save Results As")
+        if dlg.DoModal() == win32con.IDOK:
+            pn = dlg.GetPathName()
+            self._obj_.SaveFile(pn)
+        return 0
+
+    def Append(self, strng):
+        numlines = self.GetLineCount()
+        endpos = self.LineIndex(numlines - 1) + len(self.GetLine(numlines - 1))
+        self.SetSel(endpos, endpos)
+        self.ReplaceSel(strng)
+
+
+class RTDialog(dialog.Dialog):
+    def __init__(self, doc, name='RunTool'):
+        self.doc = doc
+        wc = win32con
+        style = wc.DS_MODALFRAME | wc.WS_POPUP | wc.WS_VISIBLE | wc.WS_CAPTION | wc.WS_SYSMENU | wc.DS_SETFONT
+        CS = wc.WS_CHILD | wc.WS_VISIBLE
+        tmp = [
+            [name, (0, 0, 310, 90), style, None, (8, 'MS Sans Serif')],
+            [STATIC, "Command:", -1, (7, 7, 50, 9), CS],
+            [EDIT, doc.toolcmd, 100, (50, 7, 250, 11), CS | wc.WS_TABSTOP
+             | wc.ES_AUTOHSCROLL | wc.WS_BORDER],
+
+            ##[STATIC, "File(s):",  -1, (20, 20, 30 , 9), CS],
+            [BUTTON, "&File(s):",     104, (7,  20,  40,  9), CS | wc.BS_AUTOCHECKBOX | wc.BS_LEFTTEXT | wc.WS_TABSTOP],
+            [EDIT, '-', 103, (50, 20, 250, 11), CS | wc.WS_TABSTOP | wc.ES_AUTOHSCROLL | wc.WS_BORDER],
+            [STATIC, "&Directory:",  -1, (7, 34, 40, 9), CS],
+            [EDIT, '-', 102, (50, 34, 250, 11), CS | wc.WS_TABSTOP | wc.ES_AUTOHSCROLL | wc.WS_BORDER],
+            [BUTTON, "&Prefill project root directory containing .git / Makefile / setup.py (next time)",
+             105, (7,  48,  300,  9), CS | wc.BS_AUTOCHECKBOX | wc.WS_TABSTOP],
+            #    [BUTTON, '...',                 110, (182,34,  16,  11), CS | wc.BS_PUSHBUTTON | wc.WS_TABSTOP],
+            ##[STATIC, "Options:",            -1, (7,  48,  50,  9), CS ],
+            ##[EDIT,   gp,                    101, (52, 48, 128,  11), CS | wc.WS_TABSTOP | wc.ES_AUTOHSCROLL | wc.WS_BORDER ],
+            #    [BUTTON, '...',                 111, (182,48,  16,  11), CS | wc.BS_PUSHBUTTON | wc.WS_TABSTOP],
+            [BUTTON, "&Remember", 106, (7, 70, 128, 9), CS | wc.BS_AUTOCHECKBOX | wc.WS_TABSTOP],
+            [BUTTON, "&OK", wc.IDOK, (190, 70, 50, 12), CS | wc.BS_DEFPUSHBUTTON | wc.WS_TABSTOP],
+            [BUTTON, "&Cancel", wc.IDCANCEL, (250, 70, 50, 12), CS | wc.BS_PUSHBUTTON | wc.WS_TABSTOP],
+        ]
+        dialog.Dialog.__init__(self, tmp)
+        self.AddDDX(100, 'toolcmd')
+        ##self.AddDDX(101,'tooloptions')
+        self.AddDDX(102, 'dirpattern')
+        self.AddDDX(103, 'filpattern')
+        self.AddDDX(104,'use_file')
+        self.HookCommand(self.OnUpdate, 104)
+        self.AddDDX(105,'preset_prj_root')
+        self.HookCommand(self.OnUpdatePrePrj, 105)
+        self.AddDDX(106, 'remember')
+        self._obj_.data['toolcmd'] = doc.toolcmd
+        self._obj_.data['dirpattern'] = doc.dirpattern
+        self._obj_.data['filpattern'] = doc.filpattern
+        self._obj_.data['use_file']  = doc.use_file
+        self._obj_.data['preset_prj_root'] = doc.preset_prj_root
+        self._obj_.data['remember'] = 0
+        ##self.HookCommand(self.OnMoreDirectories, 110)
+        ##self.HookCommand(self.OnMoreFiles, 111)
+
+    def OnInitDialog(self):
+        self.UpdateData(0)
+        self.files = self.GetDlgItem(103)
+        self.OnUpdate()
+        if self.doc.warncmd:
+            self.SetWindowText(self.doc.warncmd)
+        return 1  # focus on first control
+
+    def OnUpdate(self, *args):
+        self.UpdateData(1)
+        self.files.EnableWindow(not not self['use_file'])
+    def OnUpdatePrePrj(self, *args):
+        self.GetDlgItem(106).SetCheck(1)
+
+    def OnMoreDirectories(self, _cmd, _code):
+        self.getMore('RunTool\\Directories', 'dirpattern')
+
+    def OnMoreFiles(self, _cmd, _code):
+        self.getMore('RunTool\\File Types', 'filpattern')
+
+    def getMore(self, section, key):
+        self.UpdateData(1)
+        #get the items out of the ini file
+        ini = win32ui.GetProfileFileName()
+        secitems = win32api.GetProfileSection(section, ini)
+        items = []
+        for secitem in secitems:
+            items.append(secitem.split('=')[1])
+        dlg = ParamsDialog(items)
+        if dlg.DoModal() == win32con.IDOK:
+            itemstr = ';'.join(dlg.getItems())
+            self._obj_.data[key] = itemstr
+            #update the ini file with dlg.getNew()
+            i = 0
+            newitems = dlg.getNew()
+            if newitems:
+                items = items + newitems
+                for item in items:
+                    win32api.WriteProfileVal(section, repr(i), item, ini)
+                    i = i + 1
+            self.UpdateData(0)
+
+    def OnOK(self):
+        self.UpdateData(1)
+        for theid, name in [
+            (100, 'toolcmd'),
+            (102, 'dirpattern'),
+            ##(103,'filpattern'),
+        ]:
+            if not self[name]:
+                self.GetDlgItem(theid).SetFocus()
+                win32api.MessageBeep()
+                win32ui.SetStatusText("%s: Please enter a value" % name)
+                return
+        self._obj_.OnOK()
+
+
+class ParamsDialog(dialog.Dialog):
+    def __init__(self, items):
+        self.items = items
+        self.newitems = []
+        self.selections = []
+        style = win32con.DS_MODALFRAME | win32con.WS_POPUP | win32con.WS_VISIBLE | win32con.WS_CAPTION | win32con.WS_SYSMENU | win32con.DS_SETFONT
+        CS = win32con.WS_CHILD | win32con.WS_VISIBLE
+        tmp = [["RunTool Parameters", (0, 0, 205, 100), style, None, (8, "MS Sans Serif")], ]
+        tmp.append([LISTBOX, '', 107, (7, 7, 150, 72), CS | win32con.LBS_MULTIPLESEL |
+                    win32con.LBS_STANDARD | win32con.LBS_HASSTRINGS | win32con.WS_TABSTOP | win32con.LBS_NOTIFY])
+        tmp.append([BUTTON, 'OK', win32con.IDOK, (167, 7, 32, 12), CS
+                    | win32con.BS_DEFPUSHBUTTON | win32con.WS_TABSTOP])
+        tmp.append([BUTTON, 'Cancel', win32con.IDCANCEL, (167, 23, 32, 12),
+                    CS | win32con.BS_PUSHBUTTON | win32con.WS_TABSTOP])
+        tmp.append([STATIC, 'New:', -1, (2, 83, 15, 12), CS])
+        tmp.append([EDIT, '', 108, (18, 83, 139, 12), CS | win32con.WS_TABSTOP
+                    | win32con.ES_AUTOHSCROLL | win32con.WS_BORDER])
+        tmp.append([BUTTON, 'Add', 109, (167, 83, 32, 12), CS
+                    | win32con.BS_PUSHBUTTON | win32con.WS_TABSTOP])
+        dialog.Dialog.__init__(self, tmp)
+        self.HookCommand(self.OnAddItem, 109)
+        self.HookCommand(self.OnListDoubleClick, 107)
+        self.Hook
+
+    def OnInitDialog(self):
+        lb = self.GetDlgItem(107)
+        for item in self.items:
+            lb.AddString(item)
+        return self._obj_.OnInitDialog()
+
+    def OnAddItem(self, _cmd, _code):
+        eb = self.GetDlgItem(108)
+        item = eb.GetLine(0)
+        self.newitems.append(item)
+        lb = self.GetDlgItem(107)
+        i = lb.AddString(item)
+        lb.SetSel(i, 1)
+        return 1
+
+    def OnListDoubleClick(self, _cmd, code):
+        if code == win32con.LBN_DBLCLK:
+            self.OnOK()
+            return 1
+
+    def OnOK(self):
+        lb = self.GetDlgItem(107)
+        self.selections = lb.GetSelTextItems()
+        self._obj_.OnOK()
+
+    def getItems(self):
+        return self.selections
+
+    def getNew(self):
+        return self.newitems
+
+app = win32ui.GetApp()
+try:    
+    for t in app.GetDocTemplateList():
+        if t.__class__.__name__ == 'RTTemplate':
+            app.RemoveDocTemplate(t)
+except NameError:
+    pass
+
+thetemplate = RTTemplate('flake8')
+thetemplate = RTTemplate('RunTool')
+if 1:
+    # more instances
+    # HKCU\SOFTWARE\Python V.v\Python for Win32\RunTool\num_instances
+    s = win32ui.GetProfileVal('RunTool', 'num_instances', '5')
+    try: num_instances = int(s)
+    except ValueError:
+        num_instances = 5
+    for i in range(1, num_instances):
+        RTTemplate('%s.RunTool' % (i + 1))
+    #TODO: possibly expose num_instances in MainMenu/View/Options Dialog
+
+##_reload_smart = None  # suppress smart reloader

--- a/Pythonwin/pywin/framework/scriptutils.py
+++ b/Pythonwin/pywin/framework/scriptutils.py
@@ -1,6 +1,8 @@
 """
 Various utilities for running/importing a script
 """
+from __future__ import absolute_import
+from __future__ import print_function
 import sys
 import win32ui
 import win32api
@@ -10,6 +12,7 @@ from pywin.mfc import dialog
 from pywin.mfc.docview import TreeView
 import os
 import string
+import re
 import traceback
 import linecache
 import bdb
@@ -78,7 +81,7 @@ def IsOnPythonPath(path):
 	for syspath in sys.path:
 		try:
 			# Python 1.5 and later allows an empty sys.path entry.
-			if syspath and win32ui.FullPath(syspath)==path:
+			if syspath and os.path.normcase(win32ui.FullPath(syspath)) == os.path.normcase(path):
 				return 1
 		except win32ui.error as details:
 			print("Warning: The sys.path entry '%s' is invalid\n%s" % (syspath, details))
@@ -277,8 +280,8 @@ def RunScript(defName=None, defArgs=None, bShowDialog = 1, debuggingType=None):
 		win32ui.MessageBox("The file could not be opened - %s (%d)" % (exc.strerror, exc.errno))
 		return
 
-	# Get the source-code - as above, normalize \r\n
-	code = f.read().replace(byte_crlf, byte_lf).replace(byte_cr, byte_lf) + byte_lf
+	# Get the source-code - as above	##, normalize \r\n
+	code = f.read()  ##.replace(byte_crlf, byte_lf).replace(byte_cr, byte_lf) + byte_lf
 
 	# Remember and hack sys.argv for the script.
 	oldArgv = sys.argv
@@ -309,7 +312,7 @@ def RunScript(defName=None, defArgs=None, bShowDialog = 1, debuggingType=None):
 	# Get a code object - ignore the debugger for this, as it is probably a syntax error
 	# at this point
 	try:
-		codeObject = compile(code, script, "exec")
+		codeObject = compile(code, script, "exec", dont_inherit=True)
 	except:
 		# Almost certainly a syntax error!
 		_HandlePythonFailure("run script", script)
@@ -319,7 +322,7 @@ def RunScript(defName=None, defArgs=None, bShowDialog = 1, debuggingType=None):
 	try:
 		if debuggingType == RS_DEBUGGER_STEP:
 			debugger.run(codeObject, __main__.__dict__, start_stepping=1)
-		elif debuggingType == RS_DEBUGGER_GO:
+		elif debuggingType == RS_DEBUGGER_GO and debugger._GetCurrentDebugger().breaks:
 			debugger.run(codeObject, __main__.__dict__, start_stepping=0)
 		else:
 			# Post mortem or no debugging
@@ -342,15 +345,20 @@ def RunScript(defName=None, defArgs=None, bShowDialog = 1, debuggingType=None):
 		if interact.edit and interact.edit.currentView:
 			interact.edit.currentView.AppendToPrompt([])
 		bWorked = 1
+		sys.last_type, sys.last_value, sys.last_traceback = sys.exc_info()
 	except:
 		if interact.edit and interact.edit.currentView:
 			interact.edit.currentView.EnsureNoPrompt()
 		traceback.print_exc()
 		if interact.edit and interact.edit.currentView:
 			interact.edit.currentView.AppendToPrompt([])
-		if debuggingType == RS_DEBUGGER_PM:
-			debugger.pm()
-	del __main__.__file__
+			
+		sys.last_type, sys.last_value, sys.last_traceback = sys.exc_info()
+		if debuggingType != RS_DEBUGGER_NONE:
+			debugger.pm()			
+
+	
+	##del __main__.__file__   # last run __file__ should better stay for interaction
 	sys.argv = oldArgv
 	if insertedPath0:
 		del sys.path[0]
@@ -398,13 +406,13 @@ def ImportFile():
 	# module.__file__ - so we must take a copy (ie, items() in py2k,
 	# list(items()) in py3k)
 	for key, mod in list(sys.modules.items()):
-		if hasattr(mod, '__file__'):
+		if getattr(mod, '__file__', None):
 			fname = mod.__file__
 			base, ext = os.path.splitext(fname)
 			if ext.lower() in ['.pyo', '.pyc']:
 				ext = '.py'
 			fname = base + ext
-			if win32ui.ComparePath(fname, pathName):
+			if win32ui.ComparePath(fname, pathName) and mod.__name__ != '__main__':
 				modName = key
 				break
 	else: # for not broken
@@ -440,7 +448,7 @@ def ImportFile():
 				from imp import reload as my_reload # py3k
 			except ImportError:
 				my_reload = reload # reload a builtin in py2k
-			mod = my_reload(sys.modules[modName])
+			my_reload(sys.modules[modName])
 		win32ui.SetStatusText('Successfully ' + what + "ed module '"+modName+"': %s" % getattr(mod,'__file__',"<unkown file>"))
 	except:
 		_HandlePythonFailure(what)
@@ -459,16 +467,16 @@ def CheckFile():
 	win32ui.SetStatusText(what.capitalize()+'ing module...',1)
 	win32ui.DoWaitCursor(1)
 	try:
-		f = open(pathName)
+		f = open(pathName, 'rb')
 	except IOError as details:
 		print("Cant open file '%s' - %s" % (pathName, details))
 		return
 	try:
-		code = f.read() + "\n"
+		code = f.read()
 	finally:
 		f.close()
 	try:
-		codeObj = compile(code, pathName,'exec')
+		codeObj = compile(code, pathName, 'exec', dont_inherit=True)
 		if RunTabNanny(pathName):
 			win32ui.SetStatusText("Python and the TabNanny successfully checked the file '"+os.path.basename(pathName)+"'")
 	except SyntaxError:
@@ -534,7 +542,7 @@ def JumpToDocument(fileName, lineno=0, col = 1, nChars = 0, bScrollToTop = 0):
 		view = doc.GetFirstView()
 	if lineno > 0:
 		charNo = view.LineIndex(lineno-1)
-		start = charNo + col - 1
+		start = charNo + (col or 1) - 1
 		size = view.GetTextLength()
 		try:
 			view.EnsureCharsVisible(charNo)
@@ -549,16 +557,16 @@ def JumpToDocument(fileName, lineno=0, col = 1, nChars = 0, bScrollToTop = 0):
 	return view
 
 def _HandlePythonFailure(what, syntaxErrorPathName = None):
-	typ, details, tb = sys.exc_info()
+	typ, details, tb = sys.last_type, sys.last_value, sys.last_traceback = sys.exc_info()
 	if isinstance(details, SyntaxError):
 		try:
-			msg, (fileName, line, col, text) = details
-			if (not fileName or fileName =="<string>") and syntaxErrorPathName:
+			if (not details.filename or details.filename == "<string>") and syntaxErrorPathName:
 				fileName = syntaxErrorPathName
-			_JumpToPosition(fileName, line, col)
+			_JumpToPosition(details.filename, details.lineno, details.offset or 1)
 		except (TypeError, ValueError):
 			msg = str(details)
-		win32ui.SetStatusText('Failed to ' + what + ' - syntax error - %s' % msg)
+		traceback.print_exc()
+		win32ui.SetStatusText('Failed to ' + what + ' - syntax error - %s' % details.msg)
 	else:	
 		traceback.print_exc()
 		win32ui.SetStatusText('Failed to ' + what + ' - ' + str(details) )
@@ -612,12 +620,306 @@ def LocatePythonFile( fileName, bBrowseIfDir = 1 ):
 						fileName = d.GetPathName()
 						break
 					else:
-						return None
+						raise KeyboardInterrupt
 			else:
-				fileName = fileName + ".py"
-				if os.path.isfile(fileName):
+				fileName = fileName.replace('.', '/') + ".py"
+				import glob
+				fileNames = glob.glob(fileName)  # allow 1st of "pywin/fr*/int*(.py)"
+				if fileNames:
+					fileName = fileNames[0]
 					break # Found it!
 
 		else:	# for not broken out of
 			return None
 	return win32ui.FullPath(fileName)
+
+_func_code = '__code__'
+if not hasattr(LocatePythonFile, _func_code):
+	_func_code = 'func_code'	# <Py2.6
+	
+def LocateObject(obj, expr=None, editor_current=None, ns_extra=None):
+	"""Locate the source definition or container definition of `obj`.
+	expr:  optional expression for obj; e.g. 'scriptutils.myvariable'
+	ns_extra: extra namespace to search (in addition to sys.modules / __main__ / current-interact...)
+	return: DictObj(locals()) exposing: fn, lineno, col, typ, error, obj
+	"""
+	import inspect
+	ed = editor_current
+	lineno = col = 1
+	error = ''
+	fn = None
+	typ = None		# details
+	
+	expr_open = ''	 # when non-zero -> detail search to continue in source text later 
+	for _retry in 0, 1, 2:
+		try:
+			if hasattr(obj, '__wrapped__'):
+				obj = inspect.unwrap(obj)
+			try:
+				fn = inspect.getsourcefile(obj)
+			except TypeError:
+				error = str(sys.exc_info()[1])
+			else:
+				if fn is None:
+					error = 'no file found'
+				elif fn.startswith('<'):
+					fn = None
+					error = 'frozen module'
+			
+			if not fn:
+
+				# its not a module, class, method, function, traceback, frame, or code object
+								
+				if not inspect.isclass(obj) and (hasattr(obj, '__dict__') or hasattr(obj, '__slots__')):
+					
+					# user instance -> locate class definition
+					obj = obj.__class__
+					continue
+				
+				if '.' in expr:
+					
+					# probably some builtin type - lets check for pre-dot containerobject and
+					# setup for text search of attribute
+					parts = expr.split('.')  # .rsplit not in py2.3-
+					expr, expr_open = '.'.join(parts[:-1]), parts[-1]
+					if not expr:
+						break
+					if expr in ('self', 'cls'):
+						r = FindClassDef(editor_current)
+						if r is None:
+							break  # break _retry loop
+						# (classname, pos, iline, indentstr) = r					
+						expr = r[0] + '.' + expr_open
+						expr_open = ''
+					obj = GetXNamespace(expr, ns_extra)				
+					if obj is not None:
+						continue	# repeat search with pre-dot object and expr_open
+				
+			elif inspect.isclass(obj):
+
+				# finds class source faster than inspect.getsourcelines() for classes
+				# (locating classes is frequent)
+				
+				if sys.version_info > (3,):
+					s = open(fn, 'rb').read()
+					# PEP 263 decode
+					l2 = b'\n'.join(s[:256].split(b'\n', 2)[:2]) 
+					m = re.search(b'(?m)^[ \\t\\f]*#.*?coding[:=][ \\t]*([-_.a-zA-Z0-9]+)', l2)
+					s = s.decode(m and m.group(1).decode('ascii') or 'utf-8', 'replace')
+				else:
+					s = open(fn).read()				
+				ms = list(re.finditer(r'(?m)^([ \t]*)class\s*' + obj.__name__ + r'\b', s))
+				if ms:
+					# found in source code
+					typ = 'class'
+					if sys.version_info < (2, 4):
+						ms.sort(lambda a, b: cmp(a.group(1), b.group(1)))
+					else:
+						ms.sort(key=lambda m:m.group(1))
+					lineno = s[:ms[0].start()].count('\n') + 1
+					_lines = [ms[0].group()]
+					col = len(ms[0].group()) + 1
+				else:
+					# then search for code location of __init__ or other methods
+					keys = list(obj.__dict__.keys())
+					keys.sort()
+					keys.insert(0, '__init__')                        
+					for k in keys:
+						v = obj.__dict__.get(k)
+						if callable(v) and hasattr(v, _func_code):  # py23 no __code__
+							obj = v
+							break  # retry with code object
+					else:
+						for k in keys:
+							v = getattr(obj, k, None)
+							if callable(v) and hasattr(v, _func_code):
+								obj = v
+								break
+						else:
+							if hasattr(obj, '__module__'):
+								fn = getattr(sys.modules[obj.__module__], '__file__', None)
+								if fn.endswith('.pyc'):
+									fn = fn[:-4] + '.py'
+								lineno = 1
+								break
+							break # found nothing
+					continue  # cont with method
+			else:
+				
+				# getsourcelines speed is ok for non-classes 
+				_lines, lineno = inspect.getsourcelines(obj)
+				line = _lines[0]
+				name = getattr(obj, '__name__', None)
+				if name and name in line:
+					col = line.find(name) + 1 or 1
+				elif expr:
+					col = line.find(expr.split('.')[-1]) + 1 or 1
+			# found
+			
+		except EnvironmentError:
+			error = str(sys.exc_info()[1])
+			
+		break
+
+	if fn and not expr_open:
+		return DictObj(locals())
+
+	# more search for `expr` in the source code text.
+	# search for "EXPR = ..." ; "def|class|import EXPR" ; "class CONTAININGCLS:"
+	
+	if expr_open:
+		expr = expr_open
+	if fn:
+		doc = win32ui.GetApp().OpenDocumentFile(fn)
+		ed = doc.GetFirstView()
+		ed.SetSel(ed.LineIndex(lineno - 1))
+		path = fn
+
+	expr0 = expr	# initial expr
+	if ed:
+		fn_ed = ed.GetDocument().GetPathName()
+		pos = ed.GetSel()[1]
+		txt = ed.GetTextRange()
+		# search for "EXPR = ..." or "def|class|import EXPR" 
+		t_regex = t_0 = r'(?m)\b(?:%(_expr)s)\s*=[^=]|^\s*(def|class|import)\s+(%(_expr)s)\b'
+		while True:
+			_expr = re.escape(expr)
+			regex = t_regex % locals()
+			plast = None
+			for m in re.finditer(regex, txt):
+				p = m.end()
+				if p > pos and plast is not None:
+					break
+				plast = p
+				mlast = m
+			if plast is not None:
+				# inspect the last match before or first after pos of expr 
+				lineno = txt[:plast].count('\n') + 1
+				if t_regex is t_0 and lineno == ed.GetCurLineNumber() + 1:
+					# same line again and original template
+					if m.group(1) == 'class':
+						print('WARN: same inner class? --', m.groups())
+					md = re.search(r'^(\s+)def .*\bself\b', ed.GetLine())
+					if md:
+						nwhite = len(md.group(1))
+						# def <method> -> search for "class CONTAININGCLS:"
+						# (useful for navigating in huge classes)
+						t_regex = r'(?m)^\s{0,%s}(class)\s+(\w)' % (nwhite - 1)	# no inner class from here
+						continue
+					t_regex = r'\b()(%(_expr)s),'		# tuple assignment / usage possibly
+					continue
+				# found a typical definition
+				fn = fn_ed
+				col = mlast.start(mlast.lastindex or 0) - txt[:plast].rfind('\n')
+				break
+			if '.' in expr:
+				expr = expr.split('.', 1)[-1]	# drop 1st part and retry
+			else:
+				# so we only found the predot object/file and not a typical plain or
+				# nested (def/class/import/=) definition. Now we could search just for
+				# the bare string `expr` anywhere down - or give up and serve the predot
+				# part location (file line 0)
+				m = re.search(r'\b%s\b' % re.escape(expr), txt)
+				if m:
+					pos = m.start()
+					lineno = txt[:pos].count('\n') + 1
+					# found the bare string as last hope to be useful
+					fn = fn_ed
+					col = pos - txt[:pos].rfind('\n') + 1
+				break
+	
+	return DictObj(locals())
+
+class DictObj(object):
+	"""exposes dictionary as object - adding optional keyword args"""
+	def __init__(self, d=None, **kw):
+		if d is not None: self.__dict__ = d
+		if kw: self.__dict__.update(kw)
+
+def FindClassDef(ed, pos=None):
+	"""find containing class defintion in source code from current editor
+	position.
+	
+	return: (classname, pos, iline, indentstr)  OR None=no class found
+	example position resulting in class `XY`:
+	     class XY:
+	        def meth(self):
+	          abc = self.GetSomeT|hing()   # <--- pos
+	"""
+	if pos is None:
+		pos = ed.GetSel()[0]
+	txt = ed.GetTextRange()
+	
+	# find indent of current expression. simplified: no ml string, but \ in last line ..
+	
+	iline = ed.LineFromChar(pos)
+	lastline = ed.GetLine(iline - 1)
+	while lastline.endswith('\\'):
+		iline -= 1
+		lastline = ed.GetLine(iline - 1)
+	line = ed.GetLine(iline)
+	indent_expr = len(re.match(r'(\s*)', line).group(1))		#.replace('\t', '    ')
+
+	# find last def according indent
+	
+	plast = None
+	for m in re.finditer(r'(?m)^(\s{0,%s})def\s' % (indent_expr - 1), txt):
+		p = m.start()
+		if p > pos:	# and plast is not None:
+			break
+		plast = p
+		mlast = m
+	if plast is None:
+		return None
+
+	indent_def = len(mlast.group(1))
+	pos = plast
+
+	# find last class according indent
+	
+	plast = None
+	for m in re.finditer(r'(?m)^(\s{0,%s})class\s+(\w+)' % (indent_def - 1), txt):
+		p = m.start()
+		if p > pos:	# and plast is not None:
+			break
+		plast = p
+		mlast = m
+	if plast is None:
+		return None
+
+	pos = mlast.end(1)
+	return mlast.group(2), pos, ed.LineFromChar(pos), mlast.group(1)
+
+def GetXNamespace(expr='', ns_extra={}):
+	"""Get or eval `expr` in combined namespace of sys.modules, __builtins__,
+	__main__, ns_extra, and interactive (debugging) context. For calltips,
+	auto-complete, object location etc.
+	
+	When expr != '' then evaluate `expr` in that namespace and return the
+	result object - or None on failure.
+	"""
+	
+	namespace = sys.modules.copy()
+	namespace.update(__builtins__)
+	namespace.update(__main__.__dict__)
+	namespace.update(ns_extra)
+	# Get the debugger's context.
+	try:
+		from pywin.framework import interact
+		if interact.edit is not None and interact.edit.currentView is not None:
+			globs, locs = interact.edit.currentView.GetContext()[:2]
+			if globs is not __main__.__dict__:
+				namespace.update(globs)
+			if locs is not __main__.__dict__:
+				namespace.update(locs)
+			else:
+				# again - ns_extra with higher prio
+				namespace.update(ns_extra)	
+	except ImportError:
+		print("GetXNamespace ImportError interact")
+	if not expr:
+		return namespace
+	try:
+		return eval(expr, namespace)
+	except:
+		return None

--- a/Pythonwin/pywin/framework/sgrepmdi.py
+++ b/Pythonwin/pywin/framework/sgrepmdi.py
@@ -18,6 +18,7 @@
 # Hats off to Mark Hammond for providing an environment where I could cobble
 # something like this together in a couple evenings!
 
+from __future__ import absolute_import
 import win32ui
 import win32api
 from pywin.mfc import docview, dialog, window
@@ -29,6 +30,7 @@ import os
 import stat
 import glob
 from . import scriptutils
+from pywin.xtypes.moves import range
 
 def getsubdirs(d):
 	dlist = []
@@ -45,15 +47,15 @@ class dirpath:
 		dirs = {}
 		for d in dp:
 			if os.path.isdir(d):
-				d = d.lower()
-				if d not in dirs:
-					dirs[d] = None
+				_d = d.lower()
+				if _d not in dirs:
+					dirs[_d] = d
 					if recurse:
 						subdirs = getsubdirs(d)
 						for sd in subdirs:
-							sd = sd.lower()
-							if sd not in dirs:
-								dirs[sd] = None
+							_sd = sd.lower()
+							if _sd not in dirs:
+								dirs[_sd] = sd
 			elif os.path.isfile(d):
 				pass
 			else:
@@ -84,9 +86,9 @@ class dirpath:
 							if recurse:
 								subdirs = getsubdirs(xd)
 								for sd in subdirs:
-									sd = sd.lower()
-									if sd not in dirs:
-										dirs[sd] = None
+									_sd = sd.lower()
+									if _sd not in dirs:
+										dirs[_sd] = sd
 		self.dirs = []
 		for d in list(dirs.keys()):
 			self.dirs.append(d)
@@ -201,6 +203,25 @@ class GrepDocument(docview.RichEditDoc):
 		self.casesensitive = int(params[3])
 		self.recurse = int(params[4])
 		self.verbose = int(params[5])
+		
+		# Is text selected in editor or interactive? Usually the user wants to grep that.
+		try:
+			editctl = win32ui.GetMainFrame().MDIGetActive()[0].GetEditorView()
+		except (AttributeError, win32ui.error):
+			editctl = None
+		else:
+			s = editctl.GetSelText()
+			if not s:
+				try:
+					from pywin.framework import interact
+					editctl = interact.edit.currentView
+				except win32ui.error:
+					pass
+				else:
+					s = editctl.GetSelText()				
+			if s:
+				self.greppattern = re.escape(s)
+				
 		# setup some reasonable defaults.
 		if not self.dirpattern:
 			try: 
@@ -209,7 +230,7 @@ class GrepDocument(docview.RichEditDoc):
 			except (AttributeError, win32ui.error):
 				self.dirpattern = os.getcwd()
 		if not self.filpattern:
-			self.filpattern = "*.py"
+			self.filpattern = "*.py"			
 
 	def OnNewDocument(self):
 		if self.dirpattern == '':
@@ -261,7 +282,9 @@ class GrepDocument(docview.RichEditDoc):
 			#  while grep is running
 			if os.path.isfile(f):
 				win32ui.SetStatusText("Searching "+f, 0)
-				lines = open(f, 'r').readlines()
+				try: lines = open(f, 'r').readlines()
+				except UnicodeDecodeError:
+					lines = open(f, 'r', encoding='utf-8', errors='replace').readlines()
 				for i in range(len(lines)):
 					line = lines[i]
 					if self.pat.search(line) != None:
@@ -277,6 +300,7 @@ class GrepDocument(docview.RichEditDoc):
 				if self.dpndx < len(self.dp):
 					self.flist = glob.glob(self.dp[self.dpndx] + '\\' + self.fplist[self.fpndx])
 				else:
+					self.GetFirstView().Append('# Search complete.\n')
 					win32ui.SetStatusText("Search complete.", 0)
 					self.SetModifiedFlag(0) # default to not modified.
 					try:
@@ -303,6 +327,7 @@ ID_OPEN_FILE = 0xe400
 ID_GREP	 = 0xe401
 ID_SAVERESULTS = 0x402
 ID_TRYAGAIN = 0x403
+ID_EXPLORE = 0x404
 
 class GrepView(docview.RichEditView):
 	def __init__(self, doc):
@@ -320,6 +345,7 @@ class GrepView(docview.RichEditView):
 		self.HookMessage(self.OnRClick, win32con.WM_RBUTTONDOWN)
 		self.HookCommand(self.OnCmdOpenFile, ID_OPEN_FILE)
 		self.HookCommand(self.OnCmdGrep, ID_GREP)
+		self.HookCommand(self.OnCmdExplore, ID_EXPLORE)
 		self.HookCommand(self.OnCmdSave, ID_SAVERESULTS)
 		self.HookCommand(self.OnTryAgain, ID_TRYAGAIN)
 		self.HookMessage(self.OnLDblClick,win32con.WM_LBUTTONDBLCLK)
@@ -343,7 +369,8 @@ class GrepView(docview.RichEditView):
 		if regexGrepResult:
 			self.fnm = regexGrepResult.group(1)
 			self.lnnum = int(regexGrepResult.group(2))
-			menu.AppendMenu(flags, ID_OPEN_FILE, "&Open "+self.fnm)
+			menu.AppendMenu(flags, ID_OPEN_FILE, "&Open " + self.fnm)
+			menu.AppendMenu(flags, ID_EXPLORE, "&Explore " + self.fnm)
 			menu.AppendMenu(win32con.MF_SEPARATOR)
 		menu.AppendMenu(flags, ID_TRYAGAIN, "&Try Again")
 		charstart, charend = self._obj_.GetSel()
@@ -361,6 +388,9 @@ class GrepView(docview.RichEditView):
 		menu.AppendMenu(flags, ID_SAVERESULTS, 'Sa&ve results')
 		menu.TrackPopupMenu(params[5])
 		return 0
+
+	def OnCmdExplore(self, cmd, code):
+		os.startfile(os.path.dirname(self.fnm))
 
 	def OnCmdOpenFile(self, cmd, code):
 		doc = win32ui.GetApp().OpenDocumentFile(self.fnm)
@@ -406,20 +436,20 @@ class GrepDialog(dialog.Dialog):
 	def __init__(self, dp, fp, gp, cs, r, v):
 		style = win32con.DS_MODALFRAME | win32con.WS_POPUP | win32con.WS_VISIBLE | win32con.WS_CAPTION | win32con.WS_SYSMENU | win32con.DS_SETFONT
 		CS = win32con.WS_CHILD | win32con.WS_VISIBLE
-		tmp = [ ["Grep", (0, 0, 210, 90), style, None, (8, "MS Sans Serif")], ]
-		tmp.append([STATIC, "Grep For:",            -1, (7,   7,  50,  9), CS ])
-		tmp.append([EDIT,   gp,                    101, (52,  7, 144,  11), CS | win32con.WS_TABSTOP | win32con.ES_AUTOHSCROLL | win32con.WS_BORDER])
-		tmp.append([STATIC, "Directories:",         -1, (7,  20,  50,  9), CS ])
-		tmp.append([EDIT,   dp,                    102, (52, 20, 128,  11), CS | win32con.WS_TABSTOP | win32con.ES_AUTOHSCROLL | win32con.WS_BORDER])
-		tmp.append([BUTTON, '...',                 110, (182,20,  16,  11), CS | win32con.BS_PUSHBUTTON | win32con.WS_TABSTOP]) 
-		tmp.append([STATIC, "File types:",          -1, (7,  33,  50,  9), CS ])
-		tmp.append([EDIT,   fp,                    103, (52, 33, 128,  11), CS | win32con.WS_TABSTOP | win32con.ES_AUTOHSCROLL | win32con.WS_BORDER ])
-		tmp.append([BUTTON, '...',                 111, (182,33,  16,  11), CS | win32con.BS_PUSHBUTTON | win32con.WS_TABSTOP]) 
-		tmp.append([BUTTON,'Case sensitive',       104, (7,  45,  72,  9), CS | win32con.BS_AUTOCHECKBOX | win32con.BS_LEFTTEXT| win32con.WS_TABSTOP])
-		tmp.append([BUTTON,'Subdirectories',       105, (7,  56,  72,  9), CS | win32con.BS_AUTOCHECKBOX | win32con.BS_LEFTTEXT| win32con.WS_TABSTOP])
-		tmp.append([BUTTON,'Verbose',              106, (7,  67,  72,  9), CS | win32con.BS_AUTOCHECKBOX | win32con.BS_LEFTTEXT| win32con.WS_TABSTOP])
-		tmp.append([BUTTON,'OK',         win32con.IDOK, (166,53,  32, 12), CS | win32con.BS_DEFPUSHBUTTON| win32con.WS_TABSTOP])
-		tmp.append([BUTTON,'Cancel', win32con.IDCANCEL, (166,67,  32, 12), CS | win32con.BS_PUSHBUTTON| win32con.WS_TABSTOP])
+		tmp = [ ["Grep", (0, 0, 310, 90), style, None, (8, "MS Sans Serif")], ]
+		tmp.append([STATIC, "&Grep For:",            -1, (7,   7,  50,  9), CS ])
+		tmp.append([EDIT,   gp,                    101, (52,  7, 246,  11), CS | win32con.WS_TABSTOP | win32con.ES_AUTOHSCROLL | win32con.WS_BORDER])
+		tmp.append([STATIC, "&Directories:",         -1, (7,  20,  50,  9), CS ])
+		tmp.append([EDIT,   dp,                    102, (52, 20, 228,  11), CS | win32con.WS_TABSTOP | win32con.ES_AUTOHSCROLL | win32con.WS_BORDER])
+		tmp.append([BUTTON, '...',                 110, (282,20,  16,  11), CS | win32con.BS_PUSHBUTTON | win32con.WS_TABSTOP]) 
+		tmp.append([STATIC, "&File types:",          -1, (7,  33,  50,  9), CS ])
+		tmp.append([EDIT,   fp,                    103, (52, 33, 228,  11), CS | win32con.WS_TABSTOP | win32con.ES_AUTOHSCROLL | win32con.WS_BORDER ])
+		tmp.append([BUTTON, '...',                 111, (282,33,  16,  11), CS | win32con.BS_PUSHBUTTON | win32con.WS_TABSTOP]) 
+		tmp.append([BUTTON,'&Case sensitive',       104, (7,  45,  72,  9), CS | win32con.BS_AUTOCHECKBOX | win32con.BS_LEFTTEXT| win32con.WS_TABSTOP])
+		tmp.append([BUTTON,'&Subdirectories',       105, (7,  56,  72,  9), CS | win32con.BS_AUTOCHECKBOX | win32con.BS_LEFTTEXT| win32con.WS_TABSTOP])
+		tmp.append([BUTTON,'&Verbose',              106, (7,  67,  72,  9), CS | win32con.BS_AUTOCHECKBOX | win32con.BS_LEFTTEXT| win32con.WS_TABSTOP])
+		tmp.append([BUTTON,'OK',         win32con.IDOK, (266,53,  32, 12), CS | win32con.BS_DEFPUSHBUTTON| win32con.WS_TABSTOP])
+		tmp.append([BUTTON,'Cancel', win32con.IDCANCEL, (266,67,  32, 12), CS | win32con.BS_PUSHBUTTON| win32con.WS_TABSTOP])
 		dialog.Dialog.__init__(self, tmp)
 		self.AddDDX(101,'greppattern')
 		self.AddDDX(102,'dirpattern')

--- a/Pythonwin/pywin/framework/stdin.py
+++ b/Pythonwin/pywin/framework/stdin.py
@@ -16,6 +16,8 @@ the way they were, simply use this magic incantation:
     import sys
     sys.stdin = sys.stdin.real_file
 """
+from __future__ import absolute_import
+from __future__ import print_function
 import sys
 
 try:

--- a/Pythonwin/pywin/framework/toolmenu.py
+++ b/Pythonwin/pywin/framework/toolmenu.py
@@ -1,5 +1,7 @@
 # toolmenu.py
 
+from __future__ import absolute_import
+from __future__ import print_function
 import win32ui
 import win32con
 import win32api

--- a/Pythonwin/pywin/framework/window.py
+++ b/Pythonwin/pywin/framework/window.py
@@ -2,6 +2,7 @@
 
 # Most Pythonwin windows should use these classes rather than
 # the raw MFC ones if they want Pythonwin specific functionality.
+from __future__ import absolute_import
 import pywin.mfc.window
 import win32con
 

--- a/Pythonwin/pywin/idle/AutoExpand.py
+++ b/Pythonwin/pywin/idle/AutoExpand.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import string
 import re
 
@@ -64,8 +65,6 @@ class AutoExpand:
         after = self.text.get("insert wordend", "end")
         wafter = re.findall(r"\b" + word + r"\w+\b", after)
         del after
-        if not wbefore and not wafter:
-            return []
         words = []
         dict = {}
         # search backwards through words before
@@ -81,12 +80,39 @@ class AutoExpand:
                 continue
             words.append(w)
             dict[w] = w
-        words.append(word)
+        
+        # add words from interactive context
+        prevexpr = self.getprevword(self.wordchars + '.')     # faster may be: self.get_prevexpr()
+        if '.' in prevexpr:
+            ppos = prevexpr.rfind('.')
+            prevexpr, word = prevexpr[:ppos], prevexpr[ppos + 1:]   ## .rsplit('.', 1)
+        else:
+            prevexpr, word = '', prevexpr
+        ns = self.get_auto_namespace(prevexpr)      # dict or list
+        if ns:
+            for w in ns:    # sorted() ?
+                if w.startswith(word) and w not in dict:
+                    words.append(w)     # TODO: prepend when prevexpr found?
+                    dict[w] = w
+        
+        words.append(word)  # fall back to word itself finally
+        
         return words
 
-    def getprevword(self):
+    def getprevword(self, chars=wordchars):
         line = self.text.get("insert linestart", "insert")
         i = len(line)
-        while i > 0 and line[i-1] in self.wordchars:
+        while i > 0 and line[i-1] in chars:
             i = i-1
         return line[i:]
+
+    def get_auto_namespace(self, predot=''):
+        # return namespace dict/list with potential expansion candidates
+        from pywin.framework import scriptutils         
+        o = scriptutils.GetXNamespace(predot)
+        if predot:
+            return dir(o)
+        else:
+            nslist = list(o)
+            nslist.sort()
+            return nslist

--- a/Pythonwin/pywin/idle/AutoIndent.py
+++ b/Pythonwin/pywin/idle/AutoIndent.py
@@ -1,7 +1,9 @@
+from __future__ import absolute_import
 import sys
 import string, tokenize
 from . import PyParse
 from pywin import default_scintilla_encoding
+from pywin.xtypes.moves import range
 
 if sys.version_info < (3,):
     # in py2k, tokenize() takes a 'token eater' callback, while
@@ -138,6 +140,10 @@ class AutoIndent:
             else:
                 text.bell()     # at start of buffer
             return "break"
+        if  chars[-1] in '([{':
+            next = text.get("insert", "insert+1c")
+            if next in ')]}':
+                text.delete('insert', 'insert+1c')
         if  chars[-1] not in " \t":
             # easy: delete preceding real char
             text.delete("insert-1c")

--- a/Pythonwin/pywin/idle/CallTips.py
+++ b/Pythonwin/pywin/idle/CallTips.py
@@ -1,6 +1,8 @@
 # CallTips.py - An IDLE extension that provides "Call Tips" - ie, a floating window that
 # displays parameter information as you open parens.
 
+from __future__ import absolute_import
+from __future__ import print_function
 import string
 import sys
 import inspect
@@ -87,14 +89,8 @@ class CallTips:
             i = i-1
         word = chars[i:]
         if word:
-            # How is this for a hack!
-            import sys, __main__
-            namespace = sys.modules.copy()
-            namespace.update(__main__.__dict__)
-            try:
-                    return eval(word, namespace)
-            except:
-                    pass
+            from pywin.framework import scriptutils 
+            return scriptutils.GetXNamespace(word)
         return None # Can't find an object.
 
 def _find_constructor(class_ob):
@@ -102,9 +98,9 @@ def _find_constructor(class_ob):
     # constructor (ie, __init__() ) or None if we can't find one.
     try:
         if sys.version_info < (3,):
-            return class_ob.__init__.im_func
-        else:
             return class_ob.__init__.__func__
+        else:
+            return class_ob.__init__
     except AttributeError:
         for base in class_ob.__bases__:
             rc = _find_constructor(base)
@@ -129,8 +125,8 @@ def get_arg_text(ob):
                 arg_getter = getattr(inspect, "getfullargspec", inspect.getargspec)
                 argText = inspect.formatargspec(*arg_getter(fob))
             except:
-                print("Failed to format the args")
-                traceback.print_exc()
+                import win32ui
+                win32ui.SetStatusText("Failed to format the args - %s" % (repr(sys.exc_info()[0]),))
         # See if we can use the docstring
         if hasattr(ob, "__doc__"):
             doc=ob.__doc__

--- a/Pythonwin/pywin/idle/FormatParagraph.py
+++ b/Pythonwin/pywin/idle/FormatParagraph.py
@@ -14,8 +14,10 @@
 #   spaces, they will not be considered part of the same block.
 # * Fancy comments, like this bulleted list, arent handled :-)
 
+from __future__ import absolute_import
 import string
 import re
+from pywin.xtypes.moves import map, range
 
 class FormatParagraph:
 
@@ -39,7 +41,7 @@ class FormatParagraph:
     def close(self):
         self.editwin = None
 
-    def format_paragraph_event(self, event):
+    def format_paragraph_event(self, event, limit=76):
         text = self.editwin.text
         first, last = self.editwin.get_selection_indices()
         if first and last:
@@ -51,10 +53,10 @@ class FormatParagraph:
         if comment_header:
             # Reformat the comment lines - convert to text sans header.
             lines = data.split("\n")
-            lines = map(lambda st, l=len(comment_header): st[l:], lines)
+            lines = list(map(lambda st, l=len(comment_header): st[l:], lines))
             data = "\n".join(lines)
-            # Reformat to 70 chars or a 20 char width, whichever is greater.
-            format_width = max(70-len(comment_header), 20)
+            # Reformat to e.g. 70 chars or a 20 char width, whichever is greater.
+            format_width = max(limit - len(comment_header), 20)
             newdata = reformat_paragraph(data, format_width)
             # re-split and re-insert the comment header.
             newdata = newdata.split("\n")

--- a/Pythonwin/pywin/idle/IdleHistory.py
+++ b/Pythonwin/pywin/idle/IdleHistory.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import string
 
 class History:

--- a/Pythonwin/pywin/idle/PyParse.py
+++ b/Pythonwin/pywin/idle/PyParse.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
 import string
 import re
 import sys
+from pywin.xtypes.moves import map, range
 
 # Reason last stmt is continued (or C_NONE if it's not).
 C_NONE, C_BACKSLASH, C_STRING, C_BRACKET = list(range(4))
@@ -105,7 +107,7 @@ for ch in "\"'\\\n#":
 # We are called with unicode strings, and str.translate is one of the few
 # py2k functions which can't 'do the right thing' - so take care to ensure
 # _tran is full of unicode...
-_tran = ''.join(_tran)
+_tran = u''.join(_tran)
 del ch
 
 class Parser:

--- a/Pythonwin/pywin/mfc/activex.py
+++ b/Pythonwin/pywin/mfc/activex.py
@@ -1,5 +1,6 @@
 """Support for ActiveX control hosting in Pythonwin.
 """
+from __future__ import absolute_import
 import win32ui, win32uiole
 from . import window
 # XXX - we are still "classic style" classes in py2x, so we need can't yet

--- a/Pythonwin/pywin/mfc/dialog.py
+++ b/Pythonwin/pywin/mfc/dialog.py
@@ -4,6 +4,7 @@ Base class for Dialogs.  Also contains a few useful utility functions
 # dialog.py
 # Python class for Dialog Boxes in PythonWin.
 
+from __future__ import absolute_import
 import win32ui
 import win32con
 # sob - 2to3 doesn't see this as a relative import :(
@@ -62,6 +63,7 @@ class Dialog(window.Wnd):
 	# Make a dialog object look like a dictionary for the DDX support
 	def __bool__(self):
 		return True
+	__nonzero__ = __bool__
 	def __len__(self): return len(self.data)
 	def __getitem__(self, key): return self.data[key]
 	def __setitem__(self, key, item): self._obj_.data[key] = item# self.UpdateData(0)

--- a/Pythonwin/pywin/mfc/docview.py
+++ b/Pythonwin/pywin/mfc/docview.py
@@ -1,4 +1,5 @@
 # document and view classes for MFC.
+from __future__ import absolute_import
 import win32ui
 import win32con
 from . import object

--- a/Pythonwin/pywin/mfc/object.py
+++ b/Pythonwin/pywin/mfc/object.py
@@ -1,6 +1,8 @@
 # MFC base classes.
+from __future__ import absolute_import
 import sys
 import win32ui
+from pywin.xtypes.moves import range
 
 class Object:
 	def __init__(self, initObj = None):

--- a/Pythonwin/pywin/mfc/thread.py
+++ b/Pythonwin/pywin/mfc/thread.py
@@ -1,5 +1,6 @@
 # Thread and application objects
 
+from __future__ import absolute_import
 from . import object
 import win32ui
 

--- a/Pythonwin/pywin/mfc/window.py
+++ b/Pythonwin/pywin/mfc/window.py
@@ -1,4 +1,5 @@
 # The MFCish window classes.
+from __future__ import absolute_import
 from . import object
 import win32ui
 import win32con

--- a/Pythonwin/pywin/scintilla/IDLEenvironment.py
+++ b/Pythonwin/pywin/scintilla/IDLEenvironment.py
@@ -1,6 +1,8 @@
 # Code that allows Pythonwin to pretend it is IDLE
 # (at least as far as most IDLE extensions are concerned)
 
+from __future__ import absolute_import
+from __future__ import print_function
 import string
 import win32api
 import win32ui

--- a/Pythonwin/pywin/scintilla/bindings.py
+++ b/Pythonwin/pywin/scintilla/bindings.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 from . import IDLEenvironment
 import string
 import win32ui

--- a/Pythonwin/pywin/scintilla/config.py
+++ b/Pythonwin/pywin/scintilla/config.py
@@ -8,6 +8,8 @@
 # .py file, and put the config info in a docstring.  Then
 # pass a CStringIO file (rather than a filename) to the
 # config manager.
+from __future__ import absolute_import
+from __future__ import print_function
 import sys
 import string
 from . import keycodes
@@ -21,6 +23,7 @@ import glob
 import imp
 
 import win32api
+from pywin.xtypes.moves import map
 
 debugging = 0
 if debugging:
@@ -66,6 +69,7 @@ def find_config_files():
 
 class ConfigManager:
     def __init__(self, f):
+        self.parents = {}
         self.filename = "unknown"
         self.last_error = None
         self.key_to_events = {}
@@ -83,7 +87,13 @@ class ConfigManager:
             self.filename = f
             self.basename = os.path.basename(f)
             trace("Loading configuration", self.basename)
-            compiled_name = os.path.splitext(f)[0] + ".cfc"
+            rootname = os.path.splitext(f)[0]
+            cache_tag = getattr(getattr(sys, 'implementation', None), 'cache_tag', '')
+            if cache_tag:
+                dn, bn = os.path.split(rootname)
+                compiled_name = dn + os.sep + '__pycache__' + os.sep + bn + '.' + cache_tag + '.cfc'
+            else:
+                compiled_name = os.path.splitext(f)[0] + cache_tag + '.cfc'
             try:
                 cf = open(compiled_name, "rb")
                 try:
@@ -103,6 +113,8 @@ class ConfigManager:
                             return # We are ready to roll!
                 finally:
                     cf.close()
+            except ValueError as ev:
+                print("loading '%s' failed:" % compiled_name, ev)
             except (os.error, IOError, EOFError):
                 pass
             fp = open(f)
@@ -147,38 +159,53 @@ class ConfigManager:
             except (IOError, EOFError):
                 pass # Ignore errors - may be read only.
 
+    ns = None
     def configure(self, editor, subsections = None):
         # Execute the extension code, and find any events.
         # First, we "recursively" connect any we are based on.
         if subsections is None: subsections = []
-        subsections = [''] + subsections
+        if '' not in subsections: subsections = [''] + subsections
+        ns = self.ns or {}  # cached one time execution for ns
         general = self.get_data("general")
         if general:
             parents = general.get("based on", [])
-            for parent in parents:
-                trace("Configuration based on", parent, "- loading.")
-                parent = self.__class__(parent)
-                parent.configure(editor, subsections)
+            for parent_name in parents:
+                trace("Configuration based on", parent_name, "- loading.")
+                parent = self.parents.get(parent_name) or \
+                         self.parents.setdefault(parent_name, self.__class__(parent_name))
+                nsp = parent.configure(editor, subsections)
+                if self.ns is None:
+                    ns.update(nsp)
                 if parent.last_error:
                     self.report_error(parent.last_error)
 
         bindings = editor.bindings
         codeob = self.get_data("extension code")
-        if codeob is not None:
-            ns = {}
+        if self.ns is None and codeob:
+            ns['__file__'] = self.filename
             try:
                 exec(codeob, ns)
+                self.ns = ns
             except:
                 traceback.print_exc()
                 self.report_error("Executing extension code failed")
-                ns = None
-            if ns:
-                num = 0
-                for name, func in list(ns.items()):
-                    if type(func)==types.FunctionType and name[:1] != '_':
-                        bindings.bind(name, func)
-                        num = num + 1
-                trace("Configuration Extension code loaded", num, "events")
+                ##ns.clear()  ## = None
+            
+            modname = '_pywin_' + os.path.basename(self.filename).replace('.', '_')
+            mod = types.ModuleType(modname)
+            # somehow a created module __dict__ is spooky regarding reusage (attrs None) so we force set ist
+            ns.update(mod.__dict__)
+            mod.__dict__.update(ns)
+            sys.modules[mod.__name__] = mod
+
+        if ns:
+            num = 0
+            for name, func in list(ns.items()):
+                if type(func)==types.FunctionType and name[:1] != '_':
+                    bindings.bind(name, func)
+                    num = num + 1
+            trace("Configuration Extension code loaded", num, "events")
+        
         # Load the idle extensions
         for subsection in subsections:
             for ext in self.get_data("idle extensions", {}).get(subsection, []):
@@ -196,6 +223,7 @@ class ConfigManager:
             bindings.update_keymap(keymap)
             num_bound = num_bound + len(keymap)
         trace("Configuration bound", num_bound, "keys")
+        return ns
 
     def get_key_binding(self, event, subsections = None):
         if subsections is None: subsections = []
@@ -289,8 +317,8 @@ class ConfigManager:
                 "".join(lines), self.filename, "exec")
             self._save_data("extension code", c)
         except SyntaxError as details:
-            errlineno = details.lineno + start_lineno
-            # Should handle syntax errors better here, and offset the lineno.
+            errlineno = details.lineno
+            traceback.print_exc()
             self.report_error("Compiling extension code failed:\r\nFile: %s\r\nLine %d\r\n%s" \
                               % (details.filename, errlineno, details.msg))
         return line, lineno

--- a/Pythonwin/pywin/scintilla/configui.py
+++ b/Pythonwin/pywin/scintilla/configui.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from pywin.mfc import dialog
 import win32api
 import win32con

--- a/Pythonwin/pywin/scintilla/control.py
+++ b/Pythonwin/pywin/scintilla/control.py
@@ -4,6 +4,7 @@
 # a "standard" MFC edit control (eg, control.GetTextLength(), control.GetSel()
 # plus many Scintilla specific features (eg control.SCIAddStyledText())
 
+from __future__ import absolute_import
 from pywin.mfc import window
 from pywin import default_scintilla_encoding
 import win32con
@@ -14,6 +15,8 @@ import struct
 import string
 import os
 from . import scintillacon
+from pywin.xtypes.moves import map
+from pywin.xtypes import unicode_type
 
 # Load Scintilla.dll to get access to the control.
 # We expect to find this in the same directory as win32ui.pyd
@@ -74,7 +77,7 @@ class ScintillaControlInterface:
 	def SCIInsertText(self, text, pos=-1):
 		# SCIInsertText allows unicode or bytes - but if they are bytes,
 		# the caller must ensure it is encoded correctly.
-		if isinstance(text, str):
+		if isinstance(text, unicode_type):
 			text = text.encode(default_scintilla_encoding)
 		self.SendScintilla(scintillacon.SCI_INSERTTEXT, pos, text + null_byte)
 	def SCISetSavePoint(self):
@@ -170,7 +173,15 @@ class ScintillaControlInterface:
 	def SCIMarkerSetBack(self, markerNum, back):
 		self.SendScintilla(scintillacon.SCI_MARKERSETBACK, markerNum, back)
 	def SCIMarkerAdd(self, lineNo, markerNum):
-		self.SendScintilla(scintillacon.SCI_MARKERADD, lineNo, markerNum)
+		return self.SendScintilla(scintillacon.SCI_MARKERADD, lineNo, markerNum)
+	def SCIMarkerLineFromHandle(self, h):
+		#SCI_MARKERLINEFROMHANDLE(int markerHandle) -> int
+		return self.SendScintilla(scintillacon.SCI_MARKERLINEFROMHANDLE, h)
+	def SCIMarkerHandleFromLine(self, lineNo, which=0):
+		#SCI_MARKERHANDLEFROMLINE(line line, int which) -> int
+		#SCI_MARKERHANDLEFROMLINE = 2732
+		raise NotImplementedError("will be available soon?")
+		return self.SendScintilla(scintillacon.SCI_MARKERHANDLEFROMLINE, lineNo, which)
 	def SCIMarkerDelete(self, lineNo, markerNum):
 		self.SendScintilla(scintillacon.SCI_MARKERDELETE, lineNo, markerNum)
 	def SCIMarkerDeleteAll(self, markerNum=-1):
@@ -179,6 +190,8 @@ class ScintillaControlInterface:
 		return self.SendScintilla(scintillacon.SCI_MARKERGET, lineNo)
 	def SCIMarkerNext(self, lineNo, markerNum):
 		return self.SendScintilla(scintillacon.SCI_MARKERNEXT, lineNo, markerNum)
+	def SCIMarkerPrev(self, lineNo, markerNum):
+		return self.SendScintilla(scintillacon.SCI_MARKERPREVIOUS, lineNo, markerNum)
 	def SCICancel(self):
 		self.SendScintilla(scintillacon.SCI_CANCEL)
 	# AutoComplete

--- a/Pythonwin/pywin/scintilla/find.py
+++ b/Pythonwin/pywin/scintilla/find.py
@@ -1,4 +1,6 @@
 # find.py - Find and Replace
+from __future__ import absolute_import
+from __future__ import print_function
 import win32con, win32api
 import win32ui
 from pywin.mfc import dialog
@@ -243,7 +245,7 @@ class FindDialog(FindReplaceDialog):
 			["Button", "Match &case", 107, (5, 33, 100, 10), visible | win32con.BS_AUTOCHECKBOX | win32con.WS_TABSTOP],
 			["Button", "Keep &dialog open", 115, (5, 43, 100, 10), visible | win32con.BS_AUTOCHECKBOX | win32con.WS_TABSTOP],
 			["Button", "Across &open files", 116, (5, 52, 100, 10), visible | win32con.BS_AUTOCHECKBOX | win32con.WS_TABSTOP],
-			["Button", "&Remember as default search", 117, (5, 61, 150, 10), visible | win32con.BS_AUTOCHECKBOX | win32con.WS_TABSTOP],
+			["Button", "Re&member as default search", 117, (5, 61, 150, 10), visible | win32con.BS_AUTOCHECKBOX | win32con.WS_TABSTOP],
 			["Button", "&Find Next", 109, (185, 5, 50, 14), visible | win32con.BS_DEFPUSHBUTTON | win32con.WS_TABSTOP],
 			["Button", "Cancel", win32con.IDCANCEL, (185, 23, 50, 14), visible | win32con.WS_TABSTOP],
 		]
@@ -265,7 +267,7 @@ class ReplaceDialog(FindReplaceDialog):
 			["Button", "Match &case", 107, (5, 52, 100, 10), visible | win32con.BS_AUTOCHECKBOX | win32con.WS_TABSTOP],
 			["Button", "Keep &dialog open", 115, (5, 62, 100, 10), visible | win32con.BS_AUTOCHECKBOX | win32con.WS_TABSTOP],
 			["Button", "Across &open files", 116, (5, 72, 100, 10), visible | win32con.BS_AUTOCHECKBOX | win32con.WS_TABSTOP],
-			["Button", "&Remember as default search", 117, (5, 81, 150, 10), visible | win32con.BS_AUTOCHECKBOX | win32con.WS_TABSTOP],
+			["Button", "Re&member as default search", 117, (5, 81, 150, 10), visible | win32con.BS_AUTOCHECKBOX | win32con.WS_TABSTOP],
 			["Button", "&Find Next", 109, (185, 5, 50, 14), visible | win32con.BS_DEFPUSHBUTTON | win32con.WS_TABSTOP],
 			["Button", "&Replace", 110, (185, 23, 50, 14), visible | win32con.WS_TABSTOP],
 			["Button", "Replace &All", 111, (185, 41, 50, 14), visible | win32con.WS_TABSTOP],
@@ -310,10 +312,12 @@ class ReplaceDialog(FindReplaceDialog):
 	def OnFindNext(self, id, code):
 		self.DoFindNext()
 		self.CheckButtonStates()
+		self.SetFocus()		# so we can repeatedly press Alt+R here in the dialog
 
 	def OnReplace(self, id, code):
 		lastSearch.replaceText = self.editReplaceText.GetWindowText()
 		_ReplaceIt(None)
+		self.SetFocus()		# so we can repeatedly press Alt+R here in the dialog
 
 	def OnReplaceAll(self, id, code):
 		control = _GetControl(None)

--- a/Pythonwin/pywin/scintilla/formatter.py
+++ b/Pythonwin/pywin/scintilla/formatter.py
@@ -1,4 +1,6 @@
 # Does Python source formatting for Scintilla controls.
+from __future__ import absolute_import
+from __future__ import print_function
 import win32ui
 import win32api
 import win32con
@@ -6,6 +8,7 @@ import winerror
 import string
 import array
 from . import scintillacon
+from pywin.xtypes.moves import map
 
 WM_KICKIDLE = 0x036A
 

--- a/Pythonwin/pywin/scintilla/keycodes.py
+++ b/Pythonwin/pywin/scintilla/keycodes.py
@@ -1,7 +1,10 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import string
 import win32con
 import win32api
 import win32ui
+from pywin.xtypes import unichr
 
 MAPVK_VK_TO_CHAR = 2
 
@@ -130,7 +133,7 @@ def make_key_name(vk, flags):
             # Not in our virtual key map - ask Windows what character this
             # key corresponds to.
             scancode = win32api.MapVirtualKey(vk, MAPVK_VK_TO_CHAR)
-            parts.append(chr(scancode))
+            parts.append(unichr(scancode))
     sep = "+"
     if sep in parts: sep = "-"
     return sep.join([p.capitalize() for p in parts])

--- a/Pythonwin/pywin/scintilla/view.py
+++ b/Pythonwin/pywin/scintilla/view.py
@@ -1,10 +1,13 @@
 # A general purpose MFC CCtrlView view that uses Scintilla.
 
+from __future__ import absolute_import
+from __future__ import print_function
 from . import control
 from . import IDLEenvironment # IDLE emulation.
 from pywin.mfc import docview
 from pywin.mfc import dialog
 from . import scintillacon
+import win32api
 import win32con
 import win32ui
 import afxres
@@ -18,14 +21,16 @@ from . import keycodes
 import struct
 import re
 import os
+from pywin.xtypes import string_types
+from pywin.xtypes.moves import range, input
 
 PRINTDLGORD = 1538
 IDC_PRINT_MAG_EDIT = 1010
 EM_FORMATRANGE = win32con.WM_USER+57
 
-wordbreaks = "._" + string.ascii_uppercase + string.ascii_lowercase + string.digits
+wordbreaks = "_" + string.ascii_uppercase + string.ascii_lowercase + string.digits
 
-patImport=re.compile('import (?P<name>.*)')
+patImport=re.compile('import\s+(?P<name>.*)')
 
 _event_commands = [
 	# File menu
@@ -48,12 +53,17 @@ _event_commands = [
 ]
 
 _extra_event_commands = [
+	("OnDebuggerJumpToLine", 13400),
+	("OnDebuggerContinueToLine", 13402),
 	("EditDelete", afxres.ID_EDIT_CLEAR),
-	("LocateModule", win32ui.ID_FILE_LOCATE),
+	("LocateModule", win32ui.ID_FILE_LOCATE),	# deprecated
+	("LocateObject", win32ui.ID_FILE_LOCATE),
+	("LocateObjectEx", 13401),
 	("GotoLine", win32ui.ID_EDIT_GOTO_LINE),
 	("DbgBreakpointToggle", win32ui.IDC_DBG_ADD),
 	("DbgGo", win32ui.IDC_DBG_GO),
 	("DbgStepOver", win32ui.IDC_DBG_STEPOVER),
+	("DbgStepUntil", 13403),
 	("DbgStep", win32ui.IDC_DBG_STEP),
 	("DbgStepOut", win32ui.IDC_DBG_STEPOUT),
 	("DbgBreakpointClearAll", win32ui.IDC_DBG_CLEAR),
@@ -127,6 +137,7 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
 
 		self.idle = IDLEenvironment.IDLEEditorWindow(self)
 		self.idle.IDLEExtension("AutoExpand")
+		self.idle.IDLEExtension("AutoIndent")  # Required extension
 		# SendScintilla is called so frequently it is worth optimizing.
 		self.SendScintilla = self._obj_.SendMessage
 
@@ -172,7 +183,10 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
 		self.HookCommandUpdate(self.OnUpdateViewEOL, win32ui.ID_VIEW_EOL)
 		self.HookCommand(self.OnCmdViewFixedFont, win32ui.ID_VIEW_FIXED_FONT)
 		self.HookCommandUpdate(self.OnUpdateViewFixedFont, win32ui.ID_VIEW_FIXED_FONT)
-		self.HookCommand(self.OnCmdFileLocate, win32ui.ID_FILE_LOCATE)
+		self.HookCommand(self.OnDebuggerJumpToLine, 13400)		
+		self.HookCommand(self.OnDebuggerContinueToLine, 13402)		
+		self.HookCommand(self.OnLocateObjectEx, 13401)		
+		self.HookCommand(self.OnLocateObject, win32ui.ID_FILE_LOCATE)
 		self.HookCommand(self.OnCmdEditFind, win32ui.ID_EDIT_FIND)
 		self.HookCommand(self.OnCmdEditRepeat, win32ui.ID_EDIT_REPEAT)
 		self.HookCommand(self.OnCmdEditReplace, win32ui.ID_EDIT_REPLACE)
@@ -357,6 +371,114 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
 		from . import find
 		find.ShowReplaceDialog()
 
+	def OnDebuggerContinueToLine(self, cmd=None, id=None):
+		from pywin.debugger import currentDebugger as d
+		lineno = self.GetCurLineNumber() + 1
+		if self.GetDocument().GetPathName().lower() != d.curframe.f_code.co_filename.lower():
+			self.MessageBox("OnDebuggerContinueToLine works only for current frame's file.")
+			return
+		try:
+			d.do_set_untilline(d.curframe, lineno)
+		except Exception as ev:
+			self.MessageBox("OnDebuggerContinueToLine works only for current frame. Error: %s" % ev)
+		else:
+			d.ShowCurrentLine()		
+	def OnDebuggerJumpToLine(self, cmd=None, id=None):
+		from pywin.debugger import currentDebugger as d
+		lineno = self.GetCurLineNumber() + 1
+		if self.GetDocument().GetPathName().lower() != d.curframe.f_code.co_filename.lower():
+			self.MessageBox("Debugger Jump-To-Line works only for current frame's file.")
+			return
+		try: d.curframe.f_lineno = int(lineno)		# fails with long on py27x64
+		except ValueError as ev:
+			self.MessageBox("Debugger Jump-To-Line works only for current frame. Error: %s" % ev)
+		else:
+			d.ShowCurrentLine()		
+		
+	def OnLocateObjectEx(self, cmd, id):
+		return self.OnLocateObject(cmd, id, extern=True)
+	def OnLocateObject(self, cmd, id, extern=False):	
+		from pywin.framework import scriptutils
+
+		ed = self
+		path = ed.GetDocument().GetPathName()  
+		if not path:
+			ed = scriptutils.GetActiveEditControl()
+			if ed:
+				path = ed.GetDocument().GetPathName()
+		#path = self.GetDocument().GetPathName() or scriptutils.GetActiveFileName()
+		
+		if extern:
+			def jump_to(path, lineno=0, col=0):
+				import subprocess, time
+				## extviewer = 'SciTE'
+				extviewer = win32ui.GetProfileVal("Editor", "External Viewer", '') or\
+							sys.executable + ' -new'
+				p = subprocess.Popen('%(extviewer)s "%(path)s" /goto:%(lineno)s' % locals(), shell=1)
+				t_end = time.time() + 0.5
+				while time.time() < t_end:
+					if p.poll() is not None:
+						break
+					time.sleep(0.020)
+				if p.poll():
+					win32ui.MessageBox("External viewer '%(extviewer)s' not found on PATH. Check or clear HKCU\Software\Python V.v\Python for Win32\Editor\External Viewer"
+									   % locals())
+		else:
+			jump_to = scriptutils.JumpToDocument	# func(path, lineno=0)
+			def jump_to(tpath, lineno=0, col=0):
+				tpath = os.path.abspath(tpath)
+				if tpath == path:
+					ed.AddLastPosEvent()
+				return not scriptutils.JumpToDocument(tpath, lineno, col)
+					
+		# get the namespace of the (most likely) module of this file
+		ns = {}		
+		if path:
+			mainfile = win32ui.FullPath(getattr(__main__, '__file__', '.'))
+			if os.path.normcase(mainfile) == os.path.normcase(path):
+				mod = __main__
+			else:
+				modname, _newpath = scriptutils.GetPackageModuleName(path)
+				##try: __import__(modname)	 # too aggressive probably
+				##except: pass
+				##else:
+				mod = sys.modules.get(modname)
+				if mod:
+					ns = mod.__dict__
+
+		# try for an inspect-locateable living object
+		pos = self.GetSel()[0]
+		while pos and self.SCIGetCharAt(pos - 1) in ' ([{':
+			pos -= 1  #
+		expr, obj = self._GetObjectAtPos(pos=pos, leftright=True, ns_extra=ns)
+		if not obj:
+			expr_c, obj = self._GetObjectAtPos(pos=pos, bAllowCalls=True, leftright=True, ns_extra=ns)
+			if obj:
+				expr = expr_c
+		if not expr:
+			# classic finder: import statement or default (file) Locate
+			r = self.OnCmdFileLocate(0, 0)
+			if extern:
+				win32api.MessageBeep()
+			return r
+		win32ui.SetStatusText("Locating object %r  (%r)" % (expr, obj))
+
+		loc = scriptutils.LocateObject(obj, expr, editor_current=ed, ns_extra=ns)
+		if loc.fn:
+			if loc.typ == 'class' and ed and loc.lineno == ed.GetCurLineNumber() + 1:
+				# same line again -> jump to end of class source
+				import inspect
+				lines, loc.lineno = inspect.getsourcelines(loc.obj)
+				loc.lineno += len(lines)
+				loc.col = 1
+			jump_to(loc.fn, loc.lineno, loc.col)
+			return 0
+		else:
+			##win32ui.SetStatusText("Can't locate object %r (%r): %s" % (expr, loc.obj, loc.error))
+			##win32api.MessageBeep()
+			##return 0  # no further propagation
+			return self.OnCmdFileLocate(0, 0)  # classic import / file locator
+
 	def OnCmdFileLocate(self, cmd, id):
 		line = self.GetLine().strip()
 		import pywin.framework.scriptutils
@@ -364,7 +486,9 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
 		if m:
 			# Module name on this line - locate that!
 			modName = m.group('name')
-			fileName = pywin.framework.scriptutils.LocatePythonFile(modName)
+			try: fileName = pywin.framework.scriptutils.LocatePythonFile(modName)
+			except KeyboardInterrupt:
+				return 0
 			if fileName is None:
 				win32ui.SetStatusText("Can't locate module %s" % modName)
 				return 1 # Let the default get it.
@@ -372,7 +496,8 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
 				win32ui.GetApp().OpenDocumentFile(fileName)
 		else:
 			# Just to a "normal" locate - let the default handler get it.
-			return 1
+			##return 1  # may propagate odd from interactive to top editor
+			win32ui.GetApp().OnFileLocate(cmd, id)
 		return 0
 
 	def OnCmdGotoLine(self, cmd, id):
@@ -399,10 +524,10 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
 
 		self.SCIAutoCCancel() # Cancel old auto-complete lists.
 		# First try and get an object without evaluating calls
-		ob = self._GetObjectAtPos(bAllowCalls = 0)
+		expr, ob = self._GetObjectAtPos(bAllowCalls = 0)
 		# If that failed, try and process call or indexing to get the object.
 		if ob is None:
-			ob = self._GetObjectAtPos(bAllowCalls = 1)
+			expr, ob = self._GetObjectAtPos(bAllowCalls = 1)
 		items_dict = {}
 		if ob is not None:
 			try: # Catch unexpected errors when fetching attribute names from the object
@@ -415,7 +540,11 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
 				
 				# normal attributes
 				try:
-					items_dict.update(list2dict(dir(ob)))
+					if hasattr(ob, '__dir__') and not isinstance(ob, type):	# support python 2.5-
+						dirob = ob.__dir__()
+					else:
+						dirob = dir(ob)
+					items_dict.update(list2dict(dirob))
 				except AttributeError:
 					pass # object has no __dict__
 				if hasattr(ob, "__class__"):
@@ -443,9 +572,8 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
 				win32ui.SetStatusText("Error attempting to get object attributes - %s" % (repr(sys.exc_info()[0]),))
 
 		# ensure all keys are strings.
-		items = [str(k) for k in items_dict.keys()]
-		# All names that start with "_" go!
-		items = [k for k in items if not k.startswith('_')]
+		items = [str(k) for k in items_dict]
+		# All names that start with "_" go to the end in ignorecase-mode auto!
 
 		if not items:
 			# Heuristics a-la AutoExpand
@@ -481,8 +609,18 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
 				items.remove(right[1:])
 			except ValueError:
 				pass
+		if sys.version_info < (2, 4):
+			items.sort(lambda a, b: cmp(a.upper(), b.upper()))	# py23-
+		else:
+			items.sort(key=lambda x:x.upper())
 		if items:
-			items.sort()
+			# SCI_AUTOCSETORDER is not yet in pywin's scintilla version (2011), so we
+			# cannot get the underscore items to the end consistently without
+			# SCI_AUTOCSETIGNORECASE(1); but SCI_AUTOCSETIGNORECASE anyway turned out
+			# to be the better solution by far.
+			##self.SendScintilla(SCI_AUTOCSETCASEINSENSITIVEBEHAVIOUR, 1)
+			##self.SendScintilla(SCI_AUTOCSETORDER, SC_ORDER_CUSTOM)
+			self.SendScintilla(scintillacon.SCI_AUTOCSETIGNORECASE, 1)
 			self.SCIAutoCSetAutoHide(0)
 			self.SCIAutoCShow(items)
 
@@ -562,26 +700,18 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
 		return (minline,maxline,curclass)
 
 
-	def _GetObjectAtPos(self, pos = -1, bAllowCalls = 0):
-		left, right = self._GetWordSplit(pos, bAllowCalls)
-		if left: # It is an attribute lookup
-			# How is this for a hack!
-			namespace = sys.modules.copy()
-			namespace.update(__main__.__dict__)
-			# Get the debugger's context.
-			try:
-				from pywin.framework import interact
-				if interact.edit is not None and interact.edit.currentView is not None:
-					globs, locs = interact.edit.currentView.GetContext()[:2]
-					if globs: namespace.update(globs)
-					if locs: namespace.update(locs)
-			except ImportError:
-				pass
-			try:
-				return eval(left, namespace)
-			except:
-				pass
-		return None
+	def _GetObjectAtPos(self, pos = -1, bAllowCalls = 0, leftright=False, ns_extra={}):
+		if isinstance(pos, string_types):
+			expr = pos
+		else:
+			expr, right = self._GetWordSplit(pos, bAllowCalls)
+			if leftright:
+				expr = expr + right
+		if expr: 
+			# It is an attribute lookup
+			from pywin.framework import scriptutils
+			return expr, scriptutils.GetXNamespace(expr, ns_extra=ns_extra)
+		return expr, None
 
 	def _GetWordSplit(self, pos = -1, bAllowCalls = 0):
 		if pos==-1: pos = self.GetSel()[0]-1 # Character before current one
@@ -589,7 +719,7 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
 		before = []
 		after = []
 		index = pos-1
-		wordbreaks_use = wordbreaks
+		wordbreaks_use = wordbreaks + '.'
 		if bAllowCalls: wordbreaks_use = wordbreaks_use + "()[]"
 		while index>=0:
 			char = self.SCIGetCharAt(index)
@@ -597,6 +727,7 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
 			before.insert(0, char)
 			index = index-1
 		index = pos
+		wordbreaks_use = wordbreaks
 		while index<=limit:
 			char = self.SCIGetCharAt(index)
 			if char not in wordbreaks_use: break

--- a/Pythonwin/pywin/tools/TraceCollector.py
+++ b/Pythonwin/pywin/tools/TraceCollector.py
@@ -1,5 +1,7 @@
 # win32traceutil like utility for Pythonwin
-import _thread
+from __future__ import absolute_import
+from __future__ import print_function
+from pywin.xtypes.moves import _thread
 import win32trace, win32event, win32api
 from pywin.framework import winout
 

--- a/Pythonwin/pywin/tools/browseProjects.py
+++ b/Pythonwin/pywin/tools/browseProjects.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import regutil, os
 from . import hierlist
 import win32con, win32ui, win32api
@@ -7,6 +8,7 @@ import glob
 import pyclbr
 import pywin.framework.scriptutils
 import afxres
+from pywin.xtypes.moves import map
 
 class HLIErrorItem(hierlist.HierListItem):
 	def __init__(self, text):

--- a/Pythonwin/pywin/tools/browser.py
+++ b/Pythonwin/pywin/tools/browser.py
@@ -5,19 +5,23 @@
 # >>> browser.Browse()
 # or
 # >>> browser.Browse(your_module)
+from __future__ import absolute_import
 import sys
 import types
 import __main__
+import inspect
+
 import win32ui
 from pywin.mfc import dialog
 
 from . import hierlist
+from pywin.xtypes import unicode_type, long_type
 
 special_names = [ '__doc__', '__name__', '__self__' ]
 
 #
 # HierList items
-class HLIPythonObject(hierlist.HierListItem):
+class HLIPythonObject(hierlist.HierListItem, object):
 	def __init__(self, myobject=None, name=None ):
 		hierlist.HierListItem.__init__(self)
 		self.myobject = myobject
@@ -38,18 +42,21 @@ class HLIPythonObject(hierlist.HierListItem):
 	def __lt__(self, other):
 		return self.name < other.name
 	def __eq__(self, other):
-		return self.name == other.name
+		return self.name == other.name and self.myobject is other.myobject
 	def __repr__(self):
 		try:
 			type = self.GetHLIType()
 		except:
 			type = "Generic"
-		return "HLIPythonObject("+type+") - name: "+ self.name + " object: " + repr(self.myobject)
+		return "<%s(%s) - name: %s  object: %r" % (self.__class__.__name__, type, self.name, self.myobject)
 	def GetText(self):
 		try:
 			return str(self.name) + ' (' + self.GetHLIType() + ')'
 		except AttributeError:
-			return str(self.name) + ' = ' + repr(self.myobject)
+			s = repr(self.myobject)
+			if len(s) > 80:
+				s = s[:77] + ' ...'
+			return str(self.name) + ' = ' + s
 	def InsertDocString(self, lst):
 		ob = None
 		try:
@@ -65,25 +72,20 @@ class HLIPythonObject(hierlist.HierListItem):
 
 	def GetSubList(self):
 		ret = []
+		d_inst = {}
 		try:
+			# Note: using dir() would yield too much with all class attrs
+			# REQ: handle __slots__ , self.__dir__()
 			for (key, ob) in self.myobject.__dict__.items():
 				if key not in special_names:
 					ret.append(MakeHLI( ob, key ) )
+					d_inst[key] = 1
 		except (AttributeError, TypeError):
 			pass
-		try:
-			for name in self.myobject.__methods__:
-				ret.append(HLIMethod( name ))	# no MakeHLI, as cant auto detect
-		except (AttributeError, TypeError):
-			pass
-		try:
-			for member in self.myobject.__members__:
-				if not member in special_names:
-					ret.append(MakeHLI(getattr(self.myobject, member), member))
-		except (AttributeError, TypeError):
-			pass
+		
 		ret.sort()
-		self.InsertDocString(ret)
+		if ret:
+			self.InsertDocString(ret)
 		return ret
 	# if the has a dict, it is expandable.
 	def IsExpandable(self):
@@ -92,22 +94,9 @@ class HLIPythonObject(hierlist.HierListItem):
 		return self.knownExpandable
 
 	def CalculateIsExpandable(self):
-		if hasattr(self.myobject, '__doc__'):
-			return 1
 		try:
 			for key in self.myobject.__dict__.keys():
 				if key not in special_names:
-					return 1
-		except (AttributeError, TypeError):
-			pass
-		try:
-			self.myobject.__methods__
-			return 1
-		except (AttributeError, TypeError):
-			pass
-		try:
-			for item in self.myobject.__members__:
-				if item not in special_names:
 					return 1
 		except (AttributeError, TypeError):
 			pass
@@ -118,6 +107,21 @@ class HLIPythonObject(hierlist.HierListItem):
 		else:
 			return 4
 	def TakeDefaultAction(self):
+		ShowObject(self.myobject, self.name)
+
+	def LocateObject(self):
+		from pywin.framework import scriptutils
+		loc = scriptutils.LocateObject(self.myobject, self.name)
+		if loc.fn:
+			ed = scriptutils.JumpToDocument(loc.fn, loc.lineno, loc.col)
+			ed.ActivateFrame()
+			return ed	# unfortunately the focus still comes back to this browser window (?)
+		else:
+			ShowObject(self.myobject, self.name)
+
+class CLocateObject:
+	def TakeDefaultAction(self):
+		self.LocateObject()
 		ShowObject(self.myobject, self.name)
 
 
@@ -135,15 +139,31 @@ class HLIModule(HLIPythonObject):
 	def GetHLIType(self):
 		return "Module"
 
-class HLIFrame(HLIPythonObject):
+class HLIPythonDirObject(HLIPythonObject):
+	def IsExpandable(self):
+		return 1
+	def GetSubList(self, classtext=None):
+		ret = []
+		ret.append( MakeHLI( self.myobject.__class__ , classtext ))
+		for name in dir(self.myobject):
+			if name.startswith('__'):
+				continue
+			ret.append(MakeHLI(getattr(self.myobject, name), name))
+		return ret
+	
+class HLIFrame(CLocateObject, HLIPythonDirObject):	#TODO: no effect
 	def GetHLIType(self):
 		return "Stack Frame"
-
+	def GetText(self):
+		return str(self.name) + ' (%s of %r)' % (self.GetHLIType(), self.myobject.f_code.co_name)
+	def GetSubList(self):
+		return HLIPythonDirObject.GetSubList(self, "Frame of %r" % self.myobject.f_code.co_name)
+	
 class HLITraceback(HLIPythonObject):
 	def GetHLIType(self):
 		return "Traceback"
 
-class HLIClass(HLIPythonObject):
+class HLIClass(CLocateObject, HLIPythonObject):
 	def GetHLIType(self):
 		return "Class"
 	def GetSubList(self):
@@ -153,29 +173,15 @@ class HLIClass(HLIPythonObject):
 		ret = ret + HLIPythonObject.GetSubList(self)
 		return ret
 
-class HLIMethod(HLIPythonObject):
-	# myobject is just a string for methods.
-	def GetHLIType(self):
-		return "Method"
-	def GetText(self):
-		return "Method: " + self.myobject + '()'
-
-class HLICode(HLIPythonObject):
+class HLICode(CLocateObject, HLIPythonDirObject):
 	def GetHLIType(self):
 		return "Code"
+	def GetText(self):
+		return str(self.name) + ' (%s of %r)' % (self.GetHLIType(), self.myobject.co_name)
 	def IsExpandable(self):
 		return self.myobject
-	def GetSubList(self):
-		ret = []
-		ret.append( MakeHLI( self.myobject.co_consts, "Constants (co_consts)" ))
-		ret.append( MakeHLI( self.myobject.co_names, "Names (co_names)" ))
-		ret.append( MakeHLI( self.myobject.co_filename, "Filename (co_filename)" ))
-		ret.append( MakeHLI( self.myobject.co_argcount, "Number of args (co_argcount)"))
-		ret.append( MakeHLI( self.myobject.co_varnames, "Param names (co_varnames)"))
-		
-		return ret
 
-class HLIInstance(HLIPythonObject):
+class HLIInstance(CLocateObject, HLIPythonObject):
 	def GetHLIType(self):
 		return "Instance"
 	def GetText(self):
@@ -189,20 +195,26 @@ class HLIInstance(HLIPythonObject):
 		return ret
 
 
-class HLIBuiltinFunction(HLIPythonObject):
+class HLIBuiltinFunction(HLIPythonDirObject):
 	def GetHLIType(self):
 		return "Builtin Function"
 
-class HLIFunction(HLIPythonObject):
+class HLIFunction(CLocateObject, HLIPythonDirObject):
 	def GetHLIType(self):
 		return "Function"
+	def GetText(self):
+		return str(self.name) + ' (%s %r)' % (self.GetHLIType(), self.myobject.__code__.co_name)
 	def IsExpandable(self):
 		return 1
 	def GetSubList(self):
-		ret = []
+		ret = HLIPythonDirObject.GetSubList(self)
 #		ret.append( MakeHLI( self.myobject.func_argcount, "Arg Count" ))
 		try:
-			ret.append( MakeHLI( self.myobject.func_argdefs, "Arg Defs" ))
+			spec = inspect.getargspec(self.myobject)
+			ret.append( MakeHLI(spec.args, ":Args"))
+			ret.append( MakeHLI(spec.defaults, ":Defaults"))
+			ret.append( MakeHLI(spec.varargs, ":Varargs"))
+			ret.append( MakeHLI(spec.keywords, ":Keywords"))
 		except AttributeError:
 			pass
 		try:
@@ -212,10 +224,15 @@ class HLIFunction(HLIPythonObject):
 			# must be py2.5 or earlier...
 			code = self.myobject.func_code
 			globs = self.myobject.func_globals
-		ret.append(MakeHLI(code, "Code" ))
-		ret.append(MakeHLI(globs, "Globals" ))
 		self.InsertDocString(ret)
 		return ret
+
+class HLIMethod(CLocateObject, HLIPythonObject):
+	# myobject is just a string for methods.
+	def GetHLIType(self):
+		return "Method"
+	def GetText(self):
+		return "Method: " + str(self.myobject) + '()'
 
 class HLISeq(HLIPythonObject):
 	def GetHLIType(self):
@@ -265,6 +282,7 @@ class HLIString(HLIPythonObject):
 
 TypeMap = { type : HLIClass,
             types.FunctionType: HLIFunction,
+            types.MethodType: HLIMethod,	#types.MethodType is types.UnboundMethodType
             tuple: HLITuple,
             dict: HLIDict,
             list: HLIList,
@@ -274,19 +292,41 @@ TypeMap = { type : HLIClass,
             types.FrameType : HLIFrame,
             types.TracebackType : HLITraceback,
             str : HLIString,
+            unicode_type : HLIString,
             int: HLIPythonObject,
+            long_type: HLIPythonObject,
             bool: HLIPythonObject,
             float: HLIPythonObject,
+            type(None): HLIPythonObject,
            }
+if sys.version_info < (3, 0):
+	TypeMap[type] = HLIClass
 
+
+class HLIListBased(HLIInstance, HLIList):
+	def GetHLIType(self):
+		return "List based Instance"
+	def GetSubList(self):
+		return HLIInstance.GetSubList(self) + HLIList.GetSubList(self)
+
+class HLIDictBased(HLIInstance, HLIDict):
+	def GetHLIType(self):
+		return "Dict based Instance"
+	def GetSubList(self):
+		return HLIInstance.GetSubList(self) + HLIDict.GetSubList(self)
+	
 def MakeHLI( ob, name=None ):
 	try:
 		cls = TypeMap[type(ob)]
 	except KeyError:
+		if isinstance(ob, (list, tuple)):
+			cls = HLIListBased
+		elif isinstance(ob, dict):
+			cls = HLIDictBased
 		# hrmph - this check gets more and more bogus as Python
 		# improves.  Its possible we should just *always* use
 		# HLIInstance?
-		if hasattr(ob, '__class__'): # 'new style' class
+		elif hasattr(ob, '__class__'): # 'new style' class
 			cls = HLIInstance
 		else:
 			cls = HLIPythonObject
@@ -368,12 +408,14 @@ class dynamic_browser (dialog.Dialog):
 
 def Browse (ob=__main__):
     " Browse the argument, or the main dictionary "
-    root = MakeHLI (ob, 'root')
+    root = MakeHLI (ob, repr(ob))
     if not root.IsExpandable():
         raise TypeError("Browse() argument must have __dict__ attribute, or be a Browser supported type")
         
     dlg = dynamic_browser (root)
     dlg.CreateWindow()
+    dlg.SetWindowText(root.GetText())
+    return dlg
 
 #
 #

--- a/Pythonwin/pywin/tools/hierlist.py
+++ b/Pythonwin/pywin/tools/hierlist.py
@@ -13,6 +13,7 @@
 # choice.  However, you should investigate using the tree control directly
 # to provide maximum flexibility (but with extra work).
 
+from __future__ import absolute_import
 import sys
 import win32ui 
 import win32con
@@ -21,6 +22,7 @@ from win32api import RGB
 
 from pywin.mfc import object, window, docview, dialog
 import commctrl
+from pywin.xtypes.moves import map, range
 
 # helper to get the text of an arbitary item
 def GetItemText(item):
@@ -216,6 +218,7 @@ class HierList(object.Object):
 				hold = old_handles[iold]
 				if hold in self.filledItemHandlesMap:
 					self.Refresh(hold)
+				hAfter = old_handles[iold]
 			else:
 				# Remove the deleted items.
 #				print "Deleting %d (%s)" % (iold, old_items[iold])
@@ -226,7 +229,6 @@ class HierList(object.Object):
 					if hchild in self.filledItemHandlesMap:
 						del self.filledItemHandlesMap[hchild]
 				self.listControl.DeleteItem(hdelete)
-			hAfter = old_handles[iold]
 		# Fill any remaining new items:
 		for newItem in new_items[inew:]:
 #			print "Inserting new item", newItem

--- a/Pythonwin/pywin/tools/regedit.py
+++ b/Pythonwin/pywin/tools/regedit.py
@@ -1,4 +1,5 @@
 # Regedit - a Registry Editor for Python
+from __future__ import absolute_import
 import win32api, win32ui, win32con, commctrl
 from pywin.mfc import window, docview, dialog
 from . import hierlist

--- a/Pythonwin/pywin/tools/regpy.py
+++ b/Pythonwin/pywin/tools/regpy.py
@@ -1,4 +1,6 @@
 # (sort-of) Registry editor
+from __future__ import absolute_import
+from __future__ import print_function
 import win32ui
 import dialog
 import win32con

--- a/Pythonwin/pywin/user.cfg
+++ b/Pythonwin/pywin/user.cfg
@@ -1,0 +1,94 @@
+# This is the user keyboard configuration file (user.cfg) for Pythonwin - for
+# personal adaptations and extensions (via Python functions right here in
+# this file). To be active, "user" keyboard has to be selected from the
+# Pythonwin View/Options/Editor dialog. user.cfg inherits from and overrides
+# default configuration settings in default.cfg, which is link here:
+
+[General]
+Based On = default
+
+# The format of this file is very similar to a Windows INI file. Sections
+# are identified with [Section] lines, but comments use the standatd Python
+# # character.  Depending on the section, lines may not be in the standard
+# "key=value" format. You can reload and activate changes after editing this
+# file by pressing Alt+R (= ReloadConfig definied in default.cfg), or by
+# Menu/View/Options + OK.
+
+[Keys]
+# Global Keys
+
+Ctrl+Alt+H        = HelloWorldFunc
+Ctrl+Shift+F1     = HelpDjango
+Ctrl+J            = LocateObjectEx
+Ctrl+E            = ExecSelectedLines  # = Ctrl+Shift+K
+(                 = ParenOpen
+)                 = ParenClose
+{                 = CurlyOpen
+ [                = SqOpen    # (parse error w/o space at line start)
+
+[Keys:Interactive]
+# Key bindings specific to the interactive window.
+##Alt+Enter             = MyEnterKey
+
+# Events of the format <<event-name>> are events defined in IDLE extensions.
+Alt+P             = <<history-previous>>
+Alt+N             = <<history-next>>
+
+[Keys:Editor]
+# Key bindings specific to the editor
+
+[IDLE Extensions]
+# List of further IDLE extensions to load.
+
+[Extensions]
+# Python event handlers specific to this config file. Namespace (with
+# pre-defined functions) is inherited from the (Based On) config file
+# default.cfg
+
+# All functions not starting with an "_" are assumed
+# to be events, and take 2 params:
+# * editor_window is the same object passed to IDLE
+#   extensions.  editor_window.text is a text widget
+#   that conforms to the Tk text widget interface.
+# * event is the event being fired.  Will always be None
+#   in the current implementation.
+# Simply by defining these functions, they are available as
+# events.
+# Note that we bind keystrokes to these events in the various
+# [Keys] sections.
+
+def HelloWorldFunc(editor_window, event):  # Ctrl+Alt+H
+    ##import pywin.debugger; pywin.debugger.set_trace()
+    # Note: To debug this you may also set a normal break point here (F9) and
+    # activate freetrace-debugging via Shift+F5.
+    import win32api
+    msg = "Hello World from user.cfg module %s (%s)\neditor_window=%s\nevent=%s" % (
+        __name__, __file__, editor_window, event)
+    win32api.MessageBox(0, msg, "user.cfg")
+
+def ParenClose(editor_window=None, event=-1, ch=')'):
+    tk = editor_window.text
+    next = tk.get('insert', 'insert+1c')
+    if next == ch:
+        tk.delete('insert', 'insert+1c')
+    return 1    # propagate
+def ParenOpen(editor_window=None, event=-1, ch=')'):
+    tk = editor_window.text
+    next = tk.get('insert', 'insert+1c')
+    if next in ' \t\n;,.+-*/%&|^<>([{}])':
+        tk.insert('insert', ch)
+        tk.mark_set('insert', 'insert-1c')
+    if ch == ')':
+        # propagate for call tips - like default.cfg
+        return editor_window.edit.bindings.fire('<<paren-open>>')
+    return 1
+def CurlyOpen(editor_window, event):  # { key
+    return ParenOpen(editor_window, ch='}')
+def SqOpen(editor_window, event):  # [ key
+     return ParenOpen(editor_window, ch=']')
+
+def HelpDjango(editor_window, event):  # Ctrl+Shift+F1
+    # CtxHelp is inherited from default.cfg
+    word = CtxHelp(editor_window, hf_url=(
+        # registry_CHM_help_name (None->'HelpDjango'), CHM_index_template, URL_template
+        None, '%s', 'https://docs.djangoproject.com/en/3.0/search/?q=%s'))

--- a/Pythonwin/pywin/xtypes.py
+++ b/Pythonwin/pywin/xtypes.py
@@ -1,0 +1,171 @@
+# python language, type, version and compat tools for pywin
+
+from __future__ import absolute_import
+
+import sys
+import types
+
+PY2 = sys.version_info[0] == 2
+PY3 = not PY2
+if PY3:
+    unichr = chr
+    string_types = str,
+    basestring = (str, bytes)
+    integer_types = int,
+    long_type = int
+    class_types = type,
+    unicode_type = text_type = str
+    binary_type = bytes    
+    input = input
+    import builtins
+else:
+    unichr = unichr
+    string_types = basestring,
+    basestring = basestring
+    integer_types = (int, long)
+    long_type = long
+    class_types = (type, types.ClassType)
+    unicode_type = text_type = unicode
+    binary_type = str
+    input = raw_input
+    import __builtin__ as builtins
+print_ = __builtins__.get('print')
+
+class DictObj(object):
+	"""exposes a dictionary as object - adding optional keyword args"""
+	def __init__(self, d=None, **kw):
+		if d is not None: self.__dict__ = d
+		if kw: self.__dict__.update(kw)
+class Object(object):
+    """universal object with .__dict__ for ad-hoc usage with dictionary and
+    keyword init and dict proxy methods"""    
+    def __init__(self, _d=None, _pop=None, **kw):
+        if _d: self.__dict__.update(_d)
+        if kw: self.__dict__.update(kw)
+        if _pop:
+            if isinstance(_pop, basestring): _pop = _pop,
+            for x in _pop: self.__dict__.pop(x, None)
+    def __repr__(self):
+        return '%s(%r)' % (self.__class__.__name__, self.__dict__)
+    def print_(self):
+        print_("<Object 0x%X> --- print ----" % id(self))
+        for k, v in sorted(self.__dict__.items()):
+            print_("  %s = %s" % (k, v))
+    def get(self, k, default=None):
+        return self.__dict__.get(k, default)
+    def setdefault(self, k, default=None):
+        return self.__dict__.setdefault(k, default)
+    def __getitem__(self, k):
+        return self.__dict__[k]
+    def __contains__(self, k):
+        return k in self.__dict__
+    def __setitem__(self, k, v):
+        self.__dict__[k] = v
+    ##def __eq__(self, other):
+    def eq_simple(self, other):
+        return self.__class__ == other.__class__ and self.__dict__ == other.__dict__
+
+def _import_module(name):
+    """Import module, returning the module after the last dot."""
+    __import__(name)
+    return sys.modules[name]
+class _LazyDescr(object):
+    def __init__(self, name):
+        self.name = name
+    def __get__(self, obj, tp):
+        result = self._resolve()
+        setattr(obj, self.name, result)  # Invokes __set__.
+        try:
+            # This is a bit ugly, but it avoids running this again by
+            # removing this descriptor.
+            delattr(obj.__class__, self.name)
+        except AttributeError:
+            pass
+        return result
+class MovedModule(_LazyDescr):
+    __path__ = []
+    def __init__(self, name, old, new=None):
+        super(MovedModule, self).__init__(name)
+        if PY3:
+            if new is None:
+                new = name
+            self.mod = new
+        else:
+            self.mod = old
+    def _resolve(self):
+        return _import_module(self.mod)
+    def __getattr__(self, attr):
+        _module = self._resolve()
+        value = getattr(_module, attr)
+        setattr(self, attr, value)
+        return value
+class MovedAttribute(_LazyDescr):
+    def __init__(self, name, old_mod, new_mod, old_attr=None, new_attr=None):
+        super(MovedAttribute, self).__init__(name)
+        if PY3:
+            if new_mod is None:
+                new_mod = name
+            self.mod = new_mod
+            if new_attr is None:
+                if old_attr is None:
+                    new_attr = name
+                else:
+                    new_attr = old_attr
+            self.attr = new_attr
+        else:
+            self.mod = old_mod
+            if old_attr is None:
+                old_attr = name
+            self.attr = old_attr
+    def _resolve(self):
+        module = _import_module(self.mod)
+        return getattr(module, self.attr)
+_moved_attributes = [
+    MovedAttribute("input", "__builtin__", "builtins", "raw_input", "input"),
+    MovedAttribute("map", "itertools", "builtins", "imap", "map"),
+    MovedAttribute("range", "__builtin__", "builtins", "xrange", "range"),
+    MovedAttribute("reduce", "__builtin__", "functools"),
+    MovedAttribute("xrange", "__builtin__", "builtins", "xrange", "range"),
+    MovedAttribute("zip", "itertools", "builtins", "izip", "zip"),
+    ##MovedModule("builtins", "__builtin__"),
+    MovedModule("_thread", "thread", "_thread"),
+    MovedModule("queue", "Queue"),
+    MovedModule("reprlib", "repr"),
+]
+if sys.platform == "win32":
+    _moved_attributes += [
+        MovedModule("winreg", "_winreg"),
+    ]
+class _Moves(types.ModuleType):
+    def __init__(self):
+        self.__path__ = []
+        self.__name__ = __name__ + '.moves'
+        sys.modules[self.__name__] = self
+moves = _Moves()
+for attr in _moved_attributes:
+    setattr(_Moves, attr.name, attr)
+del attr
+
+if PY3:
+    def reraise(tp, value, tb=None):
+        try:
+            if value is None:
+                value = tp()
+            if value.__traceback__ is not tb:
+                raise value.with_traceback(tb)
+            raise value
+        finally:
+            value = None
+            tb = None
+else:
+    exec("""\
+def reraise(tp, value, tb=None):
+    try:
+        raise tp, value, tb
+    finally:
+        tb = None
+""")
+
+# Turn this module into a package.
+__path__ = []
+__package__ = __name__

--- a/Pythonwin/win32ui.rc
+++ b/Pythonwin/win32ui.rc
@@ -84,10 +84,11 @@ IDR_MAINFRAME MENU PRELOAD DISCARDABLE
 BEGIN
     POPUP "&File"
     BEGIN
-        MENUITEM "&New\tCtrl+N",                ID_FILE_NEW
+        MENUITEM "&New...\tCtrl+N",                ID_FILE_NEW
         MENUITEM "&Open...\tCtrl+O",            ID_FILE_OPEN
-        MENUITEM "&Locate...\tCtrl+L",          ID_FILE_LOCATE
         MENUITEM "&Run...\tCtrl+R",             ID_FILE_RUN
+        MENUITEM SEPARATOR
+        MENUITEM "&Locate...\tCtrl+L",          ID_FILE_LOCATE
         POPUP "&Debug"
         BEGIN
             MENUITEM "&Go\tF5",                     IDC_DBG_GO
@@ -132,14 +133,14 @@ IDR_TEXTTYPE MENU DISCARDABLE
 BEGIN
     POPUP "&File"
     BEGIN
-        MENUITEM "&New\tCtrl+N",                ID_FILE_NEW
+        MENUITEM "&New...\tCtrl+N",                ID_FILE_NEW
         MENUITEM "&Open...\tCtrl+O",            ID_FILE_OPEN
-        MENUITEM "&Locate...\tCtrl+L",          ID_FILE_LOCATE
         MENUITEM "&Close",                      ID_FILE_CLOSE
         MENUITEM "&Save\tCtrl+S",               ID_FILE_SAVE
         MENUITEM "Save &As...",                 ID_FILE_SAVE_AS
         MENUITEM "Sa&ve All\tCtrl+Shift+S",     ID_FILE_SAVE_ALL
         MENUITEM SEPARATOR
+        MENUITEM "&Locate...\tCtrl+L",          ID_FILE_LOCATE
         MENUITEM "&Run...\tCtrl+R",             ID_FILE_RUN
         POPUP "&Debug"
         BEGIN
@@ -228,14 +229,14 @@ IDR_PYTHONTYPE MENU DISCARDABLE
 BEGIN
     POPUP "&File"
     BEGIN
-        MENUITEM "&New\tCtrl+N",                ID_FILE_NEW
+        MENUITEM "&New...\tCtrl+N",                ID_FILE_NEW
         MENUITEM "&Open...\tCtrl+O",            ID_FILE_OPEN
-        MENUITEM "&Locate...\tCtrl+L",          ID_FILE_LOCATE
         MENUITEM "&Close",                      ID_FILE_CLOSE
         MENUITEM "&Save\tCtrl+S",               ID_FILE_SAVE
         MENUITEM "Save &As...",                 ID_FILE_SAVE_AS
         MENUITEM "Sa&ve All\tCtrl+Shift+S",     ID_FILE_SAVE_ALL
         MENUITEM SEPARATOR
+        MENUITEM "&Locate Origin/File\tCtrl+L",          ID_FILE_LOCATE
         MENUITEM "&Run...\tCtrl+R",             ID_FILE_RUN
         POPUP "&Debug"
         BEGIN
@@ -314,12 +315,12 @@ IDR_PYTHONTYPE_CNTR_IP MENU DISCARDABLE
 BEGIN
     POPUP "&File"
     BEGIN
-        MENUITEM "&New\tCtrl+N",                ID_FILE_NEW
+        MENUITEM "&New...\tCtrl+N",                ID_FILE_NEW
         MENUITEM "&Open...\tCtrl+O",            ID_FILE_OPEN
-        MENUITEM "&Locate...\tCtrl+L",          ID_FILE_LOCATE
         MENUITEM "&Close",                      ID_FILE_CLOSE
         MENUITEM "Save &As...",                 ID_FILE_SAVE_AS
         MENUITEM SEPARATOR
+        MENUITEM "&Locate...\tCtrl+L",          ID_FILE_LOCATE
         MENUITEM "&Run...\tCtrl+R",             ID_FILE_RUN
         MENUITEM "&Import..\tCtrl+I",           ID_FILE_IMPORT
         MENUITEM "&Print...\tCtrl+P",           ID_FILE_PRINT
@@ -353,7 +354,7 @@ IDR_CNTR_INPLACE MENU PRELOAD DISCARDABLE
 BEGIN
     POPUP "&File"
     BEGIN
-        MENUITEM "&New\tCtrl+N",                ID_FILE_NEW
+        MENUITEM "&New...\tCtrl+N",                ID_FILE_NEW
         MENUITEM "&Open...\tCtrl+O",            ID_FILE_OPEN
         MENUITEM "&Save\tCtrl+S",               ID_FILE_SAVE
         MENUITEM "Save &As...",                 ID_FILE_SAVE_AS
@@ -374,10 +375,11 @@ IDR_DEBUGGER MENU PRELOAD DISCARDABLE
 BEGIN
     POPUP "&File"
     BEGIN
-        MENUITEM "&New\tCtrl+N",                ID_FILE_NEW
+        MENUITEM "&New...\tCtrl+N",                ID_FILE_NEW
         MENUITEM "&Open...\tCtrl+O",            ID_FILE_OPEN
-        MENUITEM "&Locate...\tCtrl+L",          ID_FILE_LOCATE
         MENUITEM "&Run...\tCtrl+R",             ID_FILE_RUN
+        MENUITEM SEPARATOR
+        MENUITEM "&Locate Origin/File\tCtrl+L",          ID_FILE_LOCATE
         POPUP "&Debug"
         BEGIN
             MENUITEM "&Go\tF5",                     IDC_DBG_GO
@@ -719,7 +721,7 @@ BEGIN
     CONTROL         "Show &calltips",IDC_CALLTIPS,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,74,12,54,9
     LTEXT           "&Keyboard",IDC_STATIC,12,29,32,10
-    COMBOBOX        IDC_KEYBOARD_CONFIG,73,26,55,37,CBS_DROPDOWNLIST | 
+    COMBOBOX        IDC_KEYBOARD_CONFIG,53,26,75,80,CBS_DROPDOWNLIST | 
                     CBS_SORT | WS_VSCROLL | WS_TABSTOP
     GROUPBOX        "Margins Widths",IDC_STATIC,136,1,109,91
     LTEXT           "Line Numbers",IDC_STATIC,142,12,51,8


### PR DESCRIPTION
== Extensions, Improvements and Fixes to the PythonWIN IDE ( Python part in pywin.* ) ==

These changes contain many fixes and a bunch of extensions and improvements for the PythonWIN IDE - for somewhat more comfort. 
The changes piled up over years, as I often prefer the slick Pythonwin IDE / Debugger over the fat IDEs for many tasks. 
Now the stuff has been cleaned up somewhat, and I'm suggesting it here in this ide-ex branch for more or less inclusion.

Here a description of many of the changes:

* Many small fixes. Often regaring PY3 problems. Including (improved) patches mentioned in recent Issues #1541 #1547 #1556 #1559

* Ctrl+L Key (Menu/File/Locate) : Now locates any object universally - replacing the import locate tool.
* A new "last positions" scintilla marker ring
The Locate finds the definition (or foundation) of quite 'anything' below the cursor position most of the time - not just imports. Uses source code, module and interactive contexts. When the target is found in the same file, a MARKER_LASTPOS is remembered before the jump, which enables to jump back & forth between last used positions. 
```
# Ctrl+L            = LocateObject  # hardwired in Menu/File/Locate
Alt+L             = GotoLastPos  # order of creation
Shift+Alt+L       = GotoFollowingPos  # order of creation
Ctrl+Shift+L      = GotoPrevPos  # position
Ctrl+Shift+Alt+L  = GotoNextPos  # position
Ctrl+Alt+L        = AddLastPos  # also toggle-removes
Ctrl+Home         = GotoStartOfFile  # remembers last pos when far
Ctrl+End          = GotoEndOfFile  # remembers last pos when far
```
Changes in:
  ./scintilla/view.py
  ./framework/editor/color/coloreditor.py 
  ./framework/scriptutils.py
  ./default.cfg
  
* Autocomplete-Show improved. Now case insensitive which lets find things easier. Private & class (leading __) attributes are added at the end. 
  +Back = ProcessBack # required to not stop auto-complete show when hitting dot again
* CallTips improved and PY3 fixed: don't disapear too easy when backspace/del and navigating the cursor back & forth
* Extended namespace eval for context search moved to framework.scriptutils 
  (required 4x: LocateObject, KeyDot-AutoCShow, Space-AutoExpand, Calltips)
  
* F1 Key & variants in default.cfg: context help into CHM help or web-URL
A example to override is in user.cfg:
```
    # Context Sensitive Helps: they go to a default URL (defined in CtxHelp()
    # here in this file) or to CHM help, when the CHM help file is defined in
    # the registry at e.g.
    # "HKxx\Software\Python\PythonCore\V.v\Help\HelpNumpy" in the same way as
    # "HKxx\Software\Python\PythonCore\V.v\Help\Main Python Documentation"
    F1               = HelpPy
    Ctrl+F1          = HelpPyWin
    Alt+F1           = HelpMSDN
    Shift+F1         = HelpWXPY
    Shift+Alt+F1     = HelpWX

    F12              = HelpNumpy
    Shift+F12        = HelpScipy
    Ctrl+F12         = HelpPandas
    Alt+Shift+F12    = HelpSklearn
    Ctrl+Shift+F12   = HelpTensorflow

    Alt+F12          = HelpGoogle
```

* +Shift+F2          = GotoPrevBookmark

* +Shift+F3          = FindPrev

* +Ctrl+Shift+F3     = AutoFindPrev

* -Ctrl+T            = <<toggle-tabs>>
  +Ctrl+Shift+T      = <<toggle-tabs>>
  To free Ctrl-T for Scintillas line-swap

* Interactive statment debugging (also recursive now - see below)
    ./framework/interact.py  
    Ctrl+Enter        = DebugStatement
    Shift+Enter       = EnterIndent

* +Shift+F10         = DbgStepUntil
  Debugger step until : run to the next line (even beyond the last line of a loop)

* Right-Click/Debugger continue to line  (while debugging)
  Debugger continue to line of the cursor in the current execution frame: (~ do_set_untilline).
  Avoids setting (many!) temporary breakpoints or "high frequency" stepping.
  
* Right-Click/Debugger Jump to line  (while debugging)
  Debugger jumps (over) to line of the cursor without execution (backward or forward) - in the current execution frame only (-> pdb.Pdb.do_jump). Error message when other frame. This enables to repeat instructions (with changes variables etc.) or to skip execution of certain lines! In Python this is surprisingly consistent, as there cannot happen stack errors. 

* Debugger Breakpoint Window: Right-Click/Jump to Source

* Free tracing debugger : ON/OFF by Shift+F5 : Switches ON when not already debugging.
  In that mode breakpoints fire anytime during normal statement execution, in signals, timers, message&idle handlers, joint message loops etc. of the main thread. This way even PythonWin itself can be debugged easily. 
  Prompt change: `F>>> ` or `FT>>>` : F = Free tracing;  T = tracing on

* Enhanced Recursive debugger:  Ctrl+Enter debug a statament while already debugging or postmortem-tracing - limited at 3 recursions. State info by frame window title and prompts like:
```
   "DDBT>>> "  : DD = debugger pumping 2x recursive, B=state break, T=tracing on
   "DBPE>>> "  : P=at post mortem, E=at exception (no T = tracing off)
```

* During debugging (fast-)local variables can be changed now (uses PyFrame_LocalsToFast)
* Debugger deactivate/activate trace overhead for "continue" when breakpoints disapear/reappear
* Faster debugging by optimization of Debugger.stop_here()
+ Debugger continue: trace overhead switched off when breakpoints are cleared
* Debugger .user_userexcption() descently steps out of exception (via .frame_returning).
* Debugger Stack Window: Frame Locals+Globals tree view improve

* auto-import in the interactive upon NameError
  e.g. `>>> dis.dis(f) [RETURN]` auto-imports dis when not present and repeats the execution

* Ctrl+K  Copy selected or current line(s) to interactive with appropriate (un)indentation (and "if 1:" block if needed) for Edit and Execution after RETURN
* Ctrl+Shift+K  Similar, but immediately execute selected or current line(s) in Interactive context.
  In ./default.cfg  : 
```
    Ctrl+K            = InteractSelectedLines
    Ctrl+Shift+K      = ExecSelectedLines
```

* HLI Object Browser improved and updated for newer Python conventions. jump-to-source upon double-click on functions. Fix in hierlist update handling.

* support PythonWin commandline options (like "-new") with dash instead of slashes (too): slash options mix up sys.path, 
  because python init thinks its a file and wants to add its dir as #1 in sys.path

* /goto: or -goto:  commandline option : PythonWin can be raised for bugs etc. from other tools (similar to SciTE and other editors)

* new mdi_runtool.py : 
```
    # Runs external command-line tools (e.g. pyflakes/flake8, diff/git, test &
    # build jobs, cython, grep), collects their standard & error output, and allows to
    # comfortably jump to target lines or to add (noqa) ignore comments. The
    # target parser currently detects: standard compiler and
    # checker error formats, Python tracebacks, unified diff positions, `grep
    # -nH` output. Reads non-blocking from external process via thread. Multiple
    # instances with separate settings stores are exposed in Menu/File/New.

```
* user.cfg added (based on default.cfg) as example
    * further custom context help example "HelpDjango"
    * HelloWorldFunc
    * ParenOpen/ParenClose for automatic parentheses
* user.cfg custom code inherits namespace of based-on custom code (default.cfg)
    ./scintilla/config.py  .. def configure
* Added to Help menu: 'Keyboard &user.cfg', '...&default.cfg'

* fix scriptutils.IsOnPythonPath() : case insensitive path comparison
    (Ctrl+I import didn't see files being part of imported package)


== Some more (older) comments on specific change positions ==

./debugger/__init__.py
    The optional frame parameter allows to point the debugger to a frame other than the top frame.
    (Used e.g. from the testing framework)

./debugger/debugger.py : 137
    Debugger call stack view auto expanding the locals frame when expanding a stack level
    (possible the active stack level should be auto-expanded as well)
    
./framework/intpyapp.py : 230
    New command-line parameter "/goto:LINENO"
    Allow multiple files / actions on the command-line

./framework/sgrepmdi.py
    When text is selected in the editor or interactive, then pre-fill as search string in grep dialog   
    Keyboard shortcuts for grep dialog fields

./scintilla/find.py : 243    
    Keyboard shortcuts for find dialog fields
    
./scintilla/find.py : 310    
    +		self.SetFocus()		# so we can repeatedly press Alt+R here in the dialog
       
./tools/browser.py : 38    
    The Object / Stack browser needs to see changes of object identities at least (not just object names) for reasonable tree updates
    
./tools/browser.py : 279    
    List based and dict based objects should show their members like normal lists/dicts
    A None object should look simple - not look like complex (class) objects
    
./tools/hierlist.py : 216 / 227
    bug fix of incorrect update

