### PR TITLE
Fixes 1654: Fixed win32print.DeviceCapabilities() returning strings with junk in them.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,10 @@ Since build 300:
 * Shifted work in win32.lib.pywin32_bootstrap to Python's import system from
   manual path manipulations (@wkschwartz in #1651)
 
+* Fixed a bug where win32print.DeviceCapabilities would return strings
+  containing the null character followed by junk characters.
+  (#1654, #1660, Lincoln Puzey)
+
 Since build 228:
 ----------------
 * Fixed a bug where win32com.client.VARIANT params were returned in the reverse


### PR DESCRIPTION
Previously this code would `ZeroMemory()` the output buffer before passing it to `DeviceCapabilities()`,
and then assume that only characters in each string would be changed, i.e. the characters following
the null-terminator would remain null.
So it would only check if the last character in each string was null, to check if the string was null-terminated.

This assumption is wrong - sometimes `DeviceCapabilities()` sets the characters after null to junk.

Now every character in the returned buffer is checked for being null before falling back to the case where the
string takes up all available space.