### PR TITLE
Update docs from PyTime to PyDateTime (fixes #1670) 

### DIFF
--- a/com/win32com/makegw/makegwparse.py
+++ b/com/win32com/makegw/makegwparse.py
@@ -372,7 +372,7 @@ class ArgFormatterTime(ArgFormatterPythonCOM):
 		ArgFormatterPythonCOM.__init__(self, arg, builtinIndirection, declaredIndirection)
 
 	def _GetPythonTypeDesc(self):
-		return "<o PyTime>"
+		return "<o PyDateTime>"
 	def GetParsePostCode(self):
 		# variable was declared with only the builtinIndirection
 		### NOTE: this is an [in] ... so use only builtin

--- a/com/win32com/src/PyComHelpers.cpp
+++ b/com/win32com/src/PyComHelpers.cpp
@@ -274,11 +274,11 @@ PyObject *PyCom_PyObjectFromSTATSTG(STATSTG *pStat)
         pStat->type,  // @tupleitem 1|int|type|Indicates the type of storage object. This is one of the values from the
                       // storagecon.STGTY_* values.
         obSize,       // @tupleitem 2|<o ULARGE_INTEGER>|size|Specifies the size in bytes of the stream or byte array.
-        obmtime,      // @tupleitem 3|<o PyTime>|modificationTime|Indicates the last modification time for this storage,
+        obmtime,      // @tupleitem 3|<o PyDateTime>|modificationTime|Indicates the last modification time for this storage,
                       // stream, or byte array.
-        obctime,  // @tupleitem 4|<o PyTime>|creationTime|Indicates the creation time for this storage, stream, or byte
+        obctime,  // @tupleitem 4|<o PyDateTime>|creationTime|Indicates the creation time for this storage, stream, or byte
                   // array.
-        obatime,  // @tupleitem 5|<o PyTime>|accessTime|Indicates the last access time for this storage, stream or byte
+        obatime,  // @tupleitem 5|<o PyDateTime>|accessTime|Indicates the last access time for this storage, stream or byte
                   // array.
         pStat->grfMode,  // @tupleitem 6|int|mode|Indicates the access mode specified when the object was opened. This
                          // member is only valid in calls to Stat methods.
@@ -316,7 +316,7 @@ BOOL PyCom_PyObjectAsSTATSTG(PyObject *ob, STATSTG *pStat, DWORD flags /* = 0 */
     if (!PyWinObject_AsULARGE_INTEGER(obSize, &pStat->cbSize))
         return FALSE;
     if (!PyWinTime_Check(obmtime) || !PyWinTime_Check(obctime) || !PyWinTime_Check(obatime)) {
-        PyErr_SetString(PyExc_TypeError, "The time entries in a STATSTG tuple must be PyTime objects");
+        PyErr_SetString(PyExc_TypeError, "The time entries in a STATSTG tuple must be PyDateTime objects");
         return FALSE;
     }
     if (!PyWinObject_AsFILETIME(obmtime, &pStat->mtime))

--- a/com/win32com/src/extensions/PyIPropertyStorage.cpp
+++ b/com/win32com/src/extensions/PyIPropertyStorage.cpp
@@ -808,9 +808,9 @@ PyObject *PyIPropertyStorage::SetTimes(PyObject *self, PyObject *args)
     IPropertyStorage *pIPS = GetI(self);
     if (pIPS == NULL)
         return NULL;
-    // @pyparm <o PyTime>|ctime||Creation time, or None for no change
-    // @pyparm <o PyTime>|atime||Last access time, or None for no change
-    // @pyparm <o PyTime>|mtime||Modification time, or None for no change
+    // @pyparm <o PyDateTime>|ctime||Creation time, or None for no change
+    // @pyparm <o PyDateTime>|atime||Last access time, or None for no change
+    // @pyparm <o PyDateTime>|mtime||Modification time, or None for no change
     PyObject *obctime;
     PyObject *obatime;
     PyObject *obmtime;

--- a/com/win32com/src/extensions/PyIStorage.cpp
+++ b/com/win32com/src/extensions/PyIStorage.cpp
@@ -354,11 +354,11 @@ PyObject *PyIStorage::SetElementTimes(PyObject *self, PyObject *args)
         return NULL;
     // @pyparm str|name||The name of the storage object element whose times are to be modified. If NULL, the time is set
     // on the root storage rather than one of its elements.
-    // @pyparm <o PyTime>|ctime||Either the new creation time for the element or None if the creation time is not to be
+    // @pyparm <o PyDateTime>|ctime||Either the new creation time for the element or None if the creation time is not to be
     // modified.
-    // @pyparm <o PyTime>|atime||Either the new access time for the element or None if the access time is not to be
+    // @pyparm <o PyDateTime>|atime||Either the new access time for the element or None if the access time is not to be
     // modified.
-    // @pyparm <o PyTime>|mtime||Either the new modification time for the element or None if the modification time is
+    // @pyparm <o PyDateTime>|mtime||Either the new modification time for the element or None if the modification time is
     // not to be modified.
     PyObject *obName;
     PyObject *obpctime;

--- a/com/win32comext/adsi/src/PyIADsUser.i
+++ b/com/win32comext/adsi/src/PyIADsUser.i
@@ -48,7 +48,7 @@ HRESULT put_AccountDisabled(short val);
 // @pyswig int|get_AccountExpirationDate|
 HRESULT get_AccountExpirationDate(DATE *OUTPUT);
 // @pyswig |put_AccountExpirationDate|
-// @pyparm <o PyTime>|val||
+// @pyparm <o PyDateTime>|val||
 HRESULT put_AccountExpirationDate(DATE val);
 **/
 // @pyswig unicode|get_BadLoginAddress|

--- a/com/win32comext/bits/src/bits.cpp
+++ b/com/win32comext/bits/src/bits.cpp
@@ -61,7 +61,7 @@ PyObject *MakeTimeOrNone(const FILETIME &t)
 PyObject *PyObject_FromBG_JOB_TIMES(BG_JOB_TIMES *jt)
 {
     // @object BG_JOB_TIMES|A tuple of 3 elements, where each element may be
-    // None or a <o PyTime> object.  The elements are the CreationTime,
+    // None or a <o PyDateTime> object.  The elements are the CreationTime,
     // ModificationTime and TransferCompletionTime, respectively.
     return Py_BuildValue("NNN", MakeTimeOrNone(jt->CreationTime), MakeTimeOrNone(jt->ModificationTime),
                          MakeTimeOrNone(jt->TransferCompletionTime));

--- a/com/win32comext/shell/src/PyIShellItem2.cpp
+++ b/com/win32comext/shell/src/PyIShellItem2.cpp
@@ -205,7 +205,7 @@ PyObject *PyIShellItem2::GetCLSID(PyObject *self, PyObject *args)
     return PyWinObject_FromIID(val);
 }
 
-// @pymethod <o PyTime>|PyIShellItem2|GetFileTime|Retrieves the value of a property as a FILETIME
+// @pymethod <o PyDateTime>|PyIShellItem2|GetFileTime|Retrieves the value of a property as a FILETIME
 PyObject *PyIShellItem2::GetFileTime(PyObject *self, PyObject *args)
 {
     IShellItem2 *pISI2 = GetI(self);

--- a/com/win32comext/shell/src/PyIShellItemResources.cpp
+++ b/com/win32comext/shell/src/PyIShellItemResources.cpp
@@ -84,9 +84,9 @@ PyObject *PyIShellItemResources::SetTimes(PyObject *self, PyObject *args)
     IShellItemResources *pISIR = GetI(self);
     if (pISIR == NULL)
         return NULL;
-    // @pyparm <o PyTime>|pftCreation||Description for pftCreation
-    // @pyparm <o PyTime>|pftWrite||Description for pftWrite
-    // @pyparm <o PyTime>|pftAccess||Description for pftAccess
+    // @pyparm <o PyDateTime>|pftCreation||Description for pftCreation
+    // @pyparm <o PyDateTime>|pftWrite||Description for pftWrite
+    // @pyparm <o PyDateTime>|pftAccess||Description for pftAccess
     FILETIME ftCreation;
     FILETIME ftWrite;
     FILETIME ftAccess;

--- a/com/win32comext/taskscheduler/src/PyIScheduledWorkItem.cpp
+++ b/com/win32comext/taskscheduler/src/PyIScheduledWorkItem.cpp
@@ -135,7 +135,7 @@ PyObject *PyIScheduledWorkItem::GetTriggerString(PyObject *self, PyObject *args)
     return ret;
 }
 
-// @pymethod (<o PyTime>,,,)|PyIScheduledWorkItem|GetRunTimes|Return specified number of run times within given time
+// @pymethod (<o PyDateTime>,,,)|PyIScheduledWorkItem|GetRunTimes|Return specified number of run times within given time
 // frame
 PyObject *PyIScheduledWorkItem::GetRunTimes(PyObject *self, PyObject *args)
 {
@@ -143,8 +143,8 @@ PyObject *PyIScheduledWorkItem::GetRunTimes(PyObject *self, PyObject *args)
     if (pISWI == NULL)
         return NULL;
     // @pyparm int|Count||Number of run times to retrieve
-    // @pyparm <o PyTime>|Begin||Start time, defaults to current time if not passed or None
-    // @pyparm <o PyTime>|End||End time, defaults to unlimited if not passed or None
+    // @pyparm <o PyDateTime>|Begin||Start time, defaults to current time if not passed or None
+    // @pyparm <o PyDateTime>|End||End time, defaults to unlimited if not passed or None
     WORD wCount = 0, time_ind = 0;
     SYSTEMTIME start_time, end_time;
     LPSYSTEMTIME run_time = NULL, first_run_time = NULL, lpend_time = NULL;
@@ -181,7 +181,7 @@ PyObject *PyIScheduledWorkItem::GetRunTimes(PyObject *self, PyObject *args)
     return ret;
 }
 
-// @pymethod <o PyTime>|PyIScheduledWorkItem|GetNextRunTime|Returns next time that task is scheduled to run
+// @pymethod <o PyDateTime>|PyIScheduledWorkItem|GetNextRunTime|Returns next time that task is scheduled to run
 PyObject *PyIScheduledWorkItem::GetNextRunTime(PyObject *self, PyObject *args)
 {
     IScheduledWorkItem *pISWI = GetI(self);
@@ -320,7 +320,7 @@ PyObject *PyIScheduledWorkItem::EditWorkItem(PyObject *self, PyObject *args)
     return Py_None;
 }
 
-// @pymethod <o PyTime>|PyIScheduledWorkItem|GetMostRecentRunTime|Returns last time task ran
+// @pymethod <o PyDateTime>|PyIScheduledWorkItem|GetMostRecentRunTime|Returns last time task ran
 PyObject *PyIScheduledWorkItem::GetMostRecentRunTime(PyObject *self, PyObject *args)
 {
     IScheduledWorkItem *pISWI = GetI(self);

--- a/win32/src/PyTime.cpp
+++ b/win32/src/PyTime.cpp
@@ -52,22 +52,22 @@ static PyObject *GetTZUTC()
     return got;
 }
 
-// @pymethod <o PyTime>|pywintypes|Time|Creates a new time object.
+// @pymethod <o PyDateTime>|pywintypes|Time|Creates a new time object.
 PyObject *PyWinMethod_NewTime(PyObject *self, PyObject *args)
 {
     PyObject *timeOb;
     // @pyparm object|timeRepr||An integer/float/tuple time representation.
     // @comm Note that the parameter can be any object that supports
-    // int(object) - for example , another PyTime object.
+    // int(object) or another PyDateTime object.
     // <nl>The integer should be as defined by the Python time module.
-    // See the description of the <o PyTime> object for more information.
+    // See the description of the <o PyDateTime> object for more information.
     if (!PyArg_ParseTuple(args, "O", &timeOb))
         return NULL;
 
     return PyWin_NewTime(timeOb);
 }
 
-// @pymethod <o PyTime>|pywintypes|TimeStamp|Creates a new time object.
+// @pymethod <o PyDateTime>|pywintypes|TimeStamp|Creates a new time object.
 PyObject *PyWinMethod_NewTimeStamp(PyObject *self, PyObject *args)
 {
     PyObject *obts;
@@ -106,11 +106,13 @@ done:
 }
 
 // @object PyDateTime|A Python object, representing an instant in time.
-// @comm pywin32 builds for Python 3.0 use datetime objects instead of the
-// old PyTime object.
 // @comm PyDateTime is a sub-class of the regular datetime.datetime object.
 // It is subclassed so it can provide a somewhat backwards compatible
-// <om PyDateTime.Format> method, but is otherwise identical.
+// <om PyDateTime.Format> method, but is otherwise identical. Functions accepting
+// a PyDateTime object also accept a datetime.datetime object. A PyDateTime
+// object can be created via <om pywintypes.Time>.
+// @comm Migration note: pywin32 builds for Python 2 used an (incompatible)
+// PyTime object instad of datetime.
 
 struct PyMethodDef PyWinDateTimeType_methods[] = {
     {"Format", PyWinDateTimeType_Format,

--- a/win32/src/PyWinTypesmodule.cpp
+++ b/win32/src/PyWinTypesmodule.cpp
@@ -395,7 +395,7 @@ static PyObject *PyWin_CreateGuid(PyObject *self, PyObject *args)
     CoCreateGuid(&guid);
     return PyWinObject_FromIID(guid);
 }
-// @pymethod <o PyTime>|pywintypes|DosDateTimeToTime|Converts an MS-DOS Date/Time to a standard Time object.
+// @pymethod <o PyDateTime>|pywintypes|DosDateTimeToTime|Converts an MS-DOS Date/Time to a standard Time object.
 static PyObject *PyWin_DosDateTimeToTime(PyObject *self, PyObject *args)
 {
     WORD wFatDate, wFatTime;
@@ -415,9 +415,9 @@ PyObject *PyObject_FromWIN32_FIND_DATAA(WIN32_FIND_DATAA *pData)
         "lNNNNNNNss",
         pData->dwFileAttributes,  // @tupleitem 0|int|attributes|File Attributes.  A combination of the
                                   // win32com.FILE_ATTRIBUTE_* flags.
-        PyWinObject_FromFILETIME(pData->ftCreationTime),    // @tupleitem 1|<o PyTime>|createTime|File creation time.
-        PyWinObject_FromFILETIME(pData->ftLastAccessTime),  // @tupleitem 2|<o PyTime>|accessTime|File access time.
-        PyWinObject_FromFILETIME(pData->ftLastWriteTime),   // @tupleitem 3|<o PyTime>|writeTime|Time of last file write
+        PyWinObject_FromFILETIME(pData->ftCreationTime),    // @tupleitem 1|<o PyDateTime>|createTime|File creation time.
+        PyWinObject_FromFILETIME(pData->ftLastAccessTime),  // @tupleitem 2|<o PyDateTime>|accessTime|File access time.
+        PyWinObject_FromFILETIME(pData->ftLastWriteTime),   // @tupleitem 3|<o PyDateTime>|writeTime|Time of last file write
         PyLong_FromUnsignedLong(pData->nFileSizeHigh),  // @tupleitem 4|int|nFileSizeHigh|high order DWORD of file size.
         PyLong_FromUnsignedLong(pData->nFileSizeLow),   // @tupleitem 5|int|nFileSizeLow|low order DWORD of file size.
         PyLong_FromUnsignedLong(
@@ -801,8 +801,8 @@ static struct PyMethodDef pywintypes_functions[] = {
 #ifndef NO_PYWINTYPES_IID
     {"IID", PyWinMethod_NewIID, 1},  // @pymeth IID|Makes an <o PyIID> object from a string.
 #endif
-    {"Time", PyWinMethod_NewTime, 1},            // @pymeth Time|Makes a <o PyTime> object from the argument.
-    {"TimeStamp", PyWinMethod_NewTimeStamp, 1},  // @pymeth Time|Makes a <o PyTime> object from the argument.
+    {"Time", PyWinMethod_NewTime, 1},            // @pymeth Time|Makes a <o PyDateTime> object from the argument.
+    {"TimeStamp", PyWinMethod_NewTimeStamp, 1},  // @pymeth Time|Makes a <o PyDateTime> object from the argument.
 #ifndef MS_WINCE
     {"CreateGuid", PyWin_CreateGuid, 1},  // @pymeth CreateGuid|Creates a new, unique GUIID.
 #endif                                    // MS_WINCE

--- a/win32/src/win32apimodule.cpp
+++ b/win32/src/win32apimodule.cpp
@@ -2477,7 +2477,7 @@ static PyObject *PyGetTimeZoneInformation(PyObject *self, PyObject *args)
     // example, this member could contain "EST" to indicate Eastern Standard Time. This string is not used by the
     // operating system, so anything stored there using the SetTimeZoneInformation function is returned unchanged by the
     // GetTimeZoneInformation function. This string can be empty.
-    // @tupleitem 2|<o PyTime>/tuple|standardTime|Specifies a SYSTEMTIME object that contains a date and local time when
+    // @tupleitem 2|<o PyDateTime>/tuple|standardTime|Specifies a SYSTEMTIME object that contains a date and local time when
     // the transition from daylight saving time to standard time occurs on this operating system. If this date is not
     // specified, the wMonth member in the SYSTEMTIME structure must be zero. If this date is specified, the
     // DaylightDate value in the TIME_ZONE_INFORMATION structure must also be specified. <nl>To select the correct day
@@ -2489,7 +2489,7 @@ static PyObject *PyGetTimeZoneInformation(PyObject *self, PyObject *args)
     // added to the value of the Bias member to form the bias used during standard time. In most time zones, the value
     // of this member is zero.
     // @tupleitem 4|unicode|daylightName|
-    // @tupleitem 5|<o PyTime>/tuple|daylightTime|
+    // @tupleitem 5|<o PyDateTime>/tuple|daylightTime|
     // @tupleitem 6|int|daylightBias|Specifies a bias value to be used during local time translations that occur during
     // daylight saving time. This member is ignored if a value for the DaylightDate member is not supplied. <nl>This
     // value is added to the value of the Bias member to form the bias used during daylight saving time. In most time
@@ -2555,7 +2555,7 @@ static PyObject *PyGetDateFormat(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "iiO|O:GetDateFormat",
                           &locale,     // @pyparm int|locale||
                           &flags,      // @pyparm int|flags||
-                          &obTime,     // @pyparm <o PyTime>|time||The time to use, or None to use the current time.
+                          &obTime,     // @pyparm <o PyDateTime>|time||The time to use, or None to use the current time.
                           &obFormat))  // @pyparm string|format||May be None
         return NULL;
     SYSTEMTIME st, *pst = NULL;
@@ -2586,7 +2586,7 @@ static PyObject *PyGetTimeFormat(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "iiO|O:GetTimeFormat",
                           &locale,     // @pyparm int|locale||
                           &flags,      // @pyparm int|flags||
-                          &obTime,     // @pyparm <o PyTime>|time||The time to use, or None to use the current time.
+                          &obTime,     // @pyparm <o PyDateTime>|time||The time to use, or None to use the current time.
                           &obFormat))  // @pyparm string|format||May be None
         return NULL;
 
@@ -5059,7 +5059,7 @@ static PyObject *PySetLocalTime(PyObject *self, PyObject *args)
     PyObject *obst;
     if (!PyArg_ParseTuple(
             args, "O:SetLocalTime",
-            &obst))  // @pyparm <o PyTime>|SystemTime||The local time to be set.  Can also be a time tuple.
+            &obst))  // @pyparm <o PyDateTime>|SystemTime||The local time to be set.  Can also be a time tuple.
         return NULL;
     if (!PyWinObject_AsSYSTEMTIME(obst, &st))
         return NULL;

--- a/win32/src/win32credmodule.cpp
+++ b/win32/src/win32credmodule.cpp
@@ -118,7 +118,7 @@ BOOL PyWinObject_AsCREDENTIAL_ATTRIBUTEArray(PyObject *obattrs, PCREDENTIAL_ATTR
 // @prop int|Type|Type of credential, one of CRED_TYPE_* values
 // @prop <o PyUnicode>|TargetName|Target of credential, can end with * for wildcard matching
 // @prop <o PyUnicode>|Comment|Descriptive text
-// @prop <o PyTime>|LastWritten|Modification time, ignored on input
+// @prop <o PyDateTime>|LastWritten|Modification time, ignored on input
 // @prop <o PyUnicode>|CredentialBlob|Contains password for username credential, or PIN for certificate credential. This
 // member is write-only.
 // @prop int|Persist|Specifies scope of persistence, one of CRED_PERSIST_* values

--- a/win32/src/win32crypt/PyCERT_CONTEXT.cpp
+++ b/win32/src/win32crypt/PyCERT_CONTEXT.cpp
@@ -78,9 +78,9 @@ struct PyMemberDef PyCERT_CONTEXT::members[] = {
     //	<om cryptoapi.CryptDecodeObjectEx> to decode into individual components, or <om cryptoapi.CertNameToStr> to
     //	return a single formatted string
     {"Issuer", T_OBJECT, offsetof(PyCERT_CONTEXT, obdummy), READONLY},
-    // @prop <o PyTime>|NotBefore|Beginning of certificate's period of validity
+    // @prop <o PyDateTime>|NotBefore|Beginning of certificate's period of validity
     {"NotBefore", T_OBJECT, offsetof(PyCERT_CONTEXT, obdummy), READONLY},
-    // @prop <o PyTime>|NotAfter|End of certificate's period of validity
+    // @prop <o PyDateTime>|NotAfter|End of certificate's period of validity
     {"NotAfter", T_OBJECT, offsetof(PyCERT_CONTEXT, obdummy), READONLY},
     // @prop str|SignatureAlgorithm|Object id of the certifcate's signature algorithm
     {"SignatureAlgorithm", T_OBJECT, offsetof(PyCERT_CONTEXT, obdummy), READONLY},
@@ -418,7 +418,7 @@ PyObject *PyCERT_CONTEXT::PyCertGetCertificateContextProperty(PyObject *self, Py
             Py_INCREF(Py_True);
             ret = Py_True;  // no data returned, success is only indicator
             break;
-        case CERT_DATE_STAMP_PROP_ID:  // @flag CERT_DATE_STAMP_PROP_ID|<o PyTime>
+        case CERT_DATE_STAMP_PROP_ID:  // @flag CERT_DATE_STAMP_PROP_ID|<o PyDateTime>
             ret = PyWinObject_FromFILETIME(*((FILETIME *)pvData));
             break;
         case CERT_ACCESS_STATE_PROP_ID:  // @flag CERT_ACCESS_STATE_PROP_ID|int
@@ -526,7 +526,7 @@ PyObject *PyCERT_CONTEXT::PyCertSetCertificateContextProperty(PyObject *self, Py
                                      // causes it to be set
             pvData = &cdb;           // no actual data, non-NULL pvData indicates presence of flag
             break;
-        case CERT_DATE_STAMP_PROP_ID:  // @flag CERT_DATE_STAMP_PROP_ID|<o PyTime> specifying when cert was added to
+        case CERT_DATE_STAMP_PROP_ID:  // @flag CERT_DATE_STAMP_PROP_ID|<o PyDateTime> specifying when cert was added to
                                        // store
             if (!PyWinObject_AsFILETIME(obData, &ftData))
                 goto cleanup;

--- a/win32/src/win32evtlog.i
+++ b/win32/src/win32evtlog.i
@@ -185,8 +185,8 @@ PyTypeObject PyEventLogRecordType =
 /*static*/ struct PyMemberDef PyEventLogRecord::members[] = {
 	{"Reserved",           T_INT,     OFF(Reserved)}, // @prop integer|Reserved|
 	{"RecordNumber",       T_INT,	  OFF(RecordNumber)}, // @prop integer|RecordNumber|
-	{"TimeGenerated",      T_OBJECT,  OFF(TimeGenerated)}, // @prop <o PyTime>|TimeGenerated|
-	{"TimeWritten",        T_OBJECT,  OFF(TimeWritten)}, // @prop <o PyTime>|TimeWritten|
+	{"TimeGenerated",      T_OBJECT,  OFF(TimeGenerated)}, // @prop <o PyDateTime>|TimeGenerated|
+	{"TimeWritten",        T_OBJECT,  OFF(TimeWritten)}, // @prop <o PyDateTime>|TimeWritten|
 	{"EventID",            T_INT,	  OFF(EventID)}, // @prop integer|EventID|
 	{"EventType",          T_SHORT,	  OFF(EventType)}, // @prop integer|EventType|
 	{"EventCategory",      T_SHORT,   OFF(EventCategory)}, // @prop integer|EventCategory|

--- a/win32/src/win32file.i
+++ b/win32/src/win32file.i
@@ -710,13 +710,13 @@ DWORD GetFileAttributes(
 DWORD GetFileAttributesW(
     WCHAR *fileName); // @pyparm <o PyUnicode>|fileName||Name of the file to retrieve attributes for.
 
-// @pyswig (<o PyTime>, <o PyTime>, <o PyTime>)|GetFileTime|Returns a file's creation, last access, and modification times.
+// @pyswig (<o PyDateTime>, <o PyDateTime>, <o PyDateTime>)|GetFileTime|Returns a file's creation, last access, and modification times.
 // @comm Times are returned in UTC time.
 BOOLAPI GetFileTime(
     HANDLE handle, // @pyparm <o PyHANDLE>|handle||Handle to the file.
-	FILETIME *OUTPUT, // @pyparm <o PyTime>|creationTime||
-	FILETIME *OUTPUT, // @pyparm <o PyTime>|accessTime||
-	FILETIME *OUTPUT // @pyparm <o PyTime>|writeTime||
+	FILETIME *OUTPUT, // @pyparm <o PyDateTime>|creationTime||
+	FILETIME *OUTPUT, // @pyparm <o PyDateTime>|accessTime||
+	FILETIME *OUTPUT // @pyparm <o PyDateTime>|writeTime||
 );
 
 
@@ -731,9 +731,9 @@ static BOOL PyWinTime_DateTimeCheck(PyObject *ob)
 static PyObject *PySetFileTime (PyObject *self, PyObject *args, PyObject *kwargs)
 {
 	PyObject *obHandle;       // @pyparm <o PyHANDLE>|File||Previously opened handle (opened with FILE_WRITE_ATTRIBUTES access).
-	PyObject *obCreationTime = Py_None;  // @pyparm <o PyTime>|CreationTime|None|File created time. None for no change.
-	PyObject *obLastAccessTime = Py_None; // @pyparm <o PyTime>|LastAccessTime|None|File access time. None for no change.
-	PyObject *obLastWriteTime = Py_None;  // @pyparm <o PyTime>|LastWriteTime|None|File written time. None for no change.
+	PyObject *obCreationTime = Py_None;  // @pyparm <o PyDateTime>|CreationTime|None|File created time. None for no change.
+	PyObject *obLastAccessTime = Py_None; // @pyparm <o PyDateTime>|LastAccessTime|None|File access time. None for no change.
+	PyObject *obLastWriteTime = Py_None;  // @pyparm <o PyDateTime>|LastWriteTime|None|File written time. None for no change.
 	BOOL UTCTimes = FALSE;    // @pyparm boolean|UTCTimes|False|If True, input times are treated as UTC and no conversion is done, 
 							  // otherwise they are treated as local times.  Defaults to False for backward compatibility.
 							  // This parameter is ignored in Python 3.x, where you should always pass datetime objects
@@ -811,9 +811,9 @@ static PyObject *PyGetFileInformationByHandle(PyObject *self, PyObject *args)
 	// @rdesc The result is a tuple of:
 	return Py_BuildValue("kNNNkkkkkk",
 		fi.dwFileAttributes, // @tupleitem 0|int|dwFileAttributes|
-		PyWinObject_FromFILETIME(fi.ftCreationTime), // @tupleitem 1|<o PyTime>|ftCreationTime|
-		PyWinObject_FromFILETIME(fi.ftLastAccessTime),// @tupleitem 2|<o PyTime>|ftLastAccessTime|
-		PyWinObject_FromFILETIME(fi.ftLastWriteTime),// @tupleitem 3|<o PyTime>|ftLastWriteTime|
+		PyWinObject_FromFILETIME(fi.ftCreationTime), // @tupleitem 1|<o PyDateTime>|ftCreationTime|
+		PyWinObject_FromFILETIME(fi.ftLastAccessTime),// @tupleitem 2|<o PyDateTime>|ftLastAccessTime|
+		PyWinObject_FromFILETIME(fi.ftLastWriteTime),// @tupleitem 3|<o PyDateTime>|ftLastWriteTime|
 		fi.dwVolumeSerialNumber,// @tupleitem 4|int|dwVolumeSerialNumber|
 		fi.nFileSizeHigh,// @tupleitem 5|int|nFileSizeHigh|
 		fi.nFileSizeLow,// @tupleitem 6|int|nFileSizeLow|
@@ -4668,12 +4668,12 @@ static PyObject *PyObject_FromFILEX_INFO(GET_FILEEX_INFO_LEVELS level, void *p)
 //  If this parameter is specified, GetFileAttributesTransacted will be called (requires Vista or later).
 // @rdesc The result is a tuple of:
 //	@tupleitem 0|int|attributes|File Attributes.  A combination of the win32com.FILE_ATTRIBUTE_* flags.
-//	@tupleitem 1|<o PyTime>|creationTime|Specifies when the file or directory was created. 
-//	@tupleitem 2|<o PyTime>|lastAccessTime|For a file, specifies when the file was last read from 
+//	@tupleitem 1|<o PyDateTime>|creationTime|Specifies when the file or directory was created. 
+//	@tupleitem 2|<o PyDateTime>|lastAccessTime|For a file, specifies when the file was last read from 
 //		or written to. For a directory, the structure specifies when the directory was created. For 
 //		both files and directories, the specified date will be correct, but the time of day will 
 //		always be set to midnight.
-//	@tupleitem 3|<o PyTime>|lastWriteTime|For a file, the structure specifies when the file was last 
+//	@tupleitem 3|<o PyDateTime>|lastWriteTime|For a file, the structure specifies when the file was last 
 //		written to. For a directory, the structure specifies when the directory was created.
 //	@tupleitem 4|int/long|fileSize|The size of the file. This member has no meaning for directories. 
 // @comm Not all file systems can record creation and last access time and not all file systems record 
@@ -5750,8 +5750,8 @@ static PyObject *py_SetFileInformationByHandle(PyObject *self, PyObject *args, P
 	// @flagh Class|Type of input
 	switch (info_class){
 		// @flag FileBasicInfo|Dict representing a FILE_BASIC_INFO struct, containing
-		// {"CreationTime":<o PyTime>, "LastAccessTime":<o PyTime>,  "LastWriteTime":<o PyTime>,
-		//		"ChangeTime":<o PyTime>, "FileAttributes":int}
+		// {"CreationTime":<o PyDateTime>, "LastAccessTime":<o PyDateTime>,  "LastWriteTime":<o PyDateTime>,
+		//		"ChangeTime":<o PyDateTime>, "FileAttributes":int}
 		case FileBasicInfo:{
 			TmpPyObject dummy_tuple = PyTuple_New(0);
 			if (dummy_tuple == NULL)

--- a/win32/src/win32inet.i
+++ b/win32/src/win32inet.i
@@ -1745,8 +1745,8 @@ PyObject *PyCommitUrlCacheEntry(PyObject *self, PyObject *args, PyObject *kwargs
 			&obUrlName,				// @pyparm str|UrlName||The Url for which to create an entry
 			&obLocalFileName,		// @pyparm str|LocalFileName||Filename returned from <om win32inet.CreateUrlCacheEntry>.
 									//	Can be None when creating a history entry.
-			&obExpireTime,			// @pyparm <o PyTime>|ExpireTime|None|Time at which entry expires
-			&obLastModifiedTime,	// @pyparm <o PyTime>|LastModifiedTime|None|Modification time of URL
+			&obExpireTime,			// @pyparm <o PyDateTime>|ExpireTime|None|Time at which entry expires
+			&obLastModifiedTime,	// @pyparm <o PyDateTime>|LastModifiedTime|None|Modification time of URL
 			&CacheEntryType,		// @pyparm int|CacheEntryType|NORMAL_CACHE_ENTRY|Combination of *_CACHE_ENTRY flags
 			&obHeaderInfo,			// @pyparm str|HeaderInfo|None|Header data used to request Url
 			&obOriginalUrl))		// @pyparm str|OriginalUrl|None|If redirected, original site requested

--- a/win32/src/win32net/win32netmisc.cpp
+++ b/win32/src/win32net/win32netmisc.cpp
@@ -1592,13 +1592,13 @@ static PyObject *PyObject_FromNET_VALIDATE_PERSISTED_FIELDS(NET_VALIDATE_PERSIST
     PyObject *ret = PyDict_New();
     if (!ret)
         return NULL;
-    // @pyparm <o PyTime>|PasswordLastSet||
+    // @pyparm <o PyDateTime>|PasswordLastSet||
     if (f->PresentFields & NET_VALIDATE_PASSWORD_LAST_SET)
         SAFE_INSERT_NEW_REF(ret, "PasswordLastSet", PyWinObject_FromFILETIME(f->PasswordLastSet));
-    // @pyparm <o PyTime>|BadPasswordTime||
+    // @pyparm <o PyDateTime>|BadPasswordTime||
     if (f->PresentFields & NET_VALIDATE_BAD_PASSWORD_TIME)
         SAFE_INSERT_NEW_REF(ret, "BadPasswordTime", PyWinObject_FromFILETIME(f->BadPasswordTime));
-    // @pyparm <o PyTime>|LockoutTime||
+    // @pyparm <o PyDateTime>|LockoutTime||
     if (f->PresentFields & NET_VALIDATE_LOCKOUT_TIME)
         SAFE_INSERT_NEW_REF(ret, "LockoutTime", PyWinObject_FromFILETIME(f->LockoutTime));
     // @pyparm int|BadPasswordCount||

--- a/win32/src/win32security.i
+++ b/win32/src/win32security.i
@@ -3613,7 +3613,7 @@ void PyWinObject_FreeSEC_WINNT_AUTH_IDENTITY(PSEC_WINNT_AUTH_IDENTITY_W pAuthDat
 
 %}
 
-// @pyswig (<o PyCredHandle>,<o PyTime>)|AcquireCredentialsHandle|Creates a handle to credentials for use with SSPI
+// @pyswig (<o PyCredHandle>,<o PyDateTime>)|AcquireCredentialsHandle|Creates a handle to credentials for use with SSPI
 // @rdesc Returns credential handle and credential's expiration time
 %native(AcquireCredentialsHandle) PyAcquireCredentialsHandle;
 %{
@@ -3680,7 +3680,7 @@ done:
 }
 %}
 
-// @pyswig (int, int, <o PyTime>)|InitializeSecurityContext|Creates a security context based on credentials created by AcquireCredentialsHandle
+// @pyswig (int, int, <o PyDateTime>)|InitializeSecurityContext|Creates a security context based on credentials created by AcquireCredentialsHandle
 // @rdesc Return value is a tuple of (return code, attribute flags, expiration time)
 %native(InitializeSecurityContext) PyInitializeSecurityContext;
 %{

--- a/win32/src/win32security_sspi.cpp
+++ b/win32/src/win32security_sspi.cpp
@@ -890,13 +890,13 @@ PyObject *PyCtxtHandle::QueryContextAttributes(PyObject *self, PyObject *args)
             ret = Py_BuildValue("{s:l,s:l,s:l,s:l}", "MaxToken", sz->cbMaxToken, "MaxSignature", sz->cbMaxSignature,
                                 "BlockSize", sz->cbBlockSize, "SecurityTrailer", sz->cbSecurityTrailer);
             break;
-        // @flag SECPKG_ATTR_PASSWORD_EXPIRY|<o PyTime> - returns time password expires
+        // @flag SECPKG_ATTR_PASSWORD_EXPIRY|<o PyDateTime> - returns time password expires
         case SECPKG_ATTR_PASSWORD_EXPIRY:
             PSecPkgContext_PasswordExpiry pe;
             pe = (PSecPkgContext_PasswordExpiry)&buf;
             ret = PyWinObject_FromTimeStamp(pe->tsPasswordExpires);
             break;
-        // @flag SECPKG_ATTR_LIFESPAN|(<o PyTime>,<o PyTime>) - returns time period during which context is valid
+        // @flag SECPKG_ATTR_LIFESPAN|(<o PyDateTime>,<o PyDateTime>) - returns time period during which context is valid
         case SECPKG_ATTR_LIFESPAN:
             PSecPkgContext_Lifespan ls;
             ls = (PSecPkgContext_Lifespan)&buf;

--- a/win32/src/wincerapi.i
+++ b/win32/src/wincerapi.i
@@ -644,9 +644,9 @@ PyCeFindFiles(PyObject *self, PyObject *args)
 		PyObject *newItem = Py_BuildValue("lOOOllllOz",
 		// @rdesc The return value is a list of tuples, in the same format as the WIN32_FIND_DATA structure:
 			findData.dwFileAttributes, // @tupleitem 0|int|attributes|File Attributes.  A combination of the win32com.FILE_ATTRIBUTE_* flags.
-			obCreateTime, // @tupleitem 1|<o PyTime>|createTime|File creation time.
-    		obAccessTime, // @tupleitem 2|<o PyTime>|accessTime|File access time.
-    		obWriteTime, // @tupleitem 3|<o PyTime>|writeTime|Time of last file write
+			obCreateTime, // @tupleitem 1|<o PyDateTime>|createTime|File creation time.
+    		obAccessTime, // @tupleitem 2|<o PyDateTime>|accessTime|File access time.
+    		obWriteTime, // @tupleitem 3|<o PyDateTime>|writeTime|Time of last file write
     		findData.nFileSizeHigh, // @tupleitem 4|int|nFileSizeHigh|high order word of file size.
     		findData.nFileSizeLow,	// @tupleitem 5|int|nFileSizeLow|low order word of file size.
     		findData.dwOID,			// @tupleitem 6|int|OID|The object identifier for the file


### PR DESCRIPTION
Updates docs for Py3 PyDateTime / datetime.datetime

Note: I run the Autoduck for test.  
(Still uses  `PYTHON   = py -2.7`  .  `PYTHON   = py -3.7` seems to work, but the .chm file size differs some 2000 bytes. Maybe some non-ascii / unicode chars issue.)