### PR TITLE
Avoid COM dates that end up with ms=1000, instead rounding to the nex…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,10 @@ Since build 300:
 * Fix a bug in `win32profile.GetEnvironmentStrings()` relating to environment
   variables with an equals sign (@maxim-krikun in #1661)
 
+* Fixed a bug where certain COM dates would fail to be converted to a Python
+  datetime object with `ValueError: microsecond must be in 0..999999`. Shoutout
+  to @hujiaxing for reporting and helping reproduce the issue (#1655)
+
 * Added win32com.shell.SHGetKnownFolderPath() and related constants.
 
 * Shifted work in win32.lib.pywin32_bootstrap to Python's import system from

--- a/com/win32com/test/testPyComTest.py
+++ b/com/win32com/test/testPyComTest.py
@@ -273,6 +273,10 @@ def TestCommon(o, is_generated):
     later = now + datetime.timedelta(seconds=1)
     TestApplyResult(o.EarliestDate, (now, later), now)
 
+    # The below used to fail with `ValueError: microsecond must be in 0..999999` - see #1655
+    # https://planetcalc.com/7027/ says that float is: Sun, 25 Mar 1951 7:23:49 am
+    assert o.MakeDate(18712.308206013888) == datetime.datetime.fromisoformat("1951-03-25 07:23:49+00:00")
+
     progress("Checking currency")
     # currency.
     pythoncom.__future_currency__ = 1

--- a/win32/src/PyTime.cpp
+++ b/win32/src/PyTime.cpp
@@ -380,10 +380,15 @@ PyObject *PyWin_NewTime(PyObject *timeOb)
         double minutes = (hours - (int)hours) * 60.0;
         double seconds = round((minutes - (int)minutes) * 60.0, 4);
         double milliseconds = round((seconds - (int)seconds) * 1000.0, 0);
-        // assert(milliseconds>=0.0 && milliseconds<=999.0);
-
         // Strip off the msec part of time
         double TimeWithoutMsecs = t - (ONETHOUSANDMILLISECONDS / 1000.0 * milliseconds);
+
+        // We might have rounded ms to 1000 which blows up datetime. Round up
+        // to the next second.
+        if (milliseconds >= 1000) {
+            TimeWithoutMsecs += ONETHOUSANDMILLISECONDS;
+            milliseconds = 0;
+        }
 
         // Let the OS translate the variant date/time
         SYSTEMTIME st;


### PR DESCRIPTION
…t second. Fixes #1655.

Thanks for the repro @hujiaxing! However, instead of truncating the ms to 999.0 I instead rounded up to the next second. Does that look correct to you? Note also that you should be able to get builds from this PR to test if you are keen by following the links to the CI (ie, test) runs and looking for the "artifacts".