### PR TITLE
Use the README as the package's long description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2292,13 +2292,15 @@ classifiers = [ 'Environment :: Win32 (MS Windows)',
 	            'Programming Language :: Python :: Implementation :: CPython',
 	          ]
 
+my_dir = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(my_dir, 'README.md')) as f:
+    long_description = f.read()
+
 dist = setup(name="pywin32",
       version=str(build_id),
       description="Python for Window Extensions",
-      long_description="Python extensions for Microsoft Windows\n"
-                       "Provides access to much of the Win32 API, the\n"
-                       "ability to create and use COM objects, and the\n"
-                       "Pythonwin environment.",
+      long_description=long_description,
+      long_description_content_type='text/markdown',
       author="Mark Hammond (et al)",
       author_email = "mhammond@skippinet.com.au",
       url="https://github.com/mhammond/pywin32",


### PR DESCRIPTION
This should get the README showing on PyPI, as long as builds use a recent version of setuptools when run.

Per https://github.com/mhammond/pywin32/issues/1535#issuecomment-716126508, I originally had in mind to include the README in the package as a file, however I think that that ought to be happening automatically if an `sdist` build is being built with a new enough `setuptools`, so I'm not sure why that's not already the case.

Note that I'm not able to test this as I don't have a windows build environment to hand. The change itself is copy/pasted from another of my projects though, so I'm reasonably confident it should work if a new enough `setuptools` is used.