### PR TITLE
Call importlib.invalidate_caches before importing generated module

### DIFF
--- a/com/win32com/client/makepy.py
+++ b/com/win32com/client/makepy.py
@@ -70,6 +70,13 @@ import sys, os, pythoncom
 from win32com.client import genpy, selecttlb, gencache
 from win32com.client import Dispatch
 
+try:
+	import importlib
+except:
+	# We only need importlib for invalidate_caches.
+	# In old Python versions without importlib, there is nothing to invalidate.
+	pass
+
 bForDemandDefault = 0 # Default value of bForDemand - toggle this to change the world - see also gencache.py
 
 error = "makepy.error"
@@ -281,6 +288,8 @@ def GenerateFromTypeLibSpec(typelibInfo, file = None, verboseLevel = None, progr
 		finally:
 			if file is None:
 				gen.finish_writer(outputName, fileUse, worked)
+		if 'importlib' in sys.modules and hasattr(importlib, 'invalidate_caches'):
+			importlib.invalidate_caches()
 		if bToGenDir:
 			progress.SetDescription("Importing module")
 			gencache.AddModuleToCache(info.clsid, info.lcid, info.major, info.minor)
@@ -317,6 +326,8 @@ def GenerateChildFromTypeLibSpec(child, typelibInfo, verboseLevel = None, progre
 		gen = genpy.Generator(typelib, info.dll, progress)
 		gen.generate_child(child, dir_path_name)
 		progress.SetDescription("Importing module")
+		if 'importlib' in sys.modules and hasattr(importlib, 'invalidate_caches'):
+			importlib.invalidate_caches()
 		__import__("win32com.gen_py." + dir_name + "." + child)
 	progress.Close()
 

--- a/com/win32com/client/makepy.py
+++ b/com/win32com/client/makepy.py
@@ -66,16 +66,9 @@ Examples:
 
 """
 
-import sys, os, pythoncom
+import sys, os, importlib, pythoncom
 from win32com.client import genpy, selecttlb, gencache
 from win32com.client import Dispatch
-
-try:
-	import importlib
-except:
-	# We only need importlib for invalidate_caches.
-	# In old Python versions without importlib, there is nothing to invalidate.
-	pass
 
 bForDemandDefault = 0 # Default value of bForDemand - toggle this to change the world - see also gencache.py
 
@@ -288,8 +281,7 @@ def GenerateFromTypeLibSpec(typelibInfo, file = None, verboseLevel = None, progr
 		finally:
 			if file is None:
 				gen.finish_writer(outputName, fileUse, worked)
-		if 'importlib' in sys.modules and hasattr(importlib, 'invalidate_caches'):
-			importlib.invalidate_caches()
+		importlib.invalidate_caches()
 		if bToGenDir:
 			progress.SetDescription("Importing module")
 			gencache.AddModuleToCache(info.clsid, info.lcid, info.major, info.minor)
@@ -326,8 +318,7 @@ def GenerateChildFromTypeLibSpec(child, typelibInfo, verboseLevel = None, progre
 		gen = genpy.Generator(typelib, info.dll, progress)
 		gen.generate_child(child, dir_path_name)
 		progress.SetDescription("Importing module")
-		if 'importlib' in sys.modules and hasattr(importlib, 'invalidate_caches'):
-			importlib.invalidate_caches()
+		importlib.invalidate_caches()
 		__import__("win32com.gen_py." + dir_name + "." + child)
 	progress.Close()
 


### PR DESCRIPTION
Call importlib.invalidate_caches between generating a module and importing it.
Fixes #1595; please see its description.