### PR TITLE
github CI: Fix broken "::set-env". Use the new $GITHUB_ENV

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       run: pip install --upgrade setuptools wheel
 
     - name: Set Python user directory
-      run: echo "::set-env name=USER_DIR::$(python -c 'import os,site;print(os.path.dirname(site.USER_SITE))', end='')"
+      run: python -c "import os,site;open(os.environ['GITHUB_ENV'], 'a').write('USER_DIR=%s\n' % os.path.dirname(site.USER_SITE))"
 
     - name: Build package
       run: python setup.py --skip-verstamp build


### PR DESCRIPTION
as extra PR