### PR TITLE
adsi: 64-bit-compatible PyIDirectorySearch

### DIFF
--- a/com/win32comext/adsi/src/PyIDirectorySearch.i
+++ b/com/win32comext/adsi/src/PyIDirectorySearch.i
@@ -113,25 +113,130 @@ PyObject *PyIDirectorySearch::ExecuteSearch(PyObject *self, PyObject *args)
 %}
 %native(ExecuteSearch) ExecuteSearch;
 
+%{
 // @pyswig int|GetNextRow|
 // @pyparm int|handle||
 // @rdesc The result is the HRESULT from the call - no exceptions are thrown
-HRESULT_KEEP_INFO GetNextRow(ADS_SEARCH_HANDLE handle);
+PyObject *PyIDirectorySearch::GetNextRow(PyObject *self, PyObject *args) {
+    HRESULT_KEEP_INFO  _result;
+    ADS_SEARCH_HANDLE  _arg0;
+
+    IDirectorySearch *_swig_self;
+    if ((_swig_self=GetI(self))==NULL) return NULL;
+    if (!PyArg_ParseTuple(args,"l:GetNextRow",&_arg0))
+        return NULL;
+
+    Py_BEGIN_ALLOW_THREADS
+    _result = (HRESULT_KEEP_INFO )_swig_self->GetNextRow(_arg0);
+    Py_END_ALLOW_THREADS
+
+    if (FAILED(_result)) {
+        return OleSetADSIError(_result, _swig_self,  SWIG_THIS_IID);
+    }
+    return PyInt_FromLong(_result);
+}
+%}
+%native(GetNextRow) GetNextRow;
+
+%{
 // @pyswig int|GetFirstRow|
 // @pyparm int|handle||
 // @rdesc The result is the HRESULT from the call - no exceptions are thrown
-HRESULT_KEEP_INFO GetFirstRow(ADS_SEARCH_HANDLE handle);
+PyObject *PyIDirectorySearch::GetFirstRow(PyObject *self, PyObject *args) {
+    HRESULT_KEEP_INFO  _result;
+    ADS_SEARCH_HANDLE  _arg0;
+
+    IDirectorySearch *_swig_self;
+    if ((_swig_self=GetI(self))==NULL) return NULL;
+    if (!PyArg_ParseTuple(args,"l:GetFirstRow",&_arg0))
+        return NULL;
+
+    Py_BEGIN_ALLOW_THREADS
+    _result = (HRESULT_KEEP_INFO )_swig_self->GetFirstRow(_arg0);
+    Py_END_ALLOW_THREADS
+
+    if (FAILED(_result)) {
+        return OleSetADSIError(_result, _swig_self,  SWIG_THIS_IID);
+    }
+    return PyInt_FromLong(_result);
+}
+%}
+%native(GetFirstRow) GetFirstRow;
+
+%{
 // @pyswig int|GetPreviousRow|
 // @pyparm int|handle||
 // @rdesc The result is the HRESULT from the call - no exceptions are thrown
-HRESULT_KEEP_INFO GetPreviousRow(ADS_SEARCH_HANDLE handle);
+PyObject *PyIDirectorySearch::GetPreviousRow(PyObject *self, PyObject *args) {
+    HRESULT_KEEP_INFO  _result;
+    ADS_SEARCH_HANDLE  _arg0;
 
+    IDirectorySearch *_swig_self;
+    if ((_swig_self=GetI(self))==NULL) return NULL;
+    if (!PyArg_ParseTuple(args,"l:GetPreviousRow",&_arg0))
+        return NULL;
+
+    Py_BEGIN_ALLOW_THREADS
+    _result = (HRESULT_KEEP_INFO )_swig_self->GetPreviousRow(_arg0);
+    Py_END_ALLOW_THREADS
+
+    if (FAILED(_result)) {
+        return OleSetADSIError(_result, _swig_self,  SWIG_THIS_IID);
+    }
+    return PyInt_FromLong(_result);
+}
+%}
+%native(GetPreviousRow) GetPreviousRow;
+
+%{
 // @pyswig |CloseSearchHandle|Closes a previously opened search handle.
 // @pyparm int|handle||
-HRESULT CloseSearchHandle(ADS_SEARCH_HANDLE handle);
+PyObject *PyIDirectorySearch::CloseSearchHandle(PyObject *self, PyObject *args) {
+    HRESULT  _result;
+    ADS_SEARCH_HANDLE  _arg0;
+
+    IDirectorySearch *_swig_self;
+      if ((_swig_self=GetI(self))==NULL) return NULL;
+    if (!PyArg_ParseTuple(args,"l:CloseSearchHandle",&_arg0))
+        return NULL;
+
+    Py_BEGIN_ALLOW_THREADS
+    _result = (HRESULT )_swig_self->CloseSearchHandle(_arg0);
+    Py_END_ALLOW_THREADS
+
+    if (FAILED(_result)) {
+        return OleSetADSIError(_result, _swig_self, SWIG_THIS_IID);
+    }
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+%}
+%native(CloseSearchHandle) CloseSearchHandle;
+
+%{
 // @pyswig |AdandonSearch|
 // @pyparm int|handle||
-HRESULT AbandonSearch(ADS_SEARCH_HANDLE handle);
+PyObject *PyIDirectorySearch::AbandonSearch(PyObject *self, PyObject *args) {
+    HRESULT  _result;
+    ADS_SEARCH_HANDLE  _arg0;
+
+    IDirectorySearch *_swig_self;
+    if ((_swig_self=GetI(self))==NULL) return NULL;
+    if (!PyArg_ParseTuple(args,"l:AbandonSearch",&_arg0))
+        return NULL;
+
+    Py_BEGIN_ALLOW_THREADS
+    _result = (HRESULT )_swig_self->AbandonSearch(_arg0);
+    Py_END_ALLOW_THREADS
+
+    if (FAILED(_result))  {
+        return OleSetADSIError(_result, _swig_self,  SWIG_THIS_IID);
+    }
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+%}
+%native(AbandonSearch) AbandonSearch;
 
 %{
 // @pyswig (name, type, values)|GetColumn|

--- a/com/win32comext/adsi/src/PyIDirectorySearch.i
+++ b/com/win32comext/adsi/src/PyIDirectorySearch.i
@@ -103,7 +103,7 @@ PyObject *PyIDirectorySearch::ExecuteSearch(PyObject *self, PyObject *args)
 	if (FAILED(_result))
 		PyCom_BuildPyException(_result, _swig_self, IID_IDirectoryObject);
 	else {
-        ret = PyInt_FromLong((long)handle);
+        ret = PyLong_FromSsize_t((Py_ssize_t)handle);
 	} 
 	PyADSI_FreeNames(names, cnames);
     PyWinObject_FreeWCHAR(szFilter);
@@ -123,7 +123,7 @@ PyObject *PyIDirectorySearch::GetNextRow(PyObject *self, PyObject *args) {
 
     IDirectorySearch *_swig_self;
     if ((_swig_self=GetI(self))==NULL) return NULL;
-    if (!PyArg_ParseTuple(args,"l:GetNextRow",&_arg0))
+    if (!PyArg_ParseTuple(args,"n:GetNextRow",&_arg0))
         return NULL;
 
     Py_BEGIN_ALLOW_THREADS
@@ -148,7 +148,7 @@ PyObject *PyIDirectorySearch::GetFirstRow(PyObject *self, PyObject *args) {
 
     IDirectorySearch *_swig_self;
     if ((_swig_self=GetI(self))==NULL) return NULL;
-    if (!PyArg_ParseTuple(args,"l:GetFirstRow",&_arg0))
+    if (!PyArg_ParseTuple(args,"n:GetFirstRow",&_arg0))
         return NULL;
 
     Py_BEGIN_ALLOW_THREADS
@@ -173,7 +173,7 @@ PyObject *PyIDirectorySearch::GetPreviousRow(PyObject *self, PyObject *args) {
 
     IDirectorySearch *_swig_self;
     if ((_swig_self=GetI(self))==NULL) return NULL;
-    if (!PyArg_ParseTuple(args,"l:GetPreviousRow",&_arg0))
+    if (!PyArg_ParseTuple(args,"n:GetPreviousRow",&_arg0))
         return NULL;
 
     Py_BEGIN_ALLOW_THREADS
@@ -197,7 +197,7 @@ PyObject *PyIDirectorySearch::CloseSearchHandle(PyObject *self, PyObject *args) 
 
     IDirectorySearch *_swig_self;
       if ((_swig_self=GetI(self))==NULL) return NULL;
-    if (!PyArg_ParseTuple(args,"l:CloseSearchHandle",&_arg0))
+    if (!PyArg_ParseTuple(args,"n:CloseSearchHandle",&_arg0))
         return NULL;
 
     Py_BEGIN_ALLOW_THREADS
@@ -222,7 +222,7 @@ PyObject *PyIDirectorySearch::AbandonSearch(PyObject *self, PyObject *args) {
 
     IDirectorySearch *_swig_self;
     if ((_swig_self=GetI(self))==NULL) return NULL;
-    if (!PyArg_ParseTuple(args,"l:AbandonSearch",&_arg0))
+    if (!PyArg_ParseTuple(args,"n:AbandonSearch",&_arg0))
         return NULL;
 
     Py_BEGIN_ALLOW_THREADS
@@ -243,12 +243,12 @@ PyObject *PyIDirectorySearch::AbandonSearch(PyObject *self, PyObject *args) {
 PyObject *PyIDirectorySearch::GetColumn(PyObject *self, PyObject *args)
 {
 	PyObject *obName;
-    long handle;
+    Py_ssize_t handle;
 	IDirectorySearch *_swig_self;
 	if ((_swig_self=GetI(self))==NULL) return NULL;
 	// @pyparm int|handle||Handle to a search
 	// @pyparm <o PyUnicode>|name||The column name to fetch
-	if (!PyArg_ParseTuple(args, "lO:GetColumn", &handle, &obName))
+	if (!PyArg_ParseTuple(args, "nO:GetColumn", &handle, &obName))
 		return NULL;
     WCHAR *szName= NULL;
     if (!PyWinObject_AsWCHAR(obName, &szName, FALSE))
@@ -286,10 +286,10 @@ PyObject *PyIDirectorySearch::GetColumn(PyObject *self, PyObject *args)
 // @rdesc Returns None when the underlying ADSI function return S_ADS_NOMORE_COLUMNS.
 PyObject *PyIDirectorySearch::GetNextColumnName(PyObject *self, PyObject *args)
 {
-    long handle;
+    Py_ssize_t handle;
 	IDirectorySearch *_swig_self;
 	if ((_swig_self=GetI(self))==NULL) return NULL;
-	if (!PyArg_ParseTuple(args, "l:GetNextColumnName", &handle))
+	if (!PyArg_ParseTuple(args, "n:GetNextColumnName", &handle))
 		return NULL;
 	HRESULT _result;
     PyObject *ret = NULL;


### PR DESCRIPTION
PyIDirectorySearch takes and returns ADS_SEARCH_HANDLE (aka void*) as a Python int, mapped to a C long (aka int32_t). On amd64 this means the most-significant 32 bits of the pointer don't survive the trip, and typically a crash results when an invalid HANDLE is passed back into the IDirectorySearch.

This PR changes long to Py_ssize_t, which with some mumbling should ensure the HANDLE can fit in a PyLong.

Because I couldn't find a way to bend SWIG to my will, I've had to break out the previously pure-SWIG-stub methods that used ADS_SEARCH_HANDLE into native code. I don't know if there's a better way of doing this (or if maybe the API should change to PyHANDLE or something), but this seems to make my ADSI client work in 64-bit at least.
