### PR TITLE
Fixed build for com and comext on Windows 10 ARM64

### DIFF
--- a/com/win32com/src/univgw_dataconv.cpp
+++ b/com/win32com/src/univgw_dataconv.cpp
@@ -151,7 +151,7 @@ static inline bool SizeOfVT(VARTYPE vt, int *pitem_size, int *pstack_size)
     }
 #ifdef _M_IX86
     int stack_size = (item_size < 4) ? 4 : item_size;
-#elif _M_X64
+#elif _M_X64 || _M_ARM64
     // params > 64bits passed by address, and only VT_VARIANT is > 64bits.
     assert((item_size <= 8) || ((vt & VT_TYPEMASK) == VT_VARIANT));
     if (item_size > 8)
@@ -595,7 +595,7 @@ PyObject *dataconv_ReadFromInTuple(PyObject *self, PyObject *args)
         vtArgType = (VARTYPE)PyInt_AS_LONG(obArgType);
 #ifdef _M_IX86
         bIsByRef = vtArgType & VT_BYREF;
-#elif _M_X64
+#elif _M_X64 || _M_ARM64
         // params > 64bits always passed by address - and the only
         // arg we support > 64 bits is a VARIANT structure.
         bIsByRef = (vtArgType == VT_VARIANT) || (vtArgType & VT_BYREF);

--- a/com/win32comext/mapi/src/mapi_headers/MAPIUtil.h
+++ b/com/win32comext/mapi/src/mapi_headers/MAPIUtil.h
@@ -860,23 +860,23 @@ STDAPI_(VOID)			DeinitMapiUtil(VOID);
  *	it easier to write code which uses them optionally.
  */
 
-#if defined (_WIN64) && defined(_AMD64_)
+#if defined (_WIN64) && (defined (_AMD64_) || defined(_ARM64_))
 #define szHrDispatchNotifications "HrDispatchNotifications"
 #elif defined (_WIN32) && defined (_X86_)
 #define szHrDispatchNotifications "_HrDispatchNotifications@4"
 #else
-#error	"Unknown Platform: MAPI is currently supported on Win32/X86 and Win64/AMD64"
+#error	"Unknown Platform: MAPI is currently supported on Win32/X86, Win64/AMD64 and Win64/ARM64"
 #endif
 
 typedef HRESULT (STDAPICALLTYPE DISPATCHNOTIFICATIONS)(ULONG ulFlags);
 typedef DISPATCHNOTIFICATIONS FAR * LPDISPATCHNOTIFICATIONS;
 
-#if defined (_WIN64) && defined (_AMD64_)
+#if defined (_WIN64) && (defined (_AMD64_) || defined(_ARM64_))
 #define szScCreateConversationIndex "ScCreateConversationIndex"
 #elif defined (_WIN32) && defined (_X86_)
 #define szScCreateConversationIndex "_ScCreateConversationIndex@16"
 #else
-#error	"Unknown Platform: MAPI is currently supported on Win32/X86 and Win64/AMD64"
+#error	"Unknown Platform: MAPI is currently supported on Win32/X86, Win64/AMD64 and Win64/ARM64"
 #endif
 
 typedef SCODE (STDAPICALLTYPE CREATECONVERSATIONINDEX)(ULONG cbParent,

--- a/com/win32comext/mapi/src/mapi_headers/MAPIVal.h
+++ b/com/win32comext/mapi/src/mapi_headers/MAPIVal.h
@@ -1957,13 +1957,13 @@ __ValidateParameters(METHODS eMethod, LPVOID ppThis);
 #define CheckParameters_IMAPIAdviseSink_OnNotify( a1, a2, a3 ) \
 			 CheckParameters3( IMAPIAdviseSink_OnNotify, a1, a2, a3 )
 
-#if defined (_AMD64_) || defined(_X86_)
+#if defined(_AMD64_) || defined(_ARM64_)|| defined(_X86_)
 STDAPI	HrValidateParameters( METHODS eMethod, LPVOID FAR *ppFirstArg );
 #elif defined(DOS) || defined(_MAC) 
 STDAPIV	HrValidateParametersV( METHODS eMethod, ... );
 STDAPIV HrValidateParametersValist( METHODS eMethod, va_list arglist );
 #else
-#error	"Unknown Platform: MAPI is currently supported on Win32 and Win64"
+#error	"Unknown Platform: MAPI is currently supported on Win32, Win64 and WinArm64"
 #endif
 
 #ifdef __cplusplus

--- a/com/win32comext/mapi/src/mapi_stub_library/MapiStubLibrary.cpp
+++ b/com/win32comext/mapi/src/mapi_stub_library/MapiStubLibrary.cpp
@@ -25,7 +25,7 @@
 #error Outlook 2010 MAPI headers or higher must be installed
 #endif
 
-#if defined(_M_X64) || defined(_M_ARM)
+#if defined(_M_X64) || defined(_M_ARM) || defined(_M_ARM64)
 #define ExpandFunction(fn, c) #fn
 #elif defined(_M_IX86)
 #define ExpandFunction(fn, c) #fn "@" #c


### PR DESCRIPTION
Updated the MAPI headers and univgw data conversion with ifdefs for ARM64
.
Visual Studio 2017 or 2019 are required for _M_ARM64 variable to be present. See:
https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-160

This is the first patch in the series to add support for building pywin32 on ARM64.