### PR TITLE
Remove reference to version 228 as the current one

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,9 +4,6 @@ Generally created by hand after running:
    hg log -rb2xx: > log.out
 However contributors are encouraged to add their own entries for their work.
 
-Note that, baring some major issue building and cutting the release, build
-228 will be the last version supporting Python 2.
-
 
 Since build 228:
 ----------------


### PR DESCRIPTION
Now that version 300 is out and support for Python 2.7 has been dropped.