### PR TITLE
Remove index multiplying to the sizeof(WCHAR) after EvtFormatMessage in win32evtlog.i file.

### DIFF
--- a/win32/src/win32evtlog.i
+++ b/win32/src/win32evtlog.i
@@ -579,7 +579,7 @@ static PyObject *FormatMessageInternal(EVT_HANDLE metadata, EVT_HANDLE event, DW
 	}
 
 	if (flags == EvtFormatMessageKeyword) {
-		buf[returned_size * sizeof(WCHAR)] = L'\0';
+		buf[returned_size] = L'\0';
 	}
 
 	if (flags == EvtFormatMessageKeyword) {

--- a/win32/src/win32evtlog.i
+++ b/win32/src/win32evtlog.i
@@ -562,7 +562,8 @@ static PyObject *FormatMessageInternal(EVT_HANDLE metadata, EVT_HANDLE event, DW
 		allocated_size += 1; // +1 to double terminate the keyword list
 	}
 
-	buf = (WCHAR *)malloc(allocated_size * sizeof(WCHAR));
+	allocated_size *= sizeof(WCHAR);
+	buf = (WCHAR *)malloc(allocated_size);
 	if (buf == NULL) {
 		PyErr_NoMemory();
 		return NULL;
@@ -578,7 +579,7 @@ static PyObject *FormatMessageInternal(EVT_HANDLE metadata, EVT_HANDLE event, DW
 	}
 
 	if (flags == EvtFormatMessageKeyword) {
-		buf[returned_size - 1] = L'\0';
+		buf[returned_size * sizeof(WCHAR)] = L'\0';
 	}
 
 	if (flags == EvtFormatMessageKeyword) {

--- a/win32/src/win32evtlog.i
+++ b/win32/src/win32evtlog.i
@@ -562,8 +562,7 @@ static PyObject *FormatMessageInternal(EVT_HANDLE metadata, EVT_HANDLE event, DW
 		allocated_size += 1; // +1 to double terminate the keyword list
 	}
 
-	allocated_size *= sizeof(WCHAR);
-	buf = (WCHAR *)malloc(allocated_size);
+	buf = (WCHAR *)malloc(allocated_size * sizeof(WCHAR));
 	if (buf == NULL) {
 		PyErr_NoMemory();
 		return NULL;
@@ -579,7 +578,7 @@ static PyObject *FormatMessageInternal(EVT_HANDLE metadata, EVT_HANDLE event, DW
 	}
 
 	if (flags == EvtFormatMessageKeyword) {
-		buf[returned_size * sizeof(WCHAR)] = L'\0';
+		buf[returned_size - 1] = L'\0';
 	}
 
 	if (flags == EvtFormatMessageKeyword) {


### PR DESCRIPTION
This small PR removes index multiplying to the `sizeof(WCHAR)`. According to the [docs](https://docs.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtformatmessage), the `EvtFormatMessage` function does not treat the buffer size as amount bytes but as the amount of characters.