### PR TITLE
MINGW: Do not cross initializations when jumping

### DIFF
--- a/com/win32comext/mapi/src/PyIConverterSession.i
+++ b/com/win32comext/mapi/src/PyIConverterSession.i
@@ -75,10 +75,12 @@ PyObject *PyIConverterSession::MIMEToMAPI(PyObject *self, PyObject *args)
 		goto done;
 	if (!PyCom_InterfaceFromPyObject(obMsg, IID_IMessage, (void **)&pMsg, FALSE))
 		goto done;
-		
-	PY_INTERFACE_PRECALL;
-	hRes = _swig_self->MIMEToMAPI(pStream, pMsg, NULL, flags);
-	PY_INTERFACE_POSTCALL;
+
+	{
+		PY_INTERFACE_PRECALL;
+		hRes = _swig_self->MIMEToMAPI(pStream, pMsg, NULL, flags);
+		PY_INTERFACE_POSTCALL;
+	}
 	
 	if (FAILED(hRes))
 		result = OleSetOleError(hRes);
@@ -118,10 +120,12 @@ PyObject *PyIConverterSession::MAPIToMIMEStm(PyObject *self, PyObject *args)
 		goto done;	
 	if (!PyCom_InterfaceFromPyObject(obStream, IID_IStream, (void **)&pStream, FALSE))
 		goto done;
-		
-	PY_INTERFACE_PRECALL;
-	hRes = _swig_self->MAPIToMIMEStm(pMsg, pStream, flags);
-	PY_INTERFACE_POSTCALL;
+
+	{
+		PY_INTERFACE_PRECALL;
+		hRes = _swig_self->MAPIToMIMEStm(pMsg, pStream, flags);
+		PY_INTERFACE_POSTCALL;
+	}
 	
 	if (FAILED(hRes))
 		result = OleSetOleError(hRes);

--- a/com/win32comext/mapi/src/mapi.i
+++ b/com/win32comext/mapi/src/mapi.i
@@ -1037,10 +1037,12 @@ PyObject *PyOpenStreamOnFile(PyObject *self, PyObject *args)
 		if (!PyWinObject_AsString(obPrefix, &prefix, TRUE))
 			goto done;
 
-		PY_INTERFACE_PRECALL;
-		// mapiutil.h incorrectly declares OpenStreamOnFile taking type LPTSTR
-		hRes = OpenStreamOnFile(MAPIAllocateBuffer, MAPIFreeBuffer, flags, (LPTSTR)filename, (LPTSTR)prefix, &pStream);
-		PY_INTERFACE_POSTCALL;
+		{
+			PY_INTERFACE_PRECALL;
+			// mapiutil.h incorrectly declares OpenStreamOnFile taking type LPTSTR
+			hRes = OpenStreamOnFile(MAPIAllocateBuffer, MAPIFreeBuffer, flags, (LPTSTR)filename, (LPTSTR)prefix, &pStream);
+			PY_INTERFACE_POSTCALL;
+		}
 
 	done:
 		PyWinObject_FreeString(filename);
@@ -1091,9 +1093,11 @@ PyObject *PyOpenStreamOnFileW(PyObject *self, PyObject *args)
 		if (!PyWinObject_AsWCHAR(obPrefix, &prefix, TRUE))
 			goto done;
 
-		PY_INTERFACE_PRECALL;
-		hRes = OpenStreamOnFileW(MAPIAllocateBuffer, MAPIFreeBuffer, flags, filename, prefix, &pStream);
-		PY_INTERFACE_POSTCALL;
+		{
+			PY_INTERFACE_PRECALL;
+			hRes = OpenStreamOnFileW(MAPIAllocateBuffer, MAPIFreeBuffer, flags, filename, prefix, &pStream);
+			PY_INTERFACE_POSTCALL;
+		}
 
 	done:
 		PyWinObject_FreeWCHAR(filename);
@@ -1128,10 +1132,12 @@ PyObject *PyHrGetOneProp(PyObject *self, PyObject *args)
 		
 	if (!PyCom_InterfaceFromPyObject(obProp, IID_IMAPIProp, (void **)&pProp, FALSE))
 		goto done;
-	
-	PY_INTERFACE_PRECALL;
-	hRes = HrGetOneProp(pProp, propTag, &pPV);
-	PY_INTERFACE_POSTCALL;
+
+	{
+		PY_INTERFACE_PRECALL;
+		hRes = HrGetOneProp(pProp, propTag, &pPV);
+		PY_INTERFACE_POSTCALL;
+	}
 	if (FAILED(hRes))
 	{
 		OleSetOleError(hRes);
@@ -1186,10 +1192,12 @@ PyObject *PyHrSetOneProp(PyObject *self, PyObject *args)
 	}
 	if (!PyMAPIObject_AsSPropValue(obPropValue, pPV, pPV))
 		goto done;
-	
-	PY_INTERFACE_PRECALL;
-	hRes = HrSetOneProp(pProp, pPV);
-	PY_INTERFACE_POSTCALL;
+
+	{
+		PY_INTERFACE_PRECALL;
+		hRes = HrSetOneProp(pProp, pPV);
+		PY_INTERFACE_POSTCALL;
+	}
 	if (FAILED(hRes))
 	{
 		OleSetOleError(hRes);


### PR DESCRIPTION
This solves some compilation issues on mingw.

The `PY_INTERFACE_PRECALL` macro defines a variable of type `PyThreadState`. Jumping across the definition appears to work in MSVC, but is an error in gcc/mingw. Putting `PY_INTERFACE_PRECALL`/`PY_INTERFACE_POSTCALL` within a new scope solves the problem.