### PR TITLE
Introduce method to better scope GIL usage 

### DIFF
--- a/Pythonwin/ddemodule.h
+++ b/Pythonwin/ddemodule.h
@@ -30,20 +30,18 @@ class PythonDDETopicFramework : public T {
     ~PythonDDETopicFramework() { Python_delete_assoc(this); }
     virtual BOOL Exec(void *pData, DWORD dwSize)
     {
-        CEnterLeavePython celp;
-        PyObject *args = Py_BuildValue("(N)", PyWinObject_FromTCHAR((TCHAR *)pData));
-        BOOL rc = TRUE;
         CVirtualHelper helper("Exec", this);
+        PyObject *args = helper.build_args("(N)", PyWinObject_FromTCHAR((TCHAR *)pData));
+        BOOL rc = TRUE;
         if (helper.call_args(args))
             helper.retval(rc);
         return !rc;
     }
     virtual BOOL NSRequest(const TCHAR *szItem, CDDEAllocator &allocr)
     {
-        CEnterLeavePython celp;
-        PyObject *args = Py_BuildValue("(N)", PyWinObject_FromTCHAR(szItem));
-        BOOL rc = TRUE;
         CVirtualHelper helper("Request", this);
+        PyObject *args = helper.build_args("(N)", PyWinObject_FromTCHAR(szItem));
+        BOOL rc = TRUE;
         if (helper.call_args(args)) {
             CString strret;
             if (helper.retval(strret)) {
@@ -57,10 +55,9 @@ class PythonDDETopicFramework : public T {
 
     virtual BOOL NSPoke(const TCHAR *szItem, void *pData, DWORD dwSize)
     {
-        CEnterLeavePython celp;
-        PyObject *args = Py_BuildValue("(Nz#)", PyWinObject_FromTCHAR(szItem), pData, dwSize);
-        BOOL rc = TRUE;
         CVirtualHelper helper("Poke", this);
+        PyObject *args = helper.build_args("(Nz#)", PyWinObject_FromTCHAR(szItem), pData, dwSize);
+        BOOL rc = TRUE;
         if (helper.call_args(args)) {
             return TRUE;
         }

--- a/Pythonwin/pythonview.cpp
+++ b/Pythonwin/pythonview.cpp
@@ -76,7 +76,6 @@ CPythonListViewImpl::~CPythonListViewImpl() {}
 
 void CPythonListViewImpl::DrawItem(LPDRAWITEMSTRUCT lpDIS)
 {
-    CEnterLeavePython celp;
     CVirtualHelper helper("DrawItem", this);
     PyObject *obData = PyWin_GetPythonObjectFromLong(lpDIS->itemData);
     if (obData == NULL) {
@@ -96,7 +95,7 @@ void CPythonListViewImpl::DrawItem(LPDRAWITEMSTRUCT lpDIS)
         obDC = Py_None;
     }
 
-    PyObject *args = Py_BuildValue("iiiiiiO(iiii)O", lpDIS->CtlType, lpDIS->CtlID, lpDIS->itemID, lpDIS->itemAction,
+    PyObject *args = helper.build_args("iiiiiiO(iiii)O", lpDIS->CtlType, lpDIS->CtlID, lpDIS->itemID, lpDIS->itemAction,
                                    lpDIS->itemState, lpDIS->hwndItem, obDC, lpDIS->rcItem.left, lpDIS->rcItem.top,
                                    lpDIS->rcItem.right, lpDIS->rcItem.bottom, obData);
     ASSERT(args);
@@ -123,7 +122,6 @@ CPythonTreeViewImpl::~CPythonTreeViewImpl() {}
 
 void CPythonTreeViewImpl::DrawItem(LPDRAWITEMSTRUCT lpDIS)
 {
-    CEnterLeavePython celp;
     CVirtualHelper helper("DrawItem", this);
     PyObject *obData = PyWin_GetPythonObjectFromLong(lpDIS->itemData);
     if (obData == NULL) {
@@ -143,7 +141,7 @@ void CPythonTreeViewImpl::DrawItem(LPDRAWITEMSTRUCT lpDIS)
         obDC = Py_None;
     }
 
-    PyObject *args = Py_BuildValue("iiiiiiO(iiii)O", lpDIS->CtlType, lpDIS->CtlID, lpDIS->itemID, lpDIS->itemAction,
+    PyObject *args = helper.build_args("iiiiiiO(iiii)O", lpDIS->CtlType, lpDIS->CtlID, lpDIS->itemID, lpDIS->itemAction,
                                    lpDIS->itemState, lpDIS->hwndItem, obDC, lpDIS->rcItem.left, lpDIS->rcItem.top,
                                    lpDIS->rcItem.right, lpDIS->rcItem.bottom, obData);
     ASSERT(args);

--- a/Pythonwin/win32template.cpp
+++ b/Pythonwin/win32template.cpp
@@ -424,14 +424,13 @@ void CPythonDocTemplate::InitialUpdateFrame(CFrameWnd *pFrame, CDocument *pDoc, 
         CMultiDocTemplate::InitialUpdateFrame(pFrame, pDoc, bMakeVisible);
         return;
     }
-    CEnterLeavePython celp;
     PyObject *frame = (PyObject *)ui_assoc_object::make(PyCFrameWnd::type, pFrame)->GetGoodRet();
     PyObject *doc = (PyObject *)ui_assoc_object::make(PyCDocument::type, pDoc)->GetGoodRet();
 
     // @pyparm <o PyCFrameWnd>|frame||The frame window.
     // @pyparm <o PyCDocument>|frame||The document attached to the frame.
     // @pyparm int|bMakeVisible||Indicates if the frame should be made visible.
-    PyObject *arglst = Py_BuildValue("(OOi)", frame, doc, bMakeVisible);
+    PyObject *arglst = helper.build_args("(OOi)", frame, doc, bMakeVisible);
     XDODECREF(frame);
     XDODECREF(doc);
     helper.call_args(arglst);

--- a/Pythonwin/win32ui.h
+++ b/Pythonwin/win32ui.h
@@ -299,6 +299,7 @@ class PYW_EXPORT CVirtualHelper {
     CVirtualHelper(const char *iname, void *iassoc, EnumVirtualErrorHandling veh = VEH_PRINT_ERROR);
     ~CVirtualHelper();
 
+    PyObject* build_args(const char* format, ...);
     BOOL HaveHandler() { return handler != NULL; }
     // All the "call" functions return FALSE if the call failed, or no handler exists.
     BOOL call();

--- a/Pythonwin/win32uiExt.h
+++ b/Pythonwin/win32uiExt.h
@@ -273,7 +273,6 @@ class CPythonWndFramework : public T {
     {
         // @pyvirtual |PyCWnd|OnNcCalcSize|Called for the WM_NCCALCSIZE message.
         CVirtualHelper helper("OnNcCalcSize", this);
-        CEnterLeavePython celp;
         if (helper.HaveHandler()) {
             if (bCalcValidRects) {
                 PyObject *rc1 = PyWinObject_FromRECT(&lpncsp->rgrc[0], false);
@@ -286,9 +285,10 @@ class CPythonWndFramework : public T {
                     Py_INCREF(obPos);
                 }
                 else
-                    obPos = Py_BuildValue("iiiiiii", pwp->hwnd, pwp->hwndInsertAfter, pwp->x, pwp->y, pwp->cx, pwp->cy,
+                    obPos = helper.build_args("iiiiiii", pwp->hwnd, pwp->hwndInsertAfter, pwp->x, pwp->y, pwp->cx, pwp->cy,
                                           pwp->flags);
-                PyObject *args = Py_BuildValue("i(OOOO)", bCalcValidRects, rc1, rc2, rc3, obPos);
+                                  
+                PyObject *args = helper.build_args("i(OOOO)", bCalcValidRects, rc1, rc2, rc3, obPos);
                 Py_XDECREF(rc1);
                 Py_XDECREF(rc2);
                 Py_XDECREF(rc3);
@@ -297,7 +297,7 @@ class CPythonWndFramework : public T {
             }
             else {
                 PyObject *rc1 = PyWinObject_FromRECT((RECT *)lpncsp, false);
-                PyObject *args = Py_BuildValue("i(Ozzz)", bCalcValidRects, rc1, NULL, NULL, NULL);
+                PyObject *args = helper.build_args("i(Ozzz)", bCalcValidRects, rc1, NULL, NULL, NULL);
                 Py_XDECREF(rc1);
                 helper.call_args(args);
             }
@@ -318,8 +318,7 @@ class CPythonWndFramework : public T {
         CVirtualHelper helper("OnNcHitTest", this);
         // @pyparm int, int|x,y||The point to test.
         if (helper.HaveHandler()) {
-            CEnterLeavePython celp;
-            PyObject *args = Py_BuildValue("((ii))", pt.x, pt.y);
+            PyObject *args = helper.build_args("((ii))", pt.x, pt.y);
             if (helper.call_args(args)) {
                 int ret;
                 if (helper.retval(ret))
@@ -353,7 +352,6 @@ class CPythonWndFramework : public T {
         // @pyparm <o PyCWnd>|wndDeactivate||
         T::OnMDIActivate(bActivate, pAc, pDe);
         if (helper.HaveHandler()) {
-            CEnterLeavePython celp;
             PyObject *oba, *obd;
             if (pAc) {
                 oba = PyWinObject_FromCWnd(pAc);
@@ -369,7 +367,7 @@ class CPythonWndFramework : public T {
                 obd = Py_None;
                 Py_INCREF(Py_None);
             }
-            PyObject *args = Py_BuildValue("(iOO)", bActivate, oba, obd);
+            PyObject *args = helper.build_args("(iOO)", bActivate, oba, obd);
             Py_XDECREF(oba);
             Py_XDECREF(obd);
             helper.call_args(args);

--- a/Pythonwin/win32uioleClientItem.cpp
+++ b/Pythonwin/win32uioleClientItem.cpp
@@ -53,9 +53,8 @@ class PythonOleClientItem : public COleClientItem {
         // @pyvirtual int|PyCOleClientItem|OnChangeItemPosition|
         // @pyparm (int, int, int, int)|(left, top, right, bottom)||The new position
         CVirtualHelper helper("OnChangeItemPosition", this);
-        CEnterLeavePython celp;
         BOOL bRet;
-        PyObject *args = Py_BuildValue("(iiii)", rectPos.left, rectPos.top, rectPos.right, rectPos.bottom);
+        PyObject *args = helper.build_args("(iiii)", rectPos.left, rectPos.top, rectPos.right, rectPos.bottom);
         if (helper.HaveHandler() && helper.call_args(args)) {
             // Note = args decref'd by caller
             helper.retval(bRet);

--- a/Pythonwin/win32virt.cpp
+++ b/Pythonwin/win32virt.cpp
@@ -70,6 +70,19 @@ CVirtualHelper::~CVirtualHelper()
         XDODECREF(py_ob);
     }
 }
+
+PyObject* CVirtualHelper::build_args(const char* format, ...)
+{
+    // Helper to create Python objects when called outside the GIL.
+    CEnterLeavePython _celp;
+    va_list va;
+    PyObject* retval;
+    va_start(va, format);
+    retval = Py_VaBuildValue(format, va);
+    va_end(va);
+    return retval;
+}
+
 PyObject *CVirtualHelper::GetHandler() { return handler; }
 BOOL CVirtualHelper::do_call(PyObject *args)
 {


### PR DESCRIPTION
Changed local CEnterleavePython calls to a local function to have less side effects using the GIL longer.
Replaces PR #1604 which had a mangled commit history.