### PR TITLE
adodbapi: Specify Connection Mode with mode kwarg.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,6 +19,11 @@ Since build 228:
   Service has the "Enable actions for stops with errors" option enabled.
   (#1563, Lincoln Puzey)
 
+* adodbapi connect() method now accepts a "mode" keyword argument which is the
+  "Mode" property to set on the ADO "Connection" object before opening the
+  Connection. See "ConnectModeEnum" for valid values.
+  (Lincoln Puzey)
+
 Python 2 is no longer supported - so long, Python 2, you served us well!
 
 Notable changes in this transition:

--- a/adodbapi/adodbapi.py
+++ b/adodbapi/adodbapi.py
@@ -255,12 +255,14 @@ class Connection(object):
         except (Exception) as e:
             self._raiseConnectionError(KeyError,'Python string format error in connection string->')
         self.timeout = kwargs.get('timeout', 30)
+        self.mode = kwargs.get("mode", adc.adModeUnknown)
         self.kwargs = kwargs
         if verbose:
             print('%s attempting: "%s"' % (version, self.connection_string))
         self.connector = connection_maker()
         self.connector.ConnectionTimeout = self.timeout
         self.connector.ConnectionString = self.connection_string
+        self.connector.Mode = self.mode
 
         try:
             self.connector.Open()  # Open the ADO connection


### PR DESCRIPTION
adodbapi Connection.connect() method now accepts a "mode" keyword argument which is the "Mode" property to set on the ADO "Connection" object before opening the Connection.

This allows Connections to be opened with a specified mode, previously they were always opened with the default "adModeUnknown".

e.g.
```
connection = connect("MyDataSource", mode=adModeRead)
```
for opening a read-only connection.

See "ConnectModeEnum" for valid values.
https://docs.microsoft.com/en-us/sql/ado/reference/ado-api/connectmodeenum
See "Mode" property for more details.
https://docs.microsoft.com/en-us/sql/ado/reference/ado-api/mode-property-ado