### PR TITLE
Fix GIL protection with CVirtualHelper

### DIFF
--- a/Pythonwin/ddeserver.cpp
+++ b/Pythonwin/ddeserver.cpp
@@ -27,7 +27,6 @@ CDDEServerSystemTopic *PythonDDEServer::CreateSystemTopic()
     CVirtualHelper helper("CreateSystemTopic", this);
     PyObject *ob;
     if (helper.call() && helper.retval(ob)) {
-        CEnterLeavePython _celp;
         Py_XDECREF(m_obSystemTopic);
         CDDEServerSystemTopic *pT;
         if (pT = PyDDEServerSystemTopic::GetTopic(ob)) {
@@ -36,6 +35,7 @@ CDDEServerSystemTopic *PythonDDEServer::CreateSystemTopic()
             return pT;
         }
     }
+    helper.release_full();
     return new CDDEServerSystemTopic();
 }
 

--- a/Pythonwin/pythonRichEdit.cpp
+++ b/Pythonwin/pythonRichEdit.cpp
@@ -46,6 +46,7 @@ LRESULT CPythonRichEditView::WindowProc(UINT message, WPARAM wParam, LPARAM lPar
     CVirtualHelper helper("WindowProc", this);
     if (!helper.HaveHandler() || !helper.call(message, wParam, lParam) || !helper.retval(res)) {
         try {
+            helper.release_full();
             return CRichEditView::WindowProc(message, wParam, lParam);
         }
         catch (...) {
@@ -64,8 +65,10 @@ void CPythonRichEditView::OnInitialUpdate()
     CVirtualHelper helper("OnInitialUpdate", this);
     if (helper.HaveHandler())
         helper.call();
-    else
+    else {
+        helper.release_full();
         CRichEditView::OnInitialUpdate();
+    }
 }
 
 #ifdef _DEBUG

--- a/Pythonwin/pythoncbar.h
+++ b/Pythonwin/pythoncbar.h
@@ -21,8 +21,10 @@ class CPythonControlBarFramework : public CPythonWndFramework<T> {
             helper.retval(ob);
             PyArg_ParseTuple(ob, "ii", &result.cx, &result.cy);
         }
-        else
+        else {
+            helper.release_full();
             result = T::CalcFixedLayout(bStretch, bHorz);
+        }
         return result;
     }
     virtual CSize CalcDynamicLayout(int nLength, DWORD dwMode)
@@ -38,8 +40,10 @@ class CPythonControlBarFramework : public CPythonWndFramework<T> {
             helper.retval(ob);
             PyArg_ParseTuple(ob, "ii", &result.cx, &result.cy);
         }
-        else
+        else {
+            helper.release_full();
             result = T::CalcDynamicLayout(nLength, dwMode);
+        }
         return result;
     }
     virtual void OnBarStyleChange(DWORD oldStyle, DWORD newStyle)
@@ -52,6 +56,7 @@ class CPythonControlBarFramework : public CPythonWndFramework<T> {
             ;
         }
         else {
+            helper.release_full();
             T::OnBarStyleChange(oldStyle, newStyle);
         }
     }

--- a/Pythonwin/pythondoc.h
+++ b/Pythonwin/pythondoc.h
@@ -80,6 +80,7 @@ BOOL CPythonDocTemp<P>::DoSave(LPCTSTR lpszPathName, BOOL bReplace)
             return ret;
         return FALSE;
     }
+    helper.release_full();
     return P::DoSave(lpszPathName, bReplace);
 }
 
@@ -100,6 +101,7 @@ BOOL CPythonDocTemp<P>::DoFileSave()
             return ret;
         return FALSE;
     }
+    helper.release_full();
     return P::DoFileSave();
 }
 
@@ -132,7 +134,6 @@ BOOL CPythonDocTemp<P>::OnOpenDocument(const TCHAR *fileName)
     // be called.  If necessary, the handler must call this function explicitely.
     CVirtualHelper helper("OnOpenDocument", this);
     if (!helper.HaveHandler()) {
-        CEnterLeavePython _celp;  // grab lock to report error
         PyErr_SetString(ui_module_error, "PyCDocument::OnOpenDocument handler does not exist.");
         gui_print_error();
         return FALSE;
@@ -157,6 +158,7 @@ BOOL CPythonDocTemp<P>::OnNewDocument()
     // be called.  If necessary, the handler must call this function explicitely.
     CVirtualHelper helper("OnNewDocument", this);
     if (!helper.HaveHandler()) {
+        helper.release_full();
         return P::OnNewDocument();
     }
     // from here, it means a Python exception occurred, and this has been reported.
@@ -185,8 +187,10 @@ void CPythonDocTemp<P>::OnCloseDocument()
     if (helper.HaveHandler()) {
         helper.call();
     }
-    else
-        P::OnCloseDocument();
+    else {
+        helper.release_full();
+        P::OnCloseDocument();        
+    }
 }
 
 template <class P>
@@ -195,6 +199,7 @@ void CPythonDocTemp<P>::PreCloseFrame(CFrameWnd *pWnd)
     // @pyvirtual |PyCDocument|PreCloseFrame|Called before the frame window is closed.
     CVirtualHelper helper("PreCloseFrame", this);
     helper.call(pWnd);
+    helper.release_full();
     P::PreCloseFrame(pWnd);
     // @comm The MFC base implementation is always called after the Python handler returns.
 }
@@ -205,8 +210,10 @@ void CPythonDocTemp<P>::DeleteContents()
     // @pyvirtual |PyCDocument|DeleteContents|Called by the MFC architecture when a document is newly created or closed.
     // @xref <om PyCDocument.DeleteContents>
     CVirtualHelper helper("DeleteContents", this);
-    if (!helper.call())
+    if (!helper.call()) {
+        helper.release_full();
         P::DeleteContents();
+    }
     // @comm If a handler is defined for this function, the base (MFC) function will not
     // be called.  If necessary, the handler must call this function explicitely.
 }
@@ -218,8 +225,10 @@ BOOL CPythonDocTemp<P>::SaveModified()
     // @comm If a handler is defined for this function, the base (MFC) function will not
     // be called.  If necessary, the handler must call this function explicitely.
     CVirtualHelper helper("SaveModified", this);
-    if (!helper.HaveHandler())
+    if (!helper.HaveHandler()) {
+        helper.release_full();
         return P::SaveModified();
+    }
     if (helper.call()) {
         int ret;
         // @rdesc The handler should return TRUE if it is safe to continue and close
@@ -240,6 +249,7 @@ void CPythonDocTemp<P>::OnChangedViewList()
     if (helper.HaveHandler() && helper.call()) {
         return;
     }
+    helper.release_full();
     P::OnChangedViewList();
 }
 

--- a/Pythonwin/pythonpsheet.cpp
+++ b/Pythonwin/pythonpsheet.cpp
@@ -175,8 +175,10 @@ LRESULT CPythonPropertySheet::WindowProc(UINT message, WPARAM wParam, LPARAM lPa
     // @pyvirtual int|PyCPropertySheet|WindowProc|Default message handler.
     LRESULT res;
     CVirtualHelper helper("WindowProc", this);
-    if (!helper.HaveHandler() || !helper.call(message, wParam, lParam) || !helper.retval(res))
+    if (!helper.HaveHandler() || !helper.call(message, wParam, lParam) || !helper.retval(res)) {
+        helper.release_full();
         return CPropertySheet::WindowProc(message, wParam, lParam);
+    }
     return res;
 }
 #endif PYWIN_WITH_WINDOWPROC
@@ -254,6 +256,7 @@ BOOL CPythonPropertySheet::OnInitDialog()
     BOOL result = FALSE;
     CVirtualHelper helper("OnInitDialog", this);
     if (!helper.HaveHandler()) {
+        helper.release_full();
         result = CPropertySheet::OnInitDialog();
     }
     else {
@@ -340,8 +343,10 @@ void CPythonPropertySheet::OnClose()
     int ret = 1;
     if (helper.call())
         helper.retval(ret);
-    if (ret)
+    if (ret) {
+        helper.release_full();
         CPropertySheet::OnClose();
+    }
 }
 
 int CPythonPropertySheet::OnCreate(LPCREATESTRUCT lpCreateStruct)

--- a/Pythonwin/pythonview.cpp
+++ b/Pythonwin/pythonview.cpp
@@ -44,6 +44,7 @@ void CPythonViewImpl::OnPrepareDC(CDC *pDC, CPrintInfo *pInfo)
 
     CVirtualHelper helper("OnPrepareDC", this);
     helper.call(pDC, pInfo);
+    helper.release_full();
     CScrollView::OnPrepareDC(pDC, pInfo);
     // @pyparm <o PyCDC>|dc||The DC object.
 }

--- a/Pythonwin/win32template.cpp
+++ b/Pythonwin/win32template.cpp
@@ -421,6 +421,7 @@ void CPythonDocTemplate::InitialUpdateFrame(CFrameWnd *pFrame, CDocument *pDoc, 
     // The default behaviour is to call OnInitialUpdate on all views.
     CVirtualHelper helper("InitialUpdateFrame", this);
     if (!helper.HaveHandler()) {
+        helper.release_full();
         CMultiDocTemplate::InitialUpdateFrame(pFrame, pDoc, bMakeVisible);
         return;
     }
@@ -444,7 +445,6 @@ CFrameWnd *CPythonDocTemplate::CreateNewFrame(CDocument *pDoc, CFrameWnd *pOther
     ok = ok && helper.retval(retObject);
     ok = ok && ui_base_class::is_uiobject(retObject, &PyCFrameWnd::type);
     if (!ok) {
-        CEnterLeavePython _celp;
         if (PyErr_Occurred())
             gui_print_error();
         const char *typ_str = retObject ? retObject->ob_type->tp_name : "<null>";
@@ -463,7 +463,6 @@ CDocument *CPythonDocTemplate::CreateNewDocument()
     CVirtualHelper helper("CreateNewDocument", this);
     BOOL ok = helper.HaveHandler();
     if (!ok) {
-        CEnterLeavePython _celp;
         PyErr_SetString(ui_module_error, "PyCTemplate::CreateNewDocument handler does not exist.");
         TRACE0("CPythonDocTemplate::CreateNewDocument fails due to no handler\n");
         return NULL;
@@ -475,7 +474,6 @@ CDocument *CPythonDocTemplate::CreateNewDocument()
     ok = ok && ui_base_class::is_uiobject(retObject, &PyCDocument::type);
 
     if (!ok) {
-        CEnterLeavePython _celp;
         if (PyErr_Occurred())
             gui_print_error();
         const char *typ_str = retObject ? retObject->ob_type->tp_name : "<null>";
@@ -493,8 +491,10 @@ CDocument *CPythonDocTemplate::OpenDocumentFile(LPCTSTR lpszPathName, BOOL bMake
     // @pyvirtual <o PyCDocument>|PyCDocTemplate|OpenDocumentFile|Called when a document file is to be opened.
     CVirtualHelper helper("OpenDocumentFile", this);
     BOOL ok = helper.HaveHandler();
-    if (!ok)
+    if (!ok) {
+        helper.release_full();
         return CMultiDocTemplate::OpenDocumentFile(lpszPathName, bMakeVisible);
+    }
 
     ok = ok && helper.call(lpszPathName, bMakeVisible);
     PyObject *retObject = NULL;
@@ -504,7 +504,6 @@ CDocument *CPythonDocTemplate::OpenDocumentFile(LPCTSTR lpszPathName, BOOL bMake
     ok = ok && ui_base_class::is_uiobject(retObject, &PyCDocument::type);
 
     if (!ok) {
-        CEnterLeavePython _celp;
         if (PyErr_Occurred())
             gui_print_error();
         const char *typ_str = retObject ? retObject->ob_type->tp_name : "<null>";
@@ -544,7 +543,6 @@ CDocTemplate::Confidence CPythonDocTemplate::MatchDocType(LPCTSTR lpszPathName, 
             rpDocMatch = pDoc;
             return yesAlreadyOpen;
         }
-        CEnterLeavePython _celp;
         const char *typ_str = ret ? ret->ob_type->tp_name : "<null>";
         PyErr_Format(PyExc_TypeError,
                      "PyCTemplate::MatchDocType must return an integer or PyCDocument object (got %s).", typ_str);

--- a/Pythonwin/win32thread.cpp
+++ b/Pythonwin/win32thread.cpp
@@ -58,8 +58,10 @@ class CPythonWinThread : public CWinThread {
             // The main app InitInstance assumes a zero return.
             return (ret == 0);
         }
-        else
+        else {
+            helper.release_full();
             return CWinThread::InitInstance();
+        }
     }
     virtual int ExitInstance()
     {
@@ -69,16 +71,19 @@ class CPythonWinThread : public CWinThread {
             helper.retval(ret);
             return ret;
         }
-        else
+        else {
+            helper.release_full();
             return CWinThread::ExitInstance();
+        }
     }
     virtual int Run()
     {
         int ret;
         CVirtualHelper helper("Run", this);
-        if (!helper.HaveHandler())
+        if (!helper.HaveHandler()) {
+            helper.release_full();  // important
             ret = CWinThread::Run();
-        else {
+        } else {
             helper.call();
             helper.retval(ret);
         }

--- a/Pythonwin/win32ui.h
+++ b/Pythonwin/win32ui.h
@@ -294,11 +294,12 @@ PYW_EXPORT ExceptionHandlerFunc SetExceptionHandler(ExceptionHandlerFunc handler
 // The type of error handling we want...
 enum EnumVirtualErrorHandling { VEH_PRINT_ERROR, VEH_DISPLAY_DIALOG };
 
-class PYW_EXPORT CVirtualHelper {
+class PYW_EXPORT CVirtualHelper : public CEnterLeavePython {
    public:
     CVirtualHelper(const char *iname, void *iassoc, EnumVirtualErrorHandling veh = VEH_PRINT_ERROR);
     ~CVirtualHelper();
 
+    void release_full();
     BOOL HaveHandler() { return handler != NULL; }
     // All the "call" functions return FALSE if the call failed, or no handler exists.
     BOOL call();

--- a/Pythonwin/win32uimodule.cpp
+++ b/Pythonwin/win32uimodule.cpp
@@ -2523,9 +2523,10 @@ int Win32uiRun(void)
     // An error here is too late for anything to usefully print it,
     // so we use a dialog.
     CVirtualHelper helper("Run", GetApp(), VEH_DISPLAY_DIALOG);
-    if (!helper.HaveHandler())
+    if (!helper.HaveHandler()) {
+        helper.release_full();  // important
         ret = GetApp()->CWinApp::Run();
-    else {
+    } else {
         helper.call();
         helper.retval(ret);
     }

--- a/Pythonwin/win32uioleClientItem.cpp
+++ b/Pythonwin/win32uioleClientItem.cpp
@@ -15,8 +15,10 @@ class PythonOleClientItem : public COleClientItem {
             // @pyparm int|wNotification||
             // @pyparm int|dwParam||
             helper.call(wNotification, dwParam);
-        else
+        else {
+            helper.release_full();
             COleClientItem::OnChange(wNotification, dwParam);
+        }
     }
     virtual void OnActivate()
     {
@@ -24,8 +26,10 @@ class PythonOleClientItem : public COleClientItem {
         CVirtualHelper helper("OnActivate", this);
         if (helper.HaveHandler())
             helper.call();
-        else
+        else {
+            helper.release_full();
             COleClientItem::OnActivate();
+        }
     }
     virtual void OnGetItemPosition(CRect &rPosition)
     {
@@ -34,7 +38,6 @@ class PythonOleClientItem : public COleClientItem {
         if (helper.call()) {
             PyObject *ret;
             helper.retval(ret);
-            CEnterLeavePython _celp;
             PyArg_ParseTuple(ret, "iiii", &rPosition.left, &rPosition.top, &rPosition.right, &rPosition.bottom);
         }
     }
@@ -45,8 +48,10 @@ class PythonOleClientItem : public COleClientItem {
         CVirtualHelper helper("OnDeactivateUI", this);
         if (helper.HaveHandler())
             helper.call(bUndoable);
-        else
+        else {
+            helper.release_full();
             COleClientItem::OnDeactivateUI(bUndoable);
+        }
     }
     virtual BOOL OnChangeItemPosition(const CRect &rectPos)
     {
@@ -56,8 +61,10 @@ class PythonOleClientItem : public COleClientItem {
         BOOL bRet;
         if (helper.call_args("(iiii)", rectPos.left, rectPos.top, rectPos.right, rectPos.bottom)) {
             helper.retval(bRet);
-        } else
+        } else {
+            helper.release_full();
             bRet = COleClientItem::OnChangeItemPosition(rectPos);
+        }
         return bRet;
     }
     BOOL BaseOnChangeItemPosition(const CRect &rectPos) { return COleClientItem::OnChangeItemPosition(rectPos); }

--- a/win32/src/PyWinTypes.h
+++ b/win32/src/PyWinTypes.h
@@ -624,9 +624,11 @@ extern PYWINTYPES_EXPORT void PyWin_MakePendingCalls();
 
 class CEnterLeavePython {
    public:
-    CEnterLeavePython() { acquire(); }
+    CEnterLeavePython() : released(TRUE) { acquire(); }
     void acquire(void)
     {
+        if (!released)
+            return;
         state = PyGILState_Ensure();
         released = FALSE;
     }


### PR DESCRIPTION
Fixes GIL issues (after 3c9271d + 27a1ae8 and pre-existing) noticed during debugging of win32ui GUI code with threads: (indirect) Python API calls outside of GIL  (E.g.  win32template.cpp / CPythonDocTemplate::InitialUpdateFrame / GetGoodRet() / DODECREF ).

Now holds GIL during CVirtualHelper instance life by default.

Also reduces GIL enter/leave overhead: Mostly only 1x
is necessary instead of 3x or more.
