### PR TITLE
Avoid overwriting dicts.dat if it is unchanged

### DIFF
--- a/com/win32com/client/gencache.py
+++ b/com/win32com/client/gencache.py
@@ -546,27 +546,25 @@ def AddModuleToCache(typelibclsid, lcid, major, minor, verbose = 1, bFlushNow = 
 	# if mod._in_gencache_ is already true, then we are reloading this
 	# module - this doesn't mean anything special though!
 	mod._in_gencache_ = 1
-	dict = mod.CLSIDToClassMap
 	info = str(typelibclsid), lcid, major, minor
-	for clsid, cls in dict.items():
-		clsidToTypelib[clsid] = info
+	dict_modified = False
 
-	dict = mod.CLSIDToPackageMap
-	for clsid, name in dict.items():
-		clsidToTypelib[clsid] = info
+	def SetTypelibForAllClsids(dict):
+		nonlocal dict_modified
+		for clsid, cls in dict.items():
+			if clsidToTypelib.get(clsid) != info:
+				clsidToTypelib[clsid] = info
+				dict_modified = True
 
-	dict = mod.VTablesToClassMap
-	for clsid, cls in dict.items():
-		clsidToTypelib[clsid] = info
-
-	dict = mod.VTablesToPackageMap
-	for clsid, cls in dict.items():
-		clsidToTypelib[clsid] = info
+	SetTypelibForAllClsids(mod.CLSIDToClassMap)
+	SetTypelibForAllClsids(mod.CLSIDToPackageMap)
+	SetTypelibForAllClsids(mod.VTablesToClassMap)
+	SetTypelibForAllClsids(mod.VTablesToPackageMap)
 
 	# If this lib was previously redirected, drop it
 	if info in versionRedirectMap:
 		del versionRedirectMap[info]
-	if bFlushNow:
+	if bFlushNow and dict_modified:
 		_SaveDicts()
 
 def GetGeneratedInfos():


### PR DESCRIPTION
This fixes another concurrency problem that is similar to #1600 and which I hadn't noticed at the time. At the moment, `dicts.dat` is overwritten every time a Python instance accesses an interface for the first time, even if the cache files for this interface already exist and `dicts.dat` is already up to date. This causes problems if another Python instance tries to read or write `dicts.dat` at the same time. So I changed the code to update `dicts.dat` only if its contents were actually changed, making this far less likely.