### PR TITLE
Fix dynamic property put.

### DIFF
--- a/com/win32com/client/dynamic.py
+++ b/com/win32com/client/dynamic.py
@@ -121,6 +121,8 @@ def _GetDescInvokeType(entry, invoke_type):
 	# BUT - it's apparently important for an INVKIND, and working that out is TBD!
 	if varkind == pythoncom.VAR_DISPATCH and invoke_type == pythoncom.INVOKE_PROPERTYGET:
 		return pythoncom.INVOKE_FUNC | invoke_type # DISPATCH_METHOD & DISPATCH_PROPERTYGET can be combined in IDispatch::Invoke
+	elif entry.desc.desckind == pythoncom.DESCKIND_VARDESC and varkind == pythoncom.VAR_DISPATCH and invoke_type == pythoncom.INVOKE_PROPERTYPUT:
+		return pythoncom.INVOKE_PROPERTYPUT
 	else:
 		return varkind
 


### PR DESCRIPTION
Since version 224 of pywin32 the dynamic property put is broken. It seems that a fix for a regression broke it (see issues #1427 and #1199, and the corresponding change in commit 1350d43249782ea9bc271574f0290de99875afa0).
The severity of this issue increased recently as the last working version 223 is not available for the newest Python release 3.8 and 3.9.

The fix checks for the invoke type for property put and returns it accordingly. This prevents the exception reported in #1427 and successfully sets the property's value.