### PR TITLE
Fix PyWinObject_FromEnvironmentBlock behavior

### DIFF
--- a/win32/src/win32profilemodule.cpp
+++ b/win32/src/win32profilemodule.cpp
@@ -54,7 +54,7 @@ PyObject *PyWinObject_FromEnvironmentBlock(WCHAR *multistring)
             Actually, there are names started with an equal sign, e.g. per-drive working dirs are stored in the form
             "=C:=C:\\somedir", "=D:=D:\\someotherdir". These are retrievable by win32api.GetEnvironmentVariable('=C:'),
             but don't appear in os.environ. Environment variable's value may contain an equal sign.
-            So we use the first equal sign from which the string is not started
+            So we use the first equal sign from which the string is not started as a separator
         */
         eq = wcschr(multistring + 1, '=');
         if (eq == NULL) {

--- a/win32/src/win32profilemodule.cpp
+++ b/win32/src/win32profilemodule.cpp
@@ -50,11 +50,13 @@ PyObject *PyWinObject_FromEnvironmentBlock(WCHAR *multistring)
         return NULL;
     totallen = wcslen(multistring);
     while (totallen) {
-        /* Use *last* equal sign as separator, since per-drive working dirs are stored in the environment in the form
-            "=C:=C:\\somedir","=D:=D:\\someotherdir".  These are retrievable by win32api.GetEnvironmentVariable('=C:'),
-            but don't appear in os.environ and are apparently undocumented
+        /* Official docs say that the name of an environment variable cannot include an equal sign.
+            Actually, there are names started with an equal sign, e.g. per-drive working dirs are stored in the form
+            "=C:=C:\\somedir", "=D:=D:\\someotherdir". These are retrievable by win32api.GetEnvironmentVariable('=C:'),
+            but don't appear in os.environ. Environment variable's value may contain an equal sign.
+            So we use the first equal sign from which the string is not started
         */
-        eq = wcsrchr(multistring, '=');
+        eq = wcschr(multistring + 1, '=');
         if (eq == NULL) {
             // Use blank string for value if no equal sign present. ???? Maybe throw an error instead ????
             vallen = 0;


### PR DESCRIPTION
`PyWinObject_FromEnvironmentBlock` doesn't handle equal signs in environment variable correctly.

Code to reproduce:
```py
import os
import win32profile

os.environ["FOO"] = "bar=baz"

env = win32profile.GetEnvironmentStrings()
assert "FOO" not in env
assert env["FOO=bar"] == "baz"

assert os.environ["FOO"] == "bar=baz"
```