### PR TITLE
Simplify pywin32_bootstrap, avoid importing site

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,10 @@ However contributors are encouraged to add their own entries for their work.
 Note that, baring some major issue building and cutting the release, build
 228 will be the last version supporting Python 2.
 
+Since build 300:
+----------------
+* Shifted work in win32.lib.pywin32_bootstrap to Python's import system from
+  manual path manipulations (@wkschwartz in #1651)
 
 Since build 228:
 ----------------

--- a/win32/Lib/pywin32_bootstrap.py
+++ b/win32/Lib/pywin32_bootstrap.py
@@ -17,22 +17,17 @@ except NameError:
 try:
     import pywin32_system32
 except Exc:
-    path_iterator = iter([])
+    pass
 else:
     # We're guaranteed only that __path__: Iterable[str]
     # https://docs.python.org/3/reference/import.html#__path__
-    path_iterator = iter(pywin32_system32.__path__)
-
-try:
-    path = next(path_iterator)
-except StopIteration:
-    pass
-else:
-    if os.path.isdir(path):
-        if hasattr(os, "add_dll_directory"):
-            os.add_dll_directory(path)
-        # This is to ensure the pywin32 path is in the beginning to find the
-        # pywin32 DLLs first and prevent other PATH entries to shadow them
-        elif not os.environ["PATH"].startswith(path):
-            os.environ["PATH"] = os.environ["PATH"].replace(os.pathsep + path, "")
-            os.environ["PATH"] = path + os.pathsep + os.environ["PATH"]
+    for path in pywin32_system32.__path__:
+        if os.path.isdir(path):
+            if hasattr(os, "add_dll_directory"):
+                os.add_dll_directory(path)
+            # This is to ensure the pywin32 path is in the beginning to find the
+            # pywin32 DLLs first and prevent other PATH entries to shadow them
+            elif not os.environ["PATH"].startswith(path):
+                os.environ["PATH"] = os.environ["PATH"].replace(os.pathsep + path, "")
+                os.environ["PATH"] = path + os.pathsep + os.environ["PATH"]
+            break

--- a/win32/Lib/pywin32_bootstrap.py
+++ b/win32/Lib/pywin32_bootstrap.py
@@ -10,13 +10,8 @@ import os
 
 
 try:
-    Exc = ModuleNotFoundError  # Introduced in Python 3.6
-except NameError:
-    Exc = ImportError
-
-try:
     import pywin32_system32
-except Exc:
+except ImportError:  # Python ≥3.6: replace ImportError with ModuleNotFoundError
     pass
 else:
     # We're guaranteed only that __path__: Iterable[str]

--- a/win32/Lib/pywin32_bootstrap.py
+++ b/win32/Lib/pywin32_bootstrap.py
@@ -6,7 +6,6 @@
 # modules are imported.
 # If Python has `os.add_dll_directory()`, we need to call it with this path.
 # Otherwise, we add this path to PATH.
-import os
 
 
 try:
@@ -14,6 +13,7 @@ try:
 except ImportError:  # Python ≥3.6: replace ImportError with ModuleNotFoundError
     pass
 else:
+    import os
     # We're guaranteed only that __path__: Iterable[str]
     # https://docs.python.org/3/reference/import.html#__path__
     for path in pywin32_system32.__path__:

--- a/win32/Lib/pywin32_bootstrap.py
+++ b/win32/Lib/pywin32_bootstrap.py
@@ -24,15 +24,15 @@ else:
     path_iterator = iter(pywin32_system32.__path__)
 
 try:
-    pywin32_system32 = next(path_iterator)
+    path = next(path_iterator)
 except StopIteration:
     pass
 else:
-    if os.path.isdir(pywin32_system32):
+    if os.path.isdir(path):
         if hasattr(os, "add_dll_directory"):
-            os.add_dll_directory(pywin32_system32)
+            os.add_dll_directory(path)
         # This is to ensure the pywin32 path is in the beginning to find the
         # pywin32 DLLs first and prevent other PATH entries to shadow them
-        elif not os.environ["PATH"].startswith(pywin32_system32):
-            os.environ["PATH"] = os.environ["PATH"].replace(os.pathsep + pywin32_system32, "")
-            os.environ["PATH"] = pywin32_system32 + os.pathsep + os.environ["PATH"]
+        elif not os.environ["PATH"].startswith(path):
+            os.environ["PATH"] = os.environ["PATH"].replace(os.pathsep + path, "")
+            os.environ["PATH"] = path + os.pathsep + os.environ["PATH"]


### PR DESCRIPTION
Since pywin32 has dropped support for Python 2.7 since version 300 and support for Python 3.0 through 3.4 since version 223, we can now rely on [PEP-420] semantics when importing names of directories available on `sys.path` and not containing an `__init__.py`. This applies to to `pywin32_system32`. The previous version of `win32.lib.pywin32_boostrap` manually searched site-packages directories, stopping at the first one found. Now we pass this responsibility off to Python's import machinery. When we `import pywin32_system32`, if successful, `pywin32_system32` will likely be a `_frozen_importlib_external._NamespacePath` object. We obtain its first entry, being careful that it didn't support sequence indexing until Python 3.7 or so (and in any case, that's all undocumented; the [documentation promises] only that `__path__: Iterable[str]`). This first entry is the path to the directory containing the DLLs, just as before, so the remainder of the code is unchanged.

The only semantic differences between this implementation and the previous one is that
1. we no longer import `site` (always better to import less!), and
2. `pywin32_system32` is no longer _required_ to be in a site-packages directory

Just as with the previous implementation, this one does not raise an exception if `pywin32_system32` cannot be found.

I did one annoying thing in this patch to minimize the diff, which is that I redefine the variable `pywin32_system32`: first it refers to a namespace package module object, and then later it refers to the `str` directory name. It might be reasonable after initial review of the patch to rename the latter instance of the variable to something like `path`.

Finally, I added no tests and no change log entry, but can if necessary.

[PEP-420]: https://www.python.org/dev/peps/pep-0420/#specification
[documentation promises]: https://docs.python.org/3/reference/import.html#__path__