### PR TITLE
GSS-API wrap and unwrap operation for the sspi module

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,6 +20,10 @@ Since build 300:
   containing the null character followed by junk characters.
   (#1654, #1660, Lincoln Puzey)
 
+* Add wrap and unwrap operations defined in the GSSAPI to the sspi module
+  and enhance the examples given in this module.
+  (#1692, Emmanuel Coirier)
+
 Since build 228:
 ----------------
 * Fixed a bug where win32com.client.VARIANT params were returned in the reverse

--- a/win32/Lib/sspi.py
+++ b/win32/Lib/sspi.py
@@ -40,7 +40,7 @@ class _BaseAuth(object):
         return ret
 
     def encrypt(self, data):
-        """Encrypt a string, returning a tuple of (encrypted_data, encryption_data).
+        """Encrypt a string, returning a tuple of (encrypted_data, trailer).
         These can be passed to decrypt to get back the original string.
         """
         pkg_size_info=self.ctxt.QueryContextAttributes(sspicon.SECPKG_ATTR_SIZES)
@@ -184,13 +184,14 @@ class ClientAuth(_BaseAuth):
                 None, auth_info)
         _BaseAuth.__init__(self)
 
-    # Perform *one* step of the client authentication process.
+
     def authorize(self, sec_buffer_in):
+        """Perform *one* step of the client authentication process. Pass None for the first round"""
         if sec_buffer_in is not None and type(sec_buffer_in) != win32security.PySecBufferDescType:
             # User passed us the raw data - wrap it into a SecBufferDesc
             sec_buffer_new=win32security.PySecBufferDescType()
             tokenbuf=win32security.PySecBufferType(self.pkg_info['MaxToken'],
-                                                 sspicon.SECBUFFER_TOKEN)
+                                                   sspicon.SECBUFFER_TOKEN)
             tokenbuf.Buffer=sec_buffer_in
             sec_buffer_new.append(tokenbuf)
             sec_buffer_in = sec_buffer_new
@@ -249,13 +250,13 @@ class ServerAuth(_BaseAuth):
                 self.pkg_info['Name'], sspicon.SECPKG_CRED_INBOUND, None, None)
         _BaseAuth.__init__(self)
 
-    # Perform *one* step of the server authentication process.
     def authorize(self, sec_buffer_in):
+        """Perform *one* step of the server authentication process."""
         if sec_buffer_in is not None and type(sec_buffer_in) != win32security.PySecBufferDescType:
             # User passed us the raw data - wrap it into a SecBufferDesc
             sec_buffer_new=win32security.PySecBufferDescType()
             tokenbuf=win32security.PySecBufferType(self.pkg_info['MaxToken'],
-                                                 sspicon.SECBUFFER_TOKEN)
+                                                   sspicon.SECBUFFER_TOKEN)
             tokenbuf.Buffer=sec_buffer_in
             sec_buffer_new.append(tokenbuf)
             sec_buffer_in = sec_buffer_new


### PR DESCRIPTION
The sspi module offers nice classes to deal with SSPI authentication process.

But these classes miss the wrap and unwrap methods that are present in the GSS-API. Microsoft described how to emulate such calls. This pull request introduces an implementation of the described method. This code has been tested against a real MIT Kerberos on Linux.

The PR also enhances the example at the end of the file, enabling it to work with either Kerberos or NTLM.