### PR TITLE
Switch to using new buffer protocol for py3.10

### DIFF
--- a/Pythonwin/win32win.cpp
+++ b/Pythonwin/win32win.cpp
@@ -2188,6 +2188,7 @@ PyObject *ui_window_send_message(PyObject *self, PyObject *args)
     WPARAM wp = 0;
     LPARAM lp = 0;
     BOOL ok = FALSE;
+    PyWinBufferView pybuf;
     // Old code assumes the following behaviour:
     // (msg, buffer_ob) -> lparam==&buffer, wparam=len(buffer)
     // (msg, [int_arg, int_arg]) - lparam and wparam cast from ints
@@ -2196,18 +2197,16 @@ PyObject *ui_window_send_message(PyObject *self, PyObject *args)
     // for our special case before letting PyWinObject_AsPARAM at them.
     // Shortcut - our special case requires exactly 2 args be passed.
     if (args && PyTuple_Size(args) == 2) {
-        void *p;
         PyObject *obParam;
         ok = PyArg_ParseTuple(args, "iO",
                               &message,   // @pyparmalt1 int|idMessage||The ID of the message to send.
                               &obParam);  // @pyparmalt1 buffer|ob||A buffer whose size is passed in wParam, and address
                                           // is passed in lParam
         if (ok) {
-            int wParam;
-            ok = PyWinObject_AsReadBuffer(obParam, &p, &wParam);
+            ok = pybuf.init(obParam);
             if (ok) {
-                lp = (LPARAM)p;
-                wp = (WPARAM)wParam;
+                lp = (LPARAM)pybuf.ptr();
+                wp = (WPARAM)pybuf.len();
             }
         }
         // save unconditionally clearing it in the block below...

--- a/com/win32com/src/PyRecord.cpp
+++ b/com/win32com/src/PyRecord.cpp
@@ -147,10 +147,8 @@ PyObject *PyObject_FromRecordInfo(IRecordInfo *ri, void *data, ULONG cbData)
 // @pymethod <o PyRecord>|pythoncom|GetRecordFromGuids|Creates a new record object from the given GUIDs
 PyObject *pythoncom_GetRecordFromGuids(PyObject *self, PyObject *args)
 {
-    void *data = NULL;
     PyObject *obGuid, *obInfoGuid, *obdata = Py_None;
     int major, minor, lcid;
-    int cb = 0;
     if (!PyArg_ParseTuple(args, "OiiiO|O:GetRecordFromGuids",
                           &obGuid,      // @pyparm <o PyIID>|iid||The GUID of the type library
                           &major,       // @pyparm int|verMajor||The major version number of the type lib.
@@ -159,7 +157,8 @@ PyObject *pythoncom_GetRecordFromGuids(PyObject *self, PyObject *args)
                           &obInfoGuid,  // @pyparm <o PyIID>|infoIID||The GUID of the record info in the library
                           &obdata))  // @pyparm string or buffer|data|None|The raw data to initialize the record with.
         return NULL;
-    if (!PyWinObject_AsReadBuffer(obdata, &data, &cb, TRUE))
+    PyWinBufferView pybuf(obdata, false, true); // None ok
+    if (!pybuf.ok())
         return NULL;
     GUID guid, infoGuid;
     if (!PyWinObject_AsIID(obGuid, &guid))
@@ -170,7 +169,7 @@ PyObject *pythoncom_GetRecordFromGuids(PyObject *self, PyObject *args)
     HRESULT hr = GetRecordInfoFromGuids(guid, major, minor, lcid, infoGuid, &i);
     if (FAILED(hr))
         return PyCom_BuildPyException(hr);
-    PyObject *ret = PyObject_FromRecordInfo(i, data, cb);
+    PyObject *ret = PyObject_FromRecordInfo(i, pybuf.ptr(), pybuf.len());
     i->Release();
     return ret;
 }

--- a/com/win32com/src/extensions/PyGStream.cpp
+++ b/com/win32com/src/extensions/PyGStream.cpp
@@ -18,15 +18,14 @@ STDMETHODIMP PyGStream::Read(
         return hr;
 
     hr = E_FAIL;
-    VOID *buf = NULL;
-    DWORD resultlen;
-    if (PyWinObject_AsReadBuffer(result, &buf, &resultlen, FALSE)) {
-        if (resultlen > cb)
+    PyWinBufferView pybuf(result);
+    if (pybuf.ok()) {
+        if (pybuf.len() > cb)
             PyErr_SetString(PyExc_ValueError, "PyGStream::Read: returned data longer than requested");
         else {
-            memcpy(pv, buf, resultlen);
+            memcpy(pv, pybuf.ptr(), pybuf.len());
             if (pcbRead)
-                *pcbRead = resultlen;
+                *pcbRead = pybuf.len();
             hr = S_OK;
         }
     }

--- a/com/win32com/src/extensions/PyIStream.cpp
+++ b/com/win32com/src/extensions/PyIStream.cpp
@@ -46,21 +46,20 @@ PyObject *PyIStream::Read(PyObject *self, PyObject *args)
 // @pymethod |PyIStream|Write|Write data to a stream
 PyObject *PyIStream::Write(PyObject *self, PyObject *args)
 {
-    void *strValue;
     PyObject *obstrValue;
-    DWORD strSize;
     ULONG cbWritten;
     // @pyparm string|data||The binary data to write.
     if (!PyArg_ParseTuple(args, "O:Write", &obstrValue))
         return NULL;
-    if (!PyWinObject_AsReadBuffer(obstrValue, &strValue, &strSize, FALSE))
+    PyWinBufferView pybuf(obstrValue);
+    if (!pybuf.ok())
         return NULL;
     IStream *pMy = GetI(self);
     if (pMy == NULL)
         return NULL;
 
     PY_INTERFACE_PRECALL;
-    HRESULT hr = pMy->Write(strValue, strSize, &cbWritten);
+    HRESULT hr = pMy->Write(pybuf.ptr(), pybuf.len(), &cbWritten);
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pMy, IID_IStream);

--- a/com/win32com/src/extensions/PySTGMEDIUM.cpp
+++ b/com/win32com/src/extensions/PySTGMEDIUM.cpp
@@ -51,6 +51,7 @@ PyObject *PySet(PyObject *self, PyObject *args)
         case TYMED_HGLOBAL: {
             const void *buf = NULL;
             Py_ssize_t cb = 0;
+            PyWinBufferView pybuf;
             // In py3k, unicode objects don't support the buffer
             // protocol, so explicitly check string types first.
             // We need to include the NULL for strings and unicode, as the
@@ -65,8 +66,10 @@ PyObject *PySet(PyObject *self, PyObject *args)
                 buf = (void *)PyUnicode_AS_UNICODE(ob);
             }
             else {
-                if (PyObject_AsReadBuffer(ob, &buf, &cb) == -1)
+                if (!pybuf.init(ob))
                     return PyErr_Format(PyExc_TypeError, "tymed value of %d requires a string/unicode/buffer", tymed);
+                buf = pybuf.ptr();
+                cb = pybuf.len();
                 // no extra nulls etc needed here.
             }
             ps->medium.hGlobal = GlobalAlloc(GMEM_FIXED, cb);

--- a/com/win32com/src/univgw_dataconv.cpp
+++ b/com/win32com/src/univgw_dataconv.cpp
@@ -434,10 +434,10 @@ PyObject *dataconv_WriteFromOutTuple(PyObject *self, PyObject *args)
                 }
                 // keep this after string check since string can act as buffers
                 else if (obOutValue->ob_type->tp_as_buffer) {
-                    DWORD cb;
-                    if (!PyWinObject_AsReadBuffer(obOutValue, (void **)&pbOutBuffer, &cb))
+                    PyWinBufferView pybuf(obOutValue);
+                    if (!pybuf.ok())
                         goto Error;
-                    memcpy(pb, pbOutBuffer, cb);
+                    memcpy(pb, pybuf.ptr(), pybuf.len());
                 }
                 else {
                     obUse = PyNumber_Int(obOutValue);

--- a/com/win32comext/adsi/src/PyADSIUtil.cpp
+++ b/com/win32comext/adsi/src/PyADSIUtil.cpp
@@ -101,15 +101,15 @@ PyObject *PyADSIObject_FromADSVALUE(ADSVALUE &v)
             ob = PyInt_FromLong(v.Integer);
             break;
         case ADSTYPE_OCTET_STRING: {
-            void *buf;
             DWORD bufSize = v.OctetString.dwLength;
             if (!(ob = PyBuffer_New(bufSize)))
                 return NULL;
-            if (!PyWinObject_AsWriteBuffer(ob, &buf, &bufSize)) {
+            PyWinBufferView pybuf(ob, true);
+            if (!pybuf.ok()) {
                 Py_DECREF(ob);
                 return NULL;
             }
-            memcpy(buf, v.OctetString.lpValue, bufSize);
+            memcpy(pybuf.ptr(), v.OctetString.lpValue, bufSize);
         } break;
         case ADSTYPE_UTC_TIME:
             ob = PyWinObject_FromSYSTEMTIME(v.UTCTime);
@@ -121,15 +121,15 @@ PyObject *PyADSIObject_FromADSVALUE(ADSVALUE &v)
             ob = PyWinObject_FromWCHAR(v.ClassName);
             break;
         case ADSTYPE_PROV_SPECIFIC: {
-            void *buf;
             DWORD bufSize = v.ProviderSpecific.dwLength;
             if (!(ob = PyBuffer_New(bufSize)))
                 return NULL;
-            if (!PyWinObject_AsWriteBuffer(ob, &buf, &bufSize)) {
+            PyWinBufferView pybuf(ob, true);
+            if (!pybuf.ok()) {
                 Py_DECREF(ob);
                 return NULL;
             }
-            memcpy(buf, v.ProviderSpecific.lpValue, bufSize);
+            memcpy(pybuf.ptr(), v.ProviderSpecific.lpValue, bufSize);    
             break;
         }
         case ADSTYPE_NT_SECURITY_DESCRIPTOR: {

--- a/com/win32comext/internet/src/PyIInternetSecurityManager.cpp
+++ b/com/win32comext/internet/src/PyIInternetSecurityManager.cpp
@@ -330,14 +330,13 @@ STDMETHODIMP PyGInternetSecurityManager::GetSecurityId(
     if (FAILED(hr))
         return hr;
     // Process the Python results, and convert back to the real params
-    void *buf;
-    DWORD buf_len;
-    if (!PyWinObject_AsReadBuffer(result, &buf, &buf_len)) {
+    PyWinBufferView pybuf(result);
+    if (!pybuf.ok()) {
         Py_DECREF(result);
         return MAKE_PYCOM_GATEWAY_FAILURE_CODE("GetSecurityId");
     }
-    *pcbSecurityId = min(buf_len, *pcbSecurityId);
-    memcpy(pbSecurityId, buf, *pcbSecurityId);
+    *pcbSecurityId = min(pybuf.len(), *pcbSecurityId);
+    memcpy(pbSecurityId, pybuf.ptr(), *pcbSecurityId);
     Py_DECREF(result);
     return hr;
 }

--- a/com/win32comext/propsys/src/PyIPersistSerializedPropStorage.cpp
+++ b/com/win32comext/propsys/src/PyIPersistSerializedPropStorage.cpp
@@ -49,16 +49,15 @@ PyObject *PyIPersistSerializedPropStorage::SetPropertyStorage(PyObject *self, Py
     if (pIPSPS == NULL)
         return NULL;
     PyObject *obbuf;
-    void *buf;
-    DWORD bufsize;
     // @pyparm buffer|ps||Bytes or buffer object containing a serialized property store
     if (!PyArg_ParseTuple(args, "O:SetPropertyStorage", &obbuf))
         return NULL;
-    if (!PyWinObject_AsReadBuffer(obbuf, &buf, &bufsize))
+    PyWinBufferView pybuf(obbuf);
+    if (!pybuf.ok())
         return NULL;
     HRESULT hr;
     PY_INTERFACE_PRECALL;
-    hr = pIPSPS->SetPropertyStorage((PUSERIALIZEDPROPSTORAGE)buf, bufsize);
+    hr = pIPSPS->SetPropertyStorage((PUSERIALIZEDPROPSTORAGE)pybuf.ptr(), pybuf.len());
     PY_INTERFACE_POSTCALL;
 
     if (FAILED(hr))

--- a/com/win32comext/propsys/src/PyPROPVARIANT.cpp
+++ b/com/win32comext/propsys/src/PyPROPVARIANT.cpp
@@ -493,18 +493,17 @@ BOOL PyWin_NewPROPVARIANT(PyObject *ob, VARTYPE vt, PROPVARIANT *ppv)
             break;
         case VT_BLOB:
         case VT_BLOB_OBJECT: {
-            void *buf;
-            DWORD buflen;
-            ret = PyWinObject_AsReadBuffer(ob, &buf, &buflen, FALSE);
+            PyWinBufferView pybuf(ob);
+            ret = pybuf.ok();
             if (ret) {
-                ppv->blob.cbSize = buflen;
-                ppv->blob.pBlobData = (BYTE *)CoTaskMemAlloc(buflen);
+                ppv->blob.cbSize = pybuf.len();
+                ppv->blob.pBlobData = (BYTE *)CoTaskMemAlloc(pybuf.len());
                 if (ppv->blob.pBlobData == NULL) {
                     PyErr_NoMemory();
                     ret = FALSE;
                 }
                 else
-                    memcpy(ppv->blob.pBlobData, buf, buflen);
+                    memcpy(ppv->blob.pBlobData, pybuf.ptr(), pybuf.len());
             }
             break;
         }

--- a/com/win32comext/shell/src/shell.cpp
+++ b/com/win32comext/shell/src/shell.cpp
@@ -1504,14 +1504,15 @@ static PyObject *PySHAddToRecentDocs(PyObject *self, PyObject *args)
             // @flag SHARD_PIDL|<o PyIDL>, or a buffer containing a PIDL (see <om shell.PIDLAsString>)
             LPITEMIDLIST buf;
             bool freepidl = FALSE;
+            PyWinBufferView pybuf;
             if (PyObject_AsPIDL(ob, &buf, FALSE))
                 freepidl = TRUE;
             else {
                 // Also accept a string containing a contiguous PIDL for backward compatibility
                 PyErr_Clear();
-                DWORD buflen;
-                if (!PyWinObject_AsReadBuffer(ob, (void **)&buf, &buflen, FALSE))
+                if (!pybuf.init(ob))
                     return NULL;
+                buf = (LPITEMIDLIST)pybuf.ptr();
             }
             PY_INTERFACE_PRECALL;
             SHAddToRecentDocs(flags, buf);

--- a/win32/src/PyIID.cpp
+++ b/win32/src/PyIID.cpp
@@ -20,16 +20,13 @@ PyObject *PyWinMethod_NewIID(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "O|i", &obIID, &isBytes))
         return NULL;
     if (isBytes) {
-        const void *buf;
-        Py_ssize_t cb;
-        if (!PyObject_CheckReadBuffer(obIID))
-            return PyErr_Format(PyExc_TypeError, "object must be a read-buffer to read the CLSID bytes");
-        if (PyObject_AsReadBuffer(obIID, &buf, &cb))
+        PyWinBufferView pybuf(obIID);
+        if (!pybuf.ok())
             return NULL;
-        if (cb < sizeof(IID))
+        if (pybuf.len() < sizeof(IID))
             return PyErr_Format(PyExc_ValueError, "string too small - must be at least %d bytes (got %d)", sizeof(IID),
-                                cb);
-        iid = *((IID *)buf);
+                                pybuf.len());
+        iid = *((IID *)pybuf.ptr());
         return PyWinObject_FromIID(iid);
     }
     // Already an IID? Return self.

--- a/win32/src/PySECURITY_DESCRIPTOR.cpp
+++ b/win32/src/PySECURITY_DESCRIPTOR.cpp
@@ -97,13 +97,15 @@ PyObject *PyWinMethod_NewSECURITY_DESCRIPTOR(PyObject *self, PyObject *args)
 
     PyErr_Clear();
     PyObject *obsd = NULL;
-    PSECURITY_DESCRIPTOR psd;
-    Py_ssize_t buf_len;
     // @pyparmalt1 buffer|data||A buffer (eg, a string) with the raw bytes for the security descriptor.
     if (!PyArg_ParseTuple(args, "O:SECURITY_DESCRIPTOR", &obsd))
         return NULL;
-    if (PyObject_AsReadBuffer(obsd, (const void **)&psd, &buf_len) == -1)
+
+    PyWinBufferView pybuf(obsd);
+    if (!pybuf.ok())
         return NULL;
+    PSECURITY_DESCRIPTOR psd = (PSECURITY_DESCRIPTOR)pybuf.ptr();
+
     if (!IsValidSecurityDescriptor(psd)) {
         PyErr_SetString(PyExc_ValueError, "Data is not a valid security descriptor");
         return NULL;

--- a/win32/src/PyWinTypes.h
+++ b/win32/src/PyWinTypes.h
@@ -285,6 +285,27 @@ inline BOOL PyWinObject_AsReadBuffer(PyObject *ob, void **buf, int *buf_len, BOO
     return PyWinObject_AsReadBuffer(ob, buf, (DWORD *)buf_len, bNoneOk);
 }
 
+// replacement for PyWinObject_AsReadBuffer and PyWinObject_AsWriteBuffer
+class PYWINTYPES_EXPORT PyWinBufferView
+{
+public:
+    PyWinBufferView();
+    PyWinBufferView(PyObject *ob, bool bWrite = false, bool bNoneOk = false);
+    ~PyWinBufferView();
+    bool init(PyObject *ob, bool bWrite = false, bool bNoneOk = false);
+    void release();
+    bool ok();
+    void* ptr();
+    DWORD len();
+private:
+    Py_buffer m_view;
+
+    // don't copy objects and don't use C++ >= 11 -> not implemented private
+    // copy ctor and assignment operator
+    PyWinBufferView(const PyWinBufferView& src);
+    PyWinBufferView& operator=(PyWinBufferView const &);
+};
+
 /* ANSI/Unicode Support */
 /* If UNICODE defined, will be a BSTR - otherwise a char *
    Either way - PyWinObject_FreeTCHAR() must be called

--- a/win32/src/PyWinTypes.h
+++ b/win32/src/PyWinTypes.h
@@ -270,20 +270,8 @@ class TmpWCHAR {
     ~TmpWCHAR() { PyWinObject_FreeWCHAR(tmp); }
 };
 
-// Buffer functions that can be used in place of 's#' input format or PyString_AsStringAndSize
-// for 64-bit compatibility and API consistency
-PYWINTYPES_EXPORT BOOL PyWinObject_AsReadBuffer(PyObject *ob, void **buf, DWORD *buf_len, BOOL bNoneOk = FALSE);
-PYWINTYPES_EXPORT BOOL PyWinObject_AsWriteBuffer(PyObject *ob, void **buf, DWORD *buf_len, BOOL bNoneOk = FALSE);
-
 // For 64-bit python compatibility, convert sequence to tuple and check length fits in a DWORD
 PYWINTYPES_EXPORT PyObject *PyWinSequence_Tuple(PyObject *obseq, DWORD *len);
-
-// an 'int' version (but aren't 'int' and 'DWORD' the same size?
-// Maybe a signed-ness issue?
-inline BOOL PyWinObject_AsReadBuffer(PyObject *ob, void **buf, int *buf_len, BOOL bNoneOk = FALSE)
-{
-    return PyWinObject_AsReadBuffer(ob, buf, (DWORD *)buf_len, bNoneOk);
-}
 
 // replacement for PyWinObject_AsReadBuffer and PyWinObject_AsWriteBuffer
 class PYWINTYPES_EXPORT PyWinBufferView

--- a/win32/src/PyWinTypesmodule.cpp
+++ b/win32/src/PyWinTypesmodule.cpp
@@ -677,59 +677,6 @@ PyObject *PyWinObject_FromRECT(LPRECT prect)
     return Py_BuildValue("llll", prect->left, prect->top, prect->right, prect->bottom);
 }
 
-// Buffer conversion functions that use DWORD for length
-BOOL PyWinObject_AsReadBuffer(PyObject *ob, void **buf, DWORD *buf_len, BOOL bNoneOk)
-{
-    if (ob == Py_None) {
-        if (bNoneOk) {
-            *buf_len = 0;
-            *buf = NULL;
-            return TRUE;
-        }
-        PyErr_SetString(PyExc_TypeError, "Buffer cannot be None");
-        return FALSE;
-    }
-    Py_ssize_t py_len;
-    if (PyObject_AsReadBuffer(ob, (const void **)buf, &py_len) == -1)
-        return FALSE;
-
-#ifdef _WIN64
-    if (py_len > MAXDWORD) {
-        PyErr_Format(PyExc_ValueError, "Buffer length can be at most %d characters", MAXDWORD);
-        return FALSE;
-    }
-#endif
-
-    *buf_len = (DWORD)py_len;
-    return TRUE;
-}
-
-BOOL PyWinObject_AsWriteBuffer(PyObject *ob, void **buf, DWORD *buf_len, BOOL bNoneOk)
-{
-    if (ob == Py_None) {
-        if (bNoneOk) {
-            *buf_len = 0;
-            *buf = NULL;
-            return TRUE;
-        }
-        PyErr_SetString(PyExc_TypeError, "Buffer cannot be None");
-        return FALSE;
-    }
-    Py_ssize_t py_len;
-    if (PyObject_AsWriteBuffer(ob, buf, &py_len) == -1)
-        return FALSE;
-
-#ifdef _WIN64
-    if (py_len > MAXDWORD) {
-        PyErr_Format(PyExc_ValueError, "Buffer length can be at most %d characters", MAXDWORD);
-        return FALSE;
-    }
-#endif
-
-    *buf_len = (DWORD)py_len;
-    return TRUE;
-}
-
 // replacement for PyWinObject_AsReadBuffer and PyWinObject_AsWriteBuffer
 PyWinBufferView::PyWinBufferView()
 {

--- a/win32/src/PyWinTypesmodule.cpp
+++ b/win32/src/PyWinTypesmodule.cpp
@@ -640,9 +640,13 @@ BOOL PyWinObject_AsPARAM(PyObject *ob, WPARAM *pparam)
         return TRUE;
     }
 #endif
-    DWORD bufsize;
-    if (PyWinObject_AsReadBuffer(ob, (VOID **)pparam, &bufsize))
+    PyWinBufferView pybuf(ob);
+    if (pybuf.ok()) {
+        // note: this might be unsafe, as we give away the buffer pointer to a
+        // client outside of the scope where our RAII object 'pybuf' resides.
+        *pparam = (WPARAM)pybuf.ptr();
         return TRUE;
+    }
 
     PyErr_Clear();
     if (PyWinLong_AsVoidPtr(ob, (void **)pparam))

--- a/win32/src/win32apimodule.cpp
+++ b/win32/src/win32apimodule.cpp
@@ -5292,8 +5292,6 @@ static PyObject *PyUpdateResource(PyObject *self, PyObject *args)
     PyObject *obName;
     PyObject *ret = NULL;
     PyObject *obData;
-    LPVOID lpData;
-    DWORD cbData;
     WORD wLanguage = MAKELANGID(LANG_NEUTRAL, SUBLANG_NEUTRAL);
     LPWSTR lpType = NULL, lpName = NULL;
 
@@ -5306,9 +5304,10 @@ static PyObject *PyUpdateResource(PyObject *self, PyObject *args)
                           ))
         return NULL;
 
+    PyWinBufferView pybuf;
     if (PyWinObject_AsHANDLE(obhUpdate, (HANDLE *)&hUpdate) && PyWinObject_AsResourceIdW(obType, &lpType) &&
-        PyWinObject_AsResourceIdW(obName, &lpName) && PyWinObject_AsReadBuffer(obData, &lpData, &cbData, TRUE)) {
-        if (UpdateResourceW(hUpdate, lpType, lpName, wLanguage, lpData, cbData)) {
+        PyWinObject_AsResourceIdW(obName, &lpName) && pybuf.init(obData, false, true)) {
+        if (UpdateResourceW(hUpdate, lpType, lpName, wLanguage, pybuf.ptr(), pybuf.len())) {
             Py_INCREF(Py_None);
             ret = Py_None;
         }

--- a/win32/src/win32apimodule.cpp
+++ b/win32/src/win32apimodule.cpp
@@ -3587,7 +3587,17 @@ static BOOL PyWinObject_AsRegistryValue(PyObject *value, DWORD typ, BYTE **retDa
         // ALSO handle ALL unknown data types here.  Even if we cant support
         // it natively, we should handle the bits.
         default:
-            return PyWinObject_AsReadBuffer(value, (void **)retDataBuf, retDataSize, TRUE);
+        {
+            PyWinBufferView pybuf(value, false, true); // None ok
+            if (!pybuf.ok())
+                return FALSE;
+
+            // note: this might be unsafe, as we give away the buffer pointer to a
+            // client outside of the scope where our RAII object 'pybuf' resides.
+            *retDataBuf = (BYTE*)pybuf.ptr();
+            *retDataSize = pybuf.len();
+            return TRUE;
+        }
     }
 }
 

--- a/win32/src/win32clipboardmodule.cpp
+++ b/win32/src/win32clipboardmodule.cpp
@@ -835,14 +835,17 @@ static PyObject *py_set_clipboard_data(PyObject *self, PyObject *args)
 
         const void *buf = NULL;
         Py_ssize_t bufSize = 0;
+        PyWinBufferView pybuf;
         // In py3k, unicode no longer supports buffer interface
         if (PyUnicode_Check(obhandle)) {
             bufSize = PyUnicode_GET_DATA_SIZE(obhandle) + sizeof(Py_UNICODE);
             buf = (void *)PyUnicode_AS_UNICODE(obhandle);
         }
         else {
-            if (PyObject_AsReadBuffer(obhandle, &buf, &bufSize) == -1)
+            if (!pybuf.init(obhandle))
                 return NULL;
+            buf = pybuf.ptr();
+            bufSize = pybuf.len();
             if (PyString_Check(obhandle))
                 bufSize++;  // size doesnt include nulls!
                             // else assume buffer needs no terminator...

--- a/win32/src/win32crypt/PyCERT_CONTEXT.cpp
+++ b/win32/src/win32crypt/PyCERT_CONTEXT.cpp
@@ -519,6 +519,7 @@ PyObject *PyCERT_CONTEXT::PyCertSetCertificateContextProperty(PyObject *self, Py
     PyObject *ret = NULL;
     CRYPT_DATA_BLOB cdb = {0, NULL};
     void *pvData = NULL;
+    PyWinBufferView pybuf;
     // @flagh PropId|Type of input
     switch (prop) {
         case CERT_ARCHIVED_PROP_ID:  // @flag CERT_ARCHIVED_PROP_ID|None causes Archived flag to be cleared, any other
@@ -568,8 +569,10 @@ PyObject *PyCERT_CONTEXT::PyCertSetCertificateContextProperty(PyObject *self, Py
         // cryptoapi.CryptEncodeObjectEx> with X509_ENHANCED_KEY_USAGE.
         // @flag CERT_CTL_USAGE_PROP_ID|Same as CERT_ENHKEY_USAGE_PROP_ID
         case CERT_CTL_USAGE_PROP_ID:
-            if (!PyWinObject_AsReadBuffer(obData, (void **)&cdb.pbData, &cdb.cbData))
+            if (!pybuf.init(obData))
                 goto cleanup;
+            cdb.pbData = (BYTE*)pybuf.ptr();
+            cdb.cbData = pybuf.len();
             pvData = &cdb;
             break;
         /*

--- a/win32/src/win32crypt/PyCRYPTHASH.cpp
+++ b/win32/src/win32crypt/PyCRYPTHASH.cpp
@@ -123,7 +123,6 @@ PyObject *PyCRYPTHASH::PyCryptHashData(PyObject *self, PyObject *args, PyObject 
     static char *keywords[] = {"Data", "Flags", NULL};
     DWORD dwFlags = 0;  // CRYPT_USERDATA or 0
     DWORD dwDataLen = 0;
-    BYTE *pbData = NULL;
     HCRYPTHASH hcrypthash = ((PyCRYPTHASH *)self)->GetHCRYPTHASH();
     PyObject *obdata;
     // @comm If Flags is CRYPT_USERDATA, provider is expected to prompt user to
@@ -132,11 +131,13 @@ PyObject *PyCRYPTHASH::PyCryptHashData(PyObject *self, PyObject *args, PyObject 
                                      &obdata,    // @pyparm string|Data||Data to be hashed
                                      &dwFlags))  // @pyparm int|Flags|0|CRYPT_USERDATA or 0
         return NULL;
-    if (!PyWinObject_AsReadBuffer(obdata, (void **)&pbData, &dwDataLen, FALSE))
+    PyWinBufferView pybuf(obdata);
+    if (!pybuf.ok())
         return NULL;
+    dwDataLen = pybuf.len();
     if (dwFlags & CRYPT_USERDATA)
         dwDataLen = 0;
-    if (CryptHashData(hcrypthash, pbData, dwDataLen, dwFlags)) {
+    if (CryptHashData(hcrypthash, (BYTE*)pybuf.ptr(), dwDataLen, dwFlags)) {
         Py_INCREF(Py_None);
         return Py_None;
     }
@@ -206,8 +207,6 @@ PyObject *PyCRYPTHASH::PyCryptVerifySignature(PyObject *self, PyObject *args, Py
     HCRYPTKEY hcryptkey;
     LPCTSTR sDescription = NULL;  // no longer used
     DWORD dwFlags = 0;            // CRYPT_X931_FORMAT or CRYPT_NOHASHOID
-    DWORD dwSigLen = 0;
-    BYTE *pbSignature = NULL;
     HCRYPTHASH hcrypthash = ((PyCRYPTHASH *)self)->GetHCRYPTHASH();
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|k:CryptVerifySignature", keywords,
@@ -217,9 +216,10 @@ PyObject *PyCRYPTHASH::PyCryptVerifySignature(PyObject *self, PyObject *args, Py
         return NULL;
     if (!PyWinObject_AsHCRYPTKEY(obhcryptkey, &hcryptkey, FALSE))
         return NULL;
-    if (!PyWinObject_AsReadBuffer(obsig, (void **)&pbSignature, &dwSigLen, FALSE))
+    PyWinBufferView pybuf(obsig);
+    if (!pybuf.ok())
         return NULL;
-    if (CryptVerifySignature(hcrypthash, pbSignature, dwSigLen, hcryptkey, sDescription, dwFlags)) {
+    if (CryptVerifySignature(hcrypthash, (BYTE *)pybuf.ptr(), pybuf.len(), hcryptkey, sDescription, dwFlags)) {
         Py_INCREF(Py_None);
         return Py_None;
     }

--- a/win32/src/win32crypt/PyCRYPTKEY.cpp
+++ b/win32/src/win32crypt/PyCRYPTKEY.cpp
@@ -234,8 +234,8 @@ PyObject *PyCRYPTKEY::PyCryptEncrypt(PyObject *self, PyObject *args, PyObject *k
     static char *keywords[] = {"Final", "Data", "Hash", "Flags", NULL};
     PyObject *obdata, *ret = NULL, *obcrypthash = Py_None;
     BOOL Final;
-    DWORD err = 0, bytes_to_encrypt = 0, dwFlags = 0, dwDataLen = 0, dwBufLen = 0;
-    BYTE *pbData = NULL, *origdata;
+    DWORD err = 0, dwFlags = 0, dwDataLen = 0, dwBufLen = 0;
+    BYTE *pbData = NULL;
     HCRYPTHASH hcrypthash = NULL;
     HCRYPTKEY hcryptkey = ((PyCRYPTKEY *)self)->GetHCRYPTKEY();
 
@@ -248,10 +248,11 @@ PyObject *PyCRYPTKEY::PyCryptEncrypt(PyObject *self, PyObject *args, PyObject *k
         return NULL;
     if (!PyWinObject_AsHCRYPTHASH(obcrypthash, &hcrypthash, TRUE))
         return NULL;
-    if (!PyWinObject_AsReadBuffer(obdata, (void **)&origdata, &bytes_to_encrypt, FALSE))
+    PyWinBufferView pybuf(obdata);
+    if (!pybuf.ok())
         return NULL;
-    dwDataLen = bytes_to_encrypt;  // read/write - receives bytes needed for encrypted data
-    dwBufLen = bytes_to_encrypt;
+    dwDataLen = pybuf.len();  // read/write - receives bytes needed for encrypted data
+    dwBufLen = pybuf.len();
 
     // First call to get required buffer size - don't pass hash, or it will be updated twice
     if (!CryptEncrypt(hcryptkey, NULL, Final, dwFlags, NULL, &dwDataLen, dwBufLen))
@@ -259,9 +260,9 @@ PyObject *PyCRYPTKEY::PyCryptEncrypt(PyObject *self, PyObject *args, PyObject *k
     pbData = (BYTE *)malloc(dwDataLen);
     if (pbData == NULL)
         return PyErr_NoMemory();
-    memcpy(pbData, origdata, bytes_to_encrypt);
+    memcpy(pbData, pybuf.ptr(), pybuf.len());
     dwBufLen = dwDataLen;
-    dwDataLen = bytes_to_encrypt;
+    dwDataLen = pybuf.len();
     if (!CryptEncrypt(hcryptkey, hcrypthash, Final, dwFlags, pbData, &dwDataLen, dwBufLen))
         PyWin_SetAPIError("CryptEncrypt");
     else
@@ -290,15 +291,16 @@ PyObject *PyCRYPTKEY::PyCryptDecrypt(PyObject *self, PyObject *args, PyObject *k
         return NULL;
     if (!PyWinObject_AsHCRYPTHASH(obcrypthash, &hcrypthash, TRUE))
         return NULL;
-    if (!PyWinObject_AsReadBuffer(obdata, (void **)&origdata, &bytes_to_decrypt, FALSE))
+    PyWinBufferView pybuf(obdata);
+    if (!pybuf.ok())
         return NULL;
 
     // data buffer is read-write, do not pass in python's buffer
-    pbData = (BYTE *)malloc(bytes_to_decrypt);
+    pbData = (BYTE *)malloc(pybuf.len());
     if (pbData == NULL)
         return PyErr_NoMemory();
-    memcpy(pbData, origdata, bytes_to_decrypt);
-    dwDataLen = bytes_to_decrypt;  // read/write - receives length of plaintext
+    memcpy(pbData, pybuf.ptr(), pybuf.len());
+    dwDataLen = pybuf.len();  // read/write - receives length of plaintext
     // Due to padding, should never occur that buffer needed for plaintext is larger than encrypted data
     if (!CryptDecrypt(hcryptkey, hcrypthash, Final, dwFlags, pbData, &dwDataLen))
         PyWin_SetAPIError("CryptDecrypt");

--- a/win32/src/win32crypt/PyCRYPTPROV.cpp
+++ b/win32/src/win32crypt/PyCRYPTPROV.cpp
@@ -381,8 +381,7 @@ PyObject *PyCRYPTPROV::PyCryptCreateHash(PyObject *self, PyObject *args, PyObjec
 PyObject *PyCRYPTPROV::PyCryptImportKey(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     static char *keywords[] = {"Data", "PubKey", "Flags", NULL};
-    PBYTE buf;
-    DWORD buflen, flags = 0;
+    DWORD flags = 0;
     HCRYPTKEY retkey = NULL, pubkey = NULL;
     PyObject *obpubkey = Py_None, *obbuf;
     HCRYPTPROV hcryptprov = ((PyCRYPTPROV *)self)->GetHCRYPTPROV();
@@ -396,9 +395,11 @@ PyObject *PyCRYPTPROV::PyCryptImportKey(PyObject *self, PyObject *args, PyObject
         return NULL;
     if (!PyWinObject_AsHCRYPTKEY(obpubkey, &pubkey, TRUE))
         return NULL;
-    if (!PyWinObject_AsReadBuffer(obbuf, (void **)&buf, &buflen, FALSE))
+    PyWinBufferView pybuf(obbuf);
+    if (!pybuf.ok())
         return NULL;
-    if (!CryptImportKey(hcryptprov, buf, buflen, pubkey, flags, &retkey))
+
+    if (!CryptImportKey(hcryptprov, (BYTE*)pybuf.ptr(), pybuf.len(), pubkey, flags, &retkey))
         return PyWin_SetAPIError("PyCRYPTPROV::CryptImportKey");
     return new PyCRYPTKEY(retkey, self);
 }

--- a/win32/src/win32crypt/win32crypt_structs.cpp
+++ b/win32/src/win32crypt/win32crypt_structs.cpp
@@ -665,18 +665,19 @@ BOOL PyWinObject_AsCRYPT_ATTRIBUTE(PyObject *obca, PCRYPT_ATTRIBUTE pca)
     ZeroMemory(pca->rgValue, pca->cValue * sizeof(PCRYPT_ATTR_BLOB));
     for (value_ind = 0; value_ind < pca->cValue; value_ind++) {
         obvalue = PyTuple_GET_ITEM((PyObject *)tuple_values, value_ind);
-        if (!PyWinObject_AsReadBuffer(obvalue, (void **)&buf, &bufsize, FALSE)) {
+        PyWinBufferView pybuf(obvalue);
+        if (!pybuf.ok()) {
             ret = FALSE;
             break;
         }
         // Don't know if these blobs are modified anywhere, so copy the data instead of using python's internal buffer
-        pca->rgValue[value_ind].pbData = (BYTE *)malloc(bufsize);
+        pca->rgValue[value_ind].pbData = (BYTE *)malloc(pybuf.len());
         if (pca->rgValue[value_ind].pbData == NULL) {
             PyErr_NoMemory();
             ret = FALSE;
             break;
         }
-        memcpy(pca->rgValue[value_ind].pbData, buf, bufsize);
+        memcpy(pca->rgValue[value_ind].pbData, pybuf.ptr(), pybuf.len());
         pca->rgValue[value_ind].cbData = bufsize;
     }
     if (!ret)

--- a/win32/src/win32dynamicdialog.cpp
+++ b/win32/src/win32dynamicdialog.cpp
@@ -584,6 +584,7 @@ static BOOL ParseDlgItemList(CPythonDialogTemplate *dlg, PyObject *tmpl)
     DLGITEMTEMPLATE tpl = {0, 0, 0, 0, 0, 0, 0};
     BYTE *data = NULL;
     DWORD datalen = 0;
+    PyWinBufferView pybuf;
 
     PyObject *obitem = PySequence_Tuple(tmpl);
     if (obitem == NULL)
@@ -595,13 +596,13 @@ static BOOL ParseDlgItemList(CPythonDialogTemplate *dlg, PyObject *tmpl)
         goto cleanup;
     if (!PyWinObject_AsWCHAR(obcaption, &caption, TRUE))
         goto cleanup;
-    if (!PyWinObject_AsReadBuffer(obdata, (void **)&data, &datalen, TRUE))
+    if (!pybuf.init(obdata))
         goto cleanup;
 
     if (IS_INTRESOURCE(wclass))
         ret = dlg->Add((WORD)wclass, &tpl, caption);
     else
-        ret = dlg->Add(wclass, &tpl, caption, datalen, data);
+        ret = dlg->Add(wclass, &tpl, caption, pybuf.len(), (BYTE*)pybuf.ptr());
 
 cleanup:
     PyWinObject_FreeResourceId(wclass);

--- a/win32/src/win32evtlog.i
+++ b/win32/src/win32evtlog.i
@@ -355,12 +355,12 @@ PyObject * MyReportEvent( HANDLE hEventLog,
 	PyObject *rc = NULL;
 	DWORD numStrings = 0;
 	WCHAR **pStrings = NULL;
-	DWORD dataSize = 0;
-	void *pData;
 	PSID sid;
 	if (!PyWinObject_AsSID(obSID, &sid, TRUE))
 		return NULL;
-	if (!PyWinObject_AsReadBuffer(obData, &pData, &dataSize, TRUE))
+
+	PyWinBufferView pybuf(obData);
+	if (!pybuf.ok())
 		return NULL;
 	if (!PyWinObject_AsWCHARArray(obStrings, &pStrings, &numStrings, TRUE))
 		return NULL;
@@ -370,7 +370,7 @@ PyObject * MyReportEvent( HANDLE hEventLog,
 		}
 	BOOL ok;
 	Py_BEGIN_ALLOW_THREADS
-	ok = ReportEventW(hEventLog, wType, wCategory,	dwEventID, sid, (WORD)numStrings, dataSize, (const WCHAR **)pStrings, pData);
+	ok = ReportEventW(hEventLog, wType, wCategory,	dwEventID, sid, (WORD)numStrings, pybuf.len(), (const WCHAR **)pStrings, pybuf.ptr());
 	Py_END_ALLOW_THREADS
 
 	if (!ok) {

--- a/win32/src/win32helpmodule.cpp
+++ b/win32/src/win32helpmodule.cpp
@@ -50,18 +50,20 @@ static PyObject *PyWinHelp(PyObject *self, PyObject *args)
     UINT cmd;
     PyObject *obData = Py_None;
     ULONG_PTR data;
+    PyWinBufferView pybuf;
 
     if (!PyArg_ParseTuple(args, "O&Oi|O:WinHelp", PyWinObject_AsHANDLE, &hwnd, &obhlpFile, &cmd, &obData))
         return NULL;
 
-    DWORD data_len;
-    if (!PyWinObject_AsReadBuffer(obData, (void **)&data, &data_len, TRUE)) {
+    if (!pybuf.init(obData, false, true)) {
         PyErr_Clear();
         if (!PyWinLong_AsULONG_PTR(obData, &data)) {
             PyErr_SetString(PyExc_TypeError, "Data must be a buffer, None, or pointer-sized number");
             return NULL;
         }
     }
+    else
+        data = (ULONG_PTR)pybuf.ptr();
     if (!PyWinObject_AsTCHAR(obhlpFile, &hlpFile, FALSE))
         return NULL;
     PyW32_BEGIN_ALLOW_THREADS

--- a/win32/src/win32inet.i
+++ b/win32/src/win32inet.i
@@ -770,10 +770,12 @@ PyObject *PyInternetWriteFile(PyObject *self, PyObject *args)
 		return NULL;
 	if (!PyWinObject_AsHANDLE(obFile, &hFile))
 		return NULL;
-	if (!PyWinObject_AsReadBuffer(obBuffer,	&buf, &bufsize,	FALSE))
+	PyWinBufferView pybuf(obBuffer);
+	if (!pybuf.ok())
 		return NULL;
+		
 	Py_BEGIN_ALLOW_THREADS
-	ok = InternetWriteFile(hFile, buf, bufsize, &bytes_written);
+	ok = InternetWriteFile(hFile, pybuf.ptr(), pybuf.len(), &bytes_written);
 	Py_END_ALLOW_THREADS
 	if (!ok)
 		return PyWin_SetAPIError("InternetWriteFile");

--- a/win32/src/win32pipe.i
+++ b/win32/src/win32pipe.i
@@ -324,8 +324,6 @@ PyObject *MyTransactNamedPipe(PyObject *self, PyObject *args)
 PyObject *MyCallNamedPipe(PyObject *self, PyObject *args)
 {
 	PyObject *obPipeName, *obdata;
-	void *data;
-	DWORD dataSize;
 	DWORD timeOut;
 	DWORD readBufSize;
 	TCHAR *szPipeName;
@@ -339,7 +337,8 @@ PyObject *MyCallNamedPipe(PyObject *self, PyObject *args)
 		// @flag win32pipe.NMPWAIT_WAIT_FOREVER|Waits indefinitely. 
 		// @flag win32pipe.NMPWAIT_USE_DEFAULT_WAIT|Uses the default time-out specified in a call to the CreateNamedPipe function. 
 		return NULL;
-	if (!PyWinObject_AsReadBuffer(obdata, &data, &dataSize, FALSE))
+	PyWinBufferView pybuf(obdata);
+	if (!pybuf.ok())
 		return NULL;
 	if (!PyWinObject_AsTCHAR(obPipeName, &szPipeName))
 		return NULL;
@@ -351,7 +350,7 @@ PyObject *MyCallNamedPipe(PyObject *self, PyObject *args)
 	DWORD numRead = 0;
 	BOOL ok;
 	Py_BEGIN_ALLOW_THREADS
-	ok = CallNamedPipe(szPipeName, data, dataSize, readBuf, readBufSize, &numRead, timeOut);
+	ok = CallNamedPipe(szPipeName, pybuf.ptr(), pybuf.len(), readBuf, readBufSize, &numRead, timeOut);
 	Py_END_ALLOW_THREADS
 	if (!ok) {
 		PyWinObject_FreeTCHAR(szPipeName);

--- a/win32/src/win32pipe.i
+++ b/win32/src/win32pipe.i
@@ -237,8 +237,6 @@ PyObject *MyConnectNamedPipe(PyObject *self, PyObject *args)
 PyObject *MyTransactNamedPipe(PyObject *self, PyObject *args)
 {
 	PyObject *obHandle, *obWriteData, *obReadData, *obOverlapped = Py_None;
-	void *writeData;
-	DWORD cbWriteData;
 	void *readData;
 	DWORD cbReadData;
 	HANDLE handle;
@@ -257,7 +255,8 @@ PyObject *MyTransactNamedPipe(PyObject *self, PyObject *args)
 	if (!PyWinObject_AsHANDLE(obHandle, &handle))
 		return NULL;
 
-	if (!PyWinObject_AsReadBuffer(obWriteData, &writeData, &cbWriteData, FALSE))
+	PyWinBufferView read_buf, write_buf(obWriteData);
+	if (!write_buf.ok())
 		return NULL;
 
 	if (obOverlapped!=Py_None && !PyWinObject_AsOVERLAPPED(obOverlapped, &pOverlapped))
@@ -273,9 +272,12 @@ PyObject *MyTransactNamedPipe(PyObject *self, PyObject *args)
 			if (obRet==NULL)
 				return NULL;
 			// This shouldn't fail for buffer just created, but new buffer interface is screwy ...
-			DWORD newbufsize;		// maybe also check new buffer size matched requested size ?
-			if (!PyWinObject_AsReadBuffer(obRet, &readData, &newbufsize))
-				return NULL;
+			// maybe also check new buffer size matched requested size ?
+			if (!read_buf.init(obRet, true)) {
+			    Py_DECREF(obRet);
+			    return NULL;
+			    }
+			readData = read_buf.ptr();
 		} else {
 			obRet=PyString_FromStringAndSize(NULL, cbReadData);
 			if (obRet==NULL)
@@ -285,10 +287,10 @@ PyObject *MyTransactNamedPipe(PyObject *self, PyObject *args)
 		}
 	} else {
 		PyErr_Clear();
-		if (!PyWinObject_AsWriteBuffer(obReadData, &readData, &cbReadData,FALSE)){
-			PyErr_SetString(PyExc_TypeError, "Third param must be an integer or writeable buffer object");
-			return NULL;
-			}
+		if (!read_buf.init(obReadData, true))
+		    return NULL;
+		readData = read_buf.ptr();
+		cbReadData = read_buf.len();
 		// If they didn't pass an overlapped, then we can't return the
 		// original buffer as they have no way to know how many bytes
 		// were read - so leave obRet NULL and the ret will be a new
@@ -301,7 +303,7 @@ PyObject *MyTransactNamedPipe(PyObject *self, PyObject *args)
 	BOOL ok;
 	DWORD numRead = 0;
 	Py_BEGIN_ALLOW_THREADS
-	ok = TransactNamedPipe(handle, writeData, cbWriteData, readData, cbReadData, &numRead, pOverlapped);
+	ok = TransactNamedPipe(handle, write_buf.ptr(), write_buf.len(), readData, cbReadData, &numRead, pOverlapped);
 	Py_END_ALLOW_THREADS
 	DWORD err = 0;
 	if (!ok) {

--- a/win32/src/win32print/win32print.cpp
+++ b/win32/src/win32print/win32print.cpp
@@ -997,8 +997,6 @@ static PyObject *PyEndPage(PyObject *self, PyObject *args)
 static PyObject *PyWritePrinter(PyObject *self, PyObject *args)
 {
     HANDLE hprinter;
-    LPVOID buf;
-    DWORD buf_size;
     DWORD bufwritten_size;
     PyObject *obbuf;
     if (!PyArg_ParseTuple(args, "O&O:WritePrinter", PyWinObject_AsPrinterHANDLE,
@@ -1007,9 +1005,10 @@ static PyObject *PyWritePrinter(PyObject *self, PyObject *args)
                           &obbuf))  // @pyparm string|buf||String or buffer containing data to send to printer. Embedded
                                     // NULL bytes are allowed.
         return NULL;
-    if (!PyWinObject_AsReadBuffer(obbuf, &buf, &buf_size, FALSE))
+    PyWinBufferView pybuf(obbuf);
+    if (!pybuf.ok())
         return NULL;
-    if (!WritePrinter(hprinter, buf, buf_size, &bufwritten_size))
+    if (!WritePrinter(hprinter, pybuf.ptr(), pybuf.len(), &bufwritten_size))
         return PyWin_SetAPIError("WritePrinter");
     return PyLong_FromUnsignedLong(bufwritten_size);
 }


### PR DESCRIPTION
This is my draft as announced in #1588. It replaces calls to `PyObject_AsReadBuffer`, `PyObject_AsWriteBuffer`, `PyWinObject_AsReadBuffer` and `PyWinObject_AsWriteBuffer` by using a C++ class that manages the lifetime of the underlying python objects. If you have a better name for this class (`PyWinObject_GetBuffer`), I will happily apply that.

Unfortunately this draft does **not** remove all the potential problems: There were use cases of `PyWinObject_AsReadBuffer` which handed out the pointer to the buffer to external clients (after the buffer object was released) and those still exist:
- `PyWinObject_AsRegistryValue`
- `PyNCB::setattro`
- `PyWinObject_AsDATA_BLOB`
- `PyWinObject_AsCRYPT_BIT_BLOB`
- `PyWinObject_AsPBYTEArray`
- `PyWinObject_AsPARAM`

Note: The problematic places in the code are marked with a comment - search for RAII.

I sorted those by increasing 'danger'. `PyWinObject_AsRegistryValue` is harmless, because it is not exported and called only once in a way that should not lead to problems. I am also not worried about `PyNCB::setattro` as the usage of Netbios should tend to zero. I am also not too concerned about the functions from win32crypt.h as they are also not exported and used in way that looks OK to me. This leaves us with `PyWinObject_AsPARAM`: It is used all over the place in pywin32 **and it is exported** so that it is hard to tell how clients will use it.

Do you think this gaping hole defeats the very purpose of this PR?