### PR TITLE
Avoid errors in pywintypes.py when pywintypesXX.dll is missing

### DIFF
--- a/win32/Lib/pywintypes.py
+++ b/win32/Lib/pywintypes.py
@@ -38,8 +38,12 @@ def __import_pywin32_system_module__(modname, globs):
             raise ImportError("Module '%s' isn't in frozen sys.path %s" % (modname, sys.path))
     else:
         # First see if it already in our process - if so, we must use that.
-        import _win32sysloader
-        found = _win32sysloader.GetModuleFilename(filename)
+        try:
+            import _win32sysloader
+            found = _win32sysloader.GetModuleFilename(filename)
+        except ImportError:
+            found = None
+
         if found is None:
             # We ask Windows to load it next.  This is in an attempt to
             # get the exact same module loaded should pywintypes be imported
@@ -53,7 +57,10 @@ def __import_pywin32_system_module__(modname, globs):
             # load the one in the exe's dir.
             # That shouldn't really matter though, so long as we only ever
             # get one loaded.
-            found = _win32sysloader.LoadModule(filename)
+            try:
+                found = _win32sysloader.LoadModule(filename)
+            except:
+                pass
         if found is None:
             # Windows can't find it - which although isn't relevent here,
             # means that we *must* be the first win32 import, as an attempt


### PR DESCRIPTION
Trying to import any pywin32 module without `pywintypesXX.dll` present in PATH fails with `ImportError`. More specifically trying to import `pywintypes` results in:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:/dev/msys64/mingw64/lib/python3.8/site-packages/win32/lib/pywintypes.py", line 108, in <module>
    __import_pywin32_system_module__("pywintypes", globals())
  File "C:/dev/msys64/mingw64/lib/python3.8/site-packages/win32/lib/pywintypes.py", line 41, in __import_pywin32_system_module__
    import _win32sysloader
ImportError: DLL load failed while importing _win32sysloader: The specified module could not be found.
```

The code in `pywintypes.py` that tries to locate `pywintypesXX.dll` is unreachable due to an exception being thrown on [line 41](https://github.com/mhammond/pywin32/blob/d10d5594b1951c58930f42a000a6038eed6a283d/win32/Lib/pywintypes.py#L41). The suggested changes avoid the issue.

This happens under a MinGW 64 build of Python 3.8.
