### PR TITLE
Feature #1563: Report SERVICE_STOPPED with an error code if SvcRun() raises an Exception.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,14 @@ Note that, baring some major issue building and cutting the release, build
 Since build 228:
 ----------------
 
+* Changed how Services implemented with win32serviceutil.ServiceFramework
+  report that they have stopped. Now if the SvcRun() method (or the SvcDoRun()
+  method, which is called by SvcRun() by default) raises on Exception,
+  the Service will report a final SERVICE_STOPPED status with a non-zero error
+  code. This will cause the Service's recovery actions to be triggered if the
+  Service has the "Enable actions for stops with errors" option enabled.
+  (#1563, Lincoln Puzey)
+
 Python 2 is no longer supported - so long, Python 2, you served us well!
 
 Notable changes in this transition:

--- a/win32/Lib/win32serviceutil.py
+++ b/win32/Lib/win32serviceutil.py
@@ -835,6 +835,14 @@ class ServiceFramework:
             return self.SvcOtherEx(control, event_type, data)
 
     def SvcRun(self):
+        # This is the entry point the C framework calls when the Service is
+        # started. Your Service class should implement SvcDoRun().
+        # Or you can override this method for more control over the Service
+        # statuses reported to the SCM.
+
+        # If this method raises an exception, the C framework will detect this
+        # and report a SERVICE_STOPPED status with a non-zero error code.
+
         self.ReportServiceStatus(win32service.SERVICE_RUNNING)
         self.SvcDoRun()
         # Once SvcDoRun terminates, the service has stopped.


### PR DESCRIPTION
In order for the Windows Service Control Manager to see a Service process stopping
as a "failure" and run the recovery actions - e.g. Restart the service,
the process must stop without reporting the `SERVICE_STOPPED` status,
i.e. the last status reported must be something other than `SERVICE_STOPPED`.

Previously the only way to achieve this in a Service built with `win32serviceutil.ServiceFramework`
was to call `os._exit()`, because the pywin32 service framework unconditionally reported
the `SERVICE_STOPPED` status when `SvcRun()` exits, even if it raised an Exception (including SystemExit).

This commit changes this so that when `SvcRun()` exits, `SERVICE_STOPPED` is only reported if it
didn't raise an Exception. So now `SvcRun()` can (maybe intentionally) raise an Exception,
and Windows will see it as a service "failure", and run the service recovery actions.

This is nice parallel between the "failure" of the Exception being raised in Python and
Windows seeing the service as failing, even if the programmer doesn't have any knowledge of
the service statuses being reported and is only implementing SvcRun() in their class.

Also the existing call to `ReportPythonError()` that occurs if `SvcRun()` raises an Exception,
has been changed so that the error is only reported when the Exception is an instance of the
class `Exception`, i.e. not `BaseException`. This is because `BaseException` is used for control
flow and is generally not an actual Error.

So the recommended way for a service to intentionally stop with a "failure" is to raise a `SystemExit`
Exception from `SvcRun()`, which can be done by calling `sys.exit()`. This will avoid an error being
reported, and the `SERVICE_STOPPED` status won't reported, so the service control manager should see it
as a "failure", and run the recovery actions.