### PR TITLE
Handle undocumented edge case in EvtNext

### DIFF
--- a/win32/src/win32evtlog.i
+++ b/win32/src/win32evtlog.i
@@ -877,7 +877,7 @@ static PyObject *PyEvtNext(PyObject *self, PyObject *args, PyObject *kwargs)
 	if (!bsuccess){
 		free(events);
 		DWORD err=GetLastError();
-		if (err == ERROR_NO_MORE_ITEMS)
+		if (err == ERROR_NO_MORE_ITEMS || (err == ERROR_INVALID_OPERATION && nbr_returned == 0))
 			return PyTuple_New(0);
 		return PyWin_SetAPIError("EvtNext", err);
 		}


### PR DESCRIPTION
### Motivation

We getting so many occurrences of `ERROR_INVALID_OPERATION` that we ignore it. Upon further research it seems this is a known implementation detail:

https://github.com/elastic/beats/blob/ef6274d0d1e36308a333cbed69846a1bd63528ae/winlogbeat/sys/wineventlog/iterator.go#L154

https://github.com/elastic/beats/blob/ef6274d0d1e36308a333cbed69846a1bd63528ae/winlogbeat/sys/wineventlog/wineventlog_windows.go#L202-L207