### PR TITLE
Added CI job to check black formatting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# This file contains hashes of commits git blame should ignore.
+# Run `git config blame.ignoreRevsFile .git-blame-ignore-revs` to enable.
+# Requires git 2.23+.

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,6 @@
 # This file contains hashes of commits git blame should ignore.
 # Run `git config blame.ignoreRevsFile .git-blame-ignore-revs` to enable.
 # Requires git 2.23+.
+
+# 2019-09-07 formatted c++ source with clang-format
+059b7beb928225e389621802db758c75a7b8c58f

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,3 +57,11 @@ jobs:
       with:
         name: wheels
         path: dist/*.whl
+
+  black:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: psf/black@stable
+        with:
+          options: "--fast --check --diff --verbose"


### PR DESCRIPTION
I have tested this in a PR in my fork, seems to work well.

Haven't actually formatted the repo with black yet, that can be done after merging this.
@mhammond I figured I'll let you take the git-blame credit for that.

I also started off the `.git-blame-ignore-revs` file with a commit I think makes sense to ignore.