### PR TITLE
Fix and improve pywin32_postinstall.py

### DIFF
--- a/pywin32_postinstall.py
+++ b/pywin32_postinstall.py
@@ -201,7 +201,7 @@ def RegisterCOMObjects(register = 1):
         klass = getattr(mod, klass_name)
         func(klass, **flags)
 
-def RegisterPythonwin(register=True):
+def RegisterPythonwin(register=True, lib_dir=None):
     """ Add (or remove) Pythonwin to context menu for python scripts.
         ??? Should probably also add Edit command for pys files also.
         Also need to remove these keys on uninstall, but there's no function
@@ -209,7 +209,8 @@ def RegisterPythonwin(register=True):
     """
     import os
 
-    lib_dir = distutils.sysconfig.get_python_lib(plat_specific=1)
+    if lib_dir is None:
+        lib_dir = distutils.sysconfig.get_python_lib(plat_specific=1)
     classes_root=get_root_hkey()
     ## Installer executable doesn't seem to pass anything to postinstall script indicating if it's a debug build,
     pythonwin_exe = os.path.join(lib_dir, "Pythonwin", "Pythonwin.exe")
@@ -418,7 +419,7 @@ def install(lib_dir):
 
     # Register Pythonwin in context menu
     try:
-        RegisterPythonwin()
+        RegisterPythonwin(True, lib_dir)
     except:
         print('Failed to register pythonwin as editor')
         traceback.print_exc()
@@ -482,7 +483,7 @@ def uninstall(lib_dir):
         print("Failed to unregister COM objects: %s" % (why,))
 
     try:
-        RegisterPythonwin(False)
+        RegisterPythonwin(False, lib_dir)
     except Exception as why:
         print("Failed to unregister Pythonwin: %s" % (why,))
     else:

--- a/pywin32_postinstall.py
+++ b/pywin32_postinstall.py
@@ -393,11 +393,16 @@ def install(lib_dir):
                 # Register the files with the uninstaller
                 file_created(dst)
                 worked = 1
-                # If this isn't sys.prefix (ie, System32), then nuke
-                # any versions that may exist in sys.prefix - having
+                # Nuke any other versions that may exist - having
                 # duplicates causes major headaches.
+                bad_dest_dirs = [
+                    os.path.join(sys.prefix, "Library\\bin"),
+                    os.path.join(sys.prefix, "Lib\\site-packages\\win32"),
+                ]
                 if dest_dir != sys.prefix:
-                    bad_fname = os.path.join(sys.prefix, base)
+                    bad_dest_dirs.append(sys.prefix)
+                for bad_dest_dir in bad_dest_dirs:
+                    bad_fname = os.path.join(bad_dest_dir, base)
                     if os.path.exists(bad_fname):
                         # let exceptions go here - delete must succeed
                         os.unlink(bad_fname)

--- a/pywin32_postinstall.py
+++ b/pywin32_postinstall.py
@@ -234,6 +234,10 @@ def RegisterPythonwin(register=True):
         else:
             for key, sub_key, val in keys_vals:
                 try:
+                    if sub_key:
+                        hkey = winreg.OpenKey(classes_root, key)
+                        winreg.DeleteKey(hkey, sub_key)
+                        hkey.Close()
                     winreg.DeleteKey(classes_root, key)
                 except OSError as why:
                     winerror = getattr(why, 'winerror', why.errno)


### PR DESCRIPTION
#### Fix `PermissionError` on `winreg.DeleteKey(..., key)` if the key has sub keys

When calling `RegisterPythonwin(register=False)`, it tries to delete some previously registered keys from registry, but raises `PermissionError` because some keys have sub keys left inside. In order to mitigate this, added a step to delete the sub keys before actually deleting the key itself.
 
#### Let `RegisterPythonwin()` accept optional `lib_dir`

Note that the major entrypoints, `install()`/`uninstall()` functions are accepting the `lib_dir` as an argument, but `RegisterPythonwin()` inside just **ignores** that argument and tries to infer the value on its own (redundantly like what `-destination` option already did). Couldn't figure out any reason for doing so, thus changed `RegisterPythonwin()` to accept `lib_dir` as an argument too and use it in common case.

#### Introduce `RegisterHelpFile()` with `register=True/False` toggle for possible cleanup

There was no clean up process for .chm help file registry in `uninstall()` function, so added one. I thought it would be nice to remove/revert things added by this script as much as possible.

#### Add more cadidates on nuking existing dlls

I think this might be conda specific but..
I found that my installed DLLs were actually shaded by those who were installed/packaged with conda, causing `ImportError`s (DLL load failure ones) when importing some relevant packages. (Actually it's okay until version 300, but breaks as soon as the latest version 301 comes in.) So I also added those paths (where the guilty files are) to check during the nuking process.