### PR TITLE
Remove py3k typedefs

### DIFF
--- a/Pythonwin/ddeconv.cpp
+++ b/Pythonwin/ddeconv.cpp
@@ -46,7 +46,7 @@ PyObject *PyDDEConv_Connected(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     BOOL rc = pConv->Connected();
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod |PyDDEConv|Exec|Executes a command.

--- a/Pythonwin/pythonpsheet.cpp
+++ b/Pythonwin/pythonpsheet.cpp
@@ -204,8 +204,8 @@ void CPythonPropertySheet::BuildPropPageArray()
         PyErr_Fetch(&t, &v, &tb);
         PyObject *attr = PyObject_GetAttrString(py_bob->virtualInst, "customizeFont");
         if (attr) {
-            if (PyInt_Check(attr)) {
-                m_customizeFont = (BOOL)PyInt_AsLong(PyNumber_Int(attr));
+            if (PyLong_Check(attr)) {
+                m_customizeFont = (BOOL)PyLong_AsLong(PyNumber_Long(attr));
             }
         }
         PyErr_Restore(t, v, tb);

--- a/Pythonwin/win32app.cpp
+++ b/Pythonwin/win32app.cpp
@@ -355,7 +355,7 @@ static PyObject *ui_app_run(PyObject *self, PyObject *args)
     long rc = AfxGetApp()->CWinApp::Run();
     GUI_END_SAVE;
 
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod int|PyCWinApp|IsInproc|Returns a flag to indicate if the created CWinApp was in the DLL, or an external
@@ -364,7 +364,7 @@ static PyObject *ui_app_isinproc(PyObject *self, PyObject *args)
 {
     extern BOOL PyWin_bHaveMFCHost;
     CHECK_NO_ARGS2(args, IsInproc);
-    return PyInt_FromLong(!PyWin_bHaveMFCHost);
+    return PyLong_FromLong(!PyWin_bHaveMFCHost);
 }
 
 // @pymethod [<o PyCDocTemplate>,...]|PyCWinApp|GetDocTemplateList|Returns a list of all document templates.

--- a/Pythonwin/win32bitmap.cpp
+++ b/Pythonwin/win32bitmap.cpp
@@ -178,14 +178,14 @@ PyObject *ui_bitmap_load_bitmap_file(PyObject *self, PyObject *args)
         DODECREF(seeker);
         return NULL;
     }
-    if (!PyString_Check(result)) {
+    if (!PyBytes_Check(result)) {
         DODECREF(result);
         DODECREF(seeker);
         DODECREF(reader);
         PyErr_SetString(PyExc_TypeError, "object.readline() returned non-string");
         return NULL;
     }
-    Py_ssize_t len = PyString_Size(result);
+    Py_ssize_t len = PyBytes_Size(result);
     if (len != sizeof(BITMAPFILEHEADER)) {
         DODECREF(seeker);
         DODECREF(reader);
@@ -194,7 +194,7 @@ PyObject *ui_bitmap_load_bitmap_file(PyObject *self, PyObject *args)
         return NULL;
     }
     BITMAPFILEHEADER bmFileHeader;
-    memcpy(&bmFileHeader, PyString_AsString(result), len);
+    memcpy(&bmFileHeader, PyBytes_AsString(result), len);
     DODECREF(result);  // dont need this anymore
     if (bmFileHeader.bfType != DIB_HEADER_MARKER) {
         DODECREF(reader);
@@ -230,7 +230,7 @@ PyObject *ui_bitmap_load_bitmap_file(PyObject *self, PyObject *args)
         DODECREF(reader);
         return NULL;
     }
-    len = PyString_Size(result);
+    len = PyBytes_Size(result);
     /*	if (len != bitsSize) {
             DODECREF(reader);
             DODECREF(result);
@@ -241,7 +241,7 @@ PyObject *ui_bitmap_load_bitmap_file(PyObject *self, PyObject *args)
     */
     char *pBits = new char[len];
     // XXX - need memory exception handler.
-    memcpy(pBits, PyString_AsString(result), len);
+    memcpy(pBits, PyBytes_AsString(result), len);
     DODECREF(result);  // dont need this.
     DODECREF(reader);  // or this.
 
@@ -303,7 +303,7 @@ PyObject *ui_bitmap_load_ppm_file(PyObject *self, PyObject *args)
         DODECREF(reader);
         return NULL;
     }
-    Py_ssize_t lenRead = PyString_Size(result);
+    Py_ssize_t lenRead = PyBytes_Size(result);
     // work out size of bitmap
     int headerSize = sizeof(BITMAPINFOHEADER);
     // Windows requires bitmap bits aligned to a "long", which is 32 bits!
@@ -325,7 +325,7 @@ PyObject *ui_bitmap_load_ppm_file(PyObject *self, PyObject *args)
     // XXX - need mem exception
     // copy the data in.  Windows wants scan lines bottom up.
     // and also wants RGB values reversed.
-    char *pImg = PyString_AsString(result);
+    char *pImg = PyBytes_AsString(result);
     char *pMem = ((char *)pBits) + headerSize + memSize - memBytesPerScan;
     BITMAPINFOHEADER *pInfo = (BITMAPINFOHEADER *)pBits;
     for (int row = 0; row < rows; row++, pMem -= memBytesPerScan, pImg += imageBytesPerScan)
@@ -476,7 +476,7 @@ static PyObject *ui_get_bitmap_bits(PyObject *self, PyObject *args)
     }
     PyObject *rc;
     if (asString) {
-        rc = PyString_FromStringAndSize(bits, cnt);
+        rc = PyBytes_FromStringAndSize(bits, cnt);
     }
     else {
         rc = PyTuple_New(cnt);

--- a/Pythonwin/win32bitmap.cpp
+++ b/Pythonwin/win32bitmap.cpp
@@ -481,7 +481,7 @@ static PyObject *ui_get_bitmap_bits(PyObject *self, PyObject *args)
     else {
         rc = PyTuple_New(cnt);
         for (UINT i = 0; i < cnt; i++) {
-            PyTuple_SetItem(rc, i, PyInt_FromLong((long)bits[i]));
+            PyTuple_SetItem(rc, i, PyLong_FromLong((long)bits[i]));
         }
     }
     free(bits);

--- a/Pythonwin/win32cmdui.cpp
+++ b/Pythonwin/win32cmdui.cpp
@@ -275,13 +275,13 @@ PyObject *PyCCmdUI::getattro(PyObject *obname)
         CCmdUI *pCU = PyCCmdUI::GetCCmdUIPtr(this);
         if (!pCU)
             return NULL;
-        return PyInt_FromLong(pCU->m_nIndex);
+        return PyLong_FromLong(pCU->m_nIndex);
     }
     else if (strcmp(name, "m_nID") == 0) {  // @prop int|m_nID|
         CCmdUI *pCU = PyCCmdUI::GetCCmdUIPtr(this);
         if (!pCU)
             return NULL;
-        return PyInt_FromLong(pCU->m_nID);
+        return PyLong_FromLong(pCU->m_nID);
     }
     else if (strcmp(name, "m_pMenu") == 0) {  // @prop <o PyCMenu>|m_pMenu|
         CCmdUI *pCU = PyCCmdUI::GetCCmdUIPtr(this);

--- a/Pythonwin/win32control.cpp
+++ b/Pythonwin/win32control.cpp
@@ -423,7 +423,7 @@ PyObject *PyCListBox_GetItemValue(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     long rc = (long)pLB->GetItemData(item);
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod int|PyCListBox|GetSel|Returns the selection state of a specified item.
@@ -1038,7 +1038,7 @@ PyObject *PyCComboBox_GetItemValue(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     long rc = (long)pLB->GetItemData(item);
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod string|PyCComboBox|GetLBText|Gets the string from the list of a combo box.
@@ -2377,7 +2377,7 @@ PyObject *PyCSpinButtonCtrl_GetPos(PyObject *self, PyObject *args)
 
     if (!pSB)
         return NULL;
-    return PyInt_FromLong(pSB->GetPos());
+    return PyLong_FromLong(pSB->GetPos());
 }
 
 // @pymethod int|PyCSpinButtonCtrl|SetPos|Sets the current position for a spin button control.
@@ -2395,7 +2395,7 @@ PyObject *PyCSpinButtonCtrl_SetPos(PyObject *self, PyObject *args)
     int oldPos = pSB->SetPos(pos);
     GUI_END_SAVE;
     // @rdesc The result is the previous position.
-    return PyInt_FromLong(oldPos);
+    return PyLong_FromLong(oldPos);
 }
 
 // @pymethod int|PyCSpinButtonCtrl|SetRange|Sets the upper and lower limits (range) for a spin button control.

--- a/Pythonwin/win32ctrlList.cpp
+++ b/Pythonwin/win32ctrlList.cpp
@@ -268,7 +268,7 @@ PyObject *PyCListCtrl_SetColumn(PyObject *self, PyObject *args)
     PyWinObject_FreeLV_COLUMN(&lvCol);
     if (ret == -1)
         RETURN_ERR("SetColumn failed");
-    return PyInt_FromLong(ret);
+    return PyLong_FromLong(ret);
 }
 
 // @pymethod int|PyCListCtrl|InsertItem|Inserts an item into the list.
@@ -323,7 +323,7 @@ PyObject *PyCListCtrl_InsertItem(PyObject *self, PyObject *args)
     PyWinObject_FreeTCHAR(text);
     if (ret == -1)
         RETURN_ERR("InsertItem failed");
-    return PyInt_FromLong(ret);
+    return PyLong_FromLong(ret);
 }
 
 // @pymethod int|PyCListCtrl|SetItem|Sets some of all of an items attributes.

--- a/Pythonwin/win32ctrlRichEdit.cpp
+++ b/Pythonwin/win32ctrlRichEdit.cpp
@@ -121,7 +121,7 @@ DWORD CALLBACK PyCRichEditCallbackOut(DWORD_PTR dwCookie, LPBYTE pbBuff, LONG cb
         //		gui_print_error();
     }
     else {
-        retval = PyInt_AsLong(result);
+        retval = PyLong_AsLong(result);
         if (PyErr_Occurred()) {
             gui_print_error();
             //			retval = 0;
@@ -620,8 +620,8 @@ static PyObject *PyCRichEditCtrl_set_sel_and_char_format(PyObject *self, PyObjec
 
     //	PyErr_Clear();
     // Note - no reference added.
-    long start = PyInt_AsLong(PyTuple_GET_ITEM(args, 0));
-    long end = PyInt_AsLong(PyTuple_GET_ITEM(args, 1));
+    long start = PyLong_AsLong(PyTuple_GET_ITEM(args, 0));
+    long end = PyLong_AsLong(PyTuple_GET_ITEM(args, 1));
     PyObject *fmtTuple = PyTuple_GET_ITEM(args, 2);
 
     if (PyErr_Occurred())
@@ -771,7 +771,7 @@ static PyObject *PyCRichEditCtrl_get_text_length(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     long rc = pEdit->GetTextLength();  // @pyseemfc CRichEditCtrl|GetTextLength
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod int|PyCRichEditCtrl|GetModify|Nonzero if the text in this control has been modified; otherwise 0.
@@ -784,7 +784,7 @@ static PyObject *PyCRichEditCtrl_get_modify(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     BOOL rc = pEdit->GetModify();  // @pyseemfc CRichEditCtrl|GetModify
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod |PyCRichEditCtrl|SetModify|Sets the modified flag for this control

--- a/Pythonwin/win32ctrlRichEdit.cpp
+++ b/Pythonwin/win32ctrlRichEdit.cpp
@@ -95,7 +95,7 @@ DWORD CALLBACK PyCRichEditCallbackIn(DWORD_PTR dwCookie, LPBYTE pbBuff, LONG cb,
         *pcb = 0;
     }
     else {
-        char *s = PyString_AsString(result);
+        char *s = PyBytes_AsString(result);
         if (s == NULL) {
             //			gui_print_error();
         }

--- a/Pythonwin/win32ctrlTree.cpp
+++ b/Pythonwin/win32ctrlTree.cpp
@@ -414,7 +414,7 @@ PyObject *PyCTreeCtrl_GetItemState(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     long state = pList->GetItemState(item, stateMask);
     GUI_END_SAVE;
-    return PyInt_FromLong(state);
+    return PyLong_FromLong(state);
 }
 
 // @pymethod <o PyCImageList>|PyCTreeCtrl|GetImageList|Retrieves the current image list.

--- a/Pythonwin/win32dc.cpp
+++ b/Pythonwin/win32dc.cpp
@@ -509,10 +509,10 @@ static PyObject *ui_dc_ext_text_out(PyObject *self, PyObject *args)
                 widths = new int[len + 1];
                 for (Py_ssize_t i = 0; i < len; i++) {
                     PyObject *item = PyTuple_GetItem(widthObject, i);
-                    if (!PyInt_Check(item))
+                    if (!PyLong_Check(item))
                         error = TRUE;
                     else
-                        widths[i] = PyInt_AsLong(item);
+                        widths[i] = PyLong_AsLong(item);
                 }
             }
         }
@@ -680,14 +680,14 @@ static PyObject *ui_dc_polygon(PyObject *self, PyObject *args)
                 PyObject *px, *py;
                 px = PyTuple_GetItem(point_tuple, 0);
                 py = PyTuple_GetItem(point_tuple, 1);
-                if ((!PyInt_Check(px)) || (!PyInt_Check(py))) {
+                if ((!PyLong_Check(px)) || (!PyLong_Check(py))) {
                     PyErr_SetString(PyExc_ValueError, "point list must be a list of (x,y) tuples");
                     delete[] point_array;
                     return NULL;
                 }
                 else {
-                    x = PyInt_AsLong(px);
-                    y = PyInt_AsLong(py);
+                    x = PyLong_AsLong(px);
+                    y = PyLong_AsLong(py);
                     point_array[i].x = x;
                     point_array[i].y = y;
                 }
@@ -749,12 +749,12 @@ static PyObject *ui_dc_poly_bezier(PyObject *self, PyObject *args)
                         PyObject *px, *py;
                         px = PyTuple_GetItem(point, 0);
                         py = PyTuple_GetItem(point, 1);
-                        if (!PyInt_Check(px) || !PyInt_Check(py)) {
+                        if (!PyLong_Check(px) || !PyLong_Check(py)) {
                             HURL;
                         }
                         else {
-                            point_array[index].x = PyInt_AsLong(px);
-                            point_array[index].y = PyInt_AsLong(py);
+                            point_array[index].x = PyLong_AsLong(px);
+                            point_array[index].y = PyLong_AsLong(py);
                             index++;
                         }
                     }
@@ -1064,7 +1064,7 @@ static PyObject *ui_dc_get_map_mode(PyObject *self, PyObject *args)
     GUI_END_SAVE;
     if (mode == 0)
         RETURN_ERR("GetMapMode failed");
-    return PyInt_FromLong(mode);
+    return PyLong_FromLong(mode);
 }
 
 // @pymethod x, y|PyCDC|SetWindowOrg|Sets the window origin of the device context
@@ -2054,14 +2054,14 @@ static PyObject *ui_dc_polyline(PyObject *self, PyObject *args)
                 PyObject *px, *py;
                 px = PyTuple_GetItem(point_tuple, 0);
                 py = PyTuple_GetItem(point_tuple, 1);
-                if ((!PyInt_Check(px)) || (!PyInt_Check(py))) {
+                if ((!PyLong_Check(px)) || (!PyLong_Check(py))) {
                     PyErr_SetString(PyExc_ValueError, "point list must be a list of (x,y) tuples");
                     delete[] point_array;
                     return NULL;
                 }
                 else {
-                    x = PyInt_AsLong(px);
-                    y = PyInt_AsLong(py);
+                    x = PyLong_AsLong(px);
+                    y = PyLong_AsLong(py);
                     point_array[i].x = x;
                     point_array[i].y = y;
                 }

--- a/Pythonwin/win32dlg.cpp
+++ b/Pythonwin/win32dlg.cpp
@@ -200,7 +200,7 @@ static PyObject *do_exchange_edit(int id, int index, char *type, PyObject *oldVa
         case 'i': {
             int intVal = 0;
             if (oldVal)
-                intVal = (int)PyInt_AsLong(oldVal);
+                intVal = (int)PyLong_AsLong(oldVal);
             PyThreadState *_save = PyEval_SaveThread();
             TRY
             {
@@ -214,8 +214,8 @@ static PyObject *do_exchange_edit(int id, int index, char *type, PyObject *oldVa
             }
             END_CATCH_ALL
             if (o1 && o2) {
-                if (PyInt_Check(o1) && PyInt_Check(o2))
-                    DDV_MinMaxInt(pDX, intVal, PyInt_AsLong(o1), PyInt_AsLong(o2));
+                if (PyLong_Check(o1) && PyLong_Check(o2))
+                    DDV_MinMaxInt(pDX, intVal, PyLong_AsLong(o1), PyLong_AsLong(o2));
                 else
                     return set_exchange_error("Edit - must be tuple of control_id, key, 'i', intMin, intMax", index);
             }
@@ -246,8 +246,8 @@ static PyObject *do_exchange_edit(int id, int index, char *type, PyObject *oldVa
             }
             END_CATCH_ALL
             if (o1 && o2) {
-                if (PyInt_Check(o1) && o2 == NULL)
-                    DDV_MaxChars(pDX, csVal, PyInt_AsLong(o1));
+                if (PyLong_Check(o1) && o2 == NULL)
+                    DDV_MaxChars(pDX, csVal, PyLong_AsLong(o1));
                 else
                     return set_exchange_error("Edit - must be tuple of control_id, key, 's', maxLength", index);
             }
@@ -274,9 +274,9 @@ static PyObject *do_exchange_list_combo(int id, int index, char *type, PyObject 
         case 'i': {
             int intVal = 0;
             if (oldVal && oldVal != Py_None) {
-                if (!PyInt_Check(oldVal))
+                if (!PyLong_Check(oldVal))
                     return set_exchange_error("'i' format requires integers", index);
-                intVal = (int)PyInt_AsLong(oldVal);
+                intVal = (int)PyLong_AsLong(oldVal);
             }
             GUI_BGN_SAVE;
             if (bList)
@@ -384,9 +384,9 @@ static PyObject *do_exchange_button(CDialog *pDlg, int id, int index, char *type
     }
     int intVal = 0;
     if (oldVal) {
-        if (!PyInt_Check(oldVal))
+        if (!PyLong_Check(oldVal))
             return set_exchange_error("the previous value was not a number!", index);
-        intVal = (int)PyInt_AsLong(oldVal);
+        intVal = (int)PyLong_AsLong(oldVal);
     }
     GUI_BGN_SAVE;
     if (bRadio)
@@ -1058,7 +1058,7 @@ PyObject *PyCFontDialog::ui_font_dialog_create(PyObject * /*self*/, PyObject *ar
         GUI_BGN_SAVE;                                       \
         int ret = pDlg->mfcName();                          \
         GUI_END_SAVE;                                       \
-        return PyInt_FromLong(ret);                         \
+        return PyLong_FromLong(ret);                         \
     }
 
 #define MAKE_INT_PTR_METH(fnname, mfcName)                  \
@@ -1249,7 +1249,7 @@ static PyObject *ui_color_dialog_get_saved_custom_colors(PyObject *self, PyObjec
     GUI_BGN_SAVE;
     COLORREF *prc = pDlg->GetSavedCustomColors();
     GUI_END_SAVE;
-    return PyInt_FromLong((long)*prc);
+    return PyLong_FromLong((long)*prc);
 }
 
 // @pymethod |PyCColorDialog|SetCurrentColor|Sets the currently selected color.
@@ -1278,7 +1278,7 @@ static PyObject *ui_color_dialog_get_custom_colors(PyObject *self, PyObject *arg
     if (!pDlg)
         return NULL;
     PyObject *ret = PyTuple_New(16);
-    for (int i = 0; i < 16; i++) PyTuple_SET_ITEM(ret, i, PyInt_FromLong(pDlg->m_cc.lpCustColors[i]));
+    for (int i = 0; i < 16; i++) PyTuple_SET_ITEM(ret, i, PyLong_FromLong(pDlg->m_cc.lpCustColors[i]));
     return ret;
 }
 
@@ -1301,13 +1301,13 @@ static PyObject *ui_color_dialog_set_custom_colors(PyObject *self, PyObject *arg
         PyObject *obInt = NULL;
         PyObject *ob = PySequence_GetItem(obCols, i);
         if (ob != NULL)
-            obInt = PyNumber_Int(ob);
+            obInt = PyNumber_Long(ob);
         if (obInt == NULL) {
             Py_XDECREF(ob);
             PyErr_SetString(PyExc_TypeError, "The argument must be a sequence of integers of length 1-16");
             return NULL;
         }
-        pDlg->m_cc.lpCustColors[i] = PyInt_AsLong(obInt);
+        pDlg->m_cc.lpCustColors[i] = PyLong_AsLong(obInt);
         Py_DECREF(ob);
         Py_DECREF(obInt);
     }

--- a/Pythonwin/win32doc.cpp
+++ b/Pythonwin/win32doc.cpp
@@ -284,7 +284,7 @@ static PyObject *ui_doc_save_modified(PyObject *self, PyObject *args)
     BOOL rc = pDoc->CDocument::SaveModified();  // @pyseemfc CDocument|SaveModified
     GUI_END_SAVE;
     // @rdesc Nonzero if it is safe to continue and close the document; 0 if the document should not be closed.
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod |PyCDocument|SetModifiedFlag|Set the "dirty" flag for the document.

--- a/Pythonwin/win32menu.cpp
+++ b/Pythonwin/win32menu.cpp
@@ -242,7 +242,7 @@ PyObject *PyCMenu::InsertMenu(PyObject *self, PyObject *args)
         return NULL;
 
     if (obsubMenu) {
-        id = PyInt_AsLong(obsubMenu);
+        id = PyLong_AsLong(obsubMenu);
         if (id == -1 && PyErr_Occurred()) {
             PyErr_Clear();
             bHaveInt = FALSE;

--- a/Pythonwin/win32notify.cpp
+++ b/Pythonwin/win32notify.cpp
@@ -34,7 +34,7 @@ PyObject *PyNotifyMakeExtraTuple(NMHDR *ptr, char *fmt)
             ++fmt;
         switch (*fmt) {
             case 'i':
-                ob = bIgnore ? NULL : PyInt_FromLong(*((int *)pUse));
+                ob = bIgnore ? NULL : PyLong_FromLong(*((int *)pUse));
                 pUse += (sizeof(int));
                 break;
             case 'P': {  // point
@@ -157,9 +157,9 @@ void PyNotifyParseExtraTuple(NMHDR *ptr, PyObject *args, char *fmt)
         switch (*fmt) {
             case 'i':
                 if (!bIgnore) {
-                    if (!PyInt_Check(ob))
+                    if (!PyLong_Check(ob))
                         MY_RET_ERR("Expected integer object")
-                    *((int *)pUse) = PyInt_AsLong(ob);
+                    *((int *)pUse) = PyLong_AsLong(ob);
                 }
                 pUse += (sizeof(int));
                 break;

--- a/Pythonwin/win32notify.cpp
+++ b/Pythonwin/win32notify.cpp
@@ -49,7 +49,7 @@ PyObject *PyNotifyMakeExtraTuple(NMHDR *ptr, char *fmt)
             case 's':  // string buffer - same for this parse
             {
                 char *use = (*fmt == 'z') ? *(char **)pUse : pUse;
-                ob = bIgnore ? NULL : PyString_FromString("");  // HACK HACK - FIX ME FIX ME
+                ob = bIgnore ? NULL : PyBytes_FromString("");  // HACK HACK - FIX ME FIX ME
                 if (*fmt == 's') {                              // followed by buffer size;
                     int val = 0;
                     while (fmt[1] && isdigit(fmt[1])) {
@@ -67,7 +67,7 @@ PyObject *PyNotifyMakeExtraTuple(NMHDR *ptr, char *fmt)
             case 'S':  // Unicode buffer - same for this parse
             {
                 char *use = (*fmt == 'Z') ? *(char **)pUse : pUse;
-                ob = bIgnore ? NULL : PyString_FromString("");  // HACK HACK - FIX ME FIX ME
+                ob = bIgnore ? NULL : PyBytes_FromString("");  // HACK HACK - FIX ME FIX ME
                 if (*fmt == 'S') {                              // followed by buffer size;
                     int val = 0;
                     while (fmt[1] && isdigit(fmt[1])) {
@@ -200,9 +200,9 @@ void PyNotifyParseExtraTuple(NMHDR *ptr, PyObject *args, char *fmt)
                 }
                 ASSERT(bufSize);
                 if (!bIgnore) {
-                    if (!PyString_Check(ob))
+                    if (!PyBytes_Check(ob))
                         MY_RET_ERR("Expected string object")
-                    char *val = PyString_AsString(ob);
+                    char *val = PyBytes_AsString(ob);
                     SSIZE_T slen = strlen(val);
                     SSIZE_T copylen = max(bufSize - 1, slen);
                     strncpy(pUse, val, copylen);

--- a/Pythonwin/win32oleDlgInsert.cpp
+++ b/Pythonwin/win32oleDlgInsert.cpp
@@ -43,7 +43,7 @@ BOOL OLEUIINSERTOBJECTHelper::ParseDict(PyObject *obDict)
     PyObject *ob;
     ob = PyObject_GetAttrString(obDict, "Flags");
     if (ob) {
-        pConv->dwFlags = PyInt_AsLong(ob);
+        pConv->dwFlags = PyLong_AsLong(ob);
         if (pConv->dwFlags == (DWORD)-1 && PyErr_Occurred())
             return FALSE;
     }
@@ -127,7 +127,7 @@ BOOL OLEUIINSERTOBJECTHelper::ParseDict(PyObject *obDict)
 
     ob = PyObject_GetAttrString(obDict, "oleRender");
     if (ob) {
-        pConv->oleRender = PyInt_AsLong(ob);
+        pConv->oleRender = PyLong_AsLong(ob);
         if (pConv->oleRender == -1 && PyErr_Occurred())
             return FALSE;
     }
@@ -143,7 +143,7 @@ BOOL OLEUIINSERTOBJECTHelper::ParseDict(PyObject *obDict)
 
 BOOL OLEUIINSERTOBJECTHelper::BuildDict(PyObject *obDict)
 {
-    if (PyObject_SetAttrString(obDict, "Flags", PyInt_FromLong(pConv->dwFlags)))
+    if (PyObject_SetAttrString(obDict, "Flags", PyLong_FromLong(pConv->dwFlags)))
         return FALSE;
     return TRUE;
 }
@@ -188,7 +188,7 @@ PyObject *PyCOleInsertDialog_GetSelectionType(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     long rc = pDlg->GetSelectionType();
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod CLSID|PyCOleInsertDialog|GetPathName|Returns the full path to the file selected in the dialog box

--- a/Pythonwin/win32prop.cpp
+++ b/Pythonwin/win32prop.cpp
@@ -390,8 +390,8 @@ PyObject *ui_propsheet_remove_page(PyObject *self, PyObject *args)
     // @pyparmalt1 <o PyCPropertyPage>|page||The page to remove
     if (!PyArg_ParseTuple(args, "O", &ob))
         return NULL;
-    if (PyInt_Check(ob)) {
-        int id = (int)PyInt_AsLong(ob);
+    if (PyLong_Check(ob)) {
+        int id = (int)PyLong_AsLong(ob);
         GUI_BGN_SAVE;
         pPS->RemovePage(id);
         GUI_END_SAVE;
@@ -726,7 +726,7 @@ PyObject *ui_proppage_on_apply(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     BOOL bOk = pPP->CPropertyPage::OnApply();
     GUI_END_SAVE;
-    return PyInt_FromLong((long)bOk);
+    return PyLong_FromLong((long)bOk);
 }
 // @pymethod |PyCPropertyPage|OnReset|Calls the default MFC OnReset handler.
 PyObject *ui_proppage_on_reset(PyObject *self, PyObject *args)
@@ -752,7 +752,7 @@ PyObject *ui_proppage_on_query_cancel(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     BOOL bOk = pPP->CPropertyPage::OnQueryCancel();
     GUI_END_SAVE;
-    return PyInt_FromLong((long)bOk);
+    return PyLong_FromLong((long)bOk);
 }
 // @pymethod |PyCPropertyPage|OnWizardBack|Calls the default MFC OnWizardBack handler.
 PyObject *ui_proppage_on_wizard_back(PyObject *self, PyObject *args)
@@ -791,7 +791,7 @@ PyObject *ui_proppage_on_wizard_finish(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     BOOL bOk = pPP->CPropertyPage::OnWizardFinish();
     GUI_END_SAVE;
-    return PyInt_FromLong((long)bOk);
+    return PyLong_FromLong((long)bOk);
 }
 // @pymethod |PyCPropertyPage|OnCancel|Calls the default MFC OnCancel handler.
 PyObject *ui_proppage_on_cancel(PyObject *self, PyObject *args)
@@ -819,7 +819,7 @@ PyObject *ui_proppage_on_set_active(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     long rc = pPP->CPropertyPage::OnSetActive();
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
     // @rdesc The result is true if the page should be made active.
     // Typically this result should be passed to the original OnSetActive handler.
 }
@@ -835,7 +835,7 @@ PyObject *ui_proppage_on_kill_active(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     long rc = pPP->CPropertyPage::OnKillActive();
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
     // @rdesc The result is true if the page should be deselected.
     // Typically this result should be passed to the original OnSetActive handler.
 }

--- a/Pythonwin/win32splitter.cpp
+++ b/Pythonwin/win32splitter.cpp
@@ -137,7 +137,7 @@ PyObject *ui_splitter_do_kb_split(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     rc = wnd->DoKeyboardSplit();
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod <o PyCWnd>|PyCSplitterWnd|GetPane|Returns the <o PyCView> associated with the specified pane.
@@ -217,7 +217,7 @@ PyObject *ui_splitter_id_from_row_col(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     rc = wnd->IdFromRowCol(row, col);
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @object PyCSplitterWnd|A class which encapsulates an MFC <o CSplitterWnd>. Derived from a <o PyCWnd> object.

--- a/Pythonwin/win32template.cpp
+++ b/Pythonwin/win32template.cpp
@@ -537,8 +537,8 @@ CDocTemplate::Confidence CPythonDocTemplate::MatchDocType(LPCTSTR lpszPathName, 
         PyObject *ret;
         if (!helper.retval(ret))
             return CDocTemplate::noAttempt;
-        if (PyInt_Check(ret))
-            return (CDocTemplate::Confidence)PyInt_AsLong(ret);
+        if (PyLong_Check(ret))
+            return (CDocTemplate::Confidence)PyLong_AsLong(ret);
         if (ui_base_class::is_uiobject(ret, &PyCDocument::type)) {
             CDocument *pDoc = PyCDocument::GetDoc(ret);
             rpDocMatch = pDoc;

--- a/Pythonwin/win32thread.cpp
+++ b/Pythonwin/win32thread.cpp
@@ -263,7 +263,7 @@ static PyObject *ui_thread_set_thread_priority(PyObject *self, PyObject *args)
         return NULL;
 
     long rc = pThread->SetThreadPriority(priority);
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod int|PyCWinThread|Run|Starts the message pump.  Advanced users only
@@ -276,7 +276,7 @@ static PyObject *ui_thread_run(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     long rc = pThread->CWinThread::Run();
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod |PyCWinThread|CreateThread|Creates the actual thread behind the thread object.

--- a/Pythonwin/win32toolbar.cpp
+++ b/Pythonwin/win32toolbar.cpp
@@ -176,7 +176,7 @@ PyObject *PyCDockContext::getattro(PyObject *obname)
             void *pv = &((BYTE *)pC)[pm->off];
             switch (pm->type) {
                 case MT_INT:
-                    return PyInt_FromLong(*((int *)pv));
+                    return PyLong_FromLong(*((int *)pv));
                     break;
                 case MT_RECT: {
                     CRect *p = (CRect *)pv;
@@ -212,7 +212,7 @@ int PyCDockContext::setattro(PyObject *obname, PyObject *value)
             void *pv = &((BYTE *)pC)[pm->off];
             switch (pm->type) {
                 case MT_INT:
-                    *((int *)pv) = PyInt_AsLong(value);
+                    *((int *)pv) = PyLong_AsLong(value);
                     return 0;
                 case MT_RECT: {
                     CRect *p = (CRect *)pv;
@@ -468,9 +468,9 @@ PyObject *PyCControlBar::getattro(PyObject *obname)
         return ui_assoc_object::make(PyCDockContext::type, pCtlBar->m_pDockContext);
     }
     if (strcmp(name, "dwStyle") == 0)  // @prop int|dwStyle|creation style (used for layout)
-        return PyInt_FromLong(pCtlBar->m_dwStyle);
+        return PyLong_FromLong(pCtlBar->m_dwStyle);
     if (strcmp(name, "dwDockStyle") == 0)  // @prop int|dwDockStyle|indicates how bar can be docked
-        return PyInt_FromLong(pCtlBar->m_dwStyle);
+        return PyLong_FromLong(pCtlBar->m_dwStyle);
 
     return PyObject_GenericGetAttr(this, obname);
 }
@@ -485,13 +485,13 @@ int PyCControlBar::setattro(PyObject *obname, PyObject *v)
     if (!pCtlBar)
         return -1;
     if (strcmp(name, "dwStyle") == 0) {
-        pCtlBar->m_dwStyle = PyInt_AsLong(v);
+        pCtlBar->m_dwStyle = PyLong_AsLong(v);
         if (pCtlBar->m_dwStyle == -1 && PyErr_Occurred())
             return -1;
         return 0;
     }
     if (strcmp(name, "dwDockStyle") == 0) {
-        pCtlBar->m_dwDockStyle = PyInt_AsLong(v);
+        pCtlBar->m_dwDockStyle = PyLong_AsLong(v);
         if (pCtlBar->m_dwDockStyle == -1 && PyErr_Occurred())
             return -1;
         return 0;
@@ -579,10 +579,10 @@ PyObject *PyCToolBar_SetButtons(PyObject *self, PyObject *args)
                           &buttons))  // @pyparm tuple|buttons||A tuple containing the ID's of the buttons.
         return NULL;
 
-    if (PyInt_Check(buttons)) {
+    if (PyLong_Check(buttons)) {
         // @pyparmalt1 int|numButtons||The number of buttons to pre-allocate.  If this option is used, then <om
         // PyCToolBar.PySetButtonInfo> must be used.
-        BOOL rc = pToolBar->SetButtons(NULL, PyInt_AsLong(buttons));
+        BOOL rc = pToolBar->SetButtons(NULL, PyLong_AsLong(buttons));
         if (!rc)
             RETURN_API_ERR("PyCToolBar.SetButtons");
         RETURN_NONE;
@@ -597,11 +597,11 @@ PyObject *PyCToolBar_SetButtons(PyObject *self, PyObject *args)
     PyObject *o;
     for (Py_ssize_t i = 0; i < num_buttons; i++) {
         o = PyTuple_GetItem(buttons, i);
-        if (!PyInt_Check(o)) {
+        if (!PyLong_Check(o)) {
             delete button_list;
             RETURN_ERR("SetButtons expected integer button ids.");
         }
-        button_list[i] = PyInt_AsLong(o);
+        button_list[i] = PyLong_AsLong(o);
     }
     BOOL rc = pToolBar->SetButtons(button_list, PyWin_SAFE_DOWNCAST(num_buttons, Py_ssize_t, int));
     delete button_list;
@@ -1054,7 +1054,7 @@ PyObject *PyCToolBarCtrl_AddStrings(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     int rc = pTBC->AddStrings(strings);
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod |PyCToolBarCtrl|AutoSize|Resize the entire toolbar control
@@ -1595,12 +1595,12 @@ PyObject *PyCStatusBar_SetIndicators(PyObject *self, PyObject *args)
     PyObject *o;
     for (Py_ssize_t i = 0; i < num_buttons; i++) {
         o = PySequence_GetItem(buttons, i);
-        if (!PyInt_Check(o)) {
+        if (!PyLong_Check(o)) {
             Py_XDECREF(o);
             delete button_list;
             RETURN_ERR("SetIndicators expected integer button ids.");
         }
-        button_list[i] = PyInt_AsLong(o);
+        button_list[i] = PyLong_AsLong(o);
         Py_DECREF(o);
     }
     BOOL rc = pSB->SetIndicators(button_list, PyWin_SAFE_DOWNCAST(num_buttons, Py_ssize_t, int));

--- a/Pythonwin/win32tooltip.cpp
+++ b/Pythonwin/win32tooltip.cpp
@@ -163,7 +163,7 @@ static PyObject *PyCToolTipCtrl_set_max_tip_width(PyObject *self, PyObject *args
     GUI_BGN_SAVE;
     int rc = pTTC->SetMaxTipWidth(width);
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @object PyCToolTipCtrl|A windows tooltip control.  Encapsulates an MFC <c CToolTipCtrl> class.  Derived from <o

--- a/Pythonwin/win32uimodule.cpp
+++ b/Pythonwin/win32uimodule.cpp
@@ -751,7 +751,7 @@ int Python_do_int_callback(PyObject *themeth, PyObject *thearglst)
     if (result == Py_None)  // allow for None==0
         retVal = 0;
     else {
-        retVal = PyInt_AsLong(result);
+        retVal = PyLong_AsLong(result);
         if (retVal == -1 && PyErr_Occurred()) {
             gui_print_error();
             TRACE("Python_do_int_callback: callback had bad return type\n");
@@ -1018,7 +1018,7 @@ static PyObject *ui_write_profile_val(PyObject *self, PyObject *args)
         bHaveInt = FALSE;
     else {
         PyErr_Clear();
-        intVal = PyInt_AsLong(obVal);
+        intVal = PyLong_AsLong(obVal);
         if (intVal == -1 && PyErr_Occurred())
             RETURN_TYPE_ERR("Value must be string or int");
     }
@@ -1032,7 +1032,7 @@ static PyObject *ui_write_profile_val(PyObject *self, PyObject *args)
             rc = pApp->WriteProfileString(sect, entry, strVal);
         GUI_END_SAVE;
         if (rc)
-            ret = PyInt_FromLong(rc);
+            ret = PyLong_FromLong(rc);
         else
             PyErr_SetString(ui_module_error, "WriteProfileInt/String failed");
     }
@@ -1063,7 +1063,7 @@ static PyObject *ui_get_profile_val(PyObject *self, PyObject *args)
         bHaveInt = FALSE;
     else {
         PyErr_Clear();
-        intDef = PyInt_AsLong(obDef);
+        intDef = PyLong_AsLong(obDef);
         if (intDef == -1 && PyErr_Occurred())
             RETURN_TYPE_ERR("Default value must be string or int");
     }
@@ -1073,7 +1073,7 @@ static PyObject *ui_get_profile_val(PyObject *self, PyObject *args)
             GUI_BGN_SAVE;
             rc = pApp->GetProfileInt(sect, entry, intDef);
             GUI_END_SAVE;
-            ret = PyInt_FromLong(rc);
+            ret = PyLong_FromLong(rc);
         }
         else {
             CString rc;
@@ -1301,7 +1301,7 @@ static PyObject *ui_pump_waiting_messages(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     bool rc = pThread->PumpWaitingMessages(firstMsg, lastMsg);
     GUI_END_SAVE;
-    return PyInt_FromLong((int)rc == true);
+    return PyLong_FromLong((int)rc == true);
     // @comm This allows an application which is performing a long operation to dispatch paint messages during the
     // operation.
     // @rdesc The result is 1 if a WM_QUIT message was processed, otherwise 0.
@@ -1349,7 +1349,7 @@ static PyObject *ui_message_box(PyObject *self, PyObject *args)
         GUI_BGN_SAVE;
         rc = ::MessageBox(pApp->m_pMainWnd->GetSafeHwnd(), message, title ? title : pApp->m_pszAppName, style);
         GUI_END_SAVE;
-        ret = PyInt_FromLong(rc);
+        ret = PyLong_FromLong(rc);
     }
     PyWinObject_FreeTCHAR(message);
     PyWinObject_FreeTCHAR(title);
@@ -1385,7 +1385,7 @@ static PyObject *ui_compare_path(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "OO:ComparePath", &obpath1, &obpath2))
         return NULL;
     if (PyWinObject_AsTCHAR(obpath1, &path1, FALSE) && PyWinObject_AsTCHAR(obpath2, &path2, FALSE))
-        ret = PyInt_FromLong(AfxComparePath(path1, path2));
+        ret = PyLong_FromLong(AfxComparePath(path1, path2));
     PyWinObject_FreeTCHAR(path1);
     PyWinObject_FreeTCHAR(path2);
     return ret;
@@ -1686,9 +1686,9 @@ static PyObject *ui_is_debug(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, ":IsDebug"))
         return NULL;
 #ifdef _DEBUG
-    return PyInt_FromLong(1);
+    return PyLong_FromLong(1);
 #else
-    return PyInt_FromLong(0);
+    return PyLong_FromLong(0);
 #endif
     // @comm This should not normally be of relevance to the Python
     // programmer.  However, under certain circumstances Python code may
@@ -1814,7 +1814,7 @@ static PyObject *ui_get_device_caps(PyObject *, PyObject *args)
     HDC hdc;
     if (!PyWinObject_AsHANDLE(obdc, (HANDLE *)&hdc))
         return NULL;
-    return PyInt_FromLong(::GetDeviceCaps(hdc, index));
+    return PyLong_FromLong(::GetDeviceCaps(hdc, index));
 }
 
 // @pymethod int|win32ui|TranslateMessage|Calls the API version of TranslateMessage.
@@ -1828,7 +1828,7 @@ static PyObject *ui_translate_message(PyObject *, PyObject *args)
     GUI_BGN_SAVE;
     BOOL rc = ::TranslateMessage(msg);
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod string/None|win32ui|TranslateVirtualKey|

--- a/Pythonwin/win32uimodule.cpp
+++ b/Pythonwin/win32uimodule.cpp
@@ -716,8 +716,8 @@ PyObject *Python_do_callback(PyObject *themeth, PyObject *thearglst)
 
 // Copied from PyRecord.cpp, should move into pywintypes.h
 #if (PY_VERSION_HEX < 0x03000000)
-#define PyWinCoreString_ConcatAndDel PyString_ConcatAndDel
-#define PyWinCoreString_Concat PyString_Concat
+#define PyWinCoreString_ConcatAndDel PyBytes_ConcatAndDel
+#define PyWinCoreString_Concat PyBytes_Concat
 #else
 // Unicode versions of '_Concat' etc have different sigs.  Make them the
 // same here...
@@ -1788,7 +1788,7 @@ static PyObject *ui_get_bytes(PyObject *self, PyObject *args)
         return NULL;
     if (!PyWinLong_AsVoidPtr(obaddress, &address))
         return NULL;
-    return PyString_FromStringAndSize((char *)address, size);
+    return PyBytes_FromStringAndSize((char *)address, size);
 }
 // @pymethod string|win32ui|InitRichEdit|Initializes the rich edit framework.
 static PyObject *ui_init_rich_edit(PyObject *self, PyObject *args)
@@ -1849,7 +1849,7 @@ static PyObject *ui_translate_vk(PyObject *, PyObject *args)
         Py_INCREF(Py_None);
         return Py_None;
     }
-    return PyString_FromStringAndSize(result, nc);
+    return PyBytes_FromStringAndSize(result, nc);
 }
 
 /** Seems to have problems on 9x for some people (not me, though?)

--- a/Pythonwin/win32uioleClientItem.cpp
+++ b/Pythonwin/win32uioleClientItem.cpp
@@ -217,7 +217,7 @@ static PyObject *PyCOleClientItem_GetItemState(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     int rc = pCI->GetItemState();
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod <o PyIUnknown>|PyCOleClientItem|GetObject|Returns the COM object to the item.  This is the m_lpObject
@@ -286,7 +286,7 @@ static PyObject *PyCOleClientItem_OnChangeItemPosition(PyObject *self, PyObject 
     BOOL bRet = ((PythonOleClientItem *)pCI)->BaseOnChangeItemPosition(rect);
     GUI_END_SAVE;
     // @rdesc The result is a BOOL indicating if the function succeeded.  No exception is thrown.
-    return PyInt_FromLong(bRet);
+    return PyLong_FromLong(bRet);
 }
 
 // @pymethod int|PyCOleClientItem|OnDeactivateUI|Calls the underlying MFC method.

--- a/Pythonwin/win32util.cpp
+++ b/Pythonwin/win32util.cpp
@@ -96,13 +96,13 @@ PyObject *PyCRect::getattro(PyObject *obname)
     if (name == NULL)
         return NULL;
     if (strcmp(name, "left") == 0)
-        return PyInt_FromLong(m_pRect->left);
+        return PyLong_FromLong(m_pRect->left);
     if (strcmp(name, "right") == 0)
-        return PyInt_FromLong(m_pRect->right);
+        return PyLong_FromLong(m_pRect->right);
     if (strcmp(name, "top") == 0)
-        return PyInt_FromLong(m_pRect->top);
+        return PyLong_FromLong(m_pRect->top);
     if (strcmp(name, "bottom") == 0)
-        return PyInt_FromLong(m_pRect->bottom);
+        return PyLong_FromLong(m_pRect->bottom);
     return PyObject_GenericGetAttr(this, obname);
 }
 
@@ -126,13 +126,13 @@ CString PyCRect::repr()
     PyCRect *p = (PyCRect *)self;
     switch (index) {
         case 0:  // @tupleitem 0|int|left|
-            return PyInt_FromLong(p->m_pRect->left);
+            return PyLong_FromLong(p->m_pRect->left);
         case 1:  // @tupleitem 1|int|top|
-            return PyInt_FromLong(p->m_pRect->top);
+            return PyLong_FromLong(p->m_pRect->top);
         case 2:  // @tupleitem 2|int|right|
-            return PyInt_FromLong(p->m_pRect->right);
+            return PyLong_FromLong(p->m_pRect->right);
         case 3:  // @tupleitem 3|int|bottom|
-            return PyInt_FromLong(p->m_pRect->bottom);
+            return PyLong_FromLong(p->m_pRect->bottom);
     }
     PyErr_SetString(PyExc_IndexError, "index out of range");
     return NULL;
@@ -143,7 +143,7 @@ int PyCRect::setattro(PyObject *obname, PyObject *v)
     char *name = PYWIN_ATTR_CONVERT(obname);
     if (name == NULL)
         return -1;
-    int intval = PyInt_AsLong(v);
+    int intval = PyLong_AsLong(v);
     if (intval == -1 && PyErr_Occurred())
         return -1;
     if (strcmp(name, "left") == 0) {
@@ -241,14 +241,14 @@ static char *szFontName = "name";
 PyObject *LogFontToDict(const LOGFONT &lf)
 {
     return Py_BuildValue("{s:N, s:N, s:N, s:N, s:N, s:N, s:N, s:N, s:N, s:N, s:N, s:N, s:N, s:N}", szFontHeight,
-                         PyInt_FromLong(lf.lfHeight), szFontWidth, PyInt_FromLong(lf.lfWidth), szFontEscapement,
-                         PyInt_FromLong(lf.lfEscapement), szFontOrientation, PyInt_FromLong(lf.lfOrientation),
-                         szFontWeight, PyInt_FromLong(lf.lfWeight), szFontItalic, PyBool_FromLong(lf.lfItalic),
+                         PyLong_FromLong(lf.lfHeight), szFontWidth, PyLong_FromLong(lf.lfWidth), szFontEscapement,
+                         PyLong_FromLong(lf.lfEscapement), szFontOrientation, PyLong_FromLong(lf.lfOrientation),
+                         szFontWeight, PyLong_FromLong(lf.lfWeight), szFontItalic, PyBool_FromLong(lf.lfItalic),
                          szFontUnderline, PyBool_FromLong(lf.lfUnderline), szFontStrikeOut,
-                         PyBool_FromLong(lf.lfStrikeOut), szFontCharSet, PyInt_FromLong(lf.lfCharSet),
-                         szFontOutPrecision, PyInt_FromLong(lf.lfOutPrecision), szFontClipPrecision,
-                         PyInt_FromLong(lf.lfClipPrecision), szFontQuality, PyInt_FromLong(lf.lfQuality), szFontPitch,
-                         PyInt_FromLong(lf.lfPitchAndFamily), szFontName, PyWinObject_FromTCHAR(lf.lfFaceName));
+                         PyBool_FromLong(lf.lfStrikeOut), szFontCharSet, PyLong_FromLong(lf.lfCharSet),
+                         szFontOutPrecision, PyLong_FromLong(lf.lfOutPrecision), szFontClipPrecision,
+                         PyLong_FromLong(lf.lfClipPrecision), szFontQuality, PyLong_FromLong(lf.lfQuality), szFontPitch,
+                         PyLong_FromLong(lf.lfPitchAndFamily), szFontName, PyWinObject_FromTCHAR(lf.lfFaceName));
 }
 
 BOOL DictToLogFont(PyObject *font_props, LOGFONT *pLF)
@@ -309,11 +309,11 @@ PyObject *PyWinObject_FromLV_ITEM(LV_ITEM *item)
     PyObject *ret = PyTuple_New(7);
     if (ret == NULL)
         return NULL;
-    PyTuple_SET_ITEM(ret, 0, PyInt_FromLong(item->iItem));
-    PyTuple_SET_ITEM(ret, 1, PyInt_FromLong(item->iSubItem));
+    PyTuple_SET_ITEM(ret, 0, PyLong_FromLong(item->iItem));
+    PyTuple_SET_ITEM(ret, 1, PyLong_FromLong(item->iSubItem));
     if (item->mask & LVIF_STATE) {
-        PyTuple_SET_ITEM(ret, 2, PyInt_FromLong(item->state));
-        PyTuple_SET_ITEM(ret, 3, PyInt_FromLong(item->stateMask));
+        PyTuple_SET_ITEM(ret, 2, PyLong_FromLong(item->state));
+        PyTuple_SET_ITEM(ret, 3, PyLong_FromLong(item->stateMask));
     }
     else {
         Py_INCREF(Py_None);
@@ -329,7 +329,7 @@ PyObject *PyWinObject_FromLV_ITEM(LV_ITEM *item)
         PyTuple_SET_ITEM(ret, 4, Py_None);
     }
     if (item->mask & LVIF_IMAGE) {
-        PyTuple_SET_ITEM(ret, 5, PyInt_FromLong(item->iImage));
+        PyTuple_SET_ITEM(ret, 5, PyLong_FromLong(item->iImage));
     }
     else {
         Py_INCREF(Py_None);
@@ -376,13 +376,13 @@ BOOL PyWinObject_AsLV_ITEM(PyObject *args, LV_ITEM *pItem)
 
     // 0 - iItem.
     ob = PyTuple_GET_ITEM(args, 0);
-    pItem->iItem = PyInt_AsLong(ob);
+    pItem->iItem = PyLong_AsLong(ob);
     if (pItem->iImage == -1 && PyErr_Occurred())
         return FALSE;
 
     // 1 - iSubItem
     ob = PyTuple_GET_ITEM(args, 1);
-    pItem->iSubItem = PyInt_AsLong(ob);
+    pItem->iSubItem = PyLong_AsLong(ob);
     if (pItem->iSubItem == -1 && PyErr_Occurred())
         return FALSE;
 
@@ -402,10 +402,10 @@ BOOL PyWinObject_AsLV_ITEM(PyObject *args, LV_ITEM *pItem)
         return FALSE;
     }
     else {
-        pItem->state = PyInt_AsLong(ob);
+        pItem->state = PyLong_AsLong(ob);
         if (pItem->state == -1 && PyErr_Occurred())
             return FALSE;
-        pItem->stateMask = PyInt_AsLong(ob2);
+        pItem->stateMask = PyLong_AsLong(ob2);
         if (pItem->stateMask == -1 && PyErr_Occurred())
             return FALSE;
         pItem->mask |= LVIF_STATE;
@@ -425,7 +425,7 @@ BOOL PyWinObject_AsLV_ITEM(PyObject *args, LV_ITEM *pItem)
         return TRUE;
     ob = PyTuple_GET_ITEM(args, 5);
     if (ob != Py_None) {
-        pItem->iImage = PyInt_AsLong(ob);
+        pItem->iImage = PyLong_AsLong(ob);
         if (pItem->iImage == -1 && PyErr_Occurred()) {
             PyWinObject_FreeLV_ITEM(pItem);
             return FALSE;
@@ -454,14 +454,14 @@ PyObject *PyWinObject_FromLV_COLUMN(LV_COLUMN *pCol)
     if (ret == NULL)
         return NULL;
     if (pCol->mask & LVCF_FMT) {
-        PyTuple_SET_ITEM(ret, 0, PyInt_FromLong(pCol->fmt));
+        PyTuple_SET_ITEM(ret, 0, PyLong_FromLong(pCol->fmt));
     }
     else {
         Py_INCREF(Py_None);
         PyTuple_SET_ITEM(ret, 0, Py_None);
     }
     if (pCol->mask & LVCF_WIDTH) {
-        PyTuple_SET_ITEM(ret, 1, PyInt_FromLong(pCol->cx));
+        PyTuple_SET_ITEM(ret, 1, PyLong_FromLong(pCol->cx));
     }
     else {
         Py_INCREF(Py_None);
@@ -475,7 +475,7 @@ PyObject *PyWinObject_FromLV_COLUMN(LV_COLUMN *pCol)
         PyTuple_SET_ITEM(ret, 2, Py_None);
     }
     if (pCol->mask & LVCF_SUBITEM) {
-        PyTuple_SET_ITEM(ret, 3, PyInt_FromLong(pCol->iSubItem));
+        PyTuple_SET_ITEM(ret, 3, PyLong_FromLong(pCol->iSubItem));
     }
     else {
         Py_INCREF(Py_None);
@@ -517,7 +517,7 @@ BOOL PyWinObject_AsLV_COLUMN(PyObject *args, LV_COLUMN *pCol)
         return TRUE;
     ob = PyTuple_GET_ITEM(args, 0);
     if (ob != Py_None) {
-        pCol->fmt = PyInt_AsLong(ob);
+        pCol->fmt = PyLong_AsLong(ob);
         if (pCol->fmt == -1 && PyErr_Occurred())
             return FALSE;
         pCol->mask |= LVCF_FMT;
@@ -528,7 +528,7 @@ BOOL PyWinObject_AsLV_COLUMN(PyObject *args, LV_COLUMN *pCol)
         return TRUE;
     ob = PyTuple_GET_ITEM(args, 1);
     if (ob != Py_None) {
-        pCol->cx = PyInt_AsLong(ob);
+        pCol->cx = PyLong_AsLong(ob);
         if (pCol->cx == -1 && PyErr_Occurred())
             return FALSE;
         pCol->mask |= LVCF_WIDTH;
@@ -548,7 +548,7 @@ BOOL PyWinObject_AsLV_COLUMN(PyObject *args, LV_COLUMN *pCol)
         return TRUE;
     ob = PyTuple_GET_ITEM(args, 3);
     if (ob != Py_None) {
-        pCol->iSubItem = PyInt_AsLong(ob);
+        pCol->iSubItem = PyLong_AsLong(ob);
         if (pCol->iSubItem == -1 && PyErr_Occurred()) {
             PyWinObject_FreeLV_COLUMN(pCol);
             return FALSE;
@@ -576,8 +576,8 @@ PyObject *PyWinObject_FromTV_ITEM(TV_ITEM *item)
         PyTuple_SET_ITEM(ret, 0, Py_None);
     }
     if (item->mask & TVIF_STATE) {
-        PyTuple_SET_ITEM(ret, 1, PyInt_FromLong(item->state));
-        PyTuple_SET_ITEM(ret, 2, PyInt_FromLong(item->stateMask));
+        PyTuple_SET_ITEM(ret, 1, PyLong_FromLong(item->state));
+        PyTuple_SET_ITEM(ret, 2, PyLong_FromLong(item->stateMask));
     }
     else {
         Py_INCREF(Py_None);
@@ -593,14 +593,14 @@ PyObject *PyWinObject_FromTV_ITEM(TV_ITEM *item)
         PyTuple_SET_ITEM(ret, 3, Py_None);
     }
     if (item->mask & TVIF_IMAGE) {
-        PyTuple_SET_ITEM(ret, 4, PyInt_FromLong(item->iImage));
+        PyTuple_SET_ITEM(ret, 4, PyLong_FromLong(item->iImage));
     }
     else {
         Py_INCREF(Py_None);
         PyTuple_SET_ITEM(ret, 4, Py_None);
     }
     if (item->mask & TVIF_SELECTEDIMAGE) {
-        PyTuple_SET_ITEM(ret, 5, PyInt_FromLong(item->iSelectedImage));
+        PyTuple_SET_ITEM(ret, 5, PyLong_FromLong(item->iSelectedImage));
     }
     else {
         Py_INCREF(Py_None);
@@ -608,7 +608,7 @@ PyObject *PyWinObject_FromTV_ITEM(TV_ITEM *item)
     }
 
     if (item->mask & TVIF_CHILDREN) {
-        PyTuple_SET_ITEM(ret, 6, PyInt_FromLong(item->cChildren));
+        PyTuple_SET_ITEM(ret, 6, PyLong_FromLong(item->cChildren));
     }
     else {
         Py_INCREF(Py_None);
@@ -673,10 +673,10 @@ BOOL PyWinObject_AsTV_ITEM(PyObject *args, TV_ITEM *pItem)
     else {
         // @tupleitem 1|int|state|Item state.  If specified, the stateMask must also be specified.
         // @tupleitem 2|int|stateMask|Item state mask
-        pItem->state = PyInt_AsLong(ob);
+        pItem->state = PyLong_AsLong(ob);
         if (pItem->state == -1 && PyErr_Occurred())
             return FALSE;
-        pItem->stateMask = PyInt_AsLong(ob2);
+        pItem->stateMask = PyLong_AsLong(ob2);
         if (pItem->stateMask == -1 && PyErr_Occurred())
             return FALSE;
         pItem->mask |= TVIF_STATE;
@@ -698,7 +698,7 @@ BOOL PyWinObject_AsTV_ITEM(PyObject *args, TV_ITEM *pItem)
     ob = PyTuple_GET_ITEM(args, 4);
     if (ob != Py_None) {
         // @tupleitem 4|int|iImage|Image list index of icon for non-seleted state.
-        pItem->iImage = PyInt_AsLong(ob);
+        pItem->iImage = PyLong_AsLong(ob);
         if (pItem->iImage == -1 && PyErr_Occurred()) {
             PyWinObject_FreeTV_ITEM(pItem);
             return FALSE;
@@ -712,7 +712,7 @@ BOOL PyWinObject_AsTV_ITEM(PyObject *args, TV_ITEM *pItem)
     ob = PyTuple_GET_ITEM(args, 5);
     if (ob != Py_None) {
         // @tupleitem 5|int|iSelectedImage|Offset of items selected image.
-        pItem->iSelectedImage = PyInt_AsLong(ob);
+        pItem->iSelectedImage = PyLong_AsLong(ob);
         if (pItem->iSelectedImage == -1 && PyErr_Occurred()) {
             PyWinObject_FreeTV_ITEM(pItem);
             return FALSE;
@@ -726,7 +726,7 @@ BOOL PyWinObject_AsTV_ITEM(PyObject *args, TV_ITEM *pItem)
     ob = PyTuple_GET_ITEM(args, 6);
     if (ob != Py_None) {
         // @tupleitem 6|int|cChildren|Number of child items.
-        pItem->cChildren = PyInt_AsLong(ob);
+        pItem->cChildren = PyLong_AsLong(ob);
         if (pItem->cChildren == -1 && PyErr_Occurred()) {
             PyWinObject_FreeTV_ITEM(pItem);
             return FALSE;
@@ -764,11 +764,11 @@ PyObject *MakeHD_ITEMTuple(HD_ITEM *item)
     if (ret == NULL)
         return NULL;
     if (item->mask & HDI_HEIGHT)
-        PyTuple_SET_ITEM(ret, 0, PyInt_FromLong((long)0));
+        PyTuple_SET_ITEM(ret, 0, PyLong_FromLong((long)0));
     else if (item->mask & HDI_WIDTH)
-        PyTuple_SET_ITEM(ret, 0, PyInt_FromLong((long)1));
+        PyTuple_SET_ITEM(ret, 0, PyLong_FromLong((long)1));
     if ((item->mask & HDI_HEIGHT) || (item->mask & HDI_WIDTH))
-        PyTuple_SET_ITEM(ret, 1, PyInt_FromLong((long)item->cxy));
+        PyTuple_SET_ITEM(ret, 1, PyLong_FromLong((long)item->cxy));
     else {
         Py_INCREF(Py_None);
         Py_INCREF(Py_None);
@@ -791,7 +791,7 @@ PyObject *MakeHD_ITEMTuple(HD_ITEM *item)
         PyTuple_SET_ITEM(ret, 3, Py_None);
     }
     if (item->mask & HDI_FORMAT) {
-        PyTuple_SET_ITEM(ret, 4, PyInt_FromLong(item->fmt));
+        PyTuple_SET_ITEM(ret, 4, PyLong_FromLong(item->fmt));
     }
     else {
         Py_INCREF(Py_None);
@@ -843,7 +843,7 @@ BOOL ParseHD_ITEMTuple( PyObject *args, HD_ITEM *pItem)
         return FALSE;
     if (ob != Py_None) {
         // @pyparm int|cxy||Width or height of item
-        pItem->cxy = (int)PyInt_AsLong(ob);
+        pItem->cxy = (int)PyLong_AsLong(ob);
         if (PyErr_Occurred()) return FALSE;
         //mask updated above
     }
@@ -876,7 +876,7 @@ BOOL ParseHD_ITEMTuple( PyObject *args, HD_ITEM *pItem)
     if (ob != Py_None) {
         pItem->mask |= HDI_FORMAT;
         // @pyparm int|fmt||code for centering etc of string
-        pItem->fmt = (int)PyInt_AsLong(ob);
+        pItem->fmt = (int)PyLong_AsLong(ob);
     }
     // 5 - object
     if (len<6) return TRUE;
@@ -885,7 +885,7 @@ BOOL ParseHD_ITEMTuple( PyObject *args, HD_ITEM *pItem)
     if (ob != Py_None) {
         // @pyparm int|lParam||User defined integer param.
         pItem->mask |= LVIF_PARAM;
-        pItem->lParam = PyInt_AsLong(ob);
+        pItem->lParam = PyLong_AsLong(ob);
     }
     return !PyErr_Occurred();
 }
@@ -966,7 +966,7 @@ BOOL ParseParaFormatTuple(PyObject *args, PARAFORMAT *pFmt)
         Py_ssize_t tabCount = PyObject_Length(obTabStops);
         tabCount = min(MAX_TAB_STOPS, tabCount);
         for (Py_ssize_t i = 0; rc && i < tabCount; i++) {
-            pFmt->rgxTabs[i] = PyInt_AsLong(PySequence_GetItem(obTabStops, i));
+            pFmt->rgxTabs[i] = PyLong_AsLong(PySequence_GetItem(obTabStops, i));
             rc = PyErr_Occurred() == FALSE;
             if (!rc)
                 break;
@@ -985,7 +985,7 @@ PyObject *MakeParaFormatTuple(PARAFORMAT *pFmt)
     }
     else {
         obTabs = PyTuple_New(pFmt->cTabCount);
-        for (int i = 0; i < pFmt->cTabCount; i++) PyTuple_SetItem(obTabs, i, PyInt_FromLong(pFmt->rgxTabs[i]));
+        for (int i = 0; i < pFmt->cTabCount; i++) PyTuple_SetItem(obTabs, i, PyLong_FromLong(pFmt->rgxTabs[i]));
     }
     PyObject *ret = Py_BuildValue("iiiiiiiO", pFmt->dwMask, pFmt->wNumbering, pFmt->wEffects, pFmt->dxStartIndent,
                                   pFmt->dxRightIndent, pFmt->dxOffset, pFmt->wAlignment, obTabs);

--- a/Pythonwin/win32util.cpp
+++ b/Pythonwin/win32util.cpp
@@ -1152,7 +1152,7 @@ CString GetReprText(PyObject *objectUse)
     // Assumes that this will always be compiled with UNICODE defined for py3k
     s = PyObject_Str(objectUse);
     if (s) {
-        csRet = CString(PyString_AsString(s));
+        csRet = CString(PyBytes_AsString(s));
         Py_DECREF(s);
         return csRet;
     }
@@ -1169,8 +1169,8 @@ CString GetReprText(PyObject *objectUse)
     // repr() should return either a string or unicode object, but not sure if this is enforced.
     if (PyUnicode_Check(s))
         csRet = CString(PyUnicode_AS_UNICODE(s));
-    else if (PyString_Check(s))
-        csRet = CString(PyString_AS_STRING(s));
+    else if (PyBytes_Check(s))
+        csRet = CString(PyBytes_AS_STRING(s));
     else
         csRet.Format(_T("??? repr() for type %s returned type %s ???"), objectUse->ob_type->tp_name,
                      s->ob_type->tp_name);

--- a/Pythonwin/win32view.cpp
+++ b/Pythonwin/win32view.cpp
@@ -210,7 +210,7 @@ static PyObject *PyCView_on_mouse_activate(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     UINT rc = view->BaseOnMouseActivate(pWndArg, ht, msg);
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod tuple|PyCView|PreCreateWindow|Calls the underlying MFC PreCreateWindow method.

--- a/Pythonwin/win32virt.cpp
+++ b/Pythonwin/win32virt.cpp
@@ -102,8 +102,8 @@ BOOL CVirtualHelper::do_call(PyObject *args)
             PyObject *obRepr = PyObject_Repr(handler);
             char *szRepr = "<no representation (PyObject_Repr failed)>";
             if (obRepr) {
-                if (PyString_Check(obRepr))
-                    szRepr = PyString_AS_STRING(obRepr);
+                if (PyBytes_Check(obRepr))
+                    szRepr = PyBytes_AS_STRING(obRepr);
                 else if (PyUnicode_Check(obRepr))
                     szRepr = W2A(PyUnicode_AS_UNICODE(obRepr));
             }

--- a/Pythonwin/win32virt.cpp
+++ b/Pythonwin/win32virt.cpp
@@ -568,7 +568,7 @@ BOOL CVirtualHelper::retval(int &ret)
         return TRUE;
     }
     CEnterLeavePython _celp;
-    ret = PyInt_AsLong(retVal);
+    ret = PyLong_AsLong(retVal);
     if (ret == -1 && PyErr_Occurred()) {
         gui_print_error();
         return FALSE;
@@ -586,7 +586,7 @@ BOOL CVirtualHelper::retval(long &ret)
         return TRUE;
     }
     CEnterLeavePython _celp;
-    ret = PyInt_AsLong(retVal);
+    ret = PyLong_AsLong(retVal);
     if (PyErr_Occurred()) {
         gui_print_error();
         return FALSE;

--- a/Pythonwin/win32win.cpp
+++ b/Pythonwin/win32win.cpp
@@ -2614,7 +2614,7 @@ PyObject *ui_window_begin_paint(PyObject *self, PyObject *args)
     PyObject *obDC = ui_assoc_object::make(ui_dc_object::type, pTemp)->GetGoodRet();
     PyObject *obRet = Py_BuildValue("O(Ni(iiii)iiN)", obDC, PyWinLong_FromHANDLE(ps.hdc), ps.fErase, ps.rcPaint.left,
                                     ps.rcPaint.top, ps.rcPaint.right, ps.rcPaint.bottom, ps.fRestore, ps.fIncUpdate,
-                                    PyString_FromStringAndSize((char *)ps.rgbReserved, sizeof(ps.rgbReserved)));
+                                    PyBytes_FromStringAndSize((char *)ps.rgbReserved, sizeof(ps.rgbReserved)));
     Py_XDECREF(obDC);
     return obRet;
 }
@@ -2630,9 +2630,9 @@ PyObject *ui_window_end_paint(PyObject *self, PyObject *args)
                           &ps.rcPaint.right, &ps.rcPaint.bottom, &ps.fRestore, &ps.fIncUpdate, &obString))
         return NULL;
 
-    if (!PyString_Check(obString) || PyString_Size(obString) != sizeof(ps.rgbReserved))
+    if (!PyBytes_Check(obString) || PyBytes_Size(obString) != sizeof(ps.rgbReserved))
         RETURN_TYPE_ERR("Last tuple must be a string of a specific size!");
-    memcpy(ps.rgbReserved, PyString_AsString(obString), sizeof(ps.rgbReserved));
+    memcpy(ps.rgbReserved, PyBytes_AsString(obString), sizeof(ps.rgbReserved));
 
     if (!PyWinObject_AsHANDLE(obhdc, (HANDLE *)&ps.hdc))
         return NULL;

--- a/Pythonwin/win32win.cpp
+++ b/Pythonwin/win32win.cpp
@@ -101,7 +101,7 @@ BOOL Python_check_key_message(const MSG *msg)
 // WARNING - the return ptr may be temporary.
 CWnd *GetWndPtrFromParam(PyObject *ob, ui_type_CObject &type)
 {
-    if (PyInt_Check(ob) || PyLong_Check(ob)) {
+    if (PyLong_Check(ob) || PyLong_Check(ob)) {
         HWND hwnd = 0;
         if (!PyWinObject_AsHANDLE(ob, (HANDLE *)&hwnd) || !IsWindow(hwnd))
             RETURN_ERR(szErrMsgBadHandle);
@@ -171,7 +171,7 @@ BOOL ParseSCROLLINFOTuple(PyObject *args, SCROLLINFO *pInfo)
     // 0 - mask.
     if ((ob = PyTuple_GetItem(args, 0)) == NULL)
         return FALSE;
-    pInfo->fMask = (UINT)PyInt_AsLong(ob);
+    pInfo->fMask = (UINT)PyLong_AsLong(ob);
     // 1/2 - nMin/nMax
     if (len == 2) {
         PyErr_SetString(PyExc_TypeError, "SCROLLINFO - Both min and max, or neither, must be provided.");
@@ -183,10 +183,10 @@ BOOL ParseSCROLLINFOTuple(PyObject *args, SCROLLINFO *pInfo)
         return FALSE;
     if (ob != Py_None) {
         pInfo->fMask |= SIF_RANGE;
-        pInfo->nMin = PyInt_AsLong(ob);
+        pInfo->nMin = PyLong_AsLong(ob);
         if ((ob = PyTuple_GetItem(args, 2)) == NULL)
             return FALSE;
-        pInfo->nMax = PyInt_AsLong(ob);
+        pInfo->nMax = PyLong_AsLong(ob);
     }
     // 3 == nPage.
     if (len < 4)
@@ -195,7 +195,7 @@ BOOL ParseSCROLLINFOTuple(PyObject *args, SCROLLINFO *pInfo)
         return FALSE;
     if (ob != Py_None) {
         pInfo->fMask |= SIF_PAGE;
-        pInfo->nPage = PyInt_AsLong(ob);
+        pInfo->nPage = PyLong_AsLong(ob);
     }
     // 4 == nPos
     if (len < 5)
@@ -204,7 +204,7 @@ BOOL ParseSCROLLINFOTuple(PyObject *args, SCROLLINFO *pInfo)
         return FALSE;
     if (ob != Py_None) {
         pInfo->fMask |= SIF_POS;
-        pInfo->nPos = PyInt_AsLong(ob);
+        pInfo->nPos = PyLong_AsLong(ob);
     }
     // 5 == trackpos
     if (len < 6)
@@ -212,7 +212,7 @@ BOOL ParseSCROLLINFOTuple(PyObject *args, SCROLLINFO *pInfo)
     if ((ob = PyTuple_GetItem(args, 5)) == NULL)
         return FALSE;
     if (ob != Py_None) {
-        pInfo->nTrackPos = PyInt_AsLong(ob);
+        pInfo->nTrackPos = PyLong_AsLong(ob);
     }
     return TRUE;
 }
@@ -222,10 +222,10 @@ PyObject *MakeSCROLLINFOTuple(SCROLLINFO *pInfo)
     PyObject *ret = PyTuple_New(6);
     if (ret == NULL)
         return NULL;
-    PyTuple_SET_ITEM(ret, 0, PyInt_FromLong(0));
+    PyTuple_SET_ITEM(ret, 0, PyLong_FromLong(0));
     if (pInfo->fMask & SIF_RANGE) {
-        PyTuple_SET_ITEM(ret, 1, PyInt_FromLong(pInfo->nMin));
-        PyTuple_SET_ITEM(ret, 2, PyInt_FromLong(pInfo->nMax));
+        PyTuple_SET_ITEM(ret, 1, PyLong_FromLong(pInfo->nMin));
+        PyTuple_SET_ITEM(ret, 2, PyLong_FromLong(pInfo->nMax));
     }
     else {
         Py_INCREF(Py_None);
@@ -234,20 +234,20 @@ PyObject *MakeSCROLLINFOTuple(SCROLLINFO *pInfo)
         PyTuple_SET_ITEM(ret, 2, Py_None);
     }
     if (pInfo->fMask & SIF_PAGE) {
-        PyTuple_SET_ITEM(ret, 3, PyInt_FromLong(pInfo->nPage));
+        PyTuple_SET_ITEM(ret, 3, PyLong_FromLong(pInfo->nPage));
     }
     else {
         Py_INCREF(Py_None);
         PyTuple_SET_ITEM(ret, 3, Py_None);
     }
     if (pInfo->fMask & SIF_POS) {
-        PyTuple_SET_ITEM(ret, 4, PyInt_FromLong(pInfo->nPos));
+        PyTuple_SET_ITEM(ret, 4, PyLong_FromLong(pInfo->nPos));
     }
     else {
         Py_INCREF(Py_None);
         PyTuple_SET_ITEM(ret, 4, Py_None);
     }
-    PyTuple_SET_ITEM(ret, 5, PyInt_FromLong(pInfo->nTrackPos));
+    PyTuple_SET_ITEM(ret, 5, PyLong_FromLong(pInfo->nTrackPos));
     return ret;
 }
 
@@ -1118,7 +1118,7 @@ static PyObject *ui_window_get_dlg_item_int(PyObject *self, PyObject *args)
     if (!bWorked)
         RETURN_VALUE_ERR("The dialog item could not be converted to an integer");
     // @rdesc If the value can not be converted, a ValueError is raised.
-    return PyInt_FromLong(res);
+    return PyLong_FromLong(res);
     // @pyseemfc CWnd|GetDlgItemInt
 }
 
@@ -1332,7 +1332,7 @@ static PyObject *ui_window_get_scroll_pos(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     long pos = pWnd->GetScrollPos(nBar);
     GUI_END_SAVE;
-    return PyInt_FromLong(pos);
+    return PyLong_FromLong(pos);
 }
 
 // @pymethod int|PyCWnd|GetStyle|Retrieves the window style
@@ -1346,7 +1346,7 @@ static PyObject *ui_window_get_style(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     DWORD ret = pWnd->GetStyle();
     GUI_END_SAVE;
-    return PyInt_FromLong(ret);
+    return PyLong_FromLong(ret);
 }
 
 // @pymethod int|PyCWnd|GetExStyle|Retrieves the window's extended style
@@ -1360,7 +1360,7 @@ static PyObject *ui_window_get_ex_style(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     DWORD ret = pWnd->GetExStyle();
     GUI_END_SAVE;
-    return PyInt_FromLong(ret);
+    return PyLong_FromLong(ret);
 }
 
 // @pymethod <o PyCMenu>|PyCWnd|GetSystemMenu|Returns the menu object for the window's system menu.
@@ -1585,7 +1585,7 @@ static PyObject *ui_window_is_iconic(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     int rc = pWnd->IsIconic();
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 // @pymethod int|PyCWnd|IsZoomed|Determines if the window is currently maximised.
 static PyObject *ui_window_is_zoomed(PyObject *self, PyObject *args)
@@ -1597,7 +1597,7 @@ static PyObject *ui_window_is_zoomed(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     int rc = pWnd->IsZoomed();
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod int|PyCWnd|IsWindowVisible|Determines if the window is currently visible.
@@ -1610,7 +1610,7 @@ static PyObject *ui_window_is_window_visible(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     long rc = pWnd->IsWindowVisible();
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod int|PyCWnd|IsWindowEnabled|Determines if the window is currently enabled.
@@ -1623,7 +1623,7 @@ static PyObject *ui_window_is_window_enabled(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     int rc = pWnd->IsWindowEnabled();
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod |PyCWnd|MessageBox|Display a message box.
@@ -1684,7 +1684,7 @@ static PyObject *ui_window_modify_style(PyObject *self, PyObject *args)
     rc = pWnd->ModifyStyle(remove, add, flags);
     // @pyseemfc CWnd|ModifyStyle
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
     // @comm If nFlags is nonzero, ModifyStyle calls the Windows API function ::SetWindowPos and redraws the window by
     // combining nFlags with the following four preset flags: <nl>* SWP_NOSIZE	Retains the current size. <nl>*
     // SWP_NOMOVE	Retains the current position. <nl>* SWP_NOZORDER	Retains the current Z order. <nl>*
@@ -1715,7 +1715,7 @@ static PyObject *ui_window_modify_style_ex(PyObject *self, PyObject *args)
     rc = pWnd->ModifyStyleEx(remove, add, flags);
     // @pyseemfc CWnd|ModifyStyleEx
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
     // @comm If nFlags is nonzero, ModifyStyleEx calls the Windows API function ::SetWindowPos and redraws the window by
     // combining nFlags with the following four preset flags: <nl>* SWP_NOSIZE	Retains the current size. <nl>*
     // SWP_NOMOVE	Retains the current position. <nl>* SWP_NOZORDER	Retains the current Z order. <nl>*
@@ -2096,7 +2096,7 @@ static PyObject *ui_window_set_scroll_pos(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     long rc = pWnd->SetScrollPos(nBar, nPos, bRedraw);
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod |PyCWnd|SetWindowPlacement|Sets the windows placement
@@ -2827,14 +2827,14 @@ static PyObject *ui_window_map_window_points(PyObject *self, PyObject *args)
             PyObject *px, *py;
             px = PyTuple_GetItem(point_tuple, 0);
             py = PyTuple_GetItem(point_tuple, 1);
-            if ((!PyInt_Check(px)) || (!PyInt_Check(py))) {
+            if ((!PyLong_Check(px)) || (!PyLong_Check(py))) {
                 PyErr_SetString(PyExc_ValueError, "point list must be a list of (x,y) tuples");
                 delete[] point_array;
                 return NULL;
             }
             else {
-                x = PyInt_AsLong(px);
-                y = PyInt_AsLong(py);
+                x = PyLong_AsLong(px);
+                y = PyLong_AsLong(py);
                 point_array[i].x = x;
                 point_array[i].y = y;
             }
@@ -3002,7 +3002,7 @@ static PyObject *ui_window_on_set_cursor(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     UINT rc = ((WndHack *)pWnd)->OnSetCursor(pWndArg, ht, msg);
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod int|PyCWnd|OnMouseActivate|Calls the base MFC OnMouseActivate function.
@@ -3025,7 +3025,7 @@ static PyObject *ui_window_on_mouse_activate(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     UINT rc = ((WndHack *)pWnd)->OnMouseActivate(pWndArg, ht, msg);
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod tuple|PyCWnd|PreCreateWindow|Calls the underlying MFC PreCreateWindow method.
@@ -3809,7 +3809,7 @@ static PyObject *PyCFrameWnd_OnBarCheck(PyObject *self, PyObject *args)
     GUI_BGN_SAVE;
     long rc = pFrame->OnBarCheck(id);
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod int|PyCFrameWnd|OnUpdateControlBarMenu|Checks the state of a menu item

--- a/Pythonwin/win32win.h
+++ b/Pythonwin/win32win.h
@@ -131,7 +131,7 @@ PyObject *__DoBaseOnCommand(ui_type_CObject *type, PyObject *self, PyObject *arg
     ClassFramework *pcf = (ClassFramework *)ob;
     BOOL rc = pcf->_BaseOnCommand(wparam, lparam);
     GUI_END_SAVE;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 #define DoBaseOnCommand(Class, type, self, args) __DoBaseOnCommand<Class>(type, self, args)
 

--- a/SWIG/swig_lib/objc.i
+++ b/SWIG/swig_lib/objc.i
@@ -19,11 +19,11 @@ typedef Object *id;         // Make 'id' behave like any other "Object"
 
 %typemap(python,in) id {
    char *temp;
-   if (!PyString_Check($source)) {
+   if (!PyBytes_Check($source)) {
      PyErr_SetString(PyExc_TypeError,"Expecting an 'id' in argument $argnum of $name");
      return NULL;
    }
-   temp = PyString_AsString($source);
+   temp = PyBytes_AsString($source);
    if (SWIG_GetPtr(temp, (void **) &$target, 0)) {
      PyErr_SetString(PyExc_TypeError,"Expecting an 'id' in argument $argnum of $name");
      return NULL;

--- a/SWIG/swig_lib/python/ptrlang.i
+++ b/SWIG/swig_lib/python/ptrlang.i
@@ -54,8 +54,8 @@ static PyObject *ptrcast(PyObject *_PTRVALUE, char *type) {
 
   /* Check to see what kind of object _PTRVALUE is */
   
-  if (PyInt_Check(_PTRVALUE)) {
-    ptr = (void *) PyInt_AsLong(_PTRVALUE);
+  if (PyLong_Check(_PTRVALUE)) {
+    ptr = (void *) PyLong_AsLong(_PTRVALUE);
     /* Received a numerical value. Make a pointer out of it */
     r = (char *) malloc(strlen(typestr)+22);
     if (ptr) {
@@ -148,13 +148,13 @@ static PyObject *ptrvalue(PyObject *_PTRVALUE, int index, char *type) {
 
   /* Now we have a datatype.  Try to figure out what to do about it */
   if (strcmp(type,"int") == 0) {
-    obj = PyInt_FromLong((long) *(((int *) ptr) + index));
+    obj = PyLong_FromLong((long) *(((int *) ptr) + index));
   } else if (strcmp(type,"double") == 0) {
     obj = PyFloat_FromDouble((double) *(((double *) ptr)+index));
   } else if (strcmp(type,"short") == 0) {
-    obj = PyInt_FromLong((long) *(((short *) ptr)+index));
+    obj = PyLong_FromLong((long) *(((short *) ptr)+index));
   } else if (strcmp(type,"long") == 0) {
-    obj = PyInt_FromLong((long) *(((long *) ptr)+index));
+    obj = PyLong_FromLong((long) *(((long *) ptr)+index));
   } else if (strcmp(type,"float") == 0) {
     obj = PyFloat_FromDouble((double) *(((float *) ptr)+index));
   } else if (strcmp(type,"char") == 0) {
@@ -225,21 +225,21 @@ static PyObject *ptrcreate(char *type, PyObject *_PYVALUE, int numelements) {
   if (_PYVALUE) {
     if (strcmp(type,"int") == 0) {
       int *ip,i,ivalue;
-      ivalue = (int) PyInt_AsLong(_PYVALUE);
+      ivalue = (int) PyLong_AsLong(_PYVALUE);
       ip = (int *) ptr;
       for (i = 0; i < numelements; i++)
 	ip[i] = ivalue;
     } else if (strcmp(type,"short") == 0) {
       short *ip,ivalue;
       int i;
-      ivalue = (short) PyInt_AsLong(_PYVALUE);
+      ivalue = (short) PyLong_AsLong(_PYVALUE);
       ip = (short *) ptr;
       for (i = 0; i < numelements; i++)
 	ip[i] = ivalue;
     } else if (strcmp(type,"long") == 0) {
       long *ip,ivalue;
       int i;
-      ivalue = (long) PyInt_AsLong(_PYVALUE);
+      ivalue = (long) PyLong_AsLong(_PYVALUE);
       ip = (long *) ptr;
       for (i = 0; i < numelements; i++)
 	ip[i] = ivalue;
@@ -340,13 +340,13 @@ static PyObject *ptrset(PyObject *_PTRVALUE, PyObject *_PYVALUE, int index, char
   
   /* Now we have a datatype.  Try to figure out what to do about it */
   if (strcmp(type,"int") == 0) {
-    *(((int *) ptr)+index) = (int) PyInt_AsLong(_PYVALUE);
+    *(((int *) ptr)+index) = (int) PyLong_AsLong(_PYVALUE);
   } else if (strcmp(type,"double") == 0) {
     *(((double *) ptr)+index) = (double) PyFloat_AsDouble(_PYVALUE);
   } else if (strcmp(type,"short") == 0) {
-    *(((short *) ptr)+index) = (short) PyInt_AsLong(_PYVALUE);
+    *(((short *) ptr)+index) = (short) PyLong_AsLong(_PYVALUE);
   } else if (strcmp(type,"long") == 0) {
-    *(((long *) ptr)+index) = (long) PyInt_AsLong(_PYVALUE);
+    *(((long *) ptr)+index) = (long) PyLong_AsLong(_PYVALUE);
   } else if (strcmp(type,"float") == 0) {
     *(((float *) ptr)+index) = (float) PyFloat_AsDouble(_PYVALUE);
   } else if (strcmp(type,"char") == 0) {

--- a/SWIG/swig_lib/python/ptrlang.i
+++ b/SWIG/swig_lib/python/ptrlang.i
@@ -63,12 +63,12 @@ static PyObject *ptrcast(PyObject *_PTRVALUE, char *type) {
     } else {
       sprintf(r,"_0%s",typestr);
     }
-    obj = PyString_FromString(r);
+    obj = PyBytes_FromString(r);
     free(r);
-  } else if (PyString_Check(_PTRVALUE)) {
+  } else if (PyBytes_Check(_PTRVALUE)) {
     /* Have a real pointer value now.  Try to strip out the pointer
        value */
-    s = PyString_AsString(_PTRVALUE);
+    s = PyBytes_AsString(_PTRVALUE);
     r = (char *) malloc(strlen(type)+22);
     
     /* Now extract the pointer value */
@@ -78,7 +78,7 @@ static PyObject *ptrcast(PyObject *_PTRVALUE, char *type) {
       } else {
 	sprintf(r,"_0%s",typestr);
       }
-      obj = PyString_FromString(r);
+      obj = PyBytes_FromString(r);
     } else {
       obj = NULL;
     }
@@ -106,11 +106,11 @@ static PyObject *ptrvalue(PyObject *_PTRVALUE, int index, char *type) {
   char     *s;
   PyObject *obj;
 
-  if (!PyString_Check(_PTRVALUE)) {
+  if (!PyBytes_Check(_PTRVALUE)) {
     PyErr_SetString(PyExc_TypeError,"Type error in ptrvalue. Argument is not a valid pointer value.");
     return NULL;
   }
-  s = PyString_AsString(_PTRVALUE);
+  s = PyBytes_AsString(_PTRVALUE);
   if (SWIG_GetPtr(s,&ptr,0)) {
     PyErr_SetString(PyExc_TypeError,"Type error in ptrvalue. Argument is not a valid pointer value.");
     return NULL;
@@ -158,11 +158,11 @@ static PyObject *ptrvalue(PyObject *_PTRVALUE, int index, char *type) {
   } else if (strcmp(type,"float") == 0) {
     obj = PyFloat_FromDouble((double) *(((float *) ptr)+index));
   } else if (strcmp(type,"char") == 0) {
-    obj = PyString_FromString(((char *) ptr)+index);
+    obj = PyBytes_FromString(((char *) ptr)+index);
   } else if (strcmp(type,"char *") == 0) {
     char *c = *(((char **) ptr)+index);
-    if (c) obj = PyString_FromString(c);
-    else obj = PyString_FromString("NULL");
+    if (c) obj = PyBytes_FromString(c);
+    else obj = PyBytes_FromString("NULL");
   } else {
     PyErr_SetString(PyExc_TypeError,"Unable to dereference unsupported datatype.");
     return NULL;
@@ -259,13 +259,13 @@ static PyObject *ptrcreate(char *type, PyObject *_PYVALUE, int numelements) {
 	ip[i] = ivalue;
     } else if (strcmp(type,"char") == 0) {
       char *ip,*ivalue;
-      ivalue = (char *) PyString_AsString(_PYVALUE);
+      ivalue = (char *) PyBytes_AsString(_PYVALUE);
       ip = (char *) ptr;
       strncpy(ip,ivalue,numelements-1);
     } else if (strcmp(type,"char *") == 0) {
       char **ip, *ivalue;
       int  i;
-      ivalue = (char *) PyString_AsString(_PYVALUE);
+      ivalue = (char *) PyBytes_AsString(_PYVALUE);
       ip = (char **) ptr;
       for (i = 0; i < numelements; i++) {
 	if (ivalue) {
@@ -281,7 +281,7 @@ static PyObject *ptrcreate(char *type, PyObject *_PYVALUE, int numelements) {
   /* Create the pointer value */
   
   SWIG_MakePtr(temp,ptr,cast);
-  obj = PyString_FromString(temp);
+  obj = PyBytes_FromString(temp);
   return obj;
 }
 
@@ -298,11 +298,11 @@ static PyObject *ptrset(PyObject *_PTRVALUE, PyObject *_PYVALUE, int index, char
   char     *s;
   PyObject *obj;
 
-  if (!PyString_Check(_PTRVALUE)) {
+  if (!PyBytes_Check(_PTRVALUE)) {
     PyErr_SetString(PyExc_TypeError,"Type error in ptrset. Argument is not a valid pointer value.");
     return NULL;
   }
-  s = PyString_AsString(_PTRVALUE);
+  s = PyBytes_AsString(_PTRVALUE);
   if (SWIG_GetPtr(s,&ptr,0)) {
     PyErr_SetString(PyExc_TypeError,"Type error in ptrset. Argument is not a valid pointer value.");
     return NULL;
@@ -350,10 +350,10 @@ static PyObject *ptrset(PyObject *_PTRVALUE, PyObject *_PYVALUE, int index, char
   } else if (strcmp(type,"float") == 0) {
     *(((float *) ptr)+index) = (float) PyFloat_AsDouble(_PYVALUE);
   } else if (strcmp(type,"char") == 0) {
-    char *c = PyString_AsString(_PYVALUE);
+    char *c = PyBytes_AsString(_PYVALUE);
     strcpy(((char *) ptr)+index, c);
   } else if (strcmp(type,"char *") == 0) {
-    char *c = PyString_AsString(_PYVALUE);
+    char *c = PyBytes_AsString(_PYVALUE);
     char **ca = (char **) ptr;
     if (ca[index]) free(ca[index]);
     if (strcmp(c,"NULL") == 0) {
@@ -387,9 +387,9 @@ static PyObject *ptradd(PyObject *_PTRVALUE, int offset) {
 
   /* Check to see what kind of object _PTRVALUE is */
   
-  if (PyString_Check(_PTRVALUE)) {
+  if (PyBytes_Check(_PTRVALUE)) {
     /* Have a potential pointer value now.  Try to strip out the value */
-    s = PyString_AsString(_PTRVALUE);
+    s = PyBytes_AsString(_PTRVALUE);
 
     /* Try to handle a few common datatypes first */
 
@@ -418,7 +418,7 @@ static PyObject *ptradd(PyObject *_PTRVALUE, int offset) {
     } else {
       sprintf(r,"_0%s",type);
     }
-    obj = PyString_FromString(r);
+    obj = PyBytes_FromString(r);
     free(r);
   }
   return obj;
@@ -489,11 +489,11 @@ PyObject *ptrfree(PyObject *_PTRVALUE) {
   void *ptr, *junk;
   char *s;
 
-  if (!PyString_Check(_PTRVALUE)) {
+  if (!PyBytes_Check(_PTRVALUE)) {
     PyErr_SetString(PyExc_TypeError,"Type error in ptrfree. Argument is not a valid pointer value.");
     return NULL;
   }
-  s = PyString_AsString(_PTRVALUE);
+  s = PyBytes_AsString(_PTRVALUE);
   if (SWIG_GetPtr(s,&ptr,0)) {
     PyErr_SetString(PyExc_TypeError,"Type error in ptrfree. Argument is not a valid pointer value.");
     return NULL;

--- a/SWIG/swig_lib/python/python.swg
+++ b/SWIG/swig_lib/python/python.swg
@@ -69,7 +69,7 @@ static PyObject *
 swig_varlink_repr(swig_varlinkobject *v)
 {
   v = v;
-  return PyString_FromString("<Global variables>");
+  return PyBytes_FromString("<Global variables>");
 }
 
 /* ---------------------------------------------------------------------

--- a/SWIG/swig_lib/python/pythoncom.i
+++ b/SWIG/swig_lib/python/pythoncom.i
@@ -34,7 +34,7 @@ typedef long FLAGS;
 %typedef long HRESULT_KEEP_INFO;
 
 %typemap(python,out) HRESULT_KEEP_INFO {
-	$target = PyInt_FromLong($source);
+	$target = PyLong_FromLong($source);
 }
 
 %typemap(python,except) HRESULT_KEEP_INFO {

--- a/SWIG/swig_lib/python/pywintypes.i
+++ b/SWIG/swig_lib/python/pywintypes.i
@@ -100,8 +100,8 @@ typedef unsigned long ULONG;
 %typemap(python,in) char *inNullString {
 	if ($source==Py_None) {
 		$target = NULL;
-	} else if (PyString_Check($source)) {
-		$target = PyString_AsString($source);
+	} else if (PyBytes_Check($source)) {
+		$target = PyBytes_AsString($source);
 	} else {
 		PyErr_SetString(PyExc_TypeError, "Argument must be None or a string");
 		return NULL;

--- a/SWIG/swig_lib/python/pywintypes.i
+++ b/SWIG/swig_lib/python/pywintypes.i
@@ -35,6 +35,8 @@ typedef unsigned long ULONG;
 
 
 %{
+#define PyInt_FromLong PyLong_FromLong // py3k pain.
+
 #include "PyWinTypes.h"
 #ifdef NEED_PYWINOBJECTS_H
 #include "PyWinObjects.h"
@@ -586,7 +588,7 @@ typedef float HWND;
 #ifndef SWIG_PYTHONCOM
 /* This code only valid if non COM SWIG builds */
 #ifndef PYCOM_EXPORT
-	 PyDict_SetItemString(d,"UNICODE", PyInt_FromLong(
+	 PyDict_SetItemString(d,"UNICODE", PyLong_FromLong(
 #ifdef UNICODE
 	1
 #else

--- a/SWIG/swig_lib/python/typemaps.i
+++ b/SWIG/swig_lib/python/typemaps.i
@@ -87,39 +87,39 @@ or you can use the %apply directive :
 
 %typemap(python,in) int            *INPUT(int temp)
 {
-  temp = (int) PyInt_AsLong($source);
+  temp = (int) PyLong_AsLong($source);
   $target = &temp;
 }
 
 %typemap(python,in) short          *INPUT(short temp)
 {
-  temp = (short) PyInt_AsLong($source);
+  temp = (short) PyLong_AsLong($source);
   $target = &temp;
 }
 
 %typemap(python,in) long           *INPUT(long temp)
 {
-  temp = (long) PyInt_AsLong($source);
+  temp = (long) PyLong_AsLong($source);
   $target = &temp;
 }
 %typemap(python,in) unsigned int   *INPUT(unsigned int temp)
 {
-  temp = (unsigned int) PyInt_AsLong($source);
+  temp = (unsigned int) PyLong_AsLong($source);
   $target = &temp;
 }
 %typemap(python,in) unsigned short *INPUT(unsigned short temp)
 {
-  temp = (unsigned short) PyInt_AsLong($source);
+  temp = (unsigned short) PyLong_AsLong($source);
   $target = &temp;
 }
 %typemap(python,in) unsigned long  *INPUT(unsigned long temp)
 {
-  temp = (unsigned long) PyInt_AsLong($source);
+  temp = (unsigned long) PyLong_AsLong($source);
   $target = &temp;
 }
 %typemap(python,in) unsigned char  *INPUT(unsigned char temp)
 {
-  temp = (unsigned char) PyInt_AsLong($source);
+  temp = (unsigned char) PyLong_AsLong($source);
   $target = &temp;
 }
                  
@@ -194,7 +194,7 @@ output values.
                         unsigned char  *OUTPUT
 {
     PyObject *o;
-    o = PyInt_FromLong((long) (*$source));
+    o = PyLong_FromLong((long) (*$source));
     if (!$target) {
       $target = o;
     } else if ($target == Py_None) {
@@ -294,7 +294,7 @@ static PyObject* t_output_helper(PyObject* target, PyObject* o) {
                         unsigned char  *T_OUTPUT
 {
     PyObject *o;
-    o = PyInt_FromLong((long) (*$source));
+    o = PyLong_FromLong((long) (*$source));
     $target = t_output_helper($target, o);
 }
 

--- a/com/win32com/src/ErrorUtils.cpp
+++ b/com/win32com/src/ErrorUtils.cpp
@@ -152,9 +152,9 @@ static BOOL PyCom_ExcepInfoFromServerExceptionInstance(PyObject *v, EXCEPINFO *p
 
     ob = PyObject_GetAttrString(v, "code");
     if (ob && ob != Py_None) {
-        PyObject *temp = PyNumber_Int(ob);
+        PyObject *temp = PyNumber_Long(ob);
         if (temp) {
-            pExcepInfo->wCode = (unsigned short)PyInt_AsLong(temp);
+            pExcepInfo->wCode = (unsigned short)PyLong_AsLong(temp);
             Py_DECREF(temp);
         }  // XXX - else - what to do here, apart from call the user a moron :-)
     }
@@ -164,9 +164,9 @@ static BOOL PyCom_ExcepInfoFromServerExceptionInstance(PyObject *v, EXCEPINFO *p
 
     ob = PyObject_GetAttrString(v, "scode");
     if (ob && ob != Py_None) {
-        PyObject *temp = PyNumber_Int(ob);
+        PyObject *temp = PyNumber_Long(ob);
         if (temp) {
-            pExcepInfo->scode = PyInt_AsLong(temp);
+            pExcepInfo->scode = PyLong_AsLong(temp);
             Py_DECREF(temp);
         }
         else
@@ -179,9 +179,9 @@ static BOOL PyCom_ExcepInfoFromServerExceptionInstance(PyObject *v, EXCEPINFO *p
 
     ob = PyObject_GetAttrString(v, "helpcontext");
     if (ob && ob != Py_None) {
-        PyObject *temp = PyNumber_Int(ob);
+        PyObject *temp = PyNumber_Long(ob);
         if (temp) {
-            pExcepInfo->dwHelpContext = (unsigned short)PyInt_AsLong(temp);
+            pExcepInfo->dwHelpContext = (unsigned short)PyLong_AsLong(temp);
             Py_DECREF(temp);
         }
     }
@@ -223,7 +223,7 @@ BOOL PyCom_ExcepInfoFromPyObject(PyObject *v, EXCEPINFO *pExcepInfo, HRESULT *ph
         if (phresult) {
             ob = PySequence_GetItem(v, 0);
             if (ob) {
-                *phresult = PyInt_AsLong(ob);
+                *phresult = PyLong_AsLong(ob);
                 Py_DECREF(ob);
             }
         }
@@ -620,7 +620,7 @@ PyObject *PyCom_BuildPyExceptionFromEXCEPINFO(HRESULT hr, EXCEPINFO *pexcepInfo 
     PyObject *obArg;
 
     if (nArgErr != -1) {
-        obArg = PyInt_FromLong(nArgErr);
+        obArg = PyLong_FromLong(nArgErr);
     }
     else {
         obArg = Py_None;

--- a/com/win32com/src/PyGatewayBase.cpp
+++ b/com/win32com/src/PyGatewayBase.cpp
@@ -160,8 +160,8 @@ STDMETHODIMP PyGatewayBase::QueryInterface(REFIID iid, void **ppv)
         Py_DECREF(ob);
 
         if (result) {
-            if (PyInt_Check(result))
-                supports = PyInt_AsLong(result);
+            if (PyLong_Check(result))
+                supports = PyLong_AsLong(result);
             else if (PyIBase::is_object(result, &PyIUnknown::type)) {
                 // We already have the object - return it without additional QI's etc.
                 IUnknown *pUnk = PyIUnknown::GetI(result);
@@ -214,8 +214,8 @@ STDMETHODIMP PyGatewayBase::GetTypeInfoCount(UINT FAR *pctInfo)
         PyObject *result = PyObject_CallMethod(m_pPyObject, "_GetTypeInfoCount_", NULL);
 
         if (result) {
-            if (PyInt_Check(result))
-                *pctInfo = PyInt_AsLong(result);
+            if (PyLong_Check(result))
+                *pctInfo = PyLong_AsLong(result);
             PyErr_Clear();  // ignore exceptions during conversion
             Py_DECREF(result);
         }
@@ -324,7 +324,7 @@ static HRESULT getids_finish(PyObject *result, UINT cNames, DISPID FAR *rgdispid
             Py_DECREF(result);
             return E_FAIL;
         }
-        if ((rgdispid[i] = PyInt_AsLong(ob)) == DISPID_UNKNOWN)
+        if ((rgdispid[i] = PyLong_AsLong(ob)) == DISPID_UNKNOWN)
             hr = DISP_E_UNKNOWNNAME;
 
         Py_DECREF(ob);
@@ -535,7 +535,7 @@ static HRESULT invoke_finish(PyObject *dispatcher,    /* The dispatcher for the 
         // We are expecting a tuple of (hresult, argErr, userResult)
         // or a simple HRESULT.
         if (PyNumber_Check(result)) {
-            hr = PyInt_AsLong(result);
+            hr = PyLong_AsLong(result);
             Py_DECREF(result);
             return hr;
         }
@@ -547,7 +547,7 @@ static HRESULT invoke_finish(PyObject *dispatcher,    /* The dispatcher for the 
         PyObject *ob = PySequence_GetItem(result, 0);
         if (!ob)
             goto done;
-        hr = PyInt_AsLong(ob);
+        hr = PyLong_AsLong(ob);
         Py_DECREF(ob);
         ob = NULL;
 
@@ -558,7 +558,7 @@ static HRESULT invoke_finish(PyObject *dispatcher,    /* The dispatcher for the 
                 if (!ob)
                     goto done;
 
-                *puArgErr = PyInt_AsLong(ob);
+                *puArgErr = PyLong_AsLong(ob);
                 Py_DECREF(ob);
                 ob = NULL;
             }
@@ -715,8 +715,8 @@ STDMETHODIMP PyGatewayBase::GetDispID(BSTR bstrName, DWORD grfdex, DISPID *pid)
     PyObject *result = PyObject_CallMethod(m_pPyObject, "_GetDispID_", "Ol", obName, grfdex);
     Py_DECREF(obName);
     if (result) {
-        if (PyInt_Check(result))
-            *pid = PyInt_AsLong(result);
+        if (PyLong_Check(result))
+            *pid = PyLong_AsLong(result);
         else
             PyErr_SetString(PyExc_TypeError, "_GetDispID_ must return an integer object");
         Py_DECREF(result);
@@ -796,8 +796,8 @@ STDMETHODIMP PyGatewayBase::GetMemberProperties(DISPID id, DWORD grfdexFetch, DW
     PY_GATEWAY_METHOD;
     PyObject *result = PyObject_CallMethod(m_pPyObject, "_GetMemberProperties_", "ll", id, grfdexFetch);
     if (result) {
-        if (PyInt_Check(result))
-            *pgrfdex = PyInt_AsLong(result);
+        if (PyLong_Check(result))
+            *pgrfdex = PyLong_AsLong(result);
         else
             PyErr_SetString(PyExc_TypeError, "GetMemberProperties must return an integer object");
         Py_DECREF(result);
@@ -827,8 +827,8 @@ STDMETHODIMP PyGatewayBase::GetNextDispID(DWORD grfdex, DISPID id, DISPID *pid)
     PY_GATEWAY_METHOD;
     PyObject *result = PyObject_CallMethod(m_pPyObject, "_GetNextDispID_", "ll", grfdex, id);
     if (result) {
-        if (PyInt_Check(result))
-            *pid = PyInt_AsLong(result);
+        if (PyLong_Check(result))
+            *pid = PyLong_AsLong(result);
         else
             PyErr_SetString(PyExc_TypeError, "GetNextDispID must return an integer object");
         Py_DECREF(result);

--- a/com/win32com/src/PyIDispatch.cpp
+++ b/com/win32com/src/PyIDispatch.cpp
@@ -163,13 +163,13 @@ PyObject *PyIDispatch::GetIDsOfNames(PyObject *self, PyObject *args)
 
     /* if we have just one name, then return a single DISPID (int) */
     if (cNames == 1) {
-        result = PyInt_FromLong(rgdispid[0]);
+        result = PyLong_FromLong(rgdispid[0]);
     }
     else {
         result = PyTuple_New(cNames);
         if (result) {
             for (i = 0; i < cNames; ++i) {
-                PyObject *ob = PyInt_FromLong(rgdispid[i]);
+                PyObject *ob = PyLong_FromLong(rgdispid[i]);
                 if (!ob) {
                     delete[] rgdispid;
                     return NULL;
@@ -269,9 +269,9 @@ PyObject *PyIDispatch::Invoke(PyObject *self, PyObject *args)
 
     // @pyparm int|dispid||The dispid to use.  Typically this value will come from <om PyIDispatch.GetIDsOfNames> or
     // from a type library.
-    DISPID dispid = PyInt_AsLong(PyTuple_GET_ITEM(args, 0));
+    DISPID dispid = PyLong_AsLong(PyTuple_GET_ITEM(args, 0));
     // @pyparm int|lcid||The locale id to use.
-    LCID lcid = PyInt_AsLong(PyTuple_GET_ITEM(args, 1));
+    LCID lcid = PyLong_AsLong(PyTuple_GET_ITEM(args, 1));
     // @pyparm int|flags||The flags for the call.  The following flags can be used.
     // @flagh Flag|Description
     // @flag DISPATCH_METHOD|The member is invoked as a method. If a property has the same name, both this and the
@@ -280,10 +280,10 @@ PyObject *PyIDispatch::Invoke(PyObject *self, PyObject *args)
     // @flag DISPATCH_PROPERTYPUT|The member is changed as a property or data member.
     // @flag DISPATCH_PROPERTYPUTREF|The member is changed by a reference assignment, rather than a value assignment.
     // This flag is valid only when the property accepts a reference to an object.
-    UINT wFlags = PyInt_AsLong(PyTuple_GET_ITEM(args, 2));
+    UINT wFlags = PyLong_AsLong(PyTuple_GET_ITEM(args, 2));
     // @pyparm int|bResultWanted||Indicates if the result of the call should be requested.
     // @pyparm object, ...|params, ...||The parameters to pass.
-    BOOL bResultWanted = (BOOL)PyInt_AsLong(PyTuple_GET_ITEM(args, 3));
+    BOOL bResultWanted = (BOOL)PyLong_AsLong(PyTuple_GET_ITEM(args, 3));
     if (PyErr_Occurred())
         return NULL;
 
@@ -346,11 +346,11 @@ PyObject *PyIDispatch::InvokeTypes(PyObject *self, PyObject *args)
         return PyErr_Format(PyExc_TypeError, "not enough arguments (at least 5 needed)");
 
     // @pyparm int|dispid||The dispid to use.  Please see <om PyIDispatch.Invoke>.
-    DISPID dispid = PyInt_AsLong(PyTuple_GET_ITEM(args, 0));
+    DISPID dispid = PyLong_AsLong(PyTuple_GET_ITEM(args, 0));
     // @pyparm int|lcid||The locale ID.  Please see <om PyIDispatch.Invoke>.
-    LCID lcid = PyInt_AsLong(PyTuple_GET_ITEM(args, 1));
+    LCID lcid = PyLong_AsLong(PyTuple_GET_ITEM(args, 1));
     // @pyparm int|wFlags||Flags for the call.  Please see <om PyIDispatch.Invoke>.
-    UINT wFlags = PyInt_AsLong(PyTuple_GET_ITEM(args, 2));
+    UINT wFlags = PyLong_AsLong(PyTuple_GET_ITEM(args, 2));
     // @pyparm tuple|resultTypeDesc||A tuple describing the type of the
     // result.  See the comments for more information.
     PyObject *resultElemDesc = PyTuple_GET_ITEM(args, 3);
@@ -634,7 +634,7 @@ PyObject *PyIDispatchEx::GetDispID(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return SetPythonCOMError(self, hr);
-    return PyInt_FromLong(dispid);
+    return PyLong_FromLong(dispid);
 }
 
 // @pymethod object|PyIDispatchEx|InvokeEx|Provides access to properties and methods exposed by a <o PyIDispatchEx>
@@ -785,7 +785,7 @@ PyObject *PyIDispatchEx::GetMemberProperties(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return SetPythonCOMError(self, hr);
-    return PyInt_FromLong(props);
+    return PyLong_FromLong(props);
 }
 // @pymethod str|PyIDispatchEx|GetMemberName|Returns the name associated with a member id
 PyObject *PyIDispatchEx::GetMemberName(PyObject *self, PyObject *args)
@@ -826,7 +826,7 @@ PyObject *PyIDispatchEx::GetNextDispID(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (hr != S_OK)
         return SetPythonCOMError(self, hr);
-    return PyInt_FromLong(retDispid);
+    return PyLong_FromLong(retDispid);
 }
 
 // @object PyIDispatchEx|A OLE automation client object that uses the IDispatchEx scripting interface..

--- a/com/win32com/src/PyIUnknown.cpp
+++ b/com/win32com/src/PyIUnknown.cpp
@@ -33,7 +33,7 @@ PyObject *PyIUnknown::repr()
     char buf[256];
     _snprintf(buf, 256, "<%hs at 0x%0lp with obj at 0x%0lp>", ob_type->tp_name, this, m_obj);
 #if (PY_VERSION_HEX < 0x03000000)
-    return PyString_FromString(buf);
+    return PyBytes_FromString(buf);
 #else
     return PyUnicode_FromString(buf);
 #endif
@@ -78,7 +78,7 @@ pLook, pLook->m_obj, pLook->ob_refcnt, relDesc); if ( pLook->m_obj )
                                     if ( PyInstance_Check(ob) )
                                     {
                                         PyCom_LogF("   object is a Python class instance of: %s",
-PyString_AsString(((PyInstanceObject *)ob)->in_class->cl_name));
+PyBytes_AsString(((PyInstanceObject *)ob)->in_class->cl_name));
                                     }
                                     else
                                     {

--- a/com/win32com/src/PyIUnknown.cpp
+++ b/com/win32com/src/PyIUnknown.cpp
@@ -53,7 +53,7 @@ PyObject *PyIUnknown::repr()
             int len = PySequence_Length(keys);
             for (int index=0;index<len;index++) {
                 PyObject *intLook = PySequence_GetItem(keys, index);
-                PyIUnknown *pLook = (PyIUnknown *)PyInt_AsLong(intLook);
+                PyIUnknown *pLook = (PyIUnknown *)PyLong_AsLong(intLook);
                 if (pLook) {
 #ifdef NOPE_DEBUG
                     const char *relDesc = pLook->m_obj ? "NOT RELEASED" : "released";

--- a/com/win32com/src/PyRecord.cpp
+++ b/com/win32com/src/PyRecord.cpp
@@ -301,7 +301,7 @@ static PyObject *PyRecord_reduce(PyObject *self, PyObject *args)
     }
     ret =
         Py_BuildValue("O(NHHiNN)", obFunc, PyWinObject_FromIID(pta->guid), pta->wMajorVerNum, pta->wMinorVerNum,
-                      pta->lcid, PyWinObject_FromIID(structguid), PyString_FromStringAndSize((char *)pyrec->pdata, cb));
+                      pta->lcid, PyWinObject_FromIID(structguid), PyBytes_FromStringAndSize((char *)pyrec->pdata, cb));
 
 done:
     if (pta && pti)
@@ -349,8 +349,8 @@ static void _FreeFieldNames(BSTR *strings, ULONG num_names)
 }
 
 #if (PY_VERSION_HEX < 0x03000000)
-#define PyWinCoreString_ConcatAndDel PyString_ConcatAndDel
-#define PyWinCoreString_Concat PyString_Concat
+#define PyWinCoreString_ConcatAndDel PyBytes_ConcatAndDel
+#define PyWinCoreString_Concat PyBytes_Concat
 #else
 // Unicode versions of '_Concat' etc have different sigs.  Make them the
 // same here...

--- a/com/win32com/src/PyStorage.cpp
+++ b/com/win32com/src/PyStorage.cpp
@@ -263,7 +263,7 @@ PyObject *pythoncom_StgIsStorageFile(PyObject *self, PyObject *args)
     // @rdesc The return value is 1 if a storage file, else 0.  This
     // method will also raise com_error if the StgIsStorageFile function
     // returns a failure HRESULT.
-    return PyInt_FromLong(hr == 0);
+    return PyLong_FromLong(hr == 0);
 }
 #endif  // MS_WINCE
 

--- a/com/win32com/src/PythonCOM.cpp
+++ b/com/win32com/src/PythonCOM.cpp
@@ -423,7 +423,7 @@ static PyObject *pythoncom_CoRegisterClassObject(PyObject *self, PyObject *args)
     if (FAILED(hr))
         return PyCom_BuildPyException(hr);
     // @rdesc The result is a handle which should be revoked using <om pythoncom.CoRevokeClassObject>
-    return PyInt_FromLong(reg);
+    return PyLong_FromLong(reg);
 }
 // @pymethod |pythoncom|CoRevokeClassObject|Informs OLE that a class object, previously registered with the <om
 // pythoncom.CoRegisterClassObject> method, is no longer available for use.
@@ -511,7 +511,7 @@ static PyObject *pythoncom_GetInterfaceCount(PyObject *self, PyObject *args)
 {
     if (!PyArg_ParseTuple(args, ":_GetInterfaceCount"))
         return NULL;
-    return PyInt_FromLong(_PyCom_GetInterfaceCount());
+    return PyLong_FromLong(_PyCom_GetInterfaceCount());
     // @comm If is occasionally a good idea to call this function before your Python program
     // terminates.  If this function returns non-zero, then you still have PythonCOM objects
     // alive in your program (possibly in global variables).
@@ -525,7 +525,7 @@ static PyObject *pythoncom_GetGatewayCount(PyObject *self, PyObject *args)
     // is to have the process which uses these PythonCOM servers release its references.
     if (!PyArg_ParseTuple(args, ":_GetGatewayCount"))
         return NULL;
-    return PyInt_FromLong(_PyCom_GetGatewayCount());
+    return PyLong_FromLong(_PyCom_GetGatewayCount());
 }
 
 #ifndef MS_WINCE
@@ -1131,7 +1131,7 @@ static PyObject *pythoncom_RegisterActiveObject(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (S_OK != hr)
         return PyCom_BuildPyException(hr);
-    return PyInt_FromLong(dwkey);
+    return PyLong_FromLong(dwkey);
     // @rdesc The result is a handle which should be pass to <om pythoncom.RevokeActiveObject>
 }
 
@@ -1508,7 +1508,7 @@ static PyObject *pythoncom_PumpWaitingMessages(PyObject *self, PyObject *args)
         // Otherwise, dispatch the message.
         DispatchMessage(&msg);
     }  // End of PeekMessage while loop
-    Py_END_ALLOW_THREADS return PyInt_FromLong(result);
+    Py_END_ALLOW_THREADS return PyLong_FromLong(result);
 }
 
 // @pymethod |pythoncom|PumpMessages|Pumps all messages for the current thread until a WM_QUIT message.
@@ -1593,7 +1593,7 @@ static PyObject *pythoncom_CoWaitForMultipleHandles(PyObject *self, PyObject *ar
     HRESULT hr;
     Py_BEGIN_ALLOW_THREADS hr = (*pfnCoWaitForMultipleHandles)(flags, timeout, numItems, pItems, &index);
     Py_END_ALLOW_THREADS if (FAILED(hr)) { PyCom_BuildPyException(hr); }
-    else rc = PyInt_FromLong(index);
+    else rc = PyLong_FromLong(index);
     free(pItems);
     return rc;
 }
@@ -1754,7 +1754,7 @@ static PyObject *pythoncom_DoDragDrop(PyObject *, PyObject *args)
         PyCom_BuildPyException(hr);
         return NULL;
     }
-    return PyInt_FromLong(retEffect);
+    return PyLong_FromLong(retEffect);
 }
 
 // @pymethod |pythoncom|OleInitialize|Calls OleInitialized - this should rarely
@@ -2186,7 +2186,7 @@ static struct PyMethodDef pythoncom_methods[] = {
 
 int AddConstant(PyObject *dict, const char *key, long value)
 {
-    PyObject *oval = PyInt_FromLong(value);
+    PyObject *oval = PyLong_FromLong(value);
     if (!oval) {
         return 1;
     }
@@ -2214,7 +2214,7 @@ PYWIN_MODULE_INIT_FUNC(pythoncom)
     PyObject *obFlags = PySys_GetObject("coinit_flags");
     // No reference added to obFlags.
     if (obFlags) {
-        coinit_flags = PyInt_AsUnsignedLongMask(obFlags);
+        coinit_flags = PyLong_AsUnsignedLongMask(obFlags);
         if (coinit_flags == -1 && PyErr_Occurred())
             PYWIN_MODULE_INIT_RETURN_ERROR;
     }

--- a/com/win32com/src/PythonCOM.cpp
+++ b/com/win32com/src/PythonCOM.cpp
@@ -2259,7 +2259,7 @@ PYWIN_MODULE_INIT_FUNC(pythoncom)
     // end code changed by ssc
 
     // Add some symbolic constants to the module
-    // pycom_Error = PyString_FromString("pythoncom.error");
+    // pycom_Error = PyBytes_FromString("pythoncom.error");
     if (PyWinExc_COMError == NULL) {
         // This is created by PyWin_Globals_Ensure
         PyErr_SetString(PyExc_MemoryError, "can't define ole_error");

--- a/com/win32com/src/Register.cpp
+++ b/com/win32com/src/Register.cpp
@@ -225,11 +225,11 @@ PyObject *pythoncom_IsGatewayRegistered(PyObject *self, PyObject *args)
     v = PyDict_GetItem(g_obPyCom_MapServerIIDToGateway, obIID);
     if (!v) {
         PyErr_Clear();
-        v = PyInt_FromLong(0);
+        v = PyLong_FromLong(0);
     }
     else {
         Py_DECREF(v);
-        v = PyInt_FromLong(1);
+        v = PyLong_FromLong(1);
     }
     return v;
 }

--- a/com/win32com/src/Register.cpp
+++ b/com/win32com/src/Register.cpp
@@ -106,7 +106,7 @@ HRESULT PyCom_RegisterGatewayObject(REFIID iid, pfnPyGatewayConstructor ctor, co
     Py_DECREF(valueObject);
     // Now in the other server map.
     if (g_obPyCom_MapGatewayIIDToName) {
-        valueObject = PyString_FromString((char *)interfaceName);
+        valueObject = PyBytes_FromString((char *)interfaceName);
         if (!valueObject) {
             Py_DECREF(keyObject);
             return E_FAIL;

--- a/com/win32com/src/extensions/PyFUNCDESC.cpp
+++ b/com/win32com/src/extensions/PyFUNCDESC.cpp
@@ -13,7 +13,7 @@ extern void FreeMoreBuffer(void *);
 static PyObject *MakeSCODEArray(SCODE *sa, int len)
 {
     PyObject *ret = PyTuple_New(len);
-    for (int i = 0; i < len; i++) PyTuple_SetItem(ret, i, PyInt_FromLong(sa[i]));
+    for (int i = 0; i < len; i++) PyTuple_SetItem(ret, i, PyLong_FromLong(sa[i]));
     return ret;
 }
 
@@ -70,9 +70,9 @@ BOOL PyObject_AsFUNCDESC(PyObject *ob, FUNCDESC **ppfd)
             PyObject *sub = PySequence_GetItem(ob, i);
             if (sub == NULL)
                 goto done;
-            BOOL ok = PyInt_Check(sub);
+            BOOL ok = PyLong_Check(sub);
             if (ok)
-                fd->lprgscode[i] = PyInt_AsLong(sub);
+                fd->lprgscode[i] = PyLong_AsLong(sub);
             else
                 PyErr_SetString(PyExc_TypeError, "SCODE array must be a sequence of integers!");
             Py_DECREF(sub);
@@ -225,7 +225,7 @@ PyFUNCDESC::~PyFUNCDESC()
     PyObject *rc;
     switch (index) {
         case 0:  // @tupleitem 0|int|memid|
-            return PyInt_FromLong(p->memid);
+            return PyLong_FromLong(p->memid);
         case 1:  // @tupleitem 1|(int, ...)|scodeArray|
             rc = p->scodeArray ? p->scodeArray : Py_None;
             Py_INCREF(rc);
@@ -235,21 +235,21 @@ PyFUNCDESC::~PyFUNCDESC()
             Py_INCREF(rc);
             return rc;
         case 3:  // @tupleitem 3|int|funckind|
-            return PyInt_FromLong(p->funckind);
+            return PyLong_FromLong(p->funckind);
         case 4:  // @tupleitem 4|int|invkind|
-            return PyInt_FromLong(p->invkind);
+            return PyLong_FromLong(p->invkind);
         case 5:  // @tupleitem 5|int|callconv|
-            return PyInt_FromLong(p->callconv);
+            return PyLong_FromLong(p->callconv);
         case 6:  // @tupleitem 6|int|cParamsOpt|
-            return PyInt_FromLong(p->cParamsOpt);
+            return PyLong_FromLong(p->cParamsOpt);
         case 7:  // @tupleitem 7|int|oVft|
-            return PyInt_FromLong(p->oVft);
+            return PyLong_FromLong(p->oVft);
         case 8:  // @tupleitem 8|<o ELEMDESC>|rettype|
             rc = p->rettype ? p->rettype : Py_None;
             Py_INCREF(rc);
             return rc;
         case 9:  // @tupleitem 9|int|wFuncFlags|
-            return PyInt_FromLong(p->wFuncFlags);
+            return PyLong_FromLong(p->wFuncFlags);
     }
     PyErr_SetString(PyExc_IndexError, "index out of range");
     return NULL;

--- a/com/win32com/src/extensions/PyGConnectionPoint.cpp
+++ b/com/win32com/src/extensions/PyGConnectionPoint.cpp
@@ -48,7 +48,7 @@ STDMETHODIMP PyGConnectionPoint::Advise(IUnknown *pUnk, DWORD *pdwCookie)
     Py_DECREF(obUnknown);
     if (FAILED(hr))
         return hr;
-    *pdwCookie = PyInt_AsLong(result);
+    *pdwCookie = PyLong_AsLong(result);
     if (PyErr_Occurred()) {
         hr = PyCom_SetCOMErrorFromPyException(GetIID());
         *pdwCookie = 0;

--- a/com/win32com/src/extensions/PyGPersistStream.cpp
+++ b/com/win32com/src/extensions/PyGPersistStream.cpp
@@ -11,7 +11,7 @@ STDMETHODIMP PyGPersistStream::IsDirty(void)
     if (SUCCEEDED(hr)) {
         /* returning 0 means not dirty. *anything* else means dirty */
 
-        int dirty = PyInt_AsLong(result);
+        int dirty = PyLong_AsLong(result);
         Py_DECREF(result);
         hr = dirty == 0 ? S_FALSE : S_OK;
     }

--- a/com/win32com/src/extensions/PyGStream.cpp
+++ b/com/win32com/src/extensions/PyGStream.cpp
@@ -50,7 +50,7 @@ STDMETHODIMP PyGStream::Write(
     if (FAILED(hr))
         return hr;
 
-    int cbWritten = PyInt_AsLong(result);
+    int cbWritten = PyLong_AsLong(result);
     Py_DECREF(result);
     if (cbWritten == -1)
         return PyCom_SetCOMErrorFromPyException(GetIID());

--- a/com/win32com/src/extensions/PyGStream.cpp
+++ b/com/win32com/src/extensions/PyGStream.cpp
@@ -44,7 +44,7 @@ STDMETHODIMP PyGStream::Write(
 
     PY_GATEWAY_METHOD;
     PyObject *result;
-    PyObject *obbuf = PyString_FromStringAndSize((char *)pv, cb);
+    PyObject *obbuf = PyBytes_FromStringAndSize((char *)pv, cb);
     HRESULT hr = InvokeViaPolicy("Write", &result, "O", obbuf);
     Py_XDECREF(obbuf);
     if (FAILED(hr))

--- a/com/win32com/src/extensions/PyIConnectionPoint.cpp
+++ b/com/win32com/src/extensions/PyIConnectionPoint.cpp
@@ -78,7 +78,7 @@ PyObject *PyIConnectionPoint::Advise(PyObject *self, PyObject *args)
     if (FAILED(hr))
         return SetPythonCOMError(self, hr);
     // @rdesc The result is the connection point identifier used by <om PyIConnectionPoint::Unadvise>
-    return PyInt_FromLong(cookie);
+    return PyLong_FromLong(cookie);
 }
 
 // @pymethod |PyIConnectionPoint|Unadvise|Terminates an advisory connection previously established through

--- a/com/win32com/src/extensions/PyICreateTypeInfo.cpp
+++ b/com/win32com/src/extensions/PyICreateTypeInfo.cpp
@@ -167,7 +167,7 @@ PyObject *PyICreateTypeInfo::AddRefTypeInfo(PyObject *self, PyObject *args)
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pICTI, IID_ICreateTypeInfo);
-    return PyInt_FromLong(hRefType);
+    return PyLong_FromLong(hRefType);
 }
 
 // @pymethod |PyICreateTypeInfo|AddFuncDesc|Description of AddFuncDesc.

--- a/com/win32com/src/extensions/PyIDataObject.cpp
+++ b/com/win32com/src/extensions/PyIDataObject.cpp
@@ -263,7 +263,7 @@ PyObject *PyIDataObject::DAdvise(PyObject *self, PyObject *args)
         pAdvSink->Release();
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIDO, IID_IDataObject);
-    return PyInt_FromLong(dwConnection);
+    return PyLong_FromLong(dwConnection);
 }
 
 // @pymethod |PyIDataObject|DUnadvise|Disconnects a notification sink.
@@ -484,7 +484,7 @@ STDMETHODIMP PyGDataObject::DAdvise(
     Py_XDECREF(obpAdvSink);
     if (FAILED(hr))
         return hr;
-    *pdwConnection = PyInt_AsLong(result);
+    *pdwConnection = PyLong_AsLong(result);
     Py_DECREF(result);
     return hr;
 }

--- a/com/win32com/src/extensions/PyIDropSource.cpp
+++ b/com/win32com/src/extensions/PyIDropSource.cpp
@@ -84,8 +84,8 @@ STDMETHODIMP PyGDropSource::QueryContinueDrag(
     HRESULT hr = InvokeViaPolicy("QueryContinueDrag", &result, "il", fEscapePressed, grfKeyState);
     if (FAILED(hr))
         return hr;
-    if (PyInt_Check(result))
-        hr = PyInt_AsLong(result);
+    if (PyLong_Check(result))
+        hr = PyLong_AsLong(result);
     Py_DECREF(result);
     return hr;
 }
@@ -98,8 +98,8 @@ STDMETHODIMP PyGDropSource::GiveFeedback(
     HRESULT hr = InvokeViaPolicy("GiveFeedback", &result, "l", dwEffect);
     if (FAILED(hr))
         return hr;
-    if (PyInt_Check(result))
-        hr = PyInt_AsLong(result);
+    if (PyLong_Check(result))
+        hr = PyLong_AsLong(result);
     Py_DECREF(result);
     return hr;
 }

--- a/com/win32com/src/extensions/PyIDropTarget.cpp
+++ b/com/win32com/src/extensions/PyIDropTarget.cpp
@@ -58,7 +58,7 @@ PyObject *PyIDropTarget::DragEnter(PyObject *self, PyObject *args)
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIDT, IID_IDropTarget);
-    return PyInt_FromLong(dwEffect);
+    return PyLong_FromLong(dwEffect);
 }
 
 // @pymethod int|PyIDropTarget|DragOver|Called as the dragged object moves over the window
@@ -90,7 +90,7 @@ PyObject *PyIDropTarget::DragOver(PyObject *self, PyObject *args)
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIDT, IID_IDropTarget);
-    return PyInt_FromLong(dwEffect);
+    return PyLong_FromLong(dwEffect);
 }
 
 // @pymethod |PyIDropTarget|DragLeave|Called as the object is dragged back out of the window
@@ -149,7 +149,7 @@ PyObject *PyIDropTarget::Drop(PyObject *self, PyObject *args)
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIDT, IID_IDropTarget);
-    return PyInt_FromLong(dwEffect);
+    return PyLong_FromLong(dwEffect);
 }
 
 // @object PyIDropTarget|Interface that acts as a target of OLE drag and drop operations
@@ -186,8 +186,8 @@ STDMETHODIMP PyGDropTarget::DragEnter(
     Py_DECREF(obpt);
     if (FAILED(hr))
         return hr;
-    if (result && PyInt_Check(result))
-        *pdwEffect = PyInt_AsLong(result);
+    if (result && PyLong_Check(result))
+        *pdwEffect = PyLong_AsLong(result);
     Py_DECREF(result);
     return hr;
 }
@@ -207,8 +207,8 @@ STDMETHODIMP PyGDropTarget::DragOver(
     Py_DECREF(obpt);
     if (FAILED(hr))
         return hr;
-    if (result && PyInt_Check(result))
-        *pdwEffect = PyInt_AsLong(result);
+    if (result && PyLong_Check(result))
+        *pdwEffect = PyLong_AsLong(result);
     Py_DECREF(result);
     return hr;
 }
@@ -239,8 +239,8 @@ STDMETHODIMP PyGDropTarget::Drop(
     Py_DECREF(obpt);
     if (FAILED(hr))
         return hr;
-    if (result && PyInt_Check(result))
-        *pdwEffect = PyInt_AsLong(result);
+    if (result && PyLong_Check(result))
+        *pdwEffect = PyLong_AsLong(result);
     Py_DECREF(result);
     return hr;
 }

--- a/com/win32com/src/extensions/PyIExternalConnection.cpp
+++ b/com/win32com/src/extensions/PyIExternalConnection.cpp
@@ -40,7 +40,7 @@ PyObject *PyIExternalConnection::AddConnection(PyObject *self, PyObject *args)
     DWORD rc = pIEC->AddConnection(extconn, reserved);
     PY_INTERFACE_POSTCALL;
     // @rdesc The result is the number of reference counts on the object; used for debugging purposes only.
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod int|PyIExternalConnection|ReleaseConnection|Decrements an object's count of its strong external connections
@@ -64,7 +64,7 @@ PyObject *PyIExternalConnection::ReleaseConnection(PyObject *self, PyObject *arg
     DWORD rc = pIEC->ReleaseConnection(extconn, reserved, fLastReleaseCloses);
     PY_INTERFACE_POSTCALL;
     // @rdesc The result is the number of reference counts on the object; used for debugging purposes only.
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @object PyIExternalConnection|A Python wrapper for a COM IExternalConnection interface.

--- a/com/win32com/src/extensions/PyILockBytes.cpp
+++ b/com/win32com/src/extensions/PyILockBytes.cpp
@@ -292,7 +292,7 @@ STDMETHODIMP PyGLockBytes::WriteAt(
     if (FAILED(hr))
         return hr;
     // Process the Python results, and convert back to the real params
-    int cbWritten = PyInt_AsLong(result);
+    int cbWritten = PyLong_AsLong(result);
     Py_DECREF(result);
     if (cbWritten == -1) {
         PyErr_Clear();

--- a/com/win32com/src/extensions/PyILockBytes.cpp
+++ b/com/win32com/src/extensions/PyILockBytes.cpp
@@ -31,19 +31,19 @@ PyObject *PyILockBytes::ReadAt(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "Kk:ReadAt", &ulOffset.QuadPart, &cb))
         return NULL;
 
-    PyObject *pyretval = PyString_FromStringAndSize(NULL, cb);
+    PyObject *pyretval = PyBytes_FromStringAndSize(NULL, cb);
     if (pyretval == NULL)
         return NULL;
     ULONG cbRead;
     PY_INTERFACE_PRECALL;
-    HRESULT hr = pILB->ReadAt(ulOffset, PyString_AS_STRING(pyretval), cb, &cbRead);
+    HRESULT hr = pILB->ReadAt(ulOffset, PyBytes_AS_STRING(pyretval), cb, &cbRead);
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr)) {
         Py_DECREF(pyretval);
         return PyCom_BuildPyException(hr, pILB, IID_ILockBytes);
     }
     // @comm The result is a binary buffer returned in a string.
-    _PyString_Resize(&pyretval, cbRead);
+    _PyBytes_Resize(&pyretval, cbRead);
     return pyretval;
 }
 
@@ -284,7 +284,7 @@ STDMETHODIMP PyGLockBytes::WriteAt(
 
     PY_GATEWAY_METHOD;
     PyObject *obulOffset = PyWinObject_FromULARGE_INTEGER(ulOffset);
-    PyObject *obbuf = PyString_FromStringAndSize((char *)pv, cb);
+    PyObject *obbuf = PyBytes_FromStringAndSize((char *)pv, cb);
     PyObject *result;
     HRESULT hr = InvokeViaPolicy("WriteAt", &result, "OO", obulOffset, obbuf);
     Py_XDECREF(obulOffset);

--- a/com/win32com/src/extensions/PyIMoniker.cpp
+++ b/com/win32com/src/extensions/PyIMoniker.cpp
@@ -364,7 +364,7 @@ PyObject *PyIMoniker::IsEqual(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pMy, IID_IMoniker);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod int|PyIMoniker|IsSystemMoniker|Indicates whether this moniker is of one of the system-supplied moniker
@@ -384,7 +384,7 @@ PyObject *PyIMoniker::IsSystemMoniker(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pMy, IID_IMoniker);
-    return PyInt_FromLong(mksys);
+    return PyLong_FromLong(mksys);
 }
 
 // @pymethod int|PyIMoniker|Hash|Calculates a 32-bit integer using the internal state of the moniker.
@@ -402,7 +402,7 @@ PyObject *PyIMoniker::Hash(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pMy, IID_IMoniker);
-    return PyInt_FromLong(result);
+    return PyLong_FromLong(result);
 }
 
 // @object PyIMoniker|A Python interface to IMoniker

--- a/com/win32com/src/extensions/PyIPersistFile.cpp
+++ b/com/win32com/src/extensions/PyIPersistFile.cpp
@@ -34,7 +34,7 @@ PyObject *PyIPersistFile::IsDirty(PyObject *self, PyObject *args)
     // @rdesc This method returns the raw COM error code without raising the normal COM exception.
     // You should treat any error return codes as an indication that the object has changed.
     // Unless this method explicitly returns S_FALSE, assume that the object must be saved.
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod |PyIPersistFile|Load|Opens the specified file and initializes an object from the file contents.

--- a/com/win32com/src/extensions/PyIPersistStorage.cpp
+++ b/com/win32com/src/extensions/PyIPersistStorage.cpp
@@ -29,7 +29,7 @@ PyObject *PyIPersistStorage::IsDirty(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIPS, IID_IPersistStorage);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
     // @rvalue S_OK (ie, 0)|The object has changed since it was last saved.
     // @rvalue S_FALSE (ie, 1)|The object has not changed since the last save.
 }

--- a/com/win32com/src/extensions/PyIPersistStream.cpp
+++ b/com/win32com/src/extensions/PyIPersistStream.cpp
@@ -31,7 +31,7 @@ PyObject *PyIPersistStream::IsDirty(PyObject *self, PyObject *args)
         return PyCom_BuildPyException(hr, pMy, IID_IPersistStream);
 
     // anything but S_FALSE means dirty.
-    return PyInt_FromLong(hr != S_FALSE);
+    return PyLong_FromLong(hr != S_FALSE);
     // @rvalue S_OK (ie, 0)|The object has changed since it was last saved.
     // @rvalue S_FALSE (ie, 1)|The object has not changed since the last save.
 }

--- a/com/win32com/src/extensions/PyIPropertyStorage.cpp
+++ b/com/win32com/src/extensions/PyIPropertyStorage.cpp
@@ -53,7 +53,7 @@ BOOL PyWinObject_AsPROPSPECs(PyObject *ob, PROPSPEC **ppRet, ULONG *pcRet)
     ZeroMemory(*ppRet, numBytes);
     for (DWORD i = 0; i < *pcRet; i++) {
         PyObject *sub = PyTuple_GET_ITEM((PyObject *)tuple, i);
-        (*ppRet)[i].propid = PyInt_AsUnsignedLongMask(sub);
+        (*ppRet)[i].propid = PyLong_AsUnsignedLongMask(sub);
         if ((*ppRet)[i].propid != (ULONG)-1 || !PyErr_Occurred())
             (*ppRet)[i].ulKind = PRSPEC_PROPID;
         else {
@@ -151,13 +151,13 @@ PyObject *VectorToSeq(arraytype *A, ULONG count, PyObject *(*converter)(const ar
 }
 
 // Some helper functions for the Vector conversion template
-PyObject *PyWinObject_FromCHAR(CHAR c) { return PyInt_FromLong(c); }
+PyObject *PyWinObject_FromCHAR(CHAR c) { return PyLong_FromLong(c); }
 
-PyObject *PyWinObject_FromUCHAR(UCHAR uc) { return PyInt_FromLong(uc); }
+PyObject *PyWinObject_FromUCHAR(UCHAR uc) { return PyLong_FromLong(uc); }
 
-PyObject *PyWinObject_FromSHORT(SHORT s) { return PyInt_FromLong(s); }
+PyObject *PyWinObject_FromSHORT(SHORT s) { return PyLong_FromLong(s); }
 
-PyObject *PyWinObject_FromUSHORT(USHORT us) { return PyInt_FromLong(us); }
+PyObject *PyWinObject_FromUSHORT(USHORT us) { return PyLong_FromLong(us); }
 
 PyObject *PyWinObject_FromFLOAT(FLOAT f) { return PyFloat_FromDouble(f); }
 
@@ -187,27 +187,27 @@ PyObject *PyObject_FromPROPVARIANT(PROPVARIANT *pVar)
             Py_INCREF(Py_None);
             return Py_None;
         case VT_I1:
-            return PyInt_FromLong(pVar->cVal);
+            return PyLong_FromLong(pVar->cVal);
         case VT_I1 | VT_VECTOR:
             return VectorToSeq(pVar->cac.pElems, pVar->cac.cElems, PyWinObject_FromCHAR);
         case VT_UI1:
-            return PyInt_FromLong(pVar->bVal);
+            return PyLong_FromLong(pVar->bVal);
         case VT_UI1 | VT_VECTOR:
             return VectorToSeq(pVar->caub.pElems, pVar->caub.cElems, PyWinObject_FromUCHAR);
         case VT_I2:
-            return PyInt_FromLong(pVar->iVal);
+            return PyLong_FromLong(pVar->iVal);
         case VT_I2 | VT_VECTOR:
             return VectorToSeq(pVar->cai.pElems, pVar->cai.cElems, PyWinObject_FromSHORT);
         case VT_UI2:
-            return PyInt_FromLong(pVar->uiVal);
+            return PyLong_FromLong(pVar->uiVal);
         case VT_UI2 | VT_VECTOR:
             return VectorToSeq(pVar->caui.pElems, pVar->caui.cElems, PyWinObject_FromUSHORT);
         case VT_I4:
-            return PyInt_FromLong(pVar->lVal);
+            return PyLong_FromLong(pVar->lVal);
         case VT_I4 | VT_VECTOR:
-            return VectorToSeq(pVar->cal.pElems, pVar->cal.cElems, PyInt_FromLong);
+            return VectorToSeq(pVar->cal.pElems, pVar->cal.cElems, PyLong_FromLong);
         case VT_INT:
-            return PyInt_FromLong(pVar->intVal);
+            return PyLong_FromLong(pVar->intVal);
         case VT_UI4:
             return PyLong_FromUnsignedLong(pVar->ulVal);
         case VT_UI4 | VT_VECTOR:
@@ -247,9 +247,9 @@ PyObject *PyObject_FromPROPVARIANT(PROPVARIANT *pVar)
         case VT_BOOL | VT_VECTOR:
             return VectorToSeq(pVar->cabool.pElems, pVar->cabool.cElems, PyWinObject_FromVARIANT_BOOL);
         case VT_ERROR:
-            return PyInt_FromLong(pVar->scode);
+            return PyLong_FromLong(pVar->scode);
         case VT_ERROR | VT_VECTOR:
-            return VectorToSeq(pVar->cascode.pElems, pVar->cascode.cElems, PyInt_FromLong);
+            return VectorToSeq(pVar->cascode.pElems, pVar->cascode.cElems, PyLong_FromLong);
         case VT_FILETIME:
             return PyWinObject_FromFILETIME(pVar->filetime);
         case VT_FILETIME | VT_VECTOR:
@@ -383,10 +383,10 @@ BOOL PyObject_AsPROPVARIANT(PyObject *ob, PROPVARIANT *pVar)
             }
         }
 #if (PY_VERSION_HEX < 0x03000000)
-        // Not needed in Py3k, as PyInt_Check is defined to PyLong_Check
+        // Not needed in Py3k, as PyLong_Check is defined to PyLong_Check
     }
-    else if (PyInt_Check(ob)) {
-        pVar->lVal = PyInt_AsLong(ob);
+    else if (PyLong_Check(ob)) {
+        pVar->lVal = PyLong_AsLong(ob);
         pVar->vt = VT_I4;
 #endif
     }

--- a/com/win32com/src/extensions/PyIPropertyStorage.cpp
+++ b/com/win32com/src/extensions/PyIPropertyStorage.cpp
@@ -304,7 +304,7 @@ PyObject *PyObject_FromPROPVARIANT(PROPVARIANT *pVar)
             return PyObject_FromPROPVARIANTs(pVar->capropvar.pElems, pVar->capropvar.cElems);
         case VT_BLOB:
         case VT_BLOB_OBJECT:
-            return PyString_FromStringAndSize((const char *)pVar->blob.pBlobData, pVar->blob.cbSize);
+            return PyBytes_FromStringAndSize((const char *)pVar->blob.pBlobData, pVar->blob.cbSize);
             //		case VT_UNKNOWN:
             //			return PyCom_PyObjectFromIUnknown(pVar->punkVal, IID_IUnknown, TRUE);
             //		case VT_DISPATCH:
@@ -394,7 +394,7 @@ BOOL PyObject_AsPROPVARIANT(PyObject *ob, PROPVARIANT *pVar)
         pVar->dblVal = PyFloat_AsDouble(ob);
         pVar->vt = VT_R8;
     }
-    else if (PyUnicode_Check(ob) || PyString_Check(ob)) {
+    else if (PyUnicode_Check(ob) || PyBytes_Check(ob)) {
         PyWinObject_AsBstr(ob, &pVar->bstrVal);
         pVar->vt = VT_BSTR;
     }

--- a/com/win32com/src/extensions/PyIRunningObjectTable.cpp
+++ b/com/win32com/src/extensions/PyIRunningObjectTable.cpp
@@ -39,7 +39,7 @@ PyObject *PyIRunningObjectTable::IsRunning(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pMy, IID_IRunningObjectTable);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
     // @rvalue S_OK (ie, 0)|The object identified by objectName is running.
     // @rvalue S_FALSE (ie, 1)|There is no entry for objectName in the ROT, or that the object it identifies is no
     // longer running (in which case, the entry is revoked).
@@ -121,7 +121,7 @@ PyObject *PyIRunningObjectTable::Register(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (S_OK != hr)  // S_OK only acceptable
         return PyCom_BuildPyException(hr, pMy, IID_IRunningObjectTable);
-    return PyInt_FromLong(tok);
+    return PyLong_FromLong(tok);
 }
 
 // @pymethod int|PyIRunningObjectTable|Revoke|Removes from the Running Object Table

--- a/com/win32com/src/extensions/PyIStream.cpp
+++ b/com/win32com/src/extensions/PyIStream.cpp
@@ -37,7 +37,7 @@ PyObject *PyIStream::Read(PyObject *self, PyObject *args)
     if (FAILED(hr))
         result = PyCom_BuildPyException(hr, pMy, IID_IStream);
     else
-        result = PyString_FromStringAndSize(buffer, read);
+        result = PyBytes_FromStringAndSize(buffer, read);
     delete buffer;
     // @rdesc The result is a string containing binary data.
     return result;

--- a/com/win32com/src/extensions/PyIType.cpp
+++ b/com/win32com/src/extensions/PyIType.cpp
@@ -37,7 +37,7 @@ PyObject *PyITypeInfo::GetContainingTypeLib()
 
     PyObject *ret = PyTuple_New(2);
     PyTuple_SetItem(ret, 0, PyCom_PyObjectFromIUnknown(ptlib, IID_ITypeLib));
-    PyTuple_SetItem(ret, 1, PyInt_FromLong(index));
+    PyTuple_SetItem(ret, 1, PyLong_FromLong(index));
     return ret;
 }
 
@@ -378,13 +378,13 @@ static PyObject *typeinfo_getidsofnames(PyObject *self, PyObject *args)
 
     /* if we have just one name, then return a single DISPID (int) */
     if (cNames == 1) {
-        result = PyInt_FromLong(rgdispid[0]);
+        result = PyLong_FromLong(rgdispid[0]);
     }
     else {
         result = PyTuple_New(cNames);
         if (result) {
             for (i = 0; i < cNames; ++i) {
-                PyObject *ob = PyInt_FromLong(rgdispid[i]);
+                PyObject *ob = PyLong_FromLong(rgdispid[i]);
                 if (!ob) {
                     delete[] rgdispid;
                     return NULL;
@@ -534,7 +534,7 @@ PyObject *PyITypeLib::GetTypeInfoCount()
     PY_INTERFACE_PRECALL;
     long rc = pMyTypeLib->GetTypeInfoCount();
     PY_INTERFACE_POSTCALL;
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 PyObject *PyITypeLib::GetTypeInfoOfGuid(REFGUID guid)
@@ -563,7 +563,7 @@ PyObject *PyITypeLib::GetTypeInfoType(int pos)
     if (FAILED(sc))
         return PyCom_BuildPyException(sc, pMyTypeLib, IID_ITypeLib);
 
-    return PyInt_FromLong(tkind);
+    return PyLong_FromLong(tkind);
 }
 
 PyObject *PyITypeLib::GetTypeComp()
@@ -945,7 +945,7 @@ static PyObject *ITypeCompBind(ITypeComp *pTC, OLECHAR *S, unsigned short w)
     if (real_ret == NULL)
         return NULL;
     // NOTE: SET_ITEM consumes the refcounts.
-    PyTuple_SET_ITEM(real_ret, 0, PyInt_FromLong(DK));
+    PyTuple_SET_ITEM(real_ret, 0, PyLong_FromLong(DK));
     PyTuple_SET_ITEM(real_ret, 1, ret);
     return real_ret;
 }

--- a/com/win32com/src/extensions/PyITypeObjects.cpp
+++ b/com/win32com/src/extensions/PyITypeObjects.cpp
@@ -96,8 +96,8 @@ PyObject *PyObject_FromARRAYDESC(ARRAYDESC *ad)
 BOOL PyObject_AsTYPEDESC(PyObject *ob, TYPEDESC *pDesc, void *pMore)
 {
     BOOL rc = FALSE;
-    if (PyInt_Check(ob)) {  // a simple VT
-        pDesc->vt = (VARTYPE)PyInt_AsLong(ob);
+    if (PyLong_Check(ob)) {  // a simple VT
+        pDesc->vt = (VARTYPE)PyLong_AsLong(ob);
         return TRUE;  // quick exit!
     }
     if (!PySequence_Check(ob) || PySequence_Length(ob) != 2) {
@@ -107,11 +107,11 @@ BOOL PyObject_AsTYPEDESC(PyObject *ob, TYPEDESC *pDesc, void *pMore)
     PyObject *obType = PySequence_GetItem(ob, 0);
     PyObject *obExtra = PySequence_GetItem(ob, 1);
 
-    if (!PyInt_Check(obType)) {
+    if (!PyLong_Check(obType)) {
         PyErr_SetString(PyExc_TypeError, "The first sequence item must be an integer");
         goto done;
     }
-    pDesc->vt = (VARTYPE)PyInt_AsLong(obType);
+    pDesc->vt = (VARTYPE)PyLong_AsLong(obType);
     switch (pDesc->vt) {
         case VT_PTR:
         case VT_SAFEARRAY:
@@ -126,12 +126,12 @@ BOOL PyObject_AsTYPEDESC(PyObject *ob, TYPEDESC *pDesc, void *pMore)
                 goto done;
             break;
         case VT_USERDEFINED:
-            if (!PyInt_Check(obExtra)) {
+            if (!PyLong_Check(obExtra)) {
                 PyErr_SetString(PyExc_TypeError,
                                 "If the TYPEDESC is of type VT_USERDEFINED, the object must be an integer");
                 goto done;
             }
-            pDesc->hreftype = (HREFTYPE)PyInt_AsLong(obExtra);
+            pDesc->hreftype = (HREFTYPE)PyLong_AsLong(obExtra);
             break;
         default:
             break;
@@ -167,7 +167,7 @@ PyObject *PyObject_FromTYPEDESC(const TYPEDESC *td)
     else if (td->vt == VT_CARRAY)
         p3 = PyObject_FromARRAYDESC(td->lpadesc);
     else if (td->vt == VT_USERDEFINED)
-        p3 = PyInt_FromLong(td->hreftype);
+        p3 = PyLong_FromLong(td->hreftype);
 
     if (p3) {
         PyObject *ret = Py_BuildValue("(iO)", td->vt, p3);
@@ -175,7 +175,7 @@ PyObject *PyObject_FromTYPEDESC(const TYPEDESC *td)
         return ret;
     }
     else
-        return PyInt_FromLong(td->vt);
+        return PyLong_FromLong(td->vt);
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -195,11 +195,11 @@ BOOL PyObject_AsELEMDESC(PyObject *ob, ELEMDESC *pDesc, void *pMore)
     PyObject *obParamFlags = PySequence_GetItem(ob, 1);
     PyObject *obDefaultVal = PySequence_GetItem(ob, 2);
 
-    if (!PyInt_Check(obParamFlags)) {
+    if (!PyLong_Check(obParamFlags)) {
         PyErr_SetString(PyExc_TypeError, "The second sequence item must be an integer");
         goto done;
     }
-    pDesc->paramdesc.wParamFlags = (WORD)PyInt_AsLong(obParamFlags);
+    pDesc->paramdesc.wParamFlags = (WORD)PyLong_AsLong(obParamFlags);
 
     if (obDefaultVal != Py_None) {
         pDesc->paramdesc.wParamFlags |= PARAMFLAG_FHASDEFAULT;

--- a/com/win32com/src/extensions/PySTGMEDIUM.cpp
+++ b/com/win32com/src/extensions/PySTGMEDIUM.cpp
@@ -234,7 +234,7 @@ PyObject *PySTGMEDIUM::getattro(PyObject *self, PyObject *obname)
     PySTGMEDIUM *ps = (PySTGMEDIUM *)self;
     // @prop int|tymed|An integer indicating the type of data in the stgmedium
     if (strcmp(name, "tymed") == 0)
-        return PyInt_FromLong(ps->medium.tymed);
+        return PyLong_FromLong(ps->medium.tymed);
     // @prop object|data|The data in the stgmedium.
     // The result depends on the value of the 'tymed' property of the <o PySTGMEDIUM> object.
     // @flagh tymed|Result Type

--- a/com/win32com/src/extensions/PySTGMEDIUM.cpp
+++ b/com/win32com/src/extensions/PySTGMEDIUM.cpp
@@ -57,9 +57,9 @@ PyObject *PySet(PyObject *self, PyObject *args)
             // We need to include the NULL for strings and unicode, as the
             // Windows clipboard functions will assume it is there for
             // text related formats (eg, CF_TEXT).
-            if (PyString_Check(ob)) {
-                cb = PyString_GET_SIZE(ob) + 1;  // for the NULL
-                buf = (void *)PyString_AS_STRING(ob);
+            if (PyBytes_Check(ob)) {
+                cb = PyBytes_GET_SIZE(ob) + 1;  // for the NULL
+                buf = (void *)PyBytes_AS_STRING(ob);
             }
             else if (PyUnicode_Check(ob)) {
                 cb = PyUnicode_GET_DATA_SIZE(ob) + sizeof(Py_UNICODE);
@@ -254,7 +254,7 @@ PyObject *PySTGMEDIUM::getattro(PyObject *self, PyObject *obname)
                 PyObject *ret;
                 void *p = GlobalLock(ps->medium.hGlobal);
                 if (p) {
-                    ret = PyString_FromStringAndSize((char *)p, GlobalSize(ps->medium.hGlobal));
+                    ret = PyBytes_FromStringAndSize((char *)p, GlobalSize(ps->medium.hGlobal));
                     GlobalUnlock(ps->medium.hGlobal);
                 }
                 else {

--- a/com/win32com/src/extensions/PyTYPEATTR.cpp
+++ b/com/win32com/src/extensions/PyTYPEATTR.cpp
@@ -182,32 +182,32 @@ PyTYPEATTR::~PyTYPEATTR()
             Py_INCREF(rc);
             return rc;
         case 1:  // @tupleitem 1|int|lcid|The lcid
-            return PyInt_FromLong(p->lcid);
+            return PyLong_FromLong(p->lcid);
         case 2:  // @tupleitem 2|int|memidConstructor|ID of constructor
-            return PyInt_FromLong(p->memidConstructor);
+            return PyLong_FromLong(p->memidConstructor);
         case 3:  // @tupleitem 3|int|memidDestructor|ID of destructor,
-            return PyInt_FromLong(p->memidDestructor);
+            return PyLong_FromLong(p->memidDestructor);
         case 4:  // @tupleitem 4|int|cbSizeInstance|The size of an instance of this type
-            return PyInt_FromLong(p->cbSizeInstance);
+            return PyLong_FromLong(p->cbSizeInstance);
         case 5:  // @tupleitem 5|int|typekind|The kind of type this information describes.  One of the win32con.TKIND_*
                  // constants.
-            return PyInt_FromLong(p->typekind);
+            return PyLong_FromLong(p->typekind);
         case 6:  // @tupleitem 6|int|cFuncs|Number of functions.
-            return PyInt_FromLong(p->cFuncs);
+            return PyLong_FromLong(p->cFuncs);
         case 7:  // @tupleitem 7|int|cVars|Number of variables/data members.
-            return PyInt_FromLong(p->cVars);
+            return PyLong_FromLong(p->cVars);
         case 8:  // @tupleitem 8|int|cImplTypes|Number of implemented interfaces.
-            return PyInt_FromLong(p->cImplTypes);
+            return PyLong_FromLong(p->cImplTypes);
         case 9:  // @tupleitem 9|int|cbSizeVft|The size of this type's VTBL
-            return PyInt_FromLong(p->cbSizeVft);
+            return PyLong_FromLong(p->cbSizeVft);
         case 10:  // @tupleitem 10|int|cbAlignment|Byte alignment for an instance of this type.
-            return PyInt_FromLong(p->cbAlignment);
+            return PyLong_FromLong(p->cbAlignment);
         case 11:  // @tupleitem 11|int|wTypeFlags|One of the pythoncom TYPEFLAG_* constants
-            return PyInt_FromLong(p->wTypeFlags);
+            return PyLong_FromLong(p->wTypeFlags);
         case 12:  // @tupleitem 12|int|wMajorVerNum|Major version number.
-            return PyInt_FromLong(p->wMajorVerNum);
+            return PyLong_FromLong(p->wMajorVerNum);
         case 13:  // @tupleitem 13|int|wMinorVerNum|Minor version number.
-            return PyInt_FromLong(p->wMinorVerNum);
+            return PyLong_FromLong(p->wMinorVerNum);
         case 14:  // @tupleitem 14|<o TYPEDESC>|obDescAlias|If TypeKind == pythoncom.TKIND_ALIAS, specifies the type for
                   // which this type is an alias.
             rc = p->obDescAlias ? p->obDescAlias : Py_None;

--- a/com/win32com/src/extensions/PyVARDESC.cpp
+++ b/com/win32com/src/extensions/PyVARDESC.cpp
@@ -37,11 +37,11 @@ BOOL PyObject_AsVARDESC(PyObject *ob, VARDESC *v, void *pMore)
         return FALSE;
 
     if (v->varkind == VAR_PERINSTANCE) {
-        if (!PyInt_Check(pyv->value)) {
+        if (!PyLong_Check(pyv->value)) {
             PyErr_SetString(PyExc_TypeError, "If varkind==VAR_PERINSTANCE, value attribute must be an integer");
             return FALSE;
         }
-        v->oInst = PyInt_AsLong(pyv->value);
+        v->oInst = PyLong_AsLong(pyv->value);
     }
     else if (v->varkind == VAR_CONST) {
         VARIANT *pVar = (VARIANT *)AllocMore(pMore, sizeof(VARIANT), TRUE);
@@ -170,7 +170,7 @@ PyVARDESC::PyVARDESC(const VARDESC *pVD)
     desckind = DESCKIND_VARDESC;
 
     if (varkind == VAR_PERINSTANCE)
-        value = PyInt_FromLong(pVD->oInst);
+        value = PyLong_FromLong(pVD->oInst);
     else if (varkind == VAR_CONST) {
         VARIANT varValue;
 
@@ -236,7 +236,7 @@ PyVARDESC::~PyVARDESC()
     PyObject *rc;
     switch (index) {
         case 0:  // @tupleitem 0|int|memid|The id of the member
-            return PyInt_FromLong(p->memid);
+            return PyLong_FromLong(p->memid);
         case 1:  // @tupleitem 1|int/object|value|A value for the variant.  If PERINSTANCE then an offset into the
                  // instance, otherwise a variant converted to a Python object.
             rc = p->value ? p->value : Py_None;
@@ -247,9 +247,9 @@ PyVARDESC::~PyVARDESC()
             Py_INCREF(rc);
             return rc;
         case 3:  // @tupleitem 3|int|wVarFlags|Variable flags
-            return PyInt_FromLong(p->wVarFlags);
+            return PyLong_FromLong(p->wVarFlags);
         case 4:  // @tupleitem 4|int|varkind|Kind flags.
-            return PyInt_FromLong(p->varkind);
+            return PyLong_FromLong(p->varkind);
     }
     PyErr_SetString(PyExc_IndexError, "index out of range");
     return NULL;

--- a/com/win32com/src/oleargs.cpp
+++ b/com/win32com/src/oleargs.cpp
@@ -59,7 +59,7 @@ BOOL MaybeExtractPyVariant(PyObject *obj, VARTYPE *vt, PyObject **pObjValue, BOO
     PyObject *obvt = PyObject_GetAttrString(obj, "varianttype");
     if (!obvt)
         return FALSE;
-    *vt = (VARTYPE)PyInt_AsUnsignedLongMask(obvt);
+    *vt = (VARTYPE)PyLong_AsUnsignedLongMask(obvt);
     if (*vt == (VARTYPE)-1 && PyErr_Occurred()) {
         Py_DECREF(obvt);
         return FALSE;
@@ -224,10 +224,10 @@ BOOL PyCom_VariantFromPyObject(PyObject *obj, VARIANT *var)
         V_VT(var) = VT_NULL;
     }
 #if (PY_VERSION_HEX < 0x03000000)
-    // This is redundant in 3.x, since PyInt_Check is #defined to PyLong_Check
-    else if (PyInt_Check(obj)) {
+    // This is redundant in 3.x, since PyLong_Check is #defined to PyLong_Check
+    else if (PyLong_Check(obj)) {
         V_VT(var) = VT_I4;
-        V_I4(var) = PyInt_AsLong(obj);
+        V_I4(var) = PyLong_AsLong(obj);
         if (V_I4(var) == -1 && PyErr_Occurred())
             return FALSE;
     }
@@ -391,7 +391,7 @@ PyObject *PyCom_PyObjectFromVariant(const VARIANT *var)
             // The result may be too large for a simple "long".  If so,
             // we must return a long.
             if (V_UI4(&varValue) <= INT_MAX)
-                result = PyInt_FromLong(V_UI4(&varValue));
+                result = PyLong_FromLong(V_UI4(&varValue));
             else
                 result = PyLong_FromUnsignedLong(V_UI4(&varValue));
             break;
@@ -407,28 +407,28 @@ PyObject *PyCom_PyObjectFromVariant(const VARIANT *var)
                 OleSetTypeError(buf);
                 break;
             }
-            result = PyInt_FromLong(V_I4(&varValue));
+            result = PyLong_FromLong(V_I4(&varValue));
             break;
 
         case VT_UI8:
             // The result may be too large for a simple "long". If so,
             // we must return a long.
             if (V_UI8(&varValue) <= LONG_MAX)
-                result = PyInt_FromLong((long)V_UI8(&varValue));
+                result = PyLong_FromLong((long)V_UI8(&varValue));
             else
                 result = PyLong_FromUnsignedLongLong(V_UI8(&varValue));
             break;
 
         case VT_I8:
             if ((LONG_MIN <= V_I8(&varValue)) && (V_I8(&varValue) <= LONG_MAX))
-                result = PyInt_FromLong((long)V_I8(&varValue));
+                result = PyLong_FromLong((long)V_I8(&varValue));
             else
                 result = PyLong_FromLongLong(V_I8(&varValue));
             break;
 
         case VT_HRESULT:
         case VT_ERROR:
-            result = PyInt_FromLong(V_ERROR(&varValue));
+            result = PyLong_FromLong(V_ERROR(&varValue));
             break;
 
         case VT_R4:
@@ -636,10 +636,10 @@ static long PyCom_CalculatePyObjectDimension(PyObject *obItemCheck, long lDimens
         PyErr_Clear();
     }
     if (lObjectSize != -1) {  // A real sequence of size zero should be OK though.
-        ppyobSize = PyInt_FromSsize_t(lObjectSize);
+        ppyobSize = PyLong_FromSsize_t(lObjectSize);
 
         // Retrieve the stored size in this dimension
-        ppyobDimension = PyInt_FromLong(lDimension);
+        ppyobDimension = PyLong_FromLong(lDimension);
         // Note: No ref added by PyDict_GetItem
         ppyobDimensionSize = PyDict_GetItem(ppyobDimensionDictionary, ppyobDimension);
         if (NULL == ppyobDimensionSize) {
@@ -649,7 +649,7 @@ static long PyCom_CalculatePyObjectDimension(PyObject *obItemCheck, long lDimens
         }
         else {
             // Check if stored size in this dimension equals the size of the element to check
-            Py_ssize_t lStoredSize = PyInt_AsSsize_t(ppyobDimensionSize);
+            Py_ssize_t lStoredSize = PyLong_AsSsize_t(ppyobDimensionSize);
             if (lStoredSize != lObjectSize) {
                 // if not the same size => no new dimension
                 Py_XDECREF(ppyobSize);
@@ -819,7 +819,7 @@ static PyObject *PyCom_PyObjectFromSAFEARRAYDimensionItem(SAFEARRAY *psa, VARENU
             hres = SafeArrayGetElement(psa, arrayIndices, &sh);
             if (FAILED(hres))
                 break;
-            subitem = PyInt_FromLong(sh);
+            subitem = PyLong_FromLong(sh);
             break;
         }
         case VT_I4:
@@ -828,7 +828,7 @@ static PyObject *PyCom_PyObjectFromSAFEARRAYDimensionItem(SAFEARRAY *psa, VARENU
             hres = SafeArrayGetElement(psa, arrayIndices, &ln);
             if (FAILED(hres))
                 break;
-            subitem = PyInt_FromLong(ln);
+            subitem = PyLong_FromLong(ln);
             break;
         }
         case VT_I8: {
@@ -923,7 +923,7 @@ static PyObject *PyCom_PyObjectFromSAFEARRAYDimensionItem(SAFEARRAY *psa, VARENU
             hres = SafeArrayGetElement(psa, arrayIndices, &i1);
             if (FAILED(hres))
                 break;
-            subitem = PyInt_FromLong(i1);
+            subitem = PyLong_FromLong(i1);
             break;
         }
         case VT_UI2: {
@@ -1141,13 +1141,13 @@ BOOL PythonOleArgHelper::ParseTypeInformation(PyObject *reqdObjectTuple)
     PyObject *typeDesc = PyTuple_GetItem(reqdObjectTuple, 0);
     if (typeDesc == NULL)
         return FALSE;
-    m_reqdType = (VARTYPE)PyInt_AsLong(typeDesc);
+    m_reqdType = (VARTYPE)PyLong_AsLong(typeDesc);
     if (PyErr_Occurred())
         return FALSE;
     PyObject *paramFlags = PyTuple_GetItem(reqdObjectTuple, 1);
     if (paramFlags == NULL)
         return FALSE;
-    DWORD pf = (DWORD)PyInt_AsLong(paramFlags);
+    DWORD pf = (DWORD)PyLong_AsLong(paramFlags);
     if (PyErr_Occurred())
         return FALSE;
     // If we have _no_ param flags, use the BYREF-ness of the param
@@ -1337,9 +1337,9 @@ BOOL PythonOleArgHelper::MakeObjToVariant(PyObject *obj, VARIANT *var, PyObject 
                 *V_UI8REF(var) = 0;
             break;
         case VT_I4:
-            if ((obUse = PyNumber_Int(obj)) == NULL)
+            if ((obUse = PyNumber_Long(obj)) == NULL)
                 BREAK_FALSE
-            V_I4(var) = PyInt_AsLong(obUse);
+            V_I4(var) = PyLong_AsLong(obUse);
             if (V_I4(var) == -1 && PyErr_Occurred())
                 BREAK_FALSE;
             break;
@@ -1348,9 +1348,9 @@ BOOL PythonOleArgHelper::MakeObjToVariant(PyObject *obj, VARIANT *var, PyObject 
                 V_I4REF(var) = &m_lBuf;
 
             if (!VALID_BYREF_MISSING(obj)) {
-                if ((obUse = PyNumber_Int(obj)) == NULL)
+                if ((obUse = PyNumber_Long(obj)) == NULL)
                     BREAK_FALSE
-                *V_I4REF(var) = PyInt_AsLong(obUse);
+                *V_I4REF(var) = PyLong_AsLong(obUse);
                 if (*V_I4REF(var) == -1 && PyErr_Occurred())
                     BREAK_FALSE;
             }
@@ -1358,7 +1358,7 @@ BOOL PythonOleArgHelper::MakeObjToVariant(PyObject *obj, VARIANT *var, PyObject 
                 *V_I4REF(var) = 0;
             break;
         case VT_UI4:
-            if ((obUse = PyNumber_Int(obj)) == NULL)
+            if ((obUse = PyNumber_Long(obj)) == NULL)
                 BREAK_FALSE
             V_UI4(var) = PyLong_AsUnsignedLongMask(obUse);
             if (V_UI4(var) == (unsigned long)-1 && PyErr_Occurred())
@@ -1369,7 +1369,7 @@ BOOL PythonOleArgHelper::MakeObjToVariant(PyObject *obj, VARIANT *var, PyObject 
                 V_UI4REF(var) = (unsigned long *)&m_lBuf;
 
             if (!VALID_BYREF_MISSING(obj)) {
-                if ((obUse = PyNumber_Int(obj)) == NULL)
+                if ((obUse = PyNumber_Long(obj)) == NULL)
                     BREAK_FALSE
                 *V_UI4REF(var) = PyLong_AsUnsignedLongMask(obUse);
                 if (*V_UI4REF(var) == (unsigned long)-1 && PyErr_Occurred())
@@ -1379,24 +1379,24 @@ BOOL PythonOleArgHelper::MakeObjToVariant(PyObject *obj, VARIANT *var, PyObject 
                 *V_UI4REF(var) = 0;
             break;
         case VT_I2:
-            if ((obUse = PyNumber_Int(obj)) == NULL)
+            if ((obUse = PyNumber_Long(obj)) == NULL)
                 BREAK_FALSE
-            V_I2(var) = (short)PyInt_AsLong(obUse);
+            V_I2(var) = (short)PyLong_AsLong(obUse);
             break;
         case VT_I2 | VT_BYREF:
             if (bCreateBuffers)
                 V_I2REF(var) = &m_sBuf;
 
             if (!VALID_BYREF_MISSING(obj)) {
-                if ((obUse = PyNumber_Int(obj)) == NULL)
+                if ((obUse = PyNumber_Long(obj)) == NULL)
                     BREAK_FALSE
-                *V_I2REF(var) = (short)PyInt_AsLong(obUse);
+                *V_I2REF(var) = (short)PyLong_AsLong(obUse);
             }
             else
                 *V_I2REF(var) = 0;
             break;
         case VT_UI2:
-            if ((obUse = PyNumber_Int(obj)) == NULL)
+            if ((obUse = PyNumber_Long(obj)) == NULL)
                 BREAK_FALSE
             V_UI2(var) = (short)PyLong_AsUnsignedLongMask(obUse);
             break;
@@ -1405,7 +1405,7 @@ BOOL PythonOleArgHelper::MakeObjToVariant(PyObject *obj, VARIANT *var, PyObject 
                 V_UI2REF(var) = (unsigned short *)&m_sBuf;
 
             if (!VALID_BYREF_MISSING(obj)) {
-                if ((obUse = PyNumber_Int(obj)) == NULL)
+                if ((obUse = PyNumber_Long(obj)) == NULL)
                     BREAK_FALSE
                 *V_UI2REF(var) = (unsigned short)PyLong_AsUnsignedLongMask(obUse);
             }
@@ -1413,43 +1413,43 @@ BOOL PythonOleArgHelper::MakeObjToVariant(PyObject *obj, VARIANT *var, PyObject 
                 *V_UI2REF(var) = 0;
             break;
         case VT_I1:
-            if ((obUse = PyNumber_Int(obj)) == NULL)
+            if ((obUse = PyNumber_Long(obj)) == NULL)
                 BREAK_FALSE
-            V_I1(var) = (CHAR)PyInt_AsLong(obUse);
+            V_I1(var) = (CHAR)PyLong_AsLong(obUse);
             break;
         case VT_I1 | VT_BYREF:
             if (bCreateBuffers)
                 V_I1REF(var) = (char *)&m_sBuf;
 
             if (!VALID_BYREF_MISSING(obj)) {
-                if ((obUse = PyNumber_Int(obj)) == NULL)
+                if ((obUse = PyNumber_Long(obj)) == NULL)
                     BREAK_FALSE
-                *V_I1REF(var) = (CHAR)PyInt_AsLong(obUse);
+                *V_I1REF(var) = (CHAR)PyLong_AsLong(obUse);
             }
             else
                 *V_I1REF(var) = 0;
             break;
         case VT_UI1:
-            if ((obUse = PyNumber_Int(obj)) == NULL)
+            if ((obUse = PyNumber_Long(obj)) == NULL)
                 BREAK_FALSE
-            V_UI1(var) = (BYTE)PyInt_AsLong(obUse);
+            V_UI1(var) = (BYTE)PyLong_AsLong(obUse);
             break;
         case VT_UI1 | VT_BYREF:
             if (bCreateBuffers)
                 V_UI1REF(var) = (BYTE *)&m_sBuf;
 
             if (!VALID_BYREF_MISSING(obj)) {
-                if ((obUse = PyNumber_Int(obj)) == NULL)
+                if ((obUse = PyNumber_Long(obj)) == NULL)
                     BREAK_FALSE
-                *V_UI1REF(var) = (BYTE)PyInt_AsLong(obUse);
+                *V_UI1REF(var) = (BYTE)PyLong_AsLong(obUse);
             }
             else
                 *V_UI1REF(var) = 0;
             break;
         case VT_BOOL:
-            if ((obUse = PyNumber_Int(obj)) == NULL)
+            if ((obUse = PyNumber_Long(obj)) == NULL)
                 BREAK_FALSE
-            V_BOOL(var) = PyInt_AsLong(obUse) ? VARIANT_TRUE : VARIANT_FALSE;
+            V_BOOL(var) = PyLong_AsLong(obUse) ? VARIANT_TRUE : VARIANT_FALSE;
             break;
         case VT_BOOL | VT_BYREF:
             if (bCreateBuffers)
@@ -1464,9 +1464,9 @@ BOOL PythonOleArgHelper::MakeObjToVariant(PyObject *obj, VARIANT *var, PyObject 
 #endif
 
             if (!VALID_BYREF_MISSING(obj)) {
-                if ((obUse = PyNumber_Int(obj)) == NULL)
+                if ((obUse = PyNumber_Long(obj)) == NULL)
                     BREAK_FALSE
-                *MYBOOLREF = PyInt_AsLong(obj) ? VARIANT_TRUE : VARIANT_FALSE;
+                *MYBOOLREF = PyLong_AsLong(obj) ? VARIANT_TRUE : VARIANT_FALSE;
             }
             else
                 *MYBOOLREF = 0;
@@ -1573,9 +1573,9 @@ BOOL PythonOleArgHelper::MakeObjToVariant(PyObject *obj, VARIANT *var, PyObject 
                 V_ERRORREF(var) = &m_lBuf;
 
             if (!VALID_BYREF_MISSING(obj)) {
-                if ((obUse = PyNumber_Int(obj)) == NULL)
+                if ((obUse = PyNumber_Long(obj)) == NULL)
                     BREAK_FALSE
-                *V_ERRORREF(var) = PyInt_AsLong(obUse);
+                *V_ERRORREF(var) = PyLong_AsLong(obUse);
             }
             else
                 *V_ERRORREF(var) = 0;

--- a/com/win32com/src/oleargs.cpp
+++ b/com/win32com/src/oleargs.cpp
@@ -123,9 +123,9 @@ BOOL PyCom_VariantFromPyObject(PyObject *obj, VARIANT *var)
     BOOL bGoodEmpty = FALSE;  // Set if VT_EMPTY should really be used.
     V_VT(var) = VT_EMPTY;
     if (
-// In py3k we don't convert PyString_Check objects (ie, bytes) to BSTR...
+// In py3k we don't convert PyBytes_Check objects (ie, bytes) to BSTR...
 #if (PY_VERSION_HEX < 0x03000000)
-        PyString_Check(obj) ||
+        PyBytes_Check(obj) ||
 #endif
         PyUnicode_Check(obj)) {
         if (!PyWinObject_AsBstr(obj, &V_BSTR(var))) {
@@ -615,7 +615,7 @@ static long PyCom_CalculatePyObjectDimension(PyObject *obItemCheck, long lDimens
         return lDimension + 1;
 
     // Allow arbitrary sequences, but not strings or Unicode objects.
-    if (PyString_Check(obItemCheck) || PyUnicode_Check(obItemCheck) || !PySequence_Check(obItemCheck))
+    if (PyBytes_Check(obItemCheck) || PyUnicode_Check(obItemCheck) || !PySequence_Check(obItemCheck))
         return lDimension;
 
     long lReturnDimension = lDimension;
@@ -1272,7 +1272,7 @@ BOOL PythonOleArgHelper::MakeObjToVariant(PyObject *obj, VARIANT *var, PyObject 
             break;
 
         case VT_BSTR:
-            if (PyString_Check(obj) || PyUnicode_Check(obj)) {
+            if (PyBytes_Check(obj) || PyUnicode_Check(obj)) {
                 if (!PyWinObject_AsBstr(obj, &V_BSTR(var)))
                     BREAK_FALSE
             }
@@ -1293,7 +1293,7 @@ BOOL PythonOleArgHelper::MakeObjToVariant(PyObject *obj, VARIANT *var, PyObject 
             *V_BSTRREF(var) = NULL;
 
             if (!VALID_BYREF_MISSING(obj)) {
-                if (PyString_Check(obj) || PyUnicode_Check(obj)) {
+                if (PyBytes_Check(obj) || PyUnicode_Check(obj)) {
                     if (!PyWinObject_AsBstr(obj, V_BSTRREF(var)))
                         BREAK_FALSE
                 }

--- a/com/win32com/src/univgw.cpp
+++ b/com/win32com/src/univgw.cpp
@@ -680,7 +680,7 @@ static PyObject *univgw_ReadMemory(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    return PyString_FromStringAndSize((char *)p, size);
+    return PyBytes_FromStringAndSize((char *)p, size);
 }
 
 static PyObject *univgw_WriteMemory(PyObject *self, PyObject *args)

--- a/com/win32com/src/univgw.cpp
+++ b/com/win32com/src/univgw.cpp
@@ -77,7 +77,7 @@ static HRESULT univgw_dispatch(DWORD index, gw_object *_this, va_list argPtr)
 
     // prep the rest of the arguments
     PyObject *obArgs = PyTuple_New(3);
-    PyObject *obIndex = PyInt_FromLong(index);
+    PyObject *obIndex = PyLong_FromLong(index);
 
     if (obArgPtr == NULL || obArgs == NULL || obIndex == NULL) {
         set_error(vtbl->iid, L"could not create argument tuple");
@@ -113,13 +113,13 @@ static HRESULT univgw_dispatch(DWORD index, gw_object *_this, va_list argPtr)
         hr = S_OK;
     }
     else {
-        if (!PyInt_Check(result)) {
+        if (!PyLong_Check(result)) {
             Py_DECREF(result);
             set_error(vtbl->iid, L"expected integer return value");
             return E_UNEXPECTED;  // ### select a different value?
         }
 
-        hr = PyInt_AS_LONG(result);
+        hr = PyLong_AS_LONG(result);
     }
 
     Py_DECREF(result);
@@ -466,12 +466,12 @@ static PyObject *univgw_CreateVTable(PyObject *self, PyObject *args)
         if (obArgCount == NULL)
             goto error;
 
-        int argSize = PyInt_AsLong(obArgSize);
+        int argSize = PyLong_AsLong(obArgSize);
         Py_DECREF(obArgSize);
         if (argSize == -1 && PyErr_Occurred())
             goto error;
 
-        int argCount = PyInt_AsLong(obArgCount);
+        int argCount = PyLong_AsLong(obArgCount);
         Py_DECREF(obArgCount);
         if (argCount == -1 && PyErr_Occurred())
             goto error;

--- a/com/win32com/src/univgw_dataconv.cpp
+++ b/com/win32com/src/univgw_dataconv.cpp
@@ -45,7 +45,7 @@ PyObject *dataconv_strL64(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "L:strL64", &val))
         return NULL;
 
-    return PyString_FromStringAndSize((char *)&val, sizeof(val));
+    return PyBytes_FromStringAndSize((char *)&val, sizeof(val));
 }
 
 PyObject *dataconv_strUL64(PyObject *self, PyObject *args)
@@ -57,7 +57,7 @@ PyObject *dataconv_strUL64(PyObject *self, PyObject *args)
 
     unsigned __int64 val = PyLong_AsUnsignedLongLong(ob);
 
-    return PyString_FromStringAndSize((char *)&val, sizeof(val));
+    return PyBytes_FromStringAndSize((char *)&val, sizeof(val));
 }
 
 PyObject *dataconv_interface(PyObject *self, PyObject *args)
@@ -301,7 +301,7 @@ PyObject *dataconv_WriteFromOutTuple(PyObject *self, PyObject *args)
                 BSTR bstr = *(BSTR *)pbArg;
                 BSTR bstrT;
                 UINT cch = SysStringLen(bstr);
-                if (PyString_Check(obOutValue) || PyUnicode_Check(obOutValue)) {
+                if (PyBytes_Check(obOutValue) || PyUnicode_Check(obOutValue)) {
                     if (!PyWinObject_AsBstr(obOutValue, &bstrT)) {
                         goto Error;
                     }
@@ -340,7 +340,7 @@ PyObject *dataconv_WriteFromOutTuple(PyObject *self, PyObject *args)
 
                 *pbstr = NULL;
 
-                if (PyString_Check(obOutValue) || PyUnicode_Check(obOutValue)) {
+                if (PyBytes_Check(obOutValue) || PyUnicode_Check(obOutValue)) {
                     if (!PyWinObject_AsBstr(obOutValue, &bstrT)) {
                         goto Error;
                     }
@@ -428,9 +428,9 @@ PyObject *dataconv_WriteFromOutTuple(PyObject *self, PyObject *args)
             case VT_UI1 | VT_BYREF: {
                 BYTE *pb = *(BYTE **)pbArg;
                 BYTE *pbOutBuffer = NULL;
-                if (PyString_Check(obOutValue)) {
-                    pbOutBuffer = (BYTE *)PyString_AS_STRING(obOutValue);
-                    Py_ssize_t cb = PyString_GET_SIZE(obOutValue);
+                if (PyBytes_Check(obOutValue)) {
+                    pbOutBuffer = (BYTE *)PyBytes_AS_STRING(obOutValue);
+                    Py_ssize_t cb = PyBytes_GET_SIZE(obOutValue);
                     memcpy(pb, pbOutBuffer, cb);
                 }
                 // keep this after string check since string can act as buffers
@@ -667,7 +667,7 @@ PyObject *dataconv_ReadFromInTuple(PyObject *self, PyObject *args)
                         obArg = PyCom_PyObjectFromVariant((VARIANT *)pb);
                     break;
                 case VT_LPSTR:
-                    obArg = PyString_FromString(*(CHAR **)pb);
+                    obArg = PyBytes_FromString(*(CHAR **)pb);
                     break;
                 case VT_LPWSTR:
                     obArg = PyWinObject_FromOLECHAR(*(OLECHAR **)pb);

--- a/com/win32com/src/univgw_dataconv.cpp
+++ b/com/win32com/src/univgw_dataconv.cpp
@@ -229,7 +229,7 @@ PyObject *dataconv_WriteFromOutTuple(PyObject *self, PyObject *args)
 
     for (i = 0; i < cArgs; i++) {
         obArgType = PyTuple_GET_ITEM(PyTuple_GET_ITEM(obArgTypes, i), 0);
-        vtArgType = (VARTYPE)PyInt_AS_LONG(obArgType);
+        vtArgType = (VARTYPE)PyLong_AS_LONG(obArgType);
 
         // The following types aren't supported:
         // SAFEARRAY *: This requires support for SAFEARRAYs as a
@@ -243,7 +243,7 @@ PyObject *dataconv_WriteFromOutTuple(PyObject *self, PyObject *args)
         //              memory allocation policy.
 
         // Find the start of the argument.
-        pbArg = pbArgs + PyInt_AS_LONG(PyTuple_GET_ITEM(PyTuple_GET_ITEM(obArgTypes, i), 1));
+        pbArg = pbArgs + PyLong_AS_LONG(PyTuple_GET_ITEM(PyTuple_GET_ITEM(obArgTypes, i), 1));
         obOutValue = PyTuple_GET_ITEM(obRetValues, i);
 
         if (vtArgType & VT_ARRAY) {
@@ -362,11 +362,11 @@ PyObject *dataconv_WriteFromOutTuple(PyObject *self, PyObject *args)
             case VT_HRESULT | VT_BYREF:
             case VT_I4 | VT_BYREF: {
                 INT *pi = *(INT **)pbArg;
-                obUse = PyNumber_Int(obOutValue);
+                obUse = PyNumber_Long(obOutValue);
                 if (obUse == NULL) {
                     goto Error;
                 }
-                *pi = PyInt_AsLong(obUse);
+                *pi = PyLong_AsLong(obUse);
                 if (*pi == (UINT)-1 && PyErr_Occurred())
                     goto Error;
                 break;
@@ -375,18 +375,18 @@ PyObject *dataconv_WriteFromOutTuple(PyObject *self, PyObject *args)
                 UINT *pui = *(UINT **)pbArg;
                 // special care here as we could be > sys.maxint,
                 // in which case we must work with longs.
-                // Avoiding PyInt_AsUnsignedLongMask as it doesn't
+                // Avoiding PyLong_AsUnsignedLongMask as it doesn't
                 // exist in 2.2.
                 if (PyLong_Check(obOutValue)) {
                     *pui = PyLong_AsUnsignedLong(obOutValue);
                 }
                 else {
                     // just do the generic "number" thing.
-                    obUse = PyNumber_Int(obOutValue);
+                    obUse = PyNumber_Long(obOutValue);
                     if (obUse == NULL) {
                         goto Error;
                     }
-                    *pui = (UINT)PyInt_AsLong(obUse);
+                    *pui = (UINT)PyLong_AsLong(obUse);
                 }
                 if (*pui == (UINT)-1 && PyErr_Occurred())
                     goto Error;
@@ -394,33 +394,33 @@ PyObject *dataconv_WriteFromOutTuple(PyObject *self, PyObject *args)
             }
             case VT_I2 | VT_BYREF: {
                 short *ps = *(short **)pbArg;
-                obUse = PyNumber_Int(obOutValue);
+                obUse = PyNumber_Long(obOutValue);
                 if (obUse == NULL) {
                     goto Error;
                 }
-                *ps = (short)PyInt_AsLong(obUse);
+                *ps = (short)PyLong_AsLong(obUse);
                 if (*ps == (UINT)-1 && PyErr_Occurred())
                     goto Error;
                 break;
             }
             case VT_UI2 | VT_BYREF: {
                 unsigned short *pus = *(unsigned short **)pbArg;
-                obUse = PyNumber_Int(obOutValue);
+                obUse = PyNumber_Long(obOutValue);
                 if (obUse == NULL) {
                     goto Error;
                 }
-                *pus = (unsigned short)PyInt_AsLong(obUse);
+                *pus = (unsigned short)PyLong_AsLong(obUse);
                 if (*pus == (UINT)-1 && PyErr_Occurred())
                     goto Error;
                 break;
             }
             case VT_I1 | VT_BYREF: {
                 signed char *pb = *(signed char **)pbArg;
-                obUse = PyNumber_Int(obOutValue);
+                obUse = PyNumber_Long(obOutValue);
                 if (obUse == NULL) {
                     goto Error;
                 }
-                *pb = (signed char)PyInt_AsLong(obUse);
+                *pb = (signed char)PyLong_AsLong(obUse);
                 if (*pb == (UINT)-1 && PyErr_Occurred())
                     goto Error;
                 break;
@@ -441,11 +441,11 @@ PyObject *dataconv_WriteFromOutTuple(PyObject *self, PyObject *args)
                     memcpy(pb, pybuf.ptr(), pybuf.len());
                 }
                 else {
-                    obUse = PyNumber_Int(obOutValue);
+                    obUse = PyNumber_Long(obOutValue);
                     if (obUse == NULL) {
                         goto Error;
                     }
-                    *pb = (BYTE)PyInt_AsLong(obUse);
+                    *pb = (BYTE)PyLong_AsLong(obUse);
                     if (*pb == (UINT)-1 && PyErr_Occurred())
                         goto Error;
                 }
@@ -453,11 +453,11 @@ PyObject *dataconv_WriteFromOutTuple(PyObject *self, PyObject *args)
             }
             case VT_BOOL | VT_BYREF: {
                 VARIANT_BOOL *pbool = *(VARIANT_BOOL **)pbArg;
-                obUse = PyNumber_Int(obOutValue);
+                obUse = PyNumber_Long(obOutValue);
                 if (obUse == NULL) {
                     goto Error;
                 }
-                *pbool = PyInt_AsLong(obUse) ? VARIANT_TRUE : VARIANT_FALSE;
+                *pbool = PyLong_AsLong(obUse) ? VARIANT_TRUE : VARIANT_FALSE;
                 if (*pbool == (UINT)-1 && PyErr_Occurred())
                     goto Error;
                 break;
@@ -592,8 +592,8 @@ PyObject *dataconv_ReadFromInTuple(PyObject *self, PyObject *args)
         obArgType = PyTuple_GET_ITEM(PyTuple_GET_ITEM(obArgTypes, i), 0);
 
         // Position pb to point to the current argument.
-        pb = pbArg + PyInt_AS_LONG(PyTuple_GET_ITEM(PyTuple_GET_ITEM(obArgTypes, i), 1));
-        vtArgType = (VARTYPE)PyInt_AS_LONG(obArgType);
+        pb = pbArg + PyLong_AS_LONG(PyTuple_GET_ITEM(PyTuple_GET_ITEM(obArgTypes, i), 1));
+        vtArgType = (VARTYPE)PyLong_AS_LONG(obArgType);
 #ifdef _M_IX86
         bIsByRef = vtArgType & VT_BYREF;
 #elif _M_X64

--- a/com/win32comext/adsi/src/PyADSIUtil.cpp
+++ b/com/win32comext/adsi/src/PyADSIUtil.cpp
@@ -98,7 +98,7 @@ PyObject *PyADSIObject_FromADSVALUE(ADSVALUE &v)
             Py_INCREF(ob);
             break;
         case ADSTYPE_INTEGER:
-            ob = PyInt_FromLong(v.Integer);
+            ob = PyLong_FromLong(v.Integer);
             break;
         case ADSTYPE_OCTET_STRING: {
             DWORD bufSize = v.OctetString.dwLength;
@@ -172,10 +172,10 @@ BOOL PyADSIObject_AsTypedValue(PyObject *val, ADSVALUE &v)
             ok = PyWinObject_AsWCHAR(val, &v.DNString, FALSE);
             break;
         case ADSTYPE_BOOLEAN:
-            v.Boolean = PyInt_AsLong(val);
+            v.Boolean = PyLong_AsLong(val);
             break;
         case ADSTYPE_INTEGER:
-            v.Integer = PyInt_AsLong(val);
+            v.Integer = PyLong_AsLong(val);
             break;
         case ADSTYPE_UTC_TIME:
             ok = PyWinObject_AsSYSTEMTIME(val, &v.UTCTime);
@@ -207,7 +207,7 @@ BOOL PyADSIObject_AsADSVALUE(PyObject *ob, ADSVALUE &v)
             dwType = ADSTYPE_PRINTABLE_STRING;
         else if (val == Py_True || val == Py_False)
             dwType = ADSTYPE_BOOLEAN;
-        else if (PyInt_Check(val))
+        else if (PyLong_Check(val))
             dwType = ADSTYPE_INTEGER;
         else if (PyWinTime_Check(val))
             dwType = ADSTYPE_UTC_TIME;
@@ -216,8 +216,8 @@ BOOL PyADSIObject_AsADSVALUE(PyObject *ob, ADSVALUE &v)
             return FALSE;
         }
     }
-    else if (PyInt_Check(obtype))
-        dwType = PyInt_AsLong(obtype);
+    else if (PyLong_Check(obtype))
+        dwType = PyLong_AsLong(obtype);
     else {
         PyErr_SetString(PyExc_TypeError, "The type specified must be None or a string");
         return FALSE;

--- a/com/win32comext/adsi/src/PyADSIUtil.cpp
+++ b/com/win32comext/adsi/src/PyADSIUtil.cpp
@@ -203,7 +203,7 @@ BOOL PyADSIObject_AsADSVALUE(PyObject *ob, ADSVALUE &v)
     if (PyTuple_Size(ob) > 1)
         obtype = PyTuple_GET_ITEM(ob, 1);
     if (obtype == NULL || obtype == Py_None) {
-        if (PyString_Check(val) || PyUnicode_Check(val))
+        if (PyBytes_Check(val) || PyUnicode_Check(val))
             dwType = ADSTYPE_PRINTABLE_STRING;
         else if (val == Py_True || val == Py_False)
             dwType = ADSTYPE_BOOLEAN;
@@ -455,10 +455,10 @@ class PyADS_ATTR_INFO : public PyObject {
         if (strcmp(name, "__members__") == 0) {
             PyObject *ret = PyList_New(4);
             if (ret) {
-                PyList_SET_ITEM(ret, 0, PyString_FromString("AttrName"));
-                PyList_SET_ITEM(ret, 1, PyString_FromString("ControlCode"));
-                PyList_SET_ITEM(ret, 2, PyString_FromString("ADsType"));
-                PyList_SET_ITEM(ret, 3, PyString_FromString("Values"));
+                PyList_SET_ITEM(ret, 0, PyBytes_FromString("AttrName"));
+                PyList_SET_ITEM(ret, 1, PyBytes_FromString("ControlCode"));
+                PyList_SET_ITEM(ret, 2, PyBytes_FromString("ADsType"));
+                PyList_SET_ITEM(ret, 3, PyBytes_FromString("Values"));
             }
             return ret;
         }

--- a/com/win32comext/adsi/src/PyDSOPObjects.cpp
+++ b/com/win32comext/adsi/src/PyDSOPObjects.cpp
@@ -289,13 +289,13 @@ PyObject *PyDSOP_SCOPE_INIT_INFO::getattro(PyObject *self, PyObject *obname)
         return NULL;
     // @prop int|type|
     if (strcmp(name, "type") == 0)
-        return PyInt_FromLong(pssi->flType);
+        return PyLong_FromLong(pssi->flType);
     // @prop int|scope|
     if (strcmp(name, "scope") == 0)
-        return PyInt_FromLong(pssi->flScope);
+        return PyLong_FromLong(pssi->flScope);
     // @prop int|hr|
     if (strcmp(name, "hr") == 0)
-        return PyInt_FromLong(pssi->hr);
+        return PyLong_FromLong(pssi->hr);
     // @prop <o PyUnicode>|dcName|
     if (strcmp(name, "dcName") == 0)
         return PyWinObject_FromWCHAR(pssi->pwzDcName);
@@ -312,17 +312,17 @@ int PyDSOP_SCOPE_INIT_INFO::setattro(PyObject *self, PyObject *obname, PyObject 
     char *name = PyBytes_AsString(obname);
     PyErr_Clear();
     if (strcmp(name, "type") == 0) {
-        pssi->flType = PyInt_AsLong(val);
+        pssi->flType = PyLong_AsLong(val);
         if (PyErr_Occurred())
             return -1;
     }
     else if (strcmp(name, "scope") == 0) {
-        pssi->flScope = PyInt_AsLong(val);
+        pssi->flScope = PyLong_AsLong(val);
         if (PyErr_Occurred())
             return -1;
     }
     else if (strcmp(name, "scope") == 0) {
-        pssi->hr = PyInt_AsLong(val);
+        pssi->hr = PyLong_AsLong(val);
         if (PyErr_Occurred())
             return -1;
     }
@@ -413,7 +413,7 @@ PyObject *PyDSOP_FILTER_FLAGS::getattro(PyObject *self, PyObject *obname)
         return new PyDSOP_UPLEVEL_FILTER_FLAGS(p->owner);
     // @prop int|downlevel|
     if (strcmp(name, "downlevel") == 0)
-        return PyInt_FromLong(psii->FilterFlags.flDownlevel);
+        return PyLong_FromLong(psii->FilterFlags.flDownlevel);
     return PyObject_GenericGetAttr(self, obname);
 }
 
@@ -426,7 +426,7 @@ int PyDSOP_FILTER_FLAGS::setattro(PyObject *self, PyObject *obname, PyObject *va
     DSOP_SCOPE_INIT_INFO *psii = p->owner->owner->pScopes + p->owner->index;
     PyErr_Clear();
     if (strcmp(name, "downlevel") == 0) {
-        psii->FilterFlags.flDownlevel = PyInt_AsLong(val);
+        psii->FilterFlags.flDownlevel = PyLong_AsLong(val);
         if (PyErr_Occurred())
             return -1;
     }
@@ -507,13 +507,13 @@ PyObject *PyDSOP_UPLEVEL_FILTER_FLAGS::getattro(PyObject *self, PyObject *obname
         return NULL;
     // @prop int|bothModes|
     if (strcmp(name, "bothModes") == 0)
-        return PyInt_FromLong(psii->FilterFlags.Uplevel.flBothModes);
+        return PyLong_FromLong(psii->FilterFlags.Uplevel.flBothModes);
     // @prop int|mixedModeOnly|
     if (strcmp(name, "mixedModeOnly") == 0)
-        return PyInt_FromLong(psii->FilterFlags.Uplevel.flMixedModeOnly);
+        return PyLong_FromLong(psii->FilterFlags.Uplevel.flMixedModeOnly);
     // @prop int|nativeModeOnly|
     if (strcmp(name, "nativeModeOnly") == 0)
-        return PyInt_FromLong(psii->FilterFlags.Uplevel.flNativeModeOnly);
+        return PyLong_FromLong(psii->FilterFlags.Uplevel.flNativeModeOnly);
     return PyObject_GenericGetAttr(self, obname);
 }
 
@@ -526,17 +526,17 @@ int PyDSOP_UPLEVEL_FILTER_FLAGS::setattro(PyObject *self, PyObject *obname, PyOb
         return NULL;
     PyErr_Clear();
     if (strcmp(name, "bothModes") == 0) {
-        psii->FilterFlags.Uplevel.flBothModes = PyInt_AsLong(val);
+        psii->FilterFlags.Uplevel.flBothModes = PyLong_AsLong(val);
         if (PyErr_Occurred())
             return -1;
     }
     else if (strcmp(name, "mixedModeOnly") == 0) {
-        psii->FilterFlags.Uplevel.flMixedModeOnly = PyInt_AsLong(val);
+        psii->FilterFlags.Uplevel.flMixedModeOnly = PyLong_AsLong(val);
         if (PyErr_Occurred())
             return -1;
     }
     else if (strcmp(name, "nativeModeOnly") == 0) {
-        psii->FilterFlags.Uplevel.flNativeModeOnly = PyInt_AsLong(val);
+        psii->FilterFlags.Uplevel.flNativeModeOnly = PyLong_AsLong(val);
         if (PyErr_Occurred())
             return -1;
     }

--- a/com/win32comext/adsi/src/PyDSOPObjects.cpp
+++ b/com/win32comext/adsi/src/PyDSOPObjects.cpp
@@ -284,7 +284,7 @@ PyObject *PyDSOP_SCOPE_INIT_INFO::getattro(PyObject *self, PyObject *obname)
 {
     PyDSOP_SCOPE_INIT_INFO *p = (PyDSOP_SCOPE_INIT_INFO *)self;
     DSOP_SCOPE_INIT_INFO *pssi = p->owner->pScopes + p->index;
-    char *name = PyString_AsString(obname);
+    char *name = PyBytes_AsString(obname);
     if (!name)
         return NULL;
     // @prop int|type|
@@ -309,7 +309,7 @@ int PyDSOP_SCOPE_INIT_INFO::setattro(PyObject *self, PyObject *obname, PyObject 
 {
     PyDSOP_SCOPE_INIT_INFO *p = (PyDSOP_SCOPE_INIT_INFO *)self;
     DSOP_SCOPE_INIT_INFO *pssi = p->owner->pScopes + p->index;
-    char *name = PyString_AsString(obname);
+    char *name = PyBytes_AsString(obname);
     PyErr_Clear();
     if (strcmp(name, "type") == 0) {
         pssi->flType = PyInt_AsLong(val);
@@ -404,7 +404,7 @@ PyDSOP_FILTER_FLAGS::~PyDSOP_FILTER_FLAGS() { Py_DECREF(owner); }
 PyObject *PyDSOP_FILTER_FLAGS::getattro(PyObject *self, PyObject *obname)
 {
     PyDSOP_FILTER_FLAGS *p = (PyDSOP_FILTER_FLAGS *)self;
-    char *name = PyString_AsString(obname);
+    char *name = PyBytes_AsString(obname);
     if (!name)
         return NULL;
     DSOP_SCOPE_INIT_INFO *psii = p->owner->owner->pScopes + p->owner->index;
@@ -420,7 +420,7 @@ PyObject *PyDSOP_FILTER_FLAGS::getattro(PyObject *self, PyObject *obname)
 int PyDSOP_FILTER_FLAGS::setattro(PyObject *self, PyObject *obname, PyObject *val)
 {
     PyDSOP_FILTER_FLAGS *p = (PyDSOP_FILTER_FLAGS *)self;
-    char *name = PyString_AsString(obname);
+    char *name = PyBytes_AsString(obname);
     if (!name)
         return NULL;
     DSOP_SCOPE_INIT_INFO *psii = p->owner->owner->pScopes + p->owner->index;
@@ -502,7 +502,7 @@ PyObject *PyDSOP_UPLEVEL_FILTER_FLAGS::getattro(PyObject *self, PyObject *obname
 {
     PyDSOP_UPLEVEL_FILTER_FLAGS *p = (PyDSOP_UPLEVEL_FILTER_FLAGS *)self;
     DSOP_SCOPE_INIT_INFO *psii = p->owner->owner->pScopes + p->owner->index;
-    char *name = PyString_AsString(obname);
+    char *name = PyBytes_AsString(obname);
     if (!name)
         return NULL;
     // @prop int|bothModes|
@@ -521,7 +521,7 @@ int PyDSOP_UPLEVEL_FILTER_FLAGS::setattro(PyObject *self, PyObject *obname, PyOb
 {
     PyDSOP_UPLEVEL_FILTER_FLAGS *p = (PyDSOP_UPLEVEL_FILTER_FLAGS *)self;
     DSOP_SCOPE_INIT_INFO *psii = p->owner->owner->pScopes + p->owner->index;
-    char *name = PyString_AsString(obname);
+    char *name = PyBytes_AsString(obname);
     if (!name)
         return NULL;
     PyErr_Clear();

--- a/com/win32comext/adsi/src/PyIADsUser.i
+++ b/com/win32comext/adsi/src/PyIADsUser.i
@@ -28,7 +28,7 @@ IADsUser *PyIADsUser::GetI(PyObject *self)
 
 PyObject* PyIADsUser_getattro(PyObject *ob, PyObject *obname)
 {
-	char *name = PyString_AsString(obname);
+	char *name = PyBytes_AsString(obname);
 	if (!name) return NULL;
 
 	IADsUser *p = PyIADsUser::GetI(ob);

--- a/com/win32comext/adsi/src/PyIDirectoryObject.i
+++ b/com/win32comext/adsi/src/PyIDirectoryObject.i
@@ -98,7 +98,7 @@ PyObject *PyIDirectoryObject::SetObjectAttributes(PyObject *self, PyObject *args
 	if (FAILED(_result)) {
 		PyCom_BuildPyException(_result, _swig_self, IID_IDirectoryObject);
 	} else
-		ret = PyInt_FromLong(numset);
+		ret = PyLong_FromLong(numset);
 	PyADSIObject_FreeADS_ATTR_INFOs(attr, cattr);
 	return ret;
 };

--- a/com/win32comext/adsi/src/PyIDirectorySearch.i
+++ b/com/win32comext/adsi/src/PyIDirectorySearch.i
@@ -57,7 +57,7 @@ PyObject *PyIDirectorySearch::SetSearchPreference(PyObject *self, PyObject *args
 	Py_END_ALLOW_THREADS
 	PyObject *ret = NULL;
     for (i=0;i<numPrefs;i++)
-        PyList_SET_ITEM(retStatus, i, PyInt_FromLong(p[i].dwStatus));
+        PyList_SET_ITEM(retStatus, i, PyLong_FromLong(p[i].dwStatus));
     PyADSIObject_FreeADS_SEARCHPREF_INFOs(p, numPrefs);
     return Py_BuildValue("iN", _result, retStatus);
 }
@@ -133,7 +133,7 @@ PyObject *PyIDirectorySearch::GetNextRow(PyObject *self, PyObject *args) {
     if (FAILED(_result)) {
         return OleSetADSIError(_result, _swig_self,  SWIG_THIS_IID);
     }
-    return PyInt_FromLong(_result);
+    return PyLong_FromLong(_result);
 }
 %}
 %native(GetNextRow) GetNextRow;
@@ -158,7 +158,7 @@ PyObject *PyIDirectorySearch::GetFirstRow(PyObject *self, PyObject *args) {
     if (FAILED(_result)) {
         return OleSetADSIError(_result, _swig_self,  SWIG_THIS_IID);
     }
-    return PyInt_FromLong(_result);
+    return PyLong_FromLong(_result);
 }
 %}
 %native(GetFirstRow) GetFirstRow;
@@ -183,7 +183,7 @@ PyObject *PyIDirectorySearch::GetPreviousRow(PyObject *self, PyObject *args) {
     if (FAILED(_result)) {
         return OleSetADSIError(_result, _swig_self,  SWIG_THIS_IID);
     }
-    return PyInt_FromLong(_result);
+    return PyLong_FromLong(_result);
 }
 %}
 %native(GetPreviousRow) GetPreviousRow;

--- a/com/win32comext/authorization/src/PyGSecurityInformation.cpp
+++ b/com/win32comext/authorization/src/PyGSecurityInformation.cpp
@@ -277,7 +277,7 @@ STDMETHODIMP PyGSecurityInformation::MapGeneric(const GUID *pguidObjectType, UCH
     else {
         hr = InvokeViaPolicy("MapGeneric", &result, "OBk", obObjectType, *pAceFlags, *pMask);
         if (!FAILED(hr)) {
-            *pMask = PyInt_AsUnsignedLongMask(result);
+            *pMask = PyLong_AsUnsignedLongMask(result);
             if ((*pMask == -1) && PyErr_Occurred())
                 hr = MAKE_PYCOM_GATEWAY_FAILURE_CODE("MapGeneric");
             else

--- a/com/win32comext/axcontrol/src/AXControl.cpp
+++ b/com/win32comext/axcontrol/src/AXControl.cpp
@@ -377,7 +377,7 @@ static PyObject *axcontrol_OleTranslateAccelerator(PyObject *, PyObject *args)
         PyCom_BuildPyException(hr);
         goto done;
     }
-    ret = PyInt_FromLong(hr);
+    ret = PyLong_FromLong(hr);
 done:
     if (pframe)
         pframe->Release();

--- a/com/win32comext/axcontrol/src/PyIOleClientSite.cpp
+++ b/com/win32comext/axcontrol/src/PyIOleClientSite.cpp
@@ -159,7 +159,7 @@ STDMETHODIMP PyGOleClientSite::SaveObject(void)
     HRESULT hr = InvokeViaPolicy("SaveObject", &result);
     if (FAILED(hr))
         return hr;
-    hr = PyInt_AsLong(result);
+    hr = PyLong_AsLong(result);
     return hr;
 }
 

--- a/com/win32comext/axcontrol/src/PyIOleCommandTarget.cpp
+++ b/com/win32comext/axcontrol/src/PyIOleCommandTarget.cpp
@@ -185,7 +185,7 @@ STDMETHODIMP PyGOleCommandTarget::QueryStatus(
         Py_INCREF(Py_None);
     }
     else
-        obText = PyInt_FromLong(pCmdText->cmdtextf);
+        obText = PyLong_FromLong(pCmdText->cmdtextf);
     PyObject *result;
     HRESULT hr = InvokeViaPolicy("QueryStatus", &result, "NNN", obGUID, cmds, obText);
     if (FAILED(hr))

--- a/com/win32comext/axcontrol/src/PyIOleControlSite.cpp
+++ b/com/win32comext/axcontrol/src/PyIOleControlSite.cpp
@@ -121,7 +121,7 @@ PyObject *PyIOleControlSite::TranslateAccelerator(PyObject *self, PyObject *args
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIOCS, IID_IOleControlSite);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod |PyIOleControlSite|OnFocus|Description of OnFocus.

--- a/com/win32comext/axcontrol/src/PyIViewObject.cpp
+++ b/com/win32comext/axcontrol/src/PyIViewObject.cpp
@@ -242,7 +242,7 @@ STDMETHODIMP PyGViewObject::Draw(
     /* [in] */ ULONG_PTR dwContinue)
 {
     PY_GATEWAY_METHOD;
-    PyObject *obpvAspect = PyInt_FromLong(((DVASPECTINFO *)pvAspect)->dwFlags);
+    PyObject *obpvAspect = PyLong_FromLong(((DVASPECTINFO *)pvAspect)->dwFlags);
     if (obpvAspect == NULL)
         return PyCom_HandlePythonFailureToCOM();
     PyObject *obptd = PyObject_FromDVTARGETDEVICE(ptd);
@@ -283,7 +283,7 @@ STDMETHODIMP PyGViewObject::GetColorSet(
     /**
         if (ppColorSet==NULL) return E_POINTER;
         PY_GATEWAY_METHOD;
-        PyObject *obpvAspect = PyInt_FromLong(((DVASPECTINFO *)pvAspect)->dwFlags);
+        PyObject *obpvAspect = PyLong_FromLong(((DVASPECTINFO *)pvAspect)->dwFlags);
         if (obpvAspect==NULL) return PyCom_HandlePythonFailureToCOM();
 
         PyObject *obptd = PyObject_FromDVTARGETDEVICE(ptd);
@@ -305,7 +305,7 @@ STDMETHODIMP PyGViewObject::Freeze(
     /* [out] */ DWORD __RPC_FAR *pdwFreeze)
 {
     PY_GATEWAY_METHOD;
-    PyObject *obpvAspect = PyInt_FromLong(((DVASPECTINFO *)pvAspect)->dwFlags);
+    PyObject *obpvAspect = PyLong_FromLong(((DVASPECTINFO *)pvAspect)->dwFlags);
     if (obpvAspect == NULL)
         return PyCom_HandlePythonFailureToCOM();
     PyObject *result;

--- a/com/win32comext/axdebug/src/AXDebug.cpp
+++ b/com/win32comext/axdebug/src/AXDebug.cpp
@@ -198,7 +198,7 @@ static PyObject *SetThreadStateTrace(PyObject *self, PyObject *args)
     PyFrameObject *frame = state ? state->frame : NULL;
     bool bFoundFirstScriptBlock = false;
     while (frame) {
-        if (strncmp(PyString_AsString(frame->f_code->co_filename), "<Script ", 8) == 0)
+        if (strncmp(PyBytes_AsString(frame->f_code->co_filename), "<Script ", 8) == 0)
             bFoundFirstScriptBlock = true;
         else {
             if (bFoundFirstScriptBlock)

--- a/com/win32comext/axdebug/src/AXDebug.cpp
+++ b/com/win32comext/axdebug/src/AXDebug.cpp
@@ -74,7 +74,7 @@ BOOL PyAXDebug_PySOURCE_TEXT_ATTR_Length(PyObject *obAttr, ULONG *pLength)
             ok = FALSE;
             break;
         }
-        if (PyInt_Check(ob)) {
+        if (PyLong_Check(ob)) {
             ++attrLen;
         }
         else if (PySequence_Check(ob) && PySequence_Length(ob) == 2) {
@@ -82,7 +82,7 @@ BOOL PyAXDebug_PySOURCE_TEXT_ATTR_Length(PyObject *obAttr, ULONG *pLength)
             if (obRepeat == NULL)
                 ok = FALSE;
             else {
-                attrLen += PyInt_AsLong(obRepeat);
+                attrLen += PyLong_AsLong(obRepeat);
                 Py_DECREF(obRepeat);
             }
         }
@@ -110,8 +110,8 @@ BOOL PyAXDebug_PyObject_AsSOURCE_TEXT_ATTR(PyObject *obAttr, SOURCE_TEXT_ATTR *p
         for (DWORD i = 0; ok && i < seqLen; i++) {
             PyObject *ob = PySequence_GetItem(obAttr, i);
             if (ob) {
-                if (PyInt_Check(ob)) {
-                    pstaTextAttr[attrLen] = (SOURCE_TEXT_ATTR)PyInt_AsLong(ob);
+                if (PyLong_Check(ob)) {
+                    pstaTextAttr[attrLen] = (SOURCE_TEXT_ATTR)PyLong_AsLong(ob);
                     ++attrLen;
                 }
                 else if (PySequence_Check(ob) && PySequence_Length(ob) == 2) {
@@ -120,8 +120,8 @@ BOOL PyAXDebug_PyObject_AsSOURCE_TEXT_ATTR(PyObject *obAttr, SOURCE_TEXT_ATTR *p
                     if (obAttr == NULL || obRepeat == NULL)
                         ok = FALSE;
                     else {
-                        SOURCE_TEXT_ATTR attr = (SOURCE_TEXT_ATTR)PyInt_AsLong(obAttr);
-                        DWORD len = (DWORD)PyInt_AsLong(obRepeat);
+                        SOURCE_TEXT_ATTR attr = (SOURCE_TEXT_ATTR)PyLong_AsLong(obAttr);
+                        DWORD len = (DWORD)PyLong_AsLong(obRepeat);
                         if (attrLen + len <= numAttr) {
                             while (len--) pstaTextAttr[attrLen++] = attr;
                         }
@@ -152,7 +152,7 @@ PyObject *PyAXDebug_PyObject_FromSOURCE_TEXT_ATTR(const SOURCE_TEXT_ATTR *pstaTe
     PyObject *obattr = PyTuple_New(numAttr);
     if (obattr)
         for (ULONG i = 0; i < numAttr; i++) {
-            PyTuple_SET_ITEM(obattr, i, PyInt_FromLong(pstaTextAttr[i]));
+            PyTuple_SET_ITEM(obattr, i, PyLong_FromLong(pstaTextAttr[i]));
         }
     return obattr;
 }

--- a/com/win32comext/axdebug/src/PyIApplicationDebugger.cpp
+++ b/com/win32comext/axdebug/src/PyIApplicationDebugger.cpp
@@ -30,7 +30,7 @@ PyObject *PyIApplicationDebugger::QueryAlive(PyObject *self, PyObject *args)
     PY_INTERFACE_PRECALL;
     HRESULT hr = pIAD->QueryAlive();
     PY_INTERFACE_POSTCALL;
-    return PyInt_FromLong(hr == S_OK);
+    return PyLong_FromLong(hr == S_OK);
 }
 
 // @pymethod |PyIApplicationDebugger|CreateInstanceAtDebugger|Create objects in the application process address space.

--- a/com/win32comext/axdebug/src/PyIDebugApplication.cpp
+++ b/com/win32comext/axdebug/src/PyIDebugApplication.cpp
@@ -317,7 +317,7 @@ PyObject *PyIDebugApplication::QueryCurrentThreadIsDebuggerThread(PyObject *self
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return SetPythonCOMError(self, hr);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
     // @rdesc Returns S_OK if the current running thread is the debugger thread.
     // Otherwise, returns S_FALSE.
 }

--- a/com/win32comext/axdebug/src/PyIDebugProperties.cpp
+++ b/com/win32comext/axdebug/src/PyIDebugProperties.cpp
@@ -49,7 +49,7 @@ PyObject *PyObject_FromDebugPropertyInfo(const DebugPropertyInfo *p)
         SET_INC_NONE(ob);
     PyTuple_SET_ITEM(obRet, 3, ob);
     if (p->m_dwValidFields & DBGPROP_INFO_ATTRIBUTES) {
-        ob = PyInt_FromLong(p->m_dwAttrib);
+        ob = PyLong_FromLong(p->m_dwAttrib);
         if (ob == NULL)
             goto error;
     }
@@ -136,8 +136,8 @@ BOOL PyObject_AsDebugPropertyInfo(PyObject *ob, DebugPropertyInfo *p)
         goto error;
     if (thisOb == Py_None)
         ;
-    else if (PyInt_Check(thisOb)) {
-        p->m_dwAttrib = PyInt_AsLong(thisOb);
+    else if (PyLong_Check(thisOb)) {
+        p->m_dwAttrib = PyLong_AsLong(thisOb);
         p->m_dwValidFields |= DBGPROP_INFO_ATTRIBUTES;
     }
     else {

--- a/com/win32comext/axdebug/src/PyIEnumDebugPropertyInfo.cpp
+++ b/com/win32comext/axdebug/src/PyIEnumDebugPropertyInfo.cpp
@@ -150,7 +150,7 @@ PyObject *PyIEnumDebugPropertyInfo::GetCount(PyObject *self, PyObject *args)
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIEDebugPropertyInfo, IID_IEnumDebugPropertyInfo);
 
-    return PyInt_FromLong(ret);
+    return PyLong_FromLong(ret);
 }
 
 // @object PyIEnumDebugPropertyInfo|A Python interface to IEnumDebugPropertyInfo
@@ -286,7 +286,7 @@ STDMETHODIMP PyGEnumDebugPropertyInfo::GetCount(
     HRESULT hr = InvokeViaPolicy("GetCount", &result);
     if (FAILED(hr))
         return hr;
-    *pcelt = PyInt_AsLong(result);
+    *pcelt = PyLong_AsLong(result);
     Py_DECREF(result);
     return PyCom_SetCOMErrorFromPyException(IID_IEnumDebugPropertyInfo);
 }

--- a/com/win32comext/axdebug/src/PyIRemoteDebugApplication.cpp
+++ b/com/win32comext/axdebug/src/PyIRemoteDebugApplication.cpp
@@ -189,7 +189,7 @@ PyObject *PyIRemoteDebugApplication::QueryAlive(PyObject *self, PyObject *args)
     PY_INTERFACE_PRECALL;
     HRESULT hr = pIRDA->QueryAlive();
     PY_INTERFACE_POSTCALL;
-    return PyInt_FromLong(hr == S_OK);
+    return PyLong_FromLong(hr == S_OK);
 }
 
 // @pymethod <o PyIEnumRemoteDebugApplicationThreads>|PyIRemoteDebugApplication|EnumThreads|Enumerates all threads known

--- a/com/win32comext/axscript/src/AXScript.cpp
+++ b/com/win32comext/axscript/src/AXScript.cpp
@@ -89,7 +89,7 @@ static struct PyMethodDef axcom_methods[] = {{NULL, NULL}};
 
 static int AddConstant(PyObject *dict, const char *key, long value)
 {
-    PyObject *oval = PyInt_FromLong(value);
+    PyObject *oval = PyLong_FromLong(value);
     if (!oval) {
         return 1;
     }

--- a/com/win32comext/axscript/src/PyGActiveScript.cpp
+++ b/com/win32comext/axscript/src/PyGActiveScript.cpp
@@ -50,8 +50,8 @@ STDMETHODIMP PyGActiveScript::GetScriptState(
     HRESULT hr = InvokeViaPolicy("GetScriptState", &result, NULL);
     if (FAILED(hr))
         return hr;
-    if (result && PyInt_Check(result))
-        *pssState = (SCRIPTSTATE)PyInt_AsLong(result);
+    if (result && PyLong_Check(result))
+        *pssState = (SCRIPTSTATE)PyLong_AsLong(result);
     Py_XDECREF(result);
     return hr;
 }
@@ -116,8 +116,8 @@ STDMETHODIMP PyGActiveScript::GetCurrentScriptThreadID(
     if (FAILED(hr))
         return hr;
 
-    if (PyInt_Check(result)) {
-        *pstidThread = PyInt_AsLong(result);
+    if (PyLong_Check(result)) {
+        *pstidThread = PyLong_AsLong(result);
         if (PyErr_Occurred())
             hr = PyCom_SetCOMErrorFromPyException(GetIID());
     }
@@ -137,8 +137,8 @@ STDMETHODIMP PyGActiveScript::GetScriptThreadID(
     HRESULT hr = InvokeViaPolicy("GetScriptThreadID", &result, "i", dwWin32ThreadId);
     if (FAILED(hr))
         return hr;
-    if (PyInt_Check(result)) {
-        *pstidThread = PyInt_AsLong(result);
+    if (PyLong_Check(result)) {
+        *pstidThread = PyLong_AsLong(result);
         if (PyErr_Occurred())
             hr = PyCom_SetCOMErrorFromPyException(GetIID());
     }
@@ -157,8 +157,8 @@ STDMETHODIMP PyGActiveScript::GetScriptThreadState(
 
     if (FAILED(hr))
         return hr;
-    if (PyInt_Check(result)) {
-        *pstsState = (SCRIPTTHREADSTATE)PyInt_AsLong(result);
+    if (PyLong_Check(result)) {
+        *pstsState = (SCRIPTTHREADSTATE)PyLong_AsLong(result);
         if (PyErr_Occurred())
             hr = PyCom_HandlePythonFailureToCOM();
     }

--- a/com/win32comext/axscript/src/PyGActiveScriptSite.cpp
+++ b/com/win32comext/axscript/src/PyGActiveScriptSite.cpp
@@ -12,7 +12,7 @@ STDMETHODIMP PyGActiveScriptSite::GetLCID(
     if (FAILED(hr))
         return hr;
 
-    *plcid = PyInt_AsLong(result);
+    *plcid = PyLong_AsLong(result);
     Py_DECREF(result);
     return PyCom_HandlePythonFailureToCOM();
 }
@@ -160,7 +160,7 @@ STDMETHODIMP PyGActiveScriptSite::OnScriptError(
     if (result == Py_None)
         hr = S_OK;
     else {
-        hr = PyInt_AsLong(result);
+        hr = PyLong_AsLong(result);
         if (hr == -1 && PyErr_Occurred())
             hr = PyCom_HandlePythonFailureToCOM();
     }

--- a/com/win32comext/axscript/src/PyIActiveScriptSite.cpp
+++ b/com/win32comext/axscript/src/PyIActiveScriptSite.cpp
@@ -29,7 +29,7 @@ PyObject *PyIActiveScriptSite::GetLCID(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(sc))
         return SetPythonCOMError(self, sc);
-    return PyInt_FromLong(lcid);
+    return PyLong_FromLong(lcid);
 }
 
 // @pymethod int|PyIActiveScriptSite|GetItemInfo|
@@ -171,7 +171,7 @@ PyObject *PyIActiveScriptSite::OnScriptError(PyObject *self, PyObject *args)
     PyWin_MakePendingCalls();
     if (sc != E_FAIL && FAILED(sc))  // E_FAIL is documented as a normal retval.
         return SetPythonCOMError(self, sc);
-    return PyInt_FromLong(sc);
+    return PyLong_FromLong(sc);
 }
 
 // @pymethod int|PyIActiveScriptSite|OnScriptTerminate|
@@ -209,7 +209,7 @@ PyObject *PyIActiveScriptSite::OnScriptTerminate(PyObject *self, PyObject *args)
         VariantClear(pVarResult);
     if (FAILED(sc))
         return SetPythonCOMError(self, sc);
-    return PyInt_FromLong(sc);
+    return PyLong_FromLong(sc);
 }
 
 // @object PyIActiveScriptSite|An object providing the IActiveScriptSite interface

--- a/com/win32comext/axscript/src/PyIMultiInfos.cpp
+++ b/com/win32comext/axscript/src/PyIMultiInfos.cpp
@@ -32,7 +32,7 @@ PyObject *PyIProvideMultipleClassInfo::GetMultiTypeInfoCount(PyObject *self, PyO
     PY_INTERFACE_POSTCALL;
     if (FAILED(sc))
         return SetPythonCOMError(self, sc);
-    return PyInt_FromLong(num);
+    return PyLong_FromLong(num);
 }
 
 // @pymethod (various - depends on flags param)|PyIProvideMultipleClassInfo|GetInfoOfIndex|
@@ -66,7 +66,7 @@ PyObject *PyIProvideMultipleClassInfo::GetInfoOfIndex(PyObject *self, PyObject *
         PY_INTERFACE_POSTCALL;
         if (FAILED(sc))
             return SetPythonCOMError(self, sc);
-        return PyInt_FromLong(reserved);
+        return PyLong_FromLong(reserved);
     }
     if (flags == MULTICLASSINFO_GETIIDPRIMARY) {
         IID iid;

--- a/com/win32comext/bits/src/PyIBackgroundCopyJob.cpp
+++ b/com/win32comext/bits/src/PyIBackgroundCopyJob.cpp
@@ -108,7 +108,7 @@ PyObject *PyIBackgroundCopyJob::Suspend(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIBCJ, IID_IBackgroundCopyJob);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod |PyIBackgroundCopyJob|Resume|Description of Resume.
@@ -125,7 +125,7 @@ PyObject *PyIBackgroundCopyJob::Resume(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIBCJ, IID_IBackgroundCopyJob);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod |PyIBackgroundCopyJob|Cancel|Description of Cancel.
@@ -142,7 +142,7 @@ PyObject *PyIBackgroundCopyJob::Cancel(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIBCJ, IID_IBackgroundCopyJob);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod |PyIBackgroundCopyJob|Complete|Description of Complete.
@@ -161,7 +161,7 @@ PyObject *PyIBackgroundCopyJob::Complete(PyObject *self, PyObject *args)
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIBCJ, IID_IBackgroundCopyJob);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod |PyIBackgroundCopyJob|GetId|Description of GetId.
@@ -195,7 +195,7 @@ PyObject *PyIBackgroundCopyJob::GetType(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIBCJ, IID_IBackgroundCopyJob);
-    return PyInt_FromLong(val);
+    return PyLong_FromLong(val);
 }
 
 // @pymethod |PyIBackgroundCopyJob|GetProgress|Description of GetProgress.
@@ -415,7 +415,7 @@ PyObject *PyIBackgroundCopyJob::GetPriority(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIBCJ, IID_IBackgroundCopyJob);
-    return PyInt_FromLong(val);
+    return PyLong_FromLong(val);
 }
 
 // @pymethod |PyIBackgroundCopyJob|SetNotifyFlags|Description of SetNotifyFlags.
@@ -667,7 +667,7 @@ PyObject *PyIBackgroundCopyJob::TakeOwnership(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIBCJ, IID_IBackgroundCopyJob);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @object PyIBackgroundCopyJob|Description of the interface

--- a/com/win32comext/bits/src/PyIBackgroundCopyJob2.cpp
+++ b/com/win32comext/bits/src/PyIBackgroundCopyJob2.cpp
@@ -117,7 +117,7 @@ PyObject *PyIBackgroundCopyJob2::GetReplyData(PyObject *self, PyObject *args)
     }
     else {
         // MS docs the max size is 1MB - so why use an int64?
-        ret = PyString_FromStringAndSize((char *)pBuffer, (Py_ssize_t)length);
+        ret = PyBytes_FromStringAndSize((char *)pBuffer, (Py_ssize_t)length);
         CoTaskMemFree(pBuffer);
     }
     return ret;

--- a/com/win32comext/bits/src/PyIBackgroundCopyJob3.cpp
+++ b/com/win32comext/bits/src/PyIBackgroundCopyJob3.cpp
@@ -48,7 +48,7 @@ PyObject *PyIBackgroundCopyJob3::ReplaceRemotePrefix(PyObject *self, PyObject *a
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIBCJ3, IID_IBackgroundCopyJob3);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod |PyIBackgroundCopyJob3|AddFileWithRanges|Description of AddFileWithRanges.
@@ -87,7 +87,7 @@ PyObject *PyIBackgroundCopyJob3::AddFileWithRanges(PyObject *self, PyObject *arg
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIBCJ3, IID_IBackgroundCopyJob3);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod |PyIBackgroundCopyJob3|SetFileACLFlags|Description of SetFileACLFlags.
@@ -106,7 +106,7 @@ PyObject *PyIBackgroundCopyJob3::SetFileACLFlags(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIBCJ3, IID_IBackgroundCopyJob3);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod |PyIBackgroundCopyJob3|GetFileACLFlags|Description of GetFileACLFlags.

--- a/com/win32comext/directsound/src/PyIDirectSound.cpp
+++ b/com/win32comext/directsound/src/PyIDirectSound.cpp
@@ -222,7 +222,7 @@ PyObject *PyIDirectSound::GetSpeakerConfig(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    return PyInt_FromLong(config);
+    return PyLong_FromLong(config);
 }
 
 // @pymethod |PyIDirectSound|SetSpeakerConfig|The SetSpeakerConfig method specifies the speaker configuration of the

--- a/com/win32comext/directsound/src/PyIDirectSoundBuffer.cpp
+++ b/com/win32comext/directsound/src/PyIDirectSoundBuffer.cpp
@@ -339,7 +339,7 @@ PyObject *PyIDirectSoundBuffer::Update(PyObject *self, PyObject *args)
     DWORD dwAudioBytes2 = 0;
 
     PY_INTERFACE_PRECALL;
-    hr = pIDSB->Lock(dwWriteCursor, PyString_Size(obData), &lpAudioPtr1, &dwAudioBytes1, &lpAudioPtr2, &dwAudioBytes2,
+    hr = pIDSB->Lock(dwWriteCursor, PyBytes_Size(obData), &lpAudioPtr1, &dwAudioBytes1, &lpAudioPtr2, &dwAudioBytes2,
                      dwFlags);
     PY_INTERFACE_POSTCALL;
 
@@ -353,7 +353,7 @@ PyObject *PyIDirectSoundBuffer::Update(PyObject *self, PyObject *args)
 
     // Raise error if assumption isn't met
 
-    if (dwAudioBytes1 + dwAudioBytes2 != (DWORD)PyString_Size(obData)) {
+    if (dwAudioBytes1 + dwAudioBytes2 != (DWORD)PyBytes_Size(obData)) {
         PY_INTERFACE_PRECALL;
         hr = pIDSB->Unlock(lpAudioPtr1, dwAudioBytes1, lpAudioPtr2, dwAudioBytes2);
         PY_INTERFACE_POSTCALL;
@@ -363,9 +363,9 @@ PyObject *PyIDirectSoundBuffer::Update(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    memcpy(lpAudioPtr1, PyString_AsString(obData), dwAudioBytes1);
+    memcpy(lpAudioPtr1, PyBytes_AsString(obData), dwAudioBytes1);
     if (dwAudioBytes2) {
-        memcpy(lpAudioPtr2, PyString_AsString(obData) + dwAudioBytes1, dwAudioBytes2);
+        memcpy(lpAudioPtr2, PyBytes_AsString(obData) + dwAudioBytes1, dwAudioBytes2);
     }
 
     {

--- a/com/win32comext/directsound/src/PyIDirectSoundBuffer.cpp
+++ b/com/win32comext/directsound/src/PyIDirectSoundBuffer.cpp
@@ -126,7 +126,7 @@ PyObject *PyIDirectSoundBuffer::GetStatus(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    return PyInt_FromLong(dwStatus);
+    return PyLong_FromLong(dwStatus);
 }
 
 // @pymethod |PyIDirectSoundBuffer|SetFormat|Sets the format of the primary sound buffer for the application. Whenever
@@ -243,8 +243,8 @@ PyObject *PyIDirectSoundBuffer::GetCurrentPosition(PyObject *self, PyObject *arg
     if (!result)
         return NULL;
 
-    PyTuple_SetItem(result, 0, PyInt_FromLong(dwPlay));
-    PyTuple_SetItem(result, 1, PyInt_FromLong(dwWrite));
+    PyTuple_SetItem(result, 0, PyLong_FromLong(dwPlay));
+    PyTuple_SetItem(result, 1, PyLong_FromLong(dwWrite));
 
     return result;
 }
@@ -404,7 +404,7 @@ PyObject *PyIDirectSoundBuffer::GetFrequency(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    return PyInt_FromLong(dwFrequency);
+    return PyLong_FromLong(dwFrequency);
 }
 
 // @pymethod |PyIDirectSoundBuffer|GetPan|Description of GetPan.
@@ -427,7 +427,7 @@ PyObject *PyIDirectSoundBuffer::GetPan(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    return PyInt_FromLong(pan);
+    return PyLong_FromLong(pan);
 }
 
 // @pymethod |PyIDirectSoundBuffer|GetVolume|Description of GetVolume.
@@ -450,7 +450,7 @@ PyObject *PyIDirectSoundBuffer::GetVolume(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    return PyInt_FromLong(pan);
+    return PyLong_FromLong(pan);
 }
 
 // @pymethod |PyIDirectSoundBuffer|SetFrequency|Description of SetFrequency.

--- a/com/win32comext/directsound/src/PyIDirectSoundCaptureBuffer.cpp
+++ b/com/win32comext/directsound/src/PyIDirectSoundCaptureBuffer.cpp
@@ -291,15 +291,15 @@ PyObject *PyIDirectSoundCaptureBuffer::Update(PyObject *self, PyObject *args)
     // The capture buffer is circular, so we may get two pointers and have to
     // do the wrap-around ourselves.
 
-    PyObject *obData = PyString_FromStringAndSize((char *)lpAudioPtr1, dwAudioBytes1);
+    PyObject *obData = PyBytes_FromStringAndSize((char *)lpAudioPtr1, dwAudioBytes1);
     if (!obData) {
         PyErr_SetString(PyExc_MemoryError, "Update: could not allocate result string");
         goto error;
     }
     if (lpAudioPtr2) {
-        PyObject *obData2 = PyString_FromStringAndSize((char *)lpAudioPtr2, dwAudioBytes2);
+        PyObject *obData2 = PyBytes_FromStringAndSize((char *)lpAudioPtr2, dwAudioBytes2);
 
-        PyString_Concat(&obData, obData2);
+        PyBytes_Concat(&obData, obData2);
 
         if (!obData) {
             PyErr_SetString(PyExc_MemoryError, "Update: could not append to result string");

--- a/com/win32comext/directsound/src/PyIDirectSoundCaptureBuffer.cpp
+++ b/com/win32comext/directsound/src/PyIDirectSoundCaptureBuffer.cpp
@@ -129,7 +129,7 @@ PyObject *PyIDirectSoundCaptureBuffer::GetStatus(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    return PyInt_FromLong(dwStatus);
+    return PyLong_FromLong(dwStatus);
 }
 
 // @pymethod |PyIDirectSoundCaptureBuffer|Initialize|Not normally used. Used IDirectSoundCapture.CreateCaptureBuffer
@@ -194,8 +194,8 @@ PyObject *PyIDirectSoundCaptureBuffer::GetCurrentPosition(PyObject *self, PyObje
     if (!result)
         return NULL;
 
-    PyTuple_SetItem(result, 0, PyInt_FromLong(dwCapture));
-    PyTuple_SetItem(result, 1, PyInt_FromLong(dwRead));
+    PyTuple_SetItem(result, 0, PyLong_FromLong(dwCapture));
+    PyTuple_SetItem(result, 1, PyLong_FromLong(dwRead));
 
     return result;
 }

--- a/com/win32comext/directsound/src/PyIDirectSoundNotify.cpp
+++ b/com/win32comext/directsound/src/PyIDirectSoundNotify.cpp
@@ -35,10 +35,10 @@ static BOOL unpack(PyObject *tuple, DSBPOSITIONNOTIFY *&notify, int pos)
     PyObject *o0 = PyTuple_GET_ITEM(tuple, 0);
     PyObject *o1 = PyTuple_GET_ITEM(tuple, 1);
 
-    if (!o0 || !PyInt_Check(o0) || !o1 || !PyHANDLE_Check(o1))
+    if (!o0 || !PyLong_Check(o0) || !o1 || !PyHANDLE_Check(o1))
         return FALSE;
 
-    notify[pos].dwOffset = PyInt_AS_LONG(o0);
+    notify[pos].dwOffset = PyLong_AS_LONG(o0);
     if (!PyWinObject_AsHANDLE(o1, &notify[pos].hEventNotify))
         return FALSE;
 

--- a/com/win32comext/ifilter/src/PyIFilter.cpp
+++ b/com/win32comext/ifilter/src/PyIFilter.cpp
@@ -240,7 +240,7 @@ static PyObject *pyBindIFilterFromStream(PyObject *self, PyObject *args)
 
 static int AddConstant(PyObject *dict, const char *key, long value)
 {
-    PyObject *oval = PyInt_FromLong(value);
+    PyObject *oval = PyLong_FromLong(value);
     if (!oval) {
         return 1;
     }

--- a/com/win32comext/internet/src/PyIDocHostUIHandler.cpp
+++ b/com/win32comext/internet/src/PyIDocHostUIHandler.cpp
@@ -57,7 +57,7 @@ PyObject *PyIDocHostUIHandler::ShowContextMenu(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIDHUIH, IID_IDocHostUIHandler);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod |PyIDocHostUIHandler|GetHostInfo|Description of GetHostInfo.
@@ -132,7 +132,7 @@ PyObject *PyIDocHostUIHandler::ShowUI(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIDHUIH, IID_IDocHostUIHandler);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod |PyIDocHostUIHandler|HideUI|Description of HideUI.
@@ -149,7 +149,7 @@ PyObject *PyIDocHostUIHandler::HideUI(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIDHUIH, IID_IDocHostUIHandler);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod |PyIDocHostUIHandler|UpdateUI|Description of UpdateUI.
@@ -166,7 +166,7 @@ PyObject *PyIDocHostUIHandler::UpdateUI(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIDHUIH, IID_IDocHostUIHandler);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod |PyIDocHostUIHandler|EnableModeless|Description of EnableModeless.
@@ -185,7 +185,7 @@ PyObject *PyIDocHostUIHandler::EnableModeless(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIDHUIH, IID_IDocHostUIHandler);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod |PyIDocHostUIHandler|OnDocWindowActivate|Description of OnDocWindowActivate.
@@ -204,7 +204,7 @@ PyObject *PyIDocHostUIHandler::OnDocWindowActivate(PyObject *self, PyObject *arg
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIDHUIH, IID_IDocHostUIHandler);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod |PyIDocHostUIHandler|OnFrameWindowActivate|Description of OnFrameWindowActivate.
@@ -223,7 +223,7 @@ PyObject *PyIDocHostUIHandler::OnFrameWindowActivate(PyObject *self, PyObject *a
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIDHUIH, IID_IDocHostUIHandler);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod |PyIDocHostUIHandler|ResizeBorder|Description of ResizeBorder.
@@ -253,7 +253,7 @@ PyObject *PyIDocHostUIHandler::ResizeBorder(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIDHUIH, IID_IDocHostUIHandler);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod |PyIDocHostUIHandler|TranslateAccelerator|Description of TranslateAccelerator.
@@ -285,7 +285,7 @@ PyObject *PyIDocHostUIHandler::TranslateAccelerator(PyObject *self, PyObject *ar
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIDHUIH, IID_IDocHostUIHandler);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod |PyIDocHostUIHandler|GetOptionKeyPath|Description of GetOptionKeyPath.

--- a/com/win32comext/internet/src/PyIInternetProtocol.cpp
+++ b/com/win32comext/internet/src/PyIInternetProtocol.cpp
@@ -41,7 +41,7 @@ PyObject *PyIInternetProtocol::Read(PyObject *self, PyObject *args)
         return OleSetOleError(hr);
     }
 
-    PyObject *pyretval = PyString_FromStringAndSize((char *)pv, pcbRead);
+    PyObject *pyretval = PyBytes_FromStringAndSize((char *)pv, pcbRead);
     free(pv);
     return pyretval;
 }
@@ -172,13 +172,13 @@ STDMETHODIMP PyGInternetProtocol::Read(
     if (FAILED(hr))
         return hr;
     // Process the Python results, and convert back to the real params
-    if (!PyString_Check(result)) {
+    if (!PyBytes_Check(result)) {
         PyErr_SetString(PyExc_TypeError, "IInternetProtocol::Read must return a string object");
         hr = PyCom_HandlePythonFailureToCOM();
     }
     else {
-        char *buf = PyString_AsString(result);
-        *pcbRead = min(cb, (ULONG)PyString_Size(result));
+        char *buf = PyBytes_AsString(result);
+        *pcbRead = min(cb, (ULONG)PyBytes_Size(result));
         memcpy(pv, buf, *pcbRead);
     }
     return hr;

--- a/com/win32comext/internet/src/PyIInternetProtocolInfo.cpp
+++ b/com/win32comext/internet/src/PyIInternetProtocolInfo.cpp
@@ -187,7 +187,7 @@ PyObject *PyIInternetProtocolInfo::QueryInfo(PyObject *self, PyObject *args)
             free(pFreeBuf);
         return OleSetOleError(hr);
     }
-    PyObject *rc = pFreeBuf == NULL ? PyInt_FromLong(dwBuf) : PyString_FromStringAndSize((char *)pBuffer, pcbBuf);
+    PyObject *rc = pFreeBuf == NULL ? PyInt_FromLong(dwBuf) : PyBytes_FromStringAndSize((char *)pBuffer, pcbBuf);
     if (pFreeBuf)
         free(pFreeBuf);
     return rc;
@@ -313,7 +313,7 @@ STDMETHODIMP PyGInternetProtocolInfo::QueryInfo(
     Py_XDECREF(obpwzUrl);
     if (FAILED(hr))
         return hr;
-    if (!PyString_Check(result)) {
+    if (!PyBytes_Check(result)) {
         if (PyInt_Check(result)) {
             if (cbBuffer != sizeof(DWORD)) {
                 PyErr_SetString(PyExc_TypeError,
@@ -332,8 +332,8 @@ STDMETHODIMP PyGInternetProtocolInfo::QueryInfo(
         }
     }
     else {
-        *pcbBuf = min(cbBuffer, (ULONG)PyString_Size(result));
-        memcpy(pBuffer, PyString_AsString(result), *pcbBuf);
+        *pcbBuf = min(cbBuffer, (ULONG)PyBytes_Size(result));
+        memcpy(pBuffer, PyBytes_AsString(result), *pcbBuf);
     }
     Py_DECREF(result);
     return hr;

--- a/com/win32comext/internet/src/PyIInternetProtocolInfo.cpp
+++ b/com/win32comext/internet/src/PyIInternetProtocolInfo.cpp
@@ -187,7 +187,7 @@ PyObject *PyIInternetProtocolInfo::QueryInfo(PyObject *self, PyObject *args)
             free(pFreeBuf);
         return OleSetOleError(hr);
     }
-    PyObject *rc = pFreeBuf == NULL ? PyInt_FromLong(dwBuf) : PyBytes_FromStringAndSize((char *)pBuffer, pcbBuf);
+    PyObject *rc = pFreeBuf == NULL ? PyLong_FromLong(dwBuf) : PyBytes_FromStringAndSize((char *)pBuffer, pcbBuf);
     if (pFreeBuf)
         free(pFreeBuf);
     return rc;
@@ -314,7 +314,7 @@ STDMETHODIMP PyGInternetProtocolInfo::QueryInfo(
     if (FAILED(hr))
         return hr;
     if (!PyBytes_Check(result)) {
-        if (PyInt_Check(result)) {
+        if (PyLong_Check(result)) {
             if (cbBuffer != sizeof(DWORD)) {
                 PyErr_SetString(PyExc_TypeError,
                                 "IInternetProtocolInfo::QueryInfo can return an integer only when sizeof(int) bytes "
@@ -322,7 +322,7 @@ STDMETHODIMP PyGInternetProtocolInfo::QueryInfo(
                 return PyCom_HandlePythonFailureToCOM();
             }
             *pcbBuf = sizeof(DWORD);
-            *((DWORD *)pBuffer) = PyInt_AsLong(result);
+            *((DWORD *)pBuffer) = PyLong_AsLong(result);
         }
         else {
             PyErr_SetString(

--- a/com/win32comext/internet/src/PyIInternetSecurityManager.cpp
+++ b/com/win32comext/internet/src/PyIInternetSecurityManager.cpp
@@ -85,7 +85,7 @@ PyObject *PyIInternetSecurityManager::MapUrlToZone(PyObject *self, PyObject *arg
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIISM, IID_IInternetSecurityManager);
-    return PyInt_FromLong(pdwZone);
+    return PyLong_FromLong(pdwZone);
 }
 
 // @pymethod |PyIInternetSecurityManager|GetSecurityId|Description of GetSecurityId.
@@ -373,7 +373,7 @@ STDMETHODIMP PyGInternetSecurityManager::ProcessUrlAction(
         return hr;
     // Process the Python results, and convert back to the real params
     if (cbPolicy == sizeof(DWORD)) {
-        *((DWORD *)pPolicy) = PyInt_AsLong(result);
+        *((DWORD *)pPolicy) = PyLong_AsLong(result);
         if (*((DWORD *)pPolicy) == -1)
             hr = MAKE_PYCOM_GATEWAY_FAILURE_CODE("ProcessUrlAction");
     }

--- a/com/win32comext/internet/src/PyIInternetSecurityManager.cpp
+++ b/com/win32comext/internet/src/PyIInternetSecurityManager.cpp
@@ -115,7 +115,7 @@ PyObject *PyIInternetSecurityManager::GetSecurityId(PyObject *self, PyObject *ar
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIISM, IID_IInternetSecurityManager);
-    return PyString_FromStringAndSize((char *)buf, cbSecurityId);
+    return PyBytes_FromStringAndSize((char *)buf, cbSecurityId);
 }
 
 // @pymethod |PyIInternetSecurityManager|ProcessUrlAction|Description of ProcessUrlAction.
@@ -363,7 +363,7 @@ STDMETHODIMP PyGInternetSecurityManager::ProcessUrlAction(
         Py_INCREF(Py_None);
     }
     else
-        obContext = PyString_FromStringAndSize((char *)pContext, cbContext);
+        obContext = PyBytes_FromStringAndSize((char *)pContext, cbContext);
     PyObject *result;
     HRESULT hr =
         InvokeViaPolicy("ProcessUrlAction", &result, "OlOll", obpwszUrl, dwAction, obContext, dwFlags, dwReserved);

--- a/com/win32comext/internet/src/internet.cpp
+++ b/com/win32comext/internet/src/internet.cpp
@@ -133,17 +133,17 @@ PyObject *PyObject_FromBINDINFO(BINDINFO *pPD)
     PyTuple_SET_ITEM(obRet, 0, PyWinObject_FromWCHAR(pPD->szExtraInfo));
     Py_INCREF(Py_None);
     PyTuple_SET_ITEM(obRet, 1, Py_None);  // STGMEDUIM not yet supported.
-    PyTuple_SET_ITEM(obRet, 2, PyInt_FromLong(pPD->grfBindInfoF));
-    PyTuple_SET_ITEM(obRet, 3, PyInt_FromLong(pPD->dwBindVerb));
+    PyTuple_SET_ITEM(obRet, 2, PyLong_FromLong(pPD->grfBindInfoF));
+    PyTuple_SET_ITEM(obRet, 3, PyLong_FromLong(pPD->dwBindVerb));
     PyTuple_SET_ITEM(obRet, 4, PyWinObject_FromWCHAR(pPD->szCustomVerb));
     if (bNewFormat) {
-        PyTuple_SET_ITEM(obRet, 5, PyInt_FromLong(pPD->dwOptions));
-        PyTuple_SET_ITEM(obRet, 6, PyInt_FromLong(pPD->dwOptionsFlags));
-        PyTuple_SET_ITEM(obRet, 7, PyInt_FromLong(pPD->dwCodePage));
+        PyTuple_SET_ITEM(obRet, 5, PyLong_FromLong(pPD->dwOptions));
+        PyTuple_SET_ITEM(obRet, 6, PyLong_FromLong(pPD->dwOptionsFlags));
+        PyTuple_SET_ITEM(obRet, 7, PyLong_FromLong(pPD->dwCodePage));
         PyTuple_SET_ITEM(obRet, 8, PyWinObject_FromSECURITY_ATTRIBUTES(pPD->securityAttributes));
         PyTuple_SET_ITEM(obRet, 9, PyWinObject_FromIID(pPD->iid));
         PyTuple_SET_ITEM(obRet, 10, PyCom_PyObjectFromIUnknown(pPD->pUnk, pPD->iid, /*bAddRef = */ TRUE));
-        PyTuple_SET_ITEM(obRet, 11, PyInt_FromLong(pPD->dwReserved));
+        PyTuple_SET_ITEM(obRet, 11, PyLong_FromLong(pPD->dwReserved));
     }
     return obRet;
 }
@@ -184,7 +184,7 @@ static PyObject *PyCoInternetSetFeatureEnabled(PyObject *self, PyObject *args)
     HRESULT hr = (*pfnCoInternetSetFeatureEnabled)((INTERNETFEATURELIST)featureEntry, flags, enable);
     if (FAILED(hr))
         return PyCom_BuildPyException(hr);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod <o PyIInternetSecurityManager>|internet|CoInternetCreateSecurityManager|
@@ -222,7 +222,7 @@ static struct PyMethodDef internet_functions[] = {
 
 static int AddConstant(PyObject *dict, const char *key, long value)
 {
-    PyObject *oval = PyInt_FromLong(value);
+    PyObject *oval = PyLong_FromLong(value);
     if (!oval) {
         return 1;
     }

--- a/com/win32comext/mapi/src/PyIAddrBook.i
+++ b/com/win32comext/mapi/src/PyIAddrBook.i
@@ -119,7 +119,7 @@ PyObject *PyIAddrBook::CompareEntryIDs(PyObject *self, PyObject *args)
 	if (FAILED(hr))
 		rc =  OleSetOleError(hr);
 	else
-		rc = PyInt_FromLong(ulResult);
+		rc = PyLong_FromLong(ulResult);
 done:
 	PyWinObject_FreeString((char *)peid1);
 	PyWinObject_FreeString((char *)peid2);

--- a/com/win32comext/mapi/src/PyIAddrBook.i
+++ b/com/win32comext/mapi/src/PyIAddrBook.i
@@ -60,9 +60,9 @@ PyObject *PyIAddrBook::OpenEntry(PyObject *self, PyObject *args)
 	if (obEntry==Py_None) {
 		entryString = NULL;
 		entryStrLen = 0;
-	} else if (PyString_Check(obEntry)) {
-		entryString = PyString_AsString(obEntry);
-		entryStrLen = PyString_Size(obEntry);
+	} else if (PyBytes_Check(obEntry)) {
+		entryString = PyBytes_AsString(obEntry);
+		entryStrLen = PyBytes_Size(obEntry);
 	} else {
 		PyErr_SetString(PyExc_TypeError, "EntryID must be a string or None");
 		return NULL;

--- a/com/win32comext/mapi/src/PyIMAPIAdviseSink.cpp
+++ b/com/win32comext/mapi/src/PyIMAPIAdviseSink.cpp
@@ -40,7 +40,7 @@ PyObject *PyObject_FromNOTIFICATION(NOTIFICATION *n)
             NEWMAIL_NOTIFICATION &newmail = n->info.newmail;
             PyObject *msg_class = newmail.ulFlags & MAPI_UNICODE
                                       ? PyWinObject_FromWCHAR((const WCHAR *)newmail.lpszMessageClass)
-                                      : PyString_FromString((const char *)newmail.lpszMessageClass);
+                                      : PyBytes_FromString((const char *)newmail.lpszMessageClass);
             if (!msg_class)
                 return NULL;
             ret = Py_BuildValue(

--- a/com/win32comext/mapi/src/PyIMAPIContainer.i
+++ b/com/win32comext/mapi/src/PyIMAPIContainer.i
@@ -51,9 +51,9 @@ PyObject *PyIMAPIContainer::OpenEntry(PyObject *self, PyObject *args)
 	if (obEntry==Py_None) {
 		entryString = NULL;
 		entryStrLen = 0;
-	} else if (PyString_Check(obEntry)) {
-		entryString = PyString_AsString(obEntry);
-		entryStrLen = PyString_Size(obEntry);
+	} else if (PyBytes_Check(obEntry)) {
+		entryString = PyBytes_AsString(obEntry);
+		entryStrLen = PyBytes_Size(obEntry);
 	} else {
 		PyErr_SetString(PyExc_TypeError, "EntryID must be a string or None");
 		return NULL;

--- a/com/win32comext/mapi/src/PyIMAPIFolder.i
+++ b/com/win32comext/mapi/src/PyIMAPIFolder.i
@@ -162,9 +162,9 @@ PyObject *PyIMAPIFolder::DeleteFolder(PyObject *self, PyObject *args)
 		&obProgress, // @pyparm <o PyIMAPIProgress>|progress||A progress object, or None
 		&flags)) 
         return NULL;
-	if (PyString_Check(obEntryId)) {
-		eid = (LPENTRYID)PyString_AsString(obEntryId);
-		cbEID = PyString_Size(obEntryId);
+	if (PyBytes_Check(obEntryId)) {
+		eid = (LPENTRYID)PyBytes_AsString(obEntryId);
+		cbEID = PyBytes_Size(obEntryId);
 	} else {
 		PyErr_SetString(PyExc_TypeError, "EntryID must be a string");
 		return NULL;

--- a/com/win32comext/mapi/src/PyIMAPISession.i
+++ b/com/win32comext/mapi/src/PyIMAPISession.i
@@ -53,9 +53,9 @@ PyObject *PyIMAPISession::OpenEntry(PyObject *self, PyObject *args)
 	if (obEntry==Py_None) {
 		entryString = NULL;
 		entryStrLen = 0;
-	} else if (PyString_Check(obEntry)) {
-		entryString = PyString_AsString(obEntry);
-		entryStrLen = PyString_Size(obEntry);
+	} else if (PyBytes_Check(obEntry)) {
+		entryString = PyBytes_AsString(obEntry);
+		entryStrLen = PyBytes_Size(obEntry);
 	} else {
 		PyErr_SetString(PyExc_TypeError, "EntryID must be a string or None");
 		return NULL;
@@ -137,7 +137,7 @@ PyObject *PyIMAPISession::QueryIdentity(PyObject *self, PyObject *args)
 	Py_END_ALLOW_THREADS
 	PyObject *rc;
 	if (_result==S_OK)
-		rc = PyString_FromStringAndSize((char *)peid, cb);
+		rc = PyBytes_FromStringAndSize((char *)peid, cb);
 	else if (FAILED(_result)) {
            rc = OleSetOleError(_result);
     } else {
@@ -170,9 +170,9 @@ PyObject *PyIMAPISession::Advise(PyObject *self, PyObject *args)
 	if (obEntry==Py_None) {
 		entryString = NULL;
 		entryStrLen = 0;
-	} else if (PyString_Check(obEntry)) {
-		entryString = PyString_AsString(obEntry);
-		entryStrLen = PyString_Size(obEntry);
+	} else if (PyBytes_Check(obEntry)) {
+		entryString = PyBytes_AsString(obEntry);
+		entryStrLen = PyBytes_Size(obEntry);
 	} else {
 		PyErr_SetString(PyExc_TypeError, "EntryID must be a string or None");
 		return NULL;

--- a/com/win32comext/mapi/src/PyIMAPISession.i
+++ b/com/win32comext/mapi/src/PyIMAPISession.i
@@ -238,7 +238,7 @@ PyObject *PyIMAPISession::CompareEntryIDs(PyObject *self, PyObject *args)
 	if (FAILED(hr))
 		rc =  OleSetOleError(hr);
 	else
-		rc = PyInt_FromLong(ulResult);
+		rc = PyLong_FromLong(ulResult);
 done:
 	PyWinObject_FreeString((char *)peid1);
 	PyWinObject_FreeString((char *)peid2);

--- a/com/win32comext/mapi/src/PyIMsgStore.i
+++ b/com/win32comext/mapi/src/PyIMsgStore.i
@@ -54,9 +54,9 @@ PyObject *PyIMsgStore::OpenEntry(PyObject *self, PyObject *args)
 	if (obEntry==Py_None) {
 		entryString = NULL;
 		entryStrLen = 0;
-	} else if (PyString_Check(obEntry)) {
-		entryString = PyString_AsString(obEntry);
-		entryStrLen = PyString_Size(obEntry);
+	} else if (PyBytes_Check(obEntry)) {
+		entryString = PyBytes_AsString(obEntry);
+		entryStrLen = PyBytes_Size(obEntry);
 	} else {
 		PyErr_SetString(PyExc_TypeError, "EntryID must be a string or None");
 		return NULL;
@@ -111,7 +111,7 @@ PyObject *PyIMsgStore::GetReceiveFolder(PyObject *self, PyObject *args)
 		goto done;
 	}
 
-	rc = Py_BuildValue("NN", PyString_FromStringAndSize((char *)eid_out, eid_cb),
+	rc = Py_BuildValue("NN", PyBytes_FromStringAndSize((char *)eid_out, eid_cb),
 	                         PyWinObject_FromMAPIStr(sz_explicit_class, flags & MAPI_UNICODE));
 	MAPIFreeBuffer(eid_out);
 	MAPIFreeBuffer(sz_explicit_class);
@@ -264,9 +264,9 @@ PyObject *PyIMsgStore::Advise(PyObject *self, PyObject *args)
 	{
 		eid = NULL;
 		cbEID = 0;
-	} else if (PyString_Check(obEntryId)) {
-		eid = (LPENTRYID)PyString_AsString(obEntryId);
-		cbEID = PyString_Size(obEntryId);
+	} else if (PyBytes_Check(obEntryId)) {
+		eid = (LPENTRYID)PyBytes_AsString(obEntryId);
+		cbEID = PyBytes_Size(obEntryId);
 	} else {
 		PyErr_SetString(PyExc_TypeError, "EntryID must be a string");
 		return NULL;

--- a/com/win32comext/mapi/src/PyIMsgStore.i
+++ b/com/win32comext/mapi/src/PyIMsgStore.i
@@ -162,7 +162,7 @@ PyObject *PyIMsgStore::CompareEntryIDs(PyObject *self, PyObject *args)
 	if (FAILED(hr))
 		rc =  OleSetOleError(hr);
 	else
-		rc = PyInt_FromLong(ulResult);
+		rc = PyLong_FromLong(ulResult);
 done:
 	PyWinObject_FreeString((char *)peid1);
 	PyWinObject_FreeString((char *)peid2);

--- a/com/win32comext/mapi/src/exchange.i
+++ b/com/win32comext/mapi/src/exchange.i
@@ -140,7 +140,7 @@ static PyObject *PyHrMAPIFindDefaultMsgStore(PyObject *self, PyObject *args)
      if (FAILED(_result)) {
            return OleSetOleError(_result);
      }
-	 PyObject *rc = PyString_FromStringAndSize((char *)pID, entryStrLen);
+	 PyObject *rc = PyBytes_FromStringAndSize((char *)pID, entryStrLen);
 	 MAPIFreeBuffer(pID);
 	 return rc;
 }
@@ -168,7 +168,7 @@ static PyObject *PyHrMAPIFindIPMSubtree(PyObject *self, PyObject *args)
      if (FAILED(_result)) {
            return OleSetOleError(_result);
      }
-	 PyObject *rc = PyString_FromStringAndSize((char *)pID, entryStrLen);
+	 PyObject *rc = PyBytes_FromStringAndSize((char *)pID, entryStrLen);
 	 MAPIFreeBuffer(pID);
 	 return rc;
 }
@@ -197,7 +197,7 @@ static PyObject *PyHrMAPIFindInbox(PyObject *self, PyObject *args)
      if (FAILED(_result)) {
            return OleSetOleError(_result);
      }
-	 PyObject *rc = PyString_FromStringAndSize((char *)pID, entryStrLen);
+	 PyObject *rc = PyBytes_FromStringAndSize((char *)pID, entryStrLen);
 	 MAPIFreeBuffer(pID);
 	 return rc;
 }
@@ -216,7 +216,7 @@ PyObject *MyHrMAPIFindSubfolderEx(
 	HRESULT hr = HrMAPIFindSubfolderEx(lpRootFolder,chSep,lpszName,&idSize, &id);
 	if (FAILED(hr))
 		return OleSetOleError(hr);
-	PyObject *rc = PyString_FromStringAndSize((char *)id, idSize);
+	PyObject *rc = PyBytes_FromStringAndSize((char *)id, idSize);
 	MAPIFreeBuffer(id);
 	return rc;
 }
@@ -260,7 +260,7 @@ PyObject *PyHrMAPIFindFolder(PyObject *self, PyObject *args)
 		OleSetOleError(hr);
 		goto done;
 	}
-	rc = PyString_FromStringAndSize((char *)eid, cbEID);
+	rc = PyBytes_FromStringAndSize((char *)eid, cbEID);
 done:
 	if (pFolder) pFolder->Release();
 	if (szName) PyWinObject_FreeTCHAR(szName);
@@ -301,7 +301,7 @@ PyObject *PyHrMAPIFindFolderEx(PyObject *self, PyObject *args)
 		OleSetOleError(hr);
 		goto done;
 	}
-	rc = PyString_FromStringAndSize((char *)eid, cbEID);
+	rc = PyBytes_FromStringAndSize((char *)eid, cbEID);
 done:
 	if (pMDB) pMDB->Release();
 	if (szSep) PyWinObject_FreeTCHAR(szSep);
@@ -340,7 +340,7 @@ PyObject *PyHrMAPIFindStore(PyObject *self, PyObject *args)
 		OleSetOleError(hr);
 		goto done;
 	}
-	rc = PyString_FromStringAndSize((char *)eid, cbEID);
+	rc = PyBytes_FromStringAndSize((char *)eid, cbEID);
 done:
 	if (pSession) pSession->Release();
 	if (szName) PyWinObject_FreeTCHAR(szName);
@@ -398,7 +398,7 @@ PyObject *PyHrCreateDirEntryIdEx(PyObject *self, PyObject *args)
 	if (FAILED(hr))
 		return OleSetOleError(hr);
 
-	ret = PyString_FromStringAndSize((char *)entryId, cbEntryId);
+	ret = PyBytes_FromStringAndSize((char *)entryId, cbEntryId);
 done:
 	PyWinObject_FreeString(szdn);
 	if (pAddrBook) pAddrBook->Release();
@@ -430,7 +430,7 @@ static PyObject *PyHrFindExchangeGlobalAddressList(PyObject *self, PyObject *arg
            return OleSetOleError(_result);
      }
 
-	PyObject *rc = PyString_FromStringAndSize((char *)peid, cb);
+	PyObject *rc = PyBytes_FromStringAndSize((char *)peid, cb);
 	MAPIFreeBuffer(peid);
 	return rc;
 #endif

--- a/com/win32comext/mapi/src/mapi.i
+++ b/com/win32comext/mapi/src/mapi.i
@@ -108,7 +108,7 @@ static PyObject *PyBinFromHex(PyObject *self, PyObject *args)
 		PyErr_SetString(PyExc_ValueError, "FBinFromHex failed - input data is invalid");
 		return NULL;
 	}
-	PyObject *rc = PyString_FromStringAndSize((char *)buf, strSize/2);
+	PyObject *rc = PyBytes_FromStringAndSize((char *)buf, strSize/2);
 	free(buf);
 	PyWinObject_FreeTCHAR(tchar);
 	return rc;
@@ -1002,7 +1002,7 @@ static PyObject *MyRTFStreamToHTML(PyObject *self, PyObject *args)
     ret = Py_None;
     goto exit;
   }
-  ret = PyString_FromStringAndSize(htmlbuf, htmlsize-1);
+  ret = PyBytes_FromStringAndSize(htmlbuf, htmlsize-1);
 exit:
   if (pStream) pStream->Release();
   if (htmlbuf)

--- a/com/win32comext/mapi/src/mapi.i
+++ b/com/win32comext/mapi/src/mapi.i
@@ -778,7 +778,7 @@ PyObject *PyOpenIMsgSession(PyObject *self, PyObject *args)
 	PY_INTERFACE_POSTCALL;
 	if (FAILED(hr))
 		return OleSetOleError(hr);
-	return PyInt_FromLong((long)pSession);
+	return PyLong_FromLong((long)pSession);
 }
 %}
 // @pyswig |CloseIMsgSession|

--- a/com/win32comext/mapi/src/mapiutil.cpp
+++ b/com/win32comext/mapi/src/mapiutil.cpp
@@ -288,8 +288,8 @@ BOOL PyMAPIObject_AsSPropValue(PyObject *Valob, SPropValue *pv, void *pAllocMore
 
         // @flag PT_BINARY|A string containing binary data
         case PT_BINARY:
-            pv->Value.bin.lpb = (unsigned char *)PyString_AsString(ob);
-            pv->Value.bin.cb = PyString_Size(ob);
+            pv->Value.bin.lpb = (unsigned char *)PyBytes_AsString(ob);
+            pv->Value.bin.cb = PyBytes_Size(ob);
             break;
 
         // @flag PT_MV_BINARY|A sequence of strings containing binary data
@@ -300,13 +300,13 @@ BOOL PyMAPIObject_AsSPropValue(PyObject *Valob, SPropValue *pv, void *pAllocMore
                 PyObject *obmv = PySequence_GetItem(ob, i);
                 if (obmv == NULL)
                     break;
-                if (!PyString_Check(obmv)) {
+                if (!PyBytes_Check(obmv)) {
                     Py_DECREF(obmv);
                     PyErr_SetString(PyExc_TypeError, "PT_MV_BINARY elements must be strings");
                     break;
                 }
-                pv->Value.MVbin.lpbin[i].lpb = (unsigned char *)PyString_AsString(obmv);
-                pv->Value.MVbin.lpbin[i].cb = PyString_Size(obmv);
+                pv->Value.MVbin.lpbin[i].lpb = (unsigned char *)PyBytes_AsString(obmv);
+                pv->Value.MVbin.lpbin[i].cb = PyBytes_Size(obmv);
                 Py_DECREF(obmv);
             }
             break;
@@ -392,13 +392,13 @@ PyObject *PyMAPIObject_FromSPropValue(SPropValue *pv)
             val = PyWinObject_FromFILETIME(pv->Value.ft);
             break;
         case PT_STRING8:
-            val = PyString_FromString(pv->Value.lpszA);
+            val = PyBytes_FromString(pv->Value.lpszA);
             break;
         case PT_UNICODE:
             val = PyWinObject_FromWCHAR(pv->Value.lpszW);
             break;
         case PT_BINARY:
-            val = PyString_FromStringAndSize((char *)pv->Value.bin.lpb, pv->Value.bin.cb);
+            val = PyBytes_FromStringAndSize((char *)pv->Value.bin.lpb, pv->Value.bin.cb);
             break;
 
         case PT_CLSID:
@@ -472,14 +472,14 @@ PyObject *PyMAPIObject_FromSPropValue(SPropValue *pv)
                 for (i = 0; i < pv->Value.MVbin.cValues; i++)
                     PyTuple_SET_ITEM(
                         val, i,
-                        PyString_FromStringAndSize((char *)pv->Value.MVbin.lpbin[i].lpb, pv->Value.MVbin.lpbin[i].cb));
+                        PyBytes_FromStringAndSize((char *)pv->Value.MVbin.lpbin[i].lpb, pv->Value.MVbin.lpbin[i].cb));
             }
             break;
         case PT_MV_STRING8:
             val = PyTuple_New(pv->Value.MVszA.cValues);
             if (val) {
                 for (i = 0; i < pv->Value.MVszA.cValues; i++)
-                    PyTuple_SET_ITEM(val, i, PyString_FromString(pv->Value.MVszA.lppszA[i]));
+                    PyTuple_SET_ITEM(val, i, PyBytes_FromString(pv->Value.MVszA.lppszA[i]));
             }
             break;
         case PT_MV_UNICODE:
@@ -777,7 +777,7 @@ BOOL PyMAPIObject_AsSBinaryArray(PyObject *ob, SBinaryArray *pba)
 {
     BOOL bSeq = TRUE;
     int seqLen;
-    if (PyString_Check(ob)) {
+    if (PyBytes_Check(ob)) {
         seqLen = 1;
         bSeq = FALSE;
     }
@@ -804,26 +804,26 @@ BOOL PyMAPIObject_AsSBinaryArray(PyObject *ob, SBinaryArray *pba)
                 MAPIFreeBuffer(pba);
                 return FALSE;
             }
-            if (!PyString_Check(obItem)) {
+            if (!PyBytes_Check(obItem)) {
                 PyErr_SetString(PyExc_TypeError, "SBinary must be a string");
                 Py_DECREF(obItem);
                 MAPIFreeBuffer(pba);
                 return FALSE;
             }
-            pBin[i].cb = PyString_Size(obItem);
-            pBin[i].lpb = (LPBYTE)PyString_AsString(obItem);
+            pBin[i].cb = PyBytes_Size(obItem);
+            pBin[i].lpb = (LPBYTE)PyBytes_AsString(obItem);
             Py_DECREF(obItem);
         }
     }
     else {
-        if (!PyString_Check(ob)) {
+        if (!PyBytes_Check(ob)) {
             PyErr_SetString(PyExc_TypeError, "SBinary must be a string");
             MAPIFreeBuffer(pba);
             return FALSE;
         }
         // Simple string
-        pBin[0].cb = PyString_Size(ob);
-        pBin[0].lpb = (LPBYTE)PyString_AsString(ob);
+        pBin[0].cb = PyBytes_Size(ob);
+        pBin[0].lpb = (LPBYTE)PyBytes_AsString(ob);
     }
     return TRUE;
 }
@@ -1265,7 +1265,7 @@ PyObject *PyWinObject_FromMAPIStr(LPTSTR str, BOOL isUnicode)
 #if PY_MAJOR_VERSION >= 3
         return (PyObject *)PyUnicode_DecodeMBCS((LPSTR)str, strlen((LPSTR)str), NULL);
 #else
-        return PyString_FromString((LPSTR)str);
+        return PyBytes_FromString((LPSTR)str);
 #endif
     }
 }

--- a/com/win32comext/mapi/src/mapiutil.cpp
+++ b/com/win32comext/mapi/src/mapiutil.cpp
@@ -125,18 +125,18 @@ BOOL PyMAPIObject_AsSPropValue(PyObject *Valob, SPropValue *pv, void *pAllocMore
     switch (PROP_TYPE(pv->ulPropTag)) {
         // @flag PT_I2|An integer
         case PT_I2:  //		case PT_SHORT:
-            pv->Value.i = (int)PyInt_AsLong(ob);
+            pv->Value.i = (int)PyLong_AsLong(ob);
             break;
         // @flag PT_MV_I2|A sequence of integers
         case PT_MV_I2:
-            MAKE_MV(short int, pAllocMoreLinkBlock, pv->Value.MVi.lpi, pv->Value.MVi.cValues, PyInt_AsLong)
+            MAKE_MV(short int, pAllocMoreLinkBlock, pv->Value.MVi.lpi, pv->Value.MVi.cValues, PyLong_AsLong)
         // @flag PT_I4|An integer
         case PT_I4:  //		case PT_LONG:
-            pv->Value.l = PyInt_AsLong(ob);
+            pv->Value.l = PyLong_AsLong(ob);
             break;
         // @flag PT_MV_I4|A sequence of integers
         case PT_MV_I4:
-            MAKE_MV(long, pAllocMoreLinkBlock, pv->Value.MVl.lpl, pv->Value.MVl.cValues, PyInt_AsLong)
+            MAKE_MV(long, pAllocMoreLinkBlock, pv->Value.MVl.lpl, pv->Value.MVl.cValues, PyLong_AsLong)
         // @flag PT_R4|A float
         case PT_R4:  //		case PT_FLOAT:
             pv->Value.flt = (float)PyFloat_AsDouble(ob);
@@ -153,7 +153,7 @@ BOOL PyMAPIObject_AsSPropValue(PyObject *Valob, SPropValue *pv, void *pAllocMore
             MAKE_MV(double, pAllocMoreLinkBlock, pv->Value.MVdbl.lpdbl, pv->Value.MVdbl.cValues, PyFloat_AsDouble)
         // @flag PT_BOOLEAN|A boolean value (or an int)
         case PT_BOOLEAN:
-            pv->Value.b = PyInt_AsLong(ob) ? VARIANT_TRUE : VARIANT_FALSE;
+            pv->Value.b = PyLong_AsLong(ob) ? VARIANT_TRUE : VARIANT_FALSE;
             break;
 
             /*
@@ -340,7 +340,7 @@ BOOL PyMAPIObject_AsSPropValue(PyObject *Valob, SPropValue *pv, void *pAllocMore
 
         // @flag PT_ERROR|An integer error code.
         case PT_ERROR:
-            pv->Value.err = (SCODE)PyInt_AsLong(ob);
+            pv->Value.err = (SCODE)PyLong_AsLong(ob);
             break;
 
         // @flag PT_NULL|Anything!
@@ -365,10 +365,10 @@ PyObject *PyMAPIObject_FromSPropValue(SPropValue *pv)
     ULONG i;
     switch (PROP_TYPE(pv->ulPropTag)) {
         case PT_I2:  //		case PT_SHORT:
-            val = PyInt_FromLong(pv->Value.i);
+            val = PyLong_FromLong(pv->Value.i);
             break;
         case PT_I4:  //		case PT_LONG:
-            val = PyInt_FromLong(pv->Value.l);
+            val = PyLong_FromLong(pv->Value.l);
             break;
         case PT_R4:  //		case PT_FLOAT:
             val = PyFloat_FromDouble(pv->Value.flt);
@@ -409,7 +409,7 @@ PyObject *PyMAPIObject_FromSPropValue(SPropValue *pv)
             val = PyWinObject_FromLARGE_INTEGER(pv->Value.li);
             break;
         case PT_ERROR:
-            val = PyInt_FromLong(pv->Value.err);
+            val = PyLong_FromLong(pv->Value.err);
             break;
 
         case PT_NULL:
@@ -421,14 +421,14 @@ PyObject *PyMAPIObject_FromSPropValue(SPropValue *pv)
             val = PyTuple_New(pv->Value.MVi.cValues);
             if (val) {
                 for (i = 0; i < pv->Value.MVi.cValues; i++)
-                    PyTuple_SET_ITEM(val, i, PyInt_FromLong(pv->Value.MVi.lpi[i]));
+                    PyTuple_SET_ITEM(val, i, PyLong_FromLong(pv->Value.MVi.lpi[i]));
             }
             break;
         case PT_MV_LONG:
             val = PyTuple_New(pv->Value.MVi.cValues);
             if (val) {
                 for (i = 0; i < pv->Value.MVl.cValues; i++)
-                    PyTuple_SET_ITEM(val, i, PyInt_FromLong(pv->Value.MVl.lpl[i]));
+                    PyTuple_SET_ITEM(val, i, PyLong_FromLong(pv->Value.MVl.lpl[i]));
             }
             break;
         case PT_MV_R4:
@@ -507,7 +507,7 @@ PyObject *PyMAPIObject_FromSPropValue(SPropValue *pv)
             break;
 
         case PT_OBJECT:
-            val = PyInt_FromLong(pv->Value.x);
+            val = PyLong_FromLong(pv->Value.x);
             break;
 
         default:
@@ -712,7 +712,7 @@ BOOL PyMAPIObject_AsSPropTagArray(PyObject *obta, SPropTagArray **ppta)
     if (PySequence_Check(obta)) {
         seqLen = PySequence_Length(obta);
     }
-    else if (PyInt_Check(obta)) {
+    else if (PyLong_Check(obta)) {
         seqLen = 1;
         bSeq = FALSE;
     }
@@ -880,7 +880,7 @@ BOOL PyMAPIObject_AsMAPINAMEIDArray(PyObject *ob, MAPINAMEID ***pppNameId, ULONG
         BSTR bstrVal;
         if (!PyWinObject_AsIID(obIID, pIIDs + i))
             goto loop_error;
-        if (PyInt_Check(obPropId)) {
+        if (PyLong_Check(obPropId)) {
             pNew->ulKind = MNID_ID;
             pNew->Kind.lID = PyLong_AsUnsignedLong(obPropId);
         }
@@ -931,7 +931,7 @@ PyObject *PyMAPIObject_FromMAPINAMEIDArray(MAPINAMEID **pp, ULONG numEntries)
         }
         else {
             value = pLook->ulKind == MNID_STRING ? PyWinObject_FromOLECHAR(pLook->Kind.lpwstrName)
-                                                 : PyInt_FromLong(pLook->Kind.lID);
+                                                 : PyLong_FromLong(pLook->Kind.lID);
             guid = PyWinObject_FromIID(*pLook->lpguid);
         }
         PyObject *newItem = PyTuple_New(2);
@@ -1081,14 +1081,14 @@ BOOL PyMAPIObject_AsSingleSRestriction(PyObject *ob, SRestriction *pRest, void *
     PyObject *obResType = PySequence_GetItem(ob, 0);
     if (obResType == NULL)
         return FALSE;
-    if (!PyInt_Check(obResType)) {
+    if (!PyLong_Check(obResType)) {
         PyErr_SetString(PyExc_TypeError, "SRestriction must be a sequence of (integer, object)");
         Py_DECREF(obResType);
         return FALSE;
     }
     // @pyparm int|restrictionType||An integer describing the contents of the second parameter.
     // @pyparm object|restriction||An object in one of the formats describe below.
-    pRest->rt = PyInt_AsLong(obResType);
+    pRest->rt = PyLong_AsLong(obResType);
     Py_DECREF(obResType);
     PyObject *subOb = PySequence_GetItem(ob, 1);
     if (subOb == NULL)

--- a/com/win32comext/propsys/src/PyIPersistSerializedPropStorage.cpp
+++ b/com/win32comext/propsys/src/PyIPersistSerializedPropStorage.cpp
@@ -81,7 +81,7 @@ PyObject *PyIPersistSerializedPropStorage::GetPropertyStorage(PyObject *self, Py
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIPSPS, IID_IPersistSerializedPropStorage);
-    PyObject *ret = PyString_FromStringAndSize((char *)buf, bufsize);
+    PyObject *ret = PyBytes_FromStringAndSize((char *)buf, bufsize);
     CoTaskMemFree(buf);
     return ret;
 }

--- a/com/win32comext/propsys/src/PyIPropertyDescription.cpp
+++ b/com/win32comext/propsys/src/PyIPropertyDescription.cpp
@@ -74,7 +74,7 @@ PyObject *PyIPropertyDescription::GetPropertyType(PyObject *self, PyObject *args
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIPD, IID_IPropertyDescription);
-    return PyInt_FromLong(t);
+    return PyLong_FromLong(t);
 }
 
 // @pymethod str|PyIPropertyDescription|GetDisplayName|Returns the property name as shown in the UI
@@ -137,7 +137,7 @@ PyObject *PyIPropertyDescription::GetTypeFlags(PyObject *self, PyObject *args)
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIPD, IID_IPropertyDescription);
-    return PyInt_FromLong(flags);
+    return PyLong_FromLong(flags);
 }
 
 // @pymethod int|PyIPropertyDescription|GetViewFlags|Returns the view flags that control how the property is displayed
@@ -156,7 +156,7 @@ PyObject *PyIPropertyDescription::GetViewFlags(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIPD, IID_IPropertyDescription);
-    return PyInt_FromLong(flags);
+    return PyLong_FromLong(flags);
 }
 
 // @pymethod int|PyIPropertyDescription|GetDefaultColumnWidth|Returns the default width in characters
@@ -191,7 +191,7 @@ PyObject *PyIPropertyDescription::GetDisplayType(PyObject *self, PyObject *args)
     hr = pIPD->GetDisplayType(&t);
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIPD, IID_IPropertyDescription);
-    return PyInt_FromLong(t);
+    return PyLong_FromLong(t);
 }
 
 // @pymethod int|PyIPropertyDescription|GetColumnState|Returns flags that control how property is displayed in column
@@ -210,7 +210,7 @@ PyObject *PyIPropertyDescription::GetColumnState(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIPD, IID_IPropertyDescription);
-    return PyInt_FromLong(s);
+    return PyLong_FromLong(s);
 }
 
 // @pymethod int|PyIPropertyDescription|GetGroupingRange|Returns property's grouping attributes (PDGR_*)
@@ -229,7 +229,7 @@ PyObject *PyIPropertyDescription::GetGroupingRange(PyObject *self, PyObject *arg
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIPD, IID_IPropertyDescription);
-    return PyInt_FromLong(g);
+    return PyLong_FromLong(g);
 }
 
 // @pymethod int|PyIPropertyDescription|GetRelativeDescriptionType|Returns the relative description type (PDRDT_*)
@@ -248,7 +248,7 @@ PyObject *PyIPropertyDescription::GetRelativeDescriptionType(PyObject *self, PyO
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIPD, IID_IPropertyDescription);
-    return PyInt_FromLong(d);
+    return PyLong_FromLong(d);
 }
 
 // @pymethod (str, str)|PyIPropertyDescription|GetRelativeDescription|Compares two values
@@ -297,7 +297,7 @@ PyObject *PyIPropertyDescription::GetSortDescription(PyObject *self, PyObject *a
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIPD, IID_IPropertyDescription);
-    return PyInt_FromLong(d);
+    return PyLong_FromLong(d);
 }
 
 // @pymethod str|PyIPropertyDescription|GetSortDescriptionLabel|Returns description of current sort order
@@ -340,7 +340,7 @@ PyObject *PyIPropertyDescription::GetAggregationType(PyObject *self, PyObject *a
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIPD, IID_IPropertyDescription);
-    return PyInt_FromLong(a);
+    return PyLong_FromLong(a);
 }
 
 // @pymethod (int, int)|PyIPropertyDescription|GetConditionType|Returns options that determine how the property is used

--- a/com/win32comext/propsys/src/PyIPropertyStoreCache.cpp
+++ b/com/win32comext/propsys/src/PyIPropertyStoreCache.cpp
@@ -36,7 +36,7 @@ PyObject *PyIPropertyStoreCache::GetState(PyObject *self, PyObject *args)
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIPSC, IID_IPropertyStoreCache);
-    return PyInt_FromLong(state);
+    return PyLong_FromLong(state);
 }
 
 // @pymethod (<o PyPROPVARIANT>, int)|PyIPropertyStoreCache|GetValueAndState|Retrieves the current value and state of a
@@ -60,7 +60,7 @@ PyObject *PyIPropertyStoreCache::GetValueAndState(PyObject *self, PyObject *args
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIPSC, IID_IPropertyStoreCache);
-    return Py_BuildValue("NN", PyWinObject_FromPROPVARIANT(&val), PyInt_FromLong(state));
+    return Py_BuildValue("NN", PyWinObject_FromPROPVARIANT(&val), PyLong_FromLong(state));
 }
 
 // @pymethod |PyIPropertyStoreCache|SetState|Sets the state of a property

--- a/com/win32comext/propsys/src/propsys.cpp
+++ b/com/win32comext/propsys/src/propsys.cpp
@@ -291,7 +291,7 @@ static PyObject *PyStgSerializePropVariant(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr);
-    PyObject *ret = PyString_FromStringAndSize((char *)pspv, bufsize);
+    PyObject *ret = PyBytes_FromStringAndSize((char *)pspv, bufsize);
     CoTaskMemFree(pspv);
     return ret;
 };

--- a/com/win32comext/shell/src/PyIActiveDesktop.cpp
+++ b/com/win32comext/shell/src/PyIActiveDesktop.cpp
@@ -553,7 +553,7 @@ PyObject *PyIActiveDesktop::GetDesktopItemCount(PyObject *self, PyObject *args)
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIAD, IID_IActiveDesktop);
-    return PyInt_FromLong(Count);
+    return PyLong_FromLong(Count);
 }
 
 // @pymethod dict|PyIActiveDesktop|GetDesktopItem|Returns desktop item parameters by index

--- a/com/win32comext/shell/src/PyIAsyncOperation.cpp
+++ b/com/win32comext/shell/src/PyIAsyncOperation.cpp
@@ -176,13 +176,13 @@ STDMETHODIMP PyGAsyncOperation::GetAsyncMode(
     HRESULT hr = InvokeViaPolicy("GetAsyncMode", &result);
     if (FAILED(hr))
         return hr;
-    if (!PyInt_Check(result)) {
+    if (!PyLong_Check(result)) {
         PyErr_Format(PyExc_TypeError, "Result for GetAsyncMode must be a bool (got '%s')", result->ob_type->tp_name);
         hr = MAKE_PYCOM_GATEWAY_FAILURE_CODE("GetAsyncMode");
     }
     else
         // NOTE: MSDN says "VARIANT_TRUE/VARIANT_FALSE, but fails to work!
-        *pfIsOpAsync = PyInt_AsLong(result) ? TRUE : FALSE;
+        *pfIsOpAsync = PyLong_AsLong(result) ? TRUE : FALSE;
     Py_DECREF(result);
     return hr;
 }
@@ -208,13 +208,13 @@ STDMETHODIMP PyGAsyncOperation::InOperation(
     HRESULT hr = InvokeViaPolicy("InOperation", &result);
     if (FAILED(hr))
         return hr;
-    if (!PyInt_Check(result)) {
+    if (!PyLong_Check(result)) {
         PyErr_Format(PyExc_TypeError, "Result for InOperation must be a bool (got '%s')", result->ob_type->tp_name);
         hr = MAKE_PYCOM_GATEWAY_FAILURE_CODE("InOperation");
     }
     else
         // NOTE: MSDN says "VARIANT_TRUE/VARIANT_FALSE, but fails to work!
-        *pfInAsyncOp = PyInt_AsLong(result) ? TRUE : FALSE;
+        *pfInAsyncOp = PyLong_AsLong(result) ? TRUE : FALSE;
     Py_DECREF(result);
     return hr;
 }

--- a/com/win32comext/shell/src/PyIBrowserFrameOptions.cpp
+++ b/com/win32comext/shell/src/PyIBrowserFrameOptions.cpp
@@ -38,7 +38,7 @@ PyObject *PyIBrowserFrameOptions::GetFrameOptions(PyObject *self, PyObject *args
     PY_INTERFACE_PRECALL;
     hr = pIBFO->GetFrameOptions((BROWSERFRAMEOPTIONS)dwMask, &dwOptions);
     PY_INTERFACE_POSTCALL;
-    return PyInt_FromLong(dwOptions);
+    return PyLong_FromLong(dwOptions);
 }
 
 // @object PyIBrowserFrameOptions|Description of the interface
@@ -62,8 +62,8 @@ STDMETHODIMP PyGBrowserFrameOptions::GetFrameOptions(
     HRESULT hr = InvokeViaPolicy("GetFrameOptions", &result, "i", dwMask);
     if (FAILED(hr))
         return hr;
-    if (PyInt_Check(result))
-        *pdwOptions = PyInt_AsLong(result);
+    if (PyLong_Check(result))
+        *pdwOptions = PyLong_AsLong(result);
     Py_DECREF(result);
     return hr;
 }

--- a/com/win32comext/shell/src/PyICategorizer.cpp
+++ b/com/win32comext/shell/src/PyICategorizer.cpp
@@ -69,7 +69,7 @@ STDMETHODIMP PyGCategorizer::GetCategory(
         else {
             for (DWORD tuple_index = 0; tuple_index < cidl; tuple_index++) {
                 PyObject *tuple_item = PyTuple_GET_ITEM(dwords_tuple, tuple_index);
-                rgCategoryIds[tuple_index] = PyInt_AsLong(tuple_item);
+                rgCategoryIds[tuple_index] = PyLong_AsLong(tuple_item);
                 if ((rgCategoryIds[tuple_index] == -1) && PyErr_Occurred()) {
                     hr = MAKE_PYCOM_GATEWAY_FAILURE_CODE(method_name);
                     break;
@@ -118,12 +118,12 @@ STDMETHODIMP PyGCategorizer::CompareCategory(
     HRESULT hr = InvokeViaPolicy("CompareCategory", &result, "lll", csfFlags, dwCategoryId1, dwCategoryId2);
     if (FAILED(hr))
         return hr;
-    if (!PyInt_Check(result)) {
+    if (!PyLong_Check(result)) {
         PyErr_Format(PyExc_TypeError, "CompareCategory expects an int, got a %s", result->ob_type->tp_name);
         hr = MAKE_PYCOM_GATEWAY_FAILURE_CODE("GetCategory");
     }
     else {
-        hr = MAKE_HRESULT(SEVERITY_SUCCESS, 0, (USHORT)PyInt_AsLong(result));
+        hr = MAKE_HRESULT(SEVERITY_SUCCESS, 0, (USHORT)PyLong_AsLong(result));
     }
     Py_DECREF(result);
     return hr;

--- a/com/win32comext/shell/src/PyICategoryProvider.cpp
+++ b/com/win32comext/shell/src/PyICategoryProvider.cpp
@@ -185,8 +185,8 @@ STDMETHODIMP PyGCategoryProvider::CanCategorizeOnSCID(
     if (FAILED(hr))
         return hr;
     hr = S_FALSE;
-    if (PyInt_Check(ret))  // make a bool
-        hr = PyInt_AsLong(ret) ? S_OK : S_FALSE;
+    if (PyLong_Check(ret))  // make a bool
+        hr = PyLong_AsLong(ret) ? S_OK : S_FALSE;
     Py_DECREF(ret);
     return hr;
 }

--- a/com/win32comext/shell/src/PyIContextMenu.cpp
+++ b/com/win32comext/shell/src/PyIContextMenu.cpp
@@ -113,7 +113,7 @@ PyObject *PyIContextMenu::GetCommandString(PyObject *self, PyObject *args)
     if (uType & GCS_UNICODE)
         ret = PyWinObject_FromWCHAR((WCHAR *)buf);
     else
-        ret = PyString_FromString(buf);
+        ret = PyBytes_FromString(buf);
     free(buf);
     return ret;
 }
@@ -175,7 +175,7 @@ STDMETHODIMP PyGContextMenu::GetCommandString(
     HRESULT hr = InvokeViaPolicy("GetCommandString", &result, "NI", PyWinObject_FromULONG_PTR(idCmd), uFlags);
     if (FAILED(hr))
         return hr;
-    if (result && (PyString_Check(result) || PyUnicode_Check(result))) {
+    if (result && (PyBytes_Check(result) || PyUnicode_Check(result))) {
         if (uFlags == GCS_HELPTEXTW || uFlags == GCS_VERBW) {
             WCHAR *szResult;
             if (PyWinObject_AsWCHAR(result, &szResult, FALSE, NULL)) {

--- a/com/win32comext/shell/src/PyIContextMenu.cpp
+++ b/com/win32comext/shell/src/PyIContextMenu.cpp
@@ -44,7 +44,7 @@ PyObject *PyIContextMenu::QueryContextMenu(PyObject *self, PyObject *args)
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pICM, IID_IContextMenu);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod |PyIContextMenu|InvokeCommand|Executes a context menu option
@@ -145,8 +145,8 @@ STDMETHODIMP PyGContextMenu::QueryContextMenu(
                                  idCmdLast, uFlags);
     if (FAILED(hr))
         return hr;
-    if (PyInt_Check(ret))
-        hr = MAKE_HRESULT(SEVERITY_SUCCESS, 0, PyInt_AsLong(ret));
+    if (PyLong_Check(ret))
+        hr = MAKE_HRESULT(SEVERITY_SUCCESS, 0, PyLong_AsLong(ret));
     Py_DECREF(ret);
     return hr;
 }
@@ -192,8 +192,8 @@ STDMETHODIMP PyGContextMenu::GetCommandString(
         }
         hr = S_OK;
     }
-    else if (result && PyInt_Check(result)) {
-        hr = PyInt_AsLong(result) ? S_OK : S_FALSE;
+    else if (result && PyLong_Check(result)) {
+        hr = PyLong_AsLong(result) ? S_OK : S_FALSE;
     }
     Py_DECREF(result);
     return hr;

--- a/com/win32comext/shell/src/PyICopyHook.cpp
+++ b/com/win32comext/shell/src/PyICopyHook.cpp
@@ -91,7 +91,7 @@ PyGCopyHookA::CopyCallback(
                                  srcAttribs, destFile, destAttribs);
     if (FAILED(hr))
         return hr;
-    hr = PyInt_AsLong(result);
+    hr = PyLong_AsLong(result);
     if ((hr == -1) && PyErr_Occurred())
         hr = MAKE_PYCOM_GATEWAY_FAILURE_CODE("CopyCallBack");
     Py_DECREF(result);
@@ -181,7 +181,7 @@ PyGCopyHookW::CopyCallback(
                         PyWinObject_FromWCHAR(srcFile), srcAttribs, PyWinObject_FromWCHAR(destFile), destAttribs);
     if (FAILED(hr))
         return hr;
-    hr = PyInt_AsLong(result);
+    hr = PyLong_AsLong(result);
     if ((hr == -1) && PyErr_Occurred())
         hr = MAKE_PYCOM_GATEWAY_FAILURE_CODE("CopyCallBack");
     Py_DECREF(result);

--- a/com/win32comext/shell/src/PyIExplorerBrowser.cpp
+++ b/com/win32comext/shell/src/PyIExplorerBrowser.cpp
@@ -205,7 +205,7 @@ PyObject *PyIExplorerBrowser::Advise(PyObject *self, PyObject *args)
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIEB, IID_IExplorerBrowser);
-    return PyInt_FromLong(dwCookie);
+    return PyLong_FromLong(dwCookie);
 }
 
 // @pymethod |PyIExplorerBrowser|Unadvise|Description of Unadvise.

--- a/com/win32comext/shell/src/PyIExtractIcon.cpp
+++ b/com/win32comext/shell/src/PyIExtractIcon.cpp
@@ -75,7 +75,7 @@ PyObject *PyIExtractIcon::GetIconLocation(PyObject *self, PyObject *args)
         free(buf);
         return PyCom_BuildPyException(hr, pIEI, IID_IExtractIcon);
     }
-    PyObject *retStr = PyString_FromString(buf);
+    PyObject *retStr = PyBytes_FromString(buf);
     free(buf);
     return Py_BuildValue("iNii", hr, retStr, iIndex, flags);
 }
@@ -100,7 +100,7 @@ STDMETHODIMP PyGExtractIcon::Extract(
 {
     PY_GATEWAY_METHOD;
     PyObject *obpszFile;
-    obpszFile = PyString_FromString(pszFile);
+    obpszFile = PyBytes_FromString(pszFile);
     PyObject *result;
     HRESULT hr = InvokeViaPolicy("Extract", &result, "Oii", obpszFile, nIconIndex, nIconSize);
     Py_XDECREF(obpszFile);

--- a/com/win32comext/shell/src/PyIExtractIcon.cpp
+++ b/com/win32comext/shell/src/PyIExtractIcon.cpp
@@ -106,8 +106,8 @@ STDMETHODIMP PyGExtractIcon::Extract(
     Py_XDECREF(obpszFile);
     if (FAILED(hr))
         return hr;
-    if (PyInt_Check(result) || PyLong_Check(result))
-        hr = PyInt_AsLong(result);
+    if (PyLong_Check(result) || PyLong_Check(result))
+        hr = PyLong_AsLong(result);
     else {
         PyObject *oblarge, *obsmall;
         if (PyArg_ParseTuple(result, "OO", &oblarge, &obsmall) &&
@@ -140,8 +140,8 @@ STDMETHODIMP PyGExtractIcon::GetIconLocation(
         return hr;
     PyObject *obFileName;
     // Process the Python results, and convert back to the real params
-    if (PyInt_Check(result) || PyLong_Check(result))
-        hr = PyInt_AsLong(result);
+    if (PyLong_Check(result) || PyLong_Check(result))
+        hr = PyLong_AsLong(result);
     else {
         if (PyArg_ParseTuple(result, "Oii", &obFileName, piIndex, pflags)) {
             char *filename;

--- a/com/win32comext/shell/src/PyIExtractIconW.cpp
+++ b/com/win32comext/shell/src/PyIExtractIconW.cpp
@@ -110,8 +110,8 @@ STDMETHODIMP PyGExtractIconW::Extract(
     Py_XDECREF(obpszFile);
     if (FAILED(hr))
         return hr;
-    if (PyInt_Check(result) || PyLong_Check(result))
-        hr = PyInt_AsLong(result);
+    if (PyLong_Check(result) || PyLong_Check(result))
+        hr = PyLong_AsLong(result);
     else {
         PyObject *oblarge, *obsmall;
         if (PyArg_ParseTuple(result, "OO", &oblarge, &obsmall) &&
@@ -144,8 +144,8 @@ STDMETHODIMP PyGExtractIconW::GetIconLocation(
         return hr;
     PyObject *obFileName;
     // Process the Python results, and convert back to the real params
-    if (PyInt_Check(result) || PyLong_Check(result))
-        hr = PyInt_AsLong(result);
+    if (PyLong_Check(result) || PyLong_Check(result))
+        hr = PyLong_AsLong(result);
     else {
         if (PyArg_ParseTuple(result, "Oii", &obFileName, piIndex, pflags)) {
             WCHAR *filename;

--- a/com/win32comext/shell/src/PyIExtractImage.cpp
+++ b/com/win32comext/shell/src/PyIExtractImage.cpp
@@ -51,14 +51,14 @@ PyObject *PyIExtractImage::GetLocation(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "lOll:GetLocation", &dwPriority, &obrgSize, &dwRecClrDepth, &dwFlags))
         return NULL;
     BOOL bPythonIsHappy = TRUE;
-    // if (bPythonIsHappy && !PyInt_Check(obdwPriority)) bPythonIsHappy = FALSE;
+    // if (bPythonIsHappy && !PyLong_Check(obdwPriority)) bPythonIsHappy = FALSE;
     if (bPythonIsHappy && !PyWinObject_AsSIZE(obrgSize, &rgSize))
         bPythonIsHappy = FALSE;
-    // if (bPythonIsHappy && !PyInt_Check(obdwFlags)) bPythonIsHappy = FALSE;
+    // if (bPythonIsHappy && !PyLong_Check(obdwFlags)) bPythonIsHappy = FALSE;
     if (!bPythonIsHappy)
         return NULL;
-    // dwPriority = PyInt_AsLong(obdwPriority);
-    // dwFlags = PyInt_AsLong(obdwFlags);
+    // dwPriority = PyLong_AsLong(obdwPriority);
+    // dwFlags = PyLong_AsLong(obdwFlags);
     HRESULT hr;
     PY_INTERFACE_PRECALL;
     hr = pIEI->GetLocation(pszPathBuffer, elementsof(pszPathBuffer), &dwPriority, &rgSize, dwRecClrDepth, &dwFlags);

--- a/com/win32comext/shell/src/PyIExtractImage.cpp
+++ b/com/win32comext/shell/src/PyIExtractImage.cpp
@@ -95,7 +95,7 @@ PyObject *PyIExtractImage::Extract(PyObject *self, PyObject *args)
     return PyWinObject_FromHANDLE((HANDLE)hBmpThumbnail);
     // return Py_BuildValue("i", hBmpThumbnail);
     // return PyLong_FromVoidPtr((void*)hBmpThumbnail);
-    // return PyString_FromString((char*)hBmpThumbnail);
+    // return PyBytes_FromString((char*)hBmpThumbnail);
 }
 
 // @object PyIExtractImage|Description of the interface

--- a/com/win32comext/shell/src/PyIInputObject.cpp
+++ b/com/win32comext/shell/src/PyIInputObject.cpp
@@ -38,7 +38,7 @@ PyObject *PyIInputObject::TranslateAcceleratorIO(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pISV, IID_IInputObject);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod |PyIInputObject|UIActivate|Description of UIActivate.
@@ -115,8 +115,8 @@ STDMETHODIMP PyGInputObject::TranslateAcceleratorIO(
     if (FAILED(hr))
         return hr;
     // Process the Python results, and convert back to the real params
-    if (PyInt_Check(result) || PyLong_Check(result))
-        hr = PyInt_AsLong(result);
+    if (PyLong_Check(result) || PyLong_Check(result))
+        hr = PyLong_AsLong(result);
     Py_DECREF(result);
     return hr;
 }

--- a/com/win32comext/shell/src/PyIKnownFolder.cpp
+++ b/com/win32comext/shell/src/PyIKnownFolder.cpp
@@ -49,7 +49,7 @@ PyObject *PyIKnownFolder::GetCategory(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIKF, IID_IKnownFolder);
-    return PyInt_FromLong(category);
+    return PyLong_FromLong(category);
 }
 
 // @pymethod <o PyIShellItem>|PyIKnownFolder|GetShellItem|Returns a shell interface for the folder
@@ -180,7 +180,7 @@ PyObject *PyIKnownFolder::GetRedirectionCapabilities(PyObject *self, PyObject *a
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIKF, IID_IKnownFolder);
-    return PyInt_FromLong(Capabilities);
+    return PyLong_FromLong(Capabilities);
 }
 
 // @pymethod dict|PyIKnownFolder|GetFolderDefinition|Retrieves detailed information about a known folder

--- a/com/win32comext/shell/src/PyIKnownFolderManager.cpp
+++ b/com/win32comext/shell/src/PyIKnownFolderManager.cpp
@@ -56,7 +56,7 @@ PyObject *PyIKnownFolderManager::FolderIdToCsidl(PyObject *self, PyObject *args)
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIKFM, IID_IKnownFolderManager);
-    return PyInt_FromLong(csidl);
+    return PyLong_FromLong(csidl);
 }
 
 // @pymethod (<o PyIID>,...)|PyIKnownFolderManager|GetFolderIds|Retrieves all known folder ids.

--- a/com/win32comext/shell/src/PyINameSpaceTreeControl.cpp
+++ b/com/win32comext/shell/src/PyINameSpaceTreeControl.cpp
@@ -68,7 +68,7 @@ PyObject *PyINameSpaceTreeControl::TreeAdvise(PyObject *self, PyObject *args)
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pINSTC, IID_INameSpaceTreeControl);
-    return PyInt_FromLong(dwCookie);
+    return PyLong_FromLong(dwCookie);
 }
 
 // @pymethod |PyINameSpaceTreeControl|TreeUnadvise|Description of TreeUnadvise.
@@ -339,7 +339,7 @@ PyObject *PyINameSpaceTreeControl::GetItemCustomState(PyObject *self, PyObject *
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pINSTC, IID_INameSpaceTreeControl);
-    return PyInt_FromLong(iStateNumber);
+    return PyLong_FromLong(iStateNumber);
 }
 
 // @pymethod |PyINameSpaceTreeControl|SetItemCustomState|Description of SetItemCustomState.

--- a/com/win32comext/shell/src/PyIShellBrowser.cpp
+++ b/com/win32comext/shell/src/PyIShellBrowser.cpp
@@ -528,7 +528,7 @@ STDMETHODIMP PyGShellBrowser::SendControlMsg(
     PyObject *result;
     HRESULT hr = InvokeViaPolicy("SendControlMsg", &result, "iiNN", id, uMsg, PyWinObject_FromPARAM(wParam),
                                  PyWinObject_FromPARAM(lParam));
-    if (PyInt_Check(result) || PyLong_Check(result))
+    if (PyLong_Check(result) || PyLong_Check(result))
         PyWinLong_AsULONG_PTR(result, (ULONG_PTR *)pret);
     Py_DECREF(result);
     return hr;

--- a/com/win32comext/shell/src/PyIShellFolder.cpp
+++ b/com/win32comext/shell/src/PyIShellFolder.cpp
@@ -218,13 +218,13 @@ PyObject *PyIShellFolder::CompareIDs(PyObject *self, PyObject *args)
         else  // special handling of hresult
             if ((short)HRESULT_CODE(hr) < 0)
             /* pidl1 comes first */
-            ret = PyInt_FromLong(-1);
+            ret = PyLong_FromLong(-1);
         else if ((short)HRESULT_CODE(hr) > 0)
             /* pidl2 comes first */
-            ret = PyInt_FromLong(1);
+            ret = PyLong_FromLong(1);
         else
             /* the two pidls are equal */
-            ret = PyInt_FromLong(0);
+            ret = PyLong_FromLong(0);
     }
     PyObject_FreePIDL(pidl1);
     PyObject_FreePIDL(pidl2);
@@ -289,7 +289,7 @@ PyObject *PyIShellFolder::GetAttributesOf(PyObject *self, PyObject *args)
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pISF, IID_IShellFolder);
-    return PyInt_FromLong(rgfInOut);
+    return PyLong_FromLong(rgfInOut);
 }
 
 // @pymethod int, <o PyIUnknown>|PyIShellFolder|GetUIObjectOf|Creates an interface to one or more items in a shell
@@ -578,8 +578,8 @@ STDMETHODIMP PyGShellFolder::CompareIDs(
     HRESULT hr = InvokeViaPolicy("CompareIDs", &result, "NNN", obparam, obpidl1, obpidl2);
     if (FAILED(hr))
         return hr;
-    if (PyInt_Check(result))
-        hr = MAKE_HRESULT(SEVERITY_SUCCESS, 0, PyInt_AsLong(result));
+    if (PyLong_Check(result))
+        hr = MAKE_HRESULT(SEVERITY_SUCCESS, 0, PyLong_AsLong(result));
     Py_DECREF(result);
     return hr;
 }
@@ -619,8 +619,8 @@ STDMETHODIMP PyGShellFolder::GetAttributesOf(
     if (FAILED(hr))
         return hr;
     // Process the Python results, and convert back to the real params
-    if (rgfInOut && PyInt_Check(result))
-        *rgfInOut = PyInt_AsLong(result);
+    if (rgfInOut && PyLong_Check(result))
+        *rgfInOut = PyLong_AsLong(result);
     hr = PyCom_SetAndLogCOMErrorFromPyException("GetAttributesOf", IID_IShellFolder);
     Py_DECREF(result);
     return hr;

--- a/com/win32comext/shell/src/PyIShellIconOverlayIdentifier.cpp
+++ b/com/win32comext/shell/src/PyIShellIconOverlayIdentifier.cpp
@@ -129,8 +129,8 @@ STDMETHODIMP PyGShellIconOverlayIdentifier::IsMemberOf(
     HRESULT hr = InvokeViaPolicy("IsMemberOf", &ret, "Ol", obpath, attrib);
     if (FAILED(hr))
         return hr;
-    if (PyInt_Check(ret))
-        hr = PyInt_AsLong(ret);
+    if (PyLong_Check(ret))
+        hr = PyLong_AsLong(ret);
     Py_XDECREF(ret);
     return hr;
 }

--- a/com/win32comext/shell/src/PyIShellIconOverlayManager.cpp
+++ b/com/win32comext/shell/src/PyIShellIconOverlayManager.cpp
@@ -44,7 +44,7 @@ PyObject *PyIShellIconOverlayManager::GetFileOverlayInfo(PyObject *self, PyObjec
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pISIOM, IID_IShellIconOverlayManager);
-    return PyInt_FromLong(index);
+    return PyLong_FromLong(index);
 }
 
 // @pymethod |PyIShellIconOverlayManager|GetReservedOverlayInfo|Description of GetReservedOverlayInfo.
@@ -75,7 +75,7 @@ PyObject *PyIShellIconOverlayManager::GetReservedOverlayInfo(PyObject *self, PyO
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pISIOM, IID_IShellIconOverlayManager);
 
-    return PyInt_FromLong(index);
+    return PyLong_FromLong(index);
 }
 
 // @pymethod |PyIShellIconOverlayManager|RefreshOverlayImages|Description of RefreshOverlayImages.

--- a/com/win32comext/shell/src/PyIShellItem.cpp
+++ b/com/win32comext/shell/src/PyIShellItem.cpp
@@ -142,7 +142,7 @@ PyObject *PyIShellItem::Compare(PyObject *self, PyObject *args)
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pISI, IID_IShellItem);
-    return PyInt_FromLong(iOrder);
+    return PyLong_FromLong(iOrder);
 }
 
 // @object PyIShellItem|Interface that represents an item in the Explorer shell
@@ -261,7 +261,7 @@ STDMETHODIMP PyGShellItem::Compare(
     Py_XDECREF(obpsi);
     if (FAILED(hr))
         return hr;
-    *piOrder = PyInt_AsLong(result);
+    *piOrder = PyLong_AsLong(result);
     hr = PyCom_SetAndLogCOMErrorFromPyException("Compare", IID_IShellItem);
     Py_DECREF(result);
     return hr;

--- a/com/win32comext/shell/src/PyIShellItem2.cpp
+++ b/com/win32comext/shell/src/PyIShellItem2.cpp
@@ -246,7 +246,7 @@ PyObject *PyIShellItem2::GetInt32(PyObject *self, PyObject *args)
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pISI2, IID_IShellItem2);
-    return PyInt_FromLong(val);
+    return PyLong_FromLong(val);
 }
 
 // @pymethod str|PyIShellItem2|GetString|Retrieves the value of a property as a string
@@ -535,7 +535,7 @@ STDMETHODIMP PyGShellItem2::GetInt32(
     HRESULT hr = InvokeViaPolicy("GetInt32", &result, "(N)", PyObject_FromSHCOLUMNID(&key));
     if (FAILED(hr))
         return hr;
-    *pi = PyInt_AsLong(result);
+    *pi = PyLong_AsLong(result);
     if (*pi == -1 && PyErr_Occurred())
         hr = MAKE_PYCOM_GATEWAY_FAILURE_CODE("GetInt32");
     Py_DECREF(result);

--- a/com/win32comext/shell/src/PyIShellItemArray.cpp
+++ b/com/win32comext/shell/src/PyIShellItemArray.cpp
@@ -144,7 +144,7 @@ PyObject *PyIShellItemArray::GetCount(PyObject *self, PyObject *args)
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pISIA, IID_IShellItemArray);
-    return PyInt_FromLong(dwNumItems);
+    return PyLong_FromLong(dwNumItems);
 }
 
 // @pymethod <o PyIShellItem>|PyIShellItemArray|GetItemAt|Retrieves an item by index

--- a/com/win32comext/shell/src/PyIShellLibrary.cpp
+++ b/com/win32comext/shell/src/PyIShellLibrary.cpp
@@ -241,7 +241,7 @@ PyObject *PyIShellLibrary::GetOptions(PyObject *self, PyObject *args)
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pISL, IID_IShellLibrary);
-    return PyInt_FromLong(Options);
+    return PyLong_FromLong(Options);
 }
 
 // @pymethod |PyIShellLibrary|SetOptions|Sets library option flags

--- a/com/win32comext/shell/src/PyIShellLink.cpp
+++ b/com/win32comext/shell/src/PyIShellLink.cpp
@@ -279,7 +279,7 @@ PyObject *PyIShellLink::GetHotkey(PyObject *self, PyObject *args)
 
     if (FAILED(hr))
         return OleSetOleError(hr);
-    return PyInt_FromLong(hotkey);
+    return PyLong_FromLong(hotkey);
     // @comm Note: My tests do not seem to be working. at least, the values returned
     // seem not to match what the documentation says should be returned.
     // I would expect with a Hotkey of CTRL-ALT-T, to get an integer where
@@ -323,7 +323,7 @@ PyObject *PyIShellLink::GetShowCmd(PyObject *self, PyObject *args)
 
     if (FAILED(hr))
         return OleSetOleError(hr);
-    return PyInt_FromLong(iShowCmd);
+    return PyLong_FromLong(iShowCmd);
 }
 
 // @pymethod |PyIShellLink|SetShowCmd|Sets the show (SW_) command for a shell link object.

--- a/com/win32comext/shell/src/PyIShellView.cpp
+++ b/com/win32comext/shell/src/PyIShellView.cpp
@@ -39,7 +39,7 @@ PyObject *PyIShellView::TranslateAccelerator(PyObject *self, PyObject *args)
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pISV, IID_IShellView);
     // @rdesc The result is the HRESULT from the underlying TranslateAccelerator call
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod |PyIShellView|EnableModeless|Description of EnableModeless.
@@ -338,8 +338,8 @@ STDMETHODIMP PyGShellView::TranslateAccelerator(
     if (FAILED(hr))
         return hr;
     // Process the Python results, and convert back to the real params
-    if (PyInt_Check(result) || PyLong_Check(result))
-        hr = PyInt_AsLong(result);
+    if (PyLong_Check(result) || PyLong_Check(result))
+        hr = PyLong_AsLong(result);
     Py_DECREF(result);
     return hr;
 }

--- a/com/win32comext/shell/src/PyITransferSource.cpp
+++ b/com/win32comext/shell/src/PyITransferSource.cpp
@@ -222,7 +222,7 @@ PyObject *PyITransferSource::RemoveItem(PyObject *self, PyObject *args)
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pITS, IID_ITransferSource);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod (int, <o PyIShellItem>)|PyITransferSource|RenameItem|Renames a shell item
@@ -386,7 +386,7 @@ PyObject *PyITransferSource::EnterFolder(PyObject *self, PyObject *args)
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pITS, IID_ITransferSource);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod int|PyITransferSource|LeaveFolder|Informs the copy engine that the operation on a destination folder is
@@ -412,7 +412,7 @@ PyObject *PyITransferSource::LeaveFolder(PyObject *self, PyObject *args)
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pITS, IID_ITransferSource);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @object PyITransferSource|Implemented by shell folders that can act as the source of shell item operations

--- a/com/win32comext/shell/src/shell.cpp
+++ b/com/win32comext/shell/src/shell.cpp
@@ -566,7 +566,7 @@ BOOL PyObject_AsTBBUTTONs(PyObject *ob, TBBUTTON **ppButtons, UINT *pnButtons)
 PyObject *PyWinObject_FromRESOURCESTRING(LPCSTR str)
 {
     if (HIWORD(str) == 0)
-        return PyInt_FromLong(LOWORD(str));
+        return PyLong_FromLong(LOWORD(str));
     return PyBytes_FromString(str);
 }
 
@@ -1065,8 +1065,8 @@ static int CALLBACK PyBrowseCallbackProc(HWND hwnd, UINT uMsg, LPARAM lParam, LP
         goto done;
     result = PyEval_CallObject(pc->fn, args);
     // API says must return 0, but there might be a good reason.
-    if (result && PyInt_Check(result))
-        rc = PyInt_AsLong(result);
+    if (result && PyLong_Check(result))
+        rc = PyLong_AsLong(result);
 done:
     if (PyErr_Occurred()) {
         PySys_WriteStderr("SHBrowseForFolder callback failed!\n");
@@ -1912,7 +1912,7 @@ static PyObject *PySHChangeNotifyRegister(PyObject *self, PyObject *args)
     rc = (*pfnSHChangeNotifyRegister)(hwnd, sources, events, msg, 1, &entry);
     PY_INTERFACE_POSTCALL;
     PyObject_FreePIDL(entry.pidl);
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod |shell|SHChangeNotifyDeregister|Unregisters the client's window process from receiving notification events
@@ -1957,7 +1957,7 @@ static PyObject *PyDragQueryFile(PyObject *self, PyObject *args)
     if (!PyWinObject_AsHANDLE(obhglobal, (HANDLE *)&hglobal))
         return NULL;
     if (index == 0xFFFFFFFF) {
-        return PyInt_FromLong(DragQueryFile(hglobal, index, NULL, 0));
+        return PyLong_FromLong(DragQueryFile(hglobal, index, NULL, 0));
     }
     // get the buffer size
     UINT nchars = DragQueryFile(hglobal, index, NULL, 0) + 2;
@@ -1985,7 +1985,7 @@ static PyObject *PyDragQueryFileW(PyObject *self, PyObject *args)
     if (!PyWinObject_AsHANDLE(obhglobal, (HANDLE *)&hglobal))
         return NULL;
     if (index == 0xFFFFFFFF) {
-        return PyInt_FromLong(DragQueryFileW(hglobal, index, NULL, 0));
+        return PyLong_FromLong(DragQueryFileW(hglobal, index, NULL, 0));
     }
     // get the buffer size
     UINT nchars = DragQueryFileW(hglobal, index, NULL, 0) + 2;
@@ -2145,7 +2145,7 @@ static PyObject *PySHGetSettings(PyObject *self, PyObject *args)
     CHECK_SET_VAL(SSF_WIN95CLASSIC, mask, fWin95Classic);
     // If requesting any of the top 3 bits, return them as well
     if (mask & 0xE000) {
-        PyObject *val = PyInt_FromLong(state.fRestFlags);
+        PyObject *val = PyLong_FromLong(state.fRestFlags);
         if (val) {
             PyDict_SetItemString(ret, "fRestFlags", val);
             Py_DECREF(val);
@@ -2228,7 +2228,7 @@ static PyObject *PyFILEGROUPDESCRIPTORAsString(PyObject *self, PyObject *args)
         if (attr == NULL)
             PyErr_Clear();
         if (attr && attr != Py_None) {
-            fd->dwFlags = PyInt_AsLong(attr);
+            fd->dwFlags = PyLong_AsLong(attr);
             ok = !PyErr_Occurred();
         }
         Py_XDECREF(attr);
@@ -2273,7 +2273,7 @@ static PyObject *PyFILEGROUPDESCRIPTORAsString(PyObject *self, PyObject *args)
             PyErr_Clear();
         if (attr && attr != Py_None) {
             fd->dwFlags |= FD_ATTRIBUTES;
-            fd->dwFileAttributes = PyInt_AsLong(attr);
+            fd->dwFileAttributes = PyLong_AsLong(attr);
             ok = !PyErr_Occurred();
         }
         Py_XDECREF(attr);
@@ -2437,7 +2437,7 @@ static PyObject *PyStringAsFILEGROUPDESCRIPTOR(PyObject *self, PyObject *args)
         PyObject *val;
         // These structures are the same until the very end, where the
         // unicode/ascii buffer is - so we can use either pointer
-        val = PyInt_FromLong(fd->dwFlags);
+        val = PyLong_FromLong(fd->dwFlags);
         if (val)
             PyDict_SetItemString(sub, "dwFlags", val);
         Py_XDECREF(val);
@@ -2461,7 +2461,7 @@ static PyObject *PyStringAsFILEGROUPDESCRIPTOR(PyObject *self, PyObject *args)
         }
 
         if (fd->dwFlags & FD_ATTRIBUTES) {
-            val = PyInt_FromLong(fd->dwFileAttributes);
+            val = PyLong_FromLong(fd->dwFileAttributes);
             if (val)
                 PyDict_SetItemString(sub, "dwFileAttributes", val);
             Py_XDECREF(val);
@@ -2576,7 +2576,7 @@ static PyObject *PyShellExecuteEx(PyObject *self, PyObject *args, PyObject *kw)
     }
     if (obHotKey) {
         info.fMask |= SEE_MASK_HOTKEY;
-        info.dwHotKey = PyInt_AsLong(obHotKey);
+        info.dwHotKey = PyLong_AsLong(obHotKey);
         if (PyErr_Occurred())
             goto done;
     }
@@ -3831,7 +3831,7 @@ static const PyCom_InterfaceSupportInfo g_interfaceSupportData[] = {
 
 static int AddConstant(PyObject *dict, const char *key, long value)
 {
-    PyObject *oval = PyInt_FromLong(value);
+    PyObject *oval = PyLong_FromLong(value);
     if (!oval) {
         return 1;
     }

--- a/com/win32comext/taskscheduler/src/PyIScheduledWorkItem.cpp
+++ b/com/win32comext/taskscheduler/src/PyIScheduledWorkItem.cpp
@@ -483,7 +483,7 @@ PyObject *PyIScheduledWorkItem::SetWorkItemData(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "O:PyIScheduledWorkItem::SetWorkItemData", &obworkitem_data))
         return NULL;
     if (obworkitem_data != Py_None)
-        if (PyString_AsStringAndSize(obworkitem_data, (CHAR **)&workitem_data, &data_len) == -1)
+        if (PyBytes_AsStringAndSize(obworkitem_data, (CHAR **)&workitem_data, &data_len) == -1)
             return NULL;
         else
             // Task Scheduler won't take an empty string for data anymore ??????
@@ -521,7 +521,7 @@ PyObject *PyIScheduledWorkItem::GetWorkItemData(PyObject *self, PyObject *args)
     if (FAILED(hr))
         PyCom_BuildPyException(hr, pISWI, IID_IScheduledWorkItem);
     else if (workitem_data != NULL)
-        ret = PyString_FromStringAndSize((const char *)workitem_data, data_len);
+        ret = PyBytes_FromStringAndSize((const char *)workitem_data, data_len);
     else {
         Py_INCREF(Py_None);
         ret = Py_None;

--- a/isapi/src/PyExtensionObjects.cpp
+++ b/isapi/src/PyExtensionObjects.cpp
@@ -175,7 +175,7 @@ PyObject *PyVERSION_INFO::getattro(PyObject *self, PyObject *obname)
         return PyErr_Format(PyExc_RuntimeError, "VERSION_INFO structure no longer exists");
     TCHAR *name = PYISAPI_ATTR_CONVERT(obname);
     if (_tcscmp(name, _T("ExtensionDesc")) == 0) {
-        return PyString_FromString(me->m_pvi->lpszExtensionDesc);
+        return PyBytes_FromString(me->m_pvi->lpszExtensionDesc);
     }
     return PyObject_GenericGetAttr(self, obname);
 }
@@ -350,22 +350,22 @@ PyObject *PyECB::getattro(PyObject *self, PyObject *obname)
     EXTENSION_CONTROL_BLOCK *pecb = ((PyECB *)self)->m_pcb->GetECB();
 
     if (_tcscmp(name, _T("Method")) == 0)
-        return PyString_FromString(pecb->lpszMethod);
+        return PyBytes_FromString(pecb->lpszMethod);
 
     if (_tcscmp(name, _T("QueryString")) == 0)
-        return PyString_FromString(pecb->lpszQueryString);
+        return PyBytes_FromString(pecb->lpszQueryString);
 
     if (_tcscmp(name, _T("PathInfo")) == 0)
-        return PyString_FromString(pecb->lpszPathInfo);
+        return PyBytes_FromString(pecb->lpszPathInfo);
 
     if (_tcscmp(name, _T("PathTranslated")) == 0)
-        return PyString_FromString(pecb->lpszPathTranslated);
+        return PyBytes_FromString(pecb->lpszPathTranslated);
 
     if (_tcscmp(name, _T("AvailableData")) == 0)
-        return PyString_FromStringAndSize((const char *)pecb->lpbData, pecb->cbAvailable);
+        return PyBytes_FromStringAndSize((const char *)pecb->lpbData, pecb->cbAvailable);
 
     if (_tcscmp(name, _T("ContentType")) == 0)
-        return PyString_FromString(pecb->lpszContentType);
+        return PyBytes_FromString(pecb->lpszContentType);
 
     if (_tcscmp(name, _T("LogData")) == 0)
         return PyErr_Format(PyExc_AttributeError, "LogData attribute can only be set");
@@ -490,7 +490,7 @@ PyObject *PyECB::GetServerVariable(PyObject *self, PyObject *args)
     }
     PyObject *ret = strncmp("UNICODE_", variable, 8) == 0
                         ? PyUnicode_FromWideChar((WCHAR *)bufUse, bufsize / sizeof(WCHAR))
-                        : PyString_FromStringAndSize(bufUse, bufsize);
+                        : PyBytes_FromStringAndSize(bufUse, bufsize);
     if (bufUse != buf)
         free(bufUse);
     return ret;
@@ -540,9 +540,9 @@ PyObject *PyECB::ReadClient(PyObject *self, PyObject *args)
 
     PyObject *pyRes = NULL;
     if (nSize > 0)
-        pyRes = PyString_FromStringAndSize((const char *)pBuff, nSize);
+        pyRes = PyBytes_FromStringAndSize((const char *)pBuff, nSize);
     else
-        pyRes = PyString_FromStringAndSize("", 0);
+        pyRes = PyBytes_FromStringAndSize("", 0);
 
     delete[] pBuff;
 
@@ -674,9 +674,9 @@ PyObject *PyECB::GetAnonymousToken(PyObject *self, PyObject *args)
         return NULL;
     HANDLE handle;
     BOOL bRes;
-    if (PyString_Check(obStr)) {
+    if (PyBytes_Check(obStr)) {
         Py_BEGIN_ALLOW_THREADS bRes = ecb->ServerSupportFunction(ecb->ConnID, HSE_REQ_GET_ANONYMOUS_TOKEN,
-                                                                 PyString_AS_STRING(obStr), (DWORD *)&handle, NULL);
+                                                                 PyBytes_AS_STRING(obStr), (DWORD *)&handle, NULL);
         Py_END_ALLOW_THREADS
     }
     else if (PyUnicode_Check(obStr)) {
@@ -959,7 +959,7 @@ PyObject *PyECB::MapURLToPath(PyObject *self, PyObject *args)
 
     Py_BEGIN_ALLOW_THREADS ok = pecb->m_pcb->MapURLToPath(buffer, &bufSize);
     Py_END_ALLOW_THREADS if (!ok) return SetPyECBError("ServerSupportFunction(HSE_REQ_MAP_URL_TO_PATH)");
-    return PyString_FromString(buffer);
+    return PyBytes_FromString(buffer);
 }
 
 // @pymethod |EXTENSION_CONTROL_BLOCK|DoneWithSession|Calls ServerSupportFunction with HSE_REQ_DONE_WITH_SESSION

--- a/isapi/src/PyExtensionObjects.cpp
+++ b/isapi/src/PyExtensionObjects.cpp
@@ -345,7 +345,7 @@ PyObject *PyECB::getattro(PyObject *self, PyObject *obname)
     TCHAR *name = PYISAPI_ATTR_CONVERT(obname);
 
     if (_tcscmp(name, _T("softspace")) == 0)  // help 'print' semantics.
-        return PyInt_FromLong(1);
+        return PyLong_FromLong(1);
 
     EXTENSION_CONTROL_BLOCK *pecb = ((PyECB *)self)->m_pcb->GetECB();
 
@@ -386,7 +386,7 @@ int PyECB::setattro(PyObject *self, PyObject *obname, PyObject *v)
 
     if (_tcscmp(name, _T("HttpStatusCode")) == 0) {
         PyECB *pecb = (PyECB *)self;
-        DWORD status = PyInt_AsLong(v);
+        DWORD status = PyLong_AsLong(v);
         pecb->m_HttpStatusCode = status;
         if (pecb->m_pcb)
             pecb->m_pcb->SetStatus(status);
@@ -431,7 +431,7 @@ PyObject *PyECB::WriteClient(PyObject *self, PyObject *args)
         Py_BEGIN_ALLOW_THREADS bRes = pecb->m_pcb->WriteClient(buffer, &buffLenOut, reserved);
         Py_END_ALLOW_THREADS if (!bRes) return SetPyECBError("WriteClient");
     }
-    return PyInt_FromLong(buffLenOut);
+    return PyLong_FromLong(buffLenOut);
     // @rdesc the result is the number of bytes written.
 }
 
@@ -937,7 +937,7 @@ PyObject *PyECB::IsKeepAlive(PyObject *self, PyObject *args)
         Py_END_ALLOW_THREADS
     }
 
-    return PyInt_FromLong((bKeepAlive) ? 1 : 0);
+    return PyLong_FromLong((bKeepAlive) ? 1 : 0);
 }
 
 // @pymethod |EXTENSION_CONTROL_BLOCK|MapURLToPath|Calls ServerSupportFunction with HSE_REQ_MAP_URL_TO_PATH

--- a/isapi/src/PyFilterObjects.cpp
+++ b/isapi/src/PyFilterObjects.cpp
@@ -82,7 +82,7 @@ PyObject *PyFILTER_VERSION::getattro(PyObject *self, PyObject *obname)
     }
     // @prop string|FilterDesc|
     if (_tcscmp(name, _T("FilterDesc")) == 0) {
-        return PyString_FromString(me->m_pfv->lpszFilterDesc);
+        return PyBytes_FromString(me->m_pfv->lpszFilterDesc);
     }
     return PyErr_Format(PyExc_AttributeError, "PyFILTER_VERSION has no attribute '%s'", name);
 }
@@ -282,7 +282,7 @@ PyObject *PyHFC::GetServerVariable(PyObject *self, PyObject *args)
     }
     PyObject *ret = strncmp("UNICODE_", variable, 8) == 0
                         ? PyUnicode_FromWideChar((WCHAR *)bufUse, bufsize / sizeof(WCHAR))
-                        : PyString_FromStringAndSize(bufUse, bufsize);
+                        : PyBytes_FromStringAndSize(bufUse, bufsize);
     if (bufUse != buf)
         free(bufUse);
     return ret;
@@ -537,11 +537,11 @@ PyObject *PyURL_MAP::getattro(PyObject *self, PyObject *obname)
     // @prop string|URL|
     TCHAR *name = PYISAPI_ATTR_CONVERT(obname);
     if (_tcscmp(name, _T("URL")) == 0) {
-        return PyString_FromString(pMap->pszURL);
+        return PyBytes_FromString(pMap->pszURL);
     }
     // @prop string|PhysicalPath|
     if (_tcscmp(name, _T("PhysicalPath")) == 0) {
-        return PyString_FromString(pMap->pszPhysicalPath);
+        return PyBytes_FromString(pMap->pszPhysicalPath);
     }
     return PyObject_GenericGetAttr(self, obname);
 }
@@ -553,17 +553,17 @@ int PyURL_MAP::setattro(PyObject *self, PyObject *obname, PyObject *v)
         return NULL;
     TCHAR *name = PYISAPI_ATTR_CONVERT(obname);
     if (_tcscmp(name, _T("PhysicalPath")) == 0) {
-        if (!PyString_Check(v)) {
+        if (!PyBytes_Check(v)) {
             PyErr_Format(PyExc_TypeError, "PhysicalPath must be a string");
             return -1;
         }
-        int cc = PyString_Size(v);
+        int cc = PyBytes_Size(v);
         if ((DWORD)cc >= pMap->cbPathBuff) {
             PyErr_Format(PyExc_ValueError, "The string is too long - got %d chars, but max is %d", cc,
                          pMap->cbPathBuff - 1);
             return -1;
         }
-        strcpy(pMap->pszPhysicalPath, PyString_AS_STRING(v));
+        strcpy(pMap->pszPhysicalPath, PyBytes_AS_STRING(v));
         return 0;
     }
     return PyObject_GenericSetAttr(self, obname, v);
@@ -598,7 +598,7 @@ PyObject *PyPREPROC_HEADERS_GetHeader(PyObject *self, PyObject *args)
         Py_INCREF(def);
         return def;
     }
-    return PyString_FromStringAndSize(buffer, bufSize - 1);
+    return PyBytes_FromStringAndSize(buffer, bufSize - 1);
 }
 
 // @pymethod |HTTP_FILTER_PREPROC_HEADERS|SetHeader|
@@ -784,7 +784,7 @@ PyObject *PyRAW_DATA::getattro(PyObject *self, PyObject *obname)
             Py_INCREF(Py_None);
             return Py_None;
         }
-        return PyString_FromStringAndSize((const char *)pRD->pvInData, pRD->cbInData);
+        return PyBytes_FromStringAndSize((const char *)pRD->pvInData, pRD->cbInData);
     }
 
     return PyObject_GenericGetAttr(self, obname);
@@ -800,11 +800,11 @@ int PyRAW_DATA::setattro(PyObject *self, PyObject *obname, PyObject *v)
 
     TCHAR *name = PYISAPI_ATTR_CONVERT(obname);
     if (_tcscmp(name, _T("InData")) == 0) {
-        if (!PyString_Check(v)) {
+        if (!PyBytes_Check(v)) {
             PyErr_Format(PyExc_TypeError, "InData must be a string (got %s)", v->ob_type->tp_name);
             return -1;
         }
-        int cch = PyString_Size(v);
+        int cch = PyBytes_Size(v);
         void *nb = pFC->AllocMem(pFC, cch + sizeof(char), 0);
         if (nb) {
             pRD->cbInData = cch;
@@ -891,7 +891,7 @@ PyObject *PyAUTHENT::getattro(PyObject *self, PyObject *obname)
             Py_INCREF(Py_None);
             return Py_None;
         }
-        return PyString_FromString((const char *)pAE->pszUser);
+        return PyBytes_FromString((const char *)pAE->pszUser);
     }
     // @prop string|Password|
     if (_tcscmp(name, _T("Password")) == 0) {
@@ -899,7 +899,7 @@ PyObject *PyAUTHENT::getattro(PyObject *self, PyObject *obname)
             Py_INCREF(Py_None);
             return Py_None;
         }
-        return PyString_FromString((const char *)pAE->pszPassword);
+        return PyBytes_FromString((const char *)pAE->pszPassword);
     }
     return PyObject_GenericGetAttr(self, obname);
 }
@@ -914,29 +914,29 @@ int PyAUTHENT::setattro(PyObject *self, PyObject *obname, PyObject *v)
 
     TCHAR *name = PYISAPI_ATTR_CONVERT(obname);
     if (_tcscmp(name, _T("User")) == 0) {
-        if (!PyString_Check(v)) {
+        if (!PyBytes_Check(v)) {
             PyErr_Format(PyExc_TypeError, "User must be a string (got %s)", v->ob_type->tp_name);
             return -1;
         }
-        DWORD cch = PyString_Size(v);
+        DWORD cch = PyBytes_Size(v);
         if (cch >= pAE->cbUserBuff) {
             PyErr_Format(PyExc_ValueError, "The value is too long - max size is %d", pAE->cbUserBuff);
             return -1;
         }
-        strcpy(pAE->pszUser, PyString_AS_STRING(v));
+        strcpy(pAE->pszUser, PyBytes_AS_STRING(v));
         return 0;
     }
     if (_tcscmp(name, _T("Password")) == 0) {
-        if (!PyString_Check(v)) {
+        if (!PyBytes_Check(v)) {
             PyErr_Format(PyExc_TypeError, "Password must be a string (got %s)", v->ob_type->tp_name);
             return -1;
         }
-        DWORD cch = PyString_Size(v);
+        DWORD cch = PyBytes_Size(v);
         if (cch >= pAE->cbPasswordBuff) {
             PyErr_Format(PyExc_ValueError, "The value is too long - max size is %d", pAE->cbPasswordBuff);
             return -1;
         }
-        strcpy(pAE->pszPassword, PyString_AS_STRING(v));
+        strcpy(pAE->pszPassword, PyBytes_AS_STRING(v));
         return 0;
     }
     return PyObject_GenericSetAttr(self, obname, v);
@@ -1000,22 +1000,22 @@ PyObject *PyFILTER_LOG::getattro(PyObject *self, PyObject *obname)
     TCHAR *name = PYISAPI_ATTR_CONVERT(obname);
     // @prop string|ClientHostName|
     if (_tcscmp(name, _T("ClientHostName")) == 0)
-        return PyString_FromString(pLog->pszClientHostName);
+        return PyBytes_FromString(pLog->pszClientHostName);
     // @prop string|ClientUserName|
     if (_tcscmp(name, _T("ClientUserName")) == 0)
-        return PyString_FromString(pLog->pszClientUserName);
+        return PyBytes_FromString(pLog->pszClientUserName);
     // @prop string|ServerName|
     if (_tcscmp(name, _T("ServerName")) == 0)
-        return PyString_FromString(pLog->pszServerName);
+        return PyBytes_FromString(pLog->pszServerName);
     // @prop string|Operation|
     if (_tcscmp(name, _T("Operation")) == 0)
-        return PyString_FromString(pLog->pszOperation);
+        return PyBytes_FromString(pLog->pszOperation);
     // @prop string|Target|
     if (_tcscmp(name, _T("Target")) == 0)
-        return PyString_FromString(pLog->pszTarget);
+        return PyBytes_FromString(pLog->pszTarget);
     // @prop string|Parameters|
     if (_tcscmp(name, _T("Parameters")) == 0)
-        return PyString_FromString(pLog->pszParameters);
+        return PyBytes_FromString(pLog->pszParameters);
     // @prop int|HttpStatus|
     if (_tcscmp(name, _T("HttpStatus")) == 0)
         return PyInt_FromLong(pLog->dwHttpStatus);
@@ -1030,17 +1030,17 @@ PyObject *PyFILTER_LOG::getattro(PyObject *self, PyObject *obname)
 
 #define CHECK_SET_FILTER_LOG_STRING(struct_elem)                             \
     if (_tcscmp(name, _T(#struct_elem)) == 0) {                              \
-        if (!PyString_Check(v)) {                                            \
+        if (!PyBytes_Check(v)) {                                            \
             PyErr_Format(PyExc_TypeError, #struct_elem " must be a string"); \
             return -1;                                                       \
         }                                                                    \
-        int cc = PyString_Size(v) + sizeof(CHAR);                            \
+        int cc = PyBytes_Size(v) + sizeof(CHAR);                            \
         char *buf = (char *)pFC->AllocMem(pFC, cc, 0);                       \
         if (!buf) {                                                          \
             PyErr_NoMemory();                                                \
             return -1;                                                       \
         }                                                                    \
-        strncpy(buf, PyString_AS_STRING(v), cc);                             \
+        strncpy(buf, PyBytes_AS_STRING(v), cc);                             \
         pLog->psz##struct_elem = buf;                                        \
         return 0;                                                            \
     }

--- a/isapi/src/PyFilterObjects.cpp
+++ b/isapi/src/PyFilterObjects.cpp
@@ -70,15 +70,15 @@ PyObject *PyFILTER_VERSION::getattro(PyObject *self, PyObject *obname)
     TCHAR *name = PYISAPI_ATTR_CONVERT(obname);
     // @prop int|ServerFilterVersion|(read-only)
     if (_tcscmp(name, _T("ServerFilterVersion")) == 0) {
-        return PyInt_FromLong(me->m_pfv->dwServerFilterVersion);
+        return PyLong_FromLong(me->m_pfv->dwServerFilterVersion);
     }
     // @prop int|FilterVersion|
     if (_tcscmp(name, _T("FilterVersion")) == 0) {
-        return PyInt_FromLong(me->m_pfv->dwFilterVersion);
+        return PyLong_FromLong(me->m_pfv->dwFilterVersion);
     }
     // @prop int|Flags|
     if (_tcscmp(name, _T("Flags")) == 0) {
-        return PyInt_FromLong(me->m_pfv->dwFlags);
+        return PyLong_FromLong(me->m_pfv->dwFlags);
     }
     // @prop string|FilterDesc|
     if (_tcscmp(name, _T("FilterDesc")) == 0) {
@@ -100,18 +100,18 @@ int PyFILTER_VERSION::setattro(PyObject *self, PyObject *obname, PyObject *v)
     }
     TCHAR *name = PYISAPI_ATTR_CONVERT(obname);
     if (_tcscmp(name, _T("FilterVersion")) == 0) {
-        if (!PyInt_Check(v)) {
+        if (!PyLong_Check(v)) {
             PyErr_Format(PyExc_ValueError, "FilterVersion must be an int (got %s)", v->ob_type->tp_name);
             return -1;
         }
-        me->m_pfv->dwFilterVersion = PyInt_AsLong(v);
+        me->m_pfv->dwFilterVersion = PyLong_AsLong(v);
     }
     else if (_tcscmp(name, _T("Flags")) == 0) {
-        if (!PyInt_Check(v)) {
+        if (!PyLong_Check(v)) {
             PyErr_Format(PyExc_ValueError, "Flags must be an int (got %s)", v->ob_type->tp_name);
             return -1;
         }
-        me->m_pfv->dwFlags = PyInt_AsLong(v);
+        me->m_pfv->dwFlags = PyLong_AsLong(v);
     }
     else if (_tcscmp(name, _T("FilterDesc")) == 0) {
         DWORD size;
@@ -1018,10 +1018,10 @@ PyObject *PyFILTER_LOG::getattro(PyObject *self, PyObject *obname)
         return PyBytes_FromString(pLog->pszParameters);
     // @prop int|HttpStatus|
     if (_tcscmp(name, _T("HttpStatus")) == 0)
-        return PyInt_FromLong(pLog->dwHttpStatus);
+        return PyLong_FromLong(pLog->dwHttpStatus);
     // @prop int|HttpStatus|
     if (_tcscmp(name, _T("Win32Status")) == 0)
-        return PyInt_FromLong(pLog->dwWin32Status);
+        return PyLong_FromLong(pLog->dwWin32Status);
     return PyObject_GenericGetAttr(self, obname);
 }
 
@@ -1047,11 +1047,11 @@ PyObject *PyFILTER_LOG::getattro(PyObject *self, PyObject *obname)
 
 #define CHECK_SET_FILTER_LOG_LONG(struct_elem)                                 \
     if (_tcscmp(name, _T(#struct_elem)) == 0) {                                \
-        if (!PyInt_Check(v)) {                                                 \
+        if (!PyLong_Check(v)) {                                                 \
             PyErr_Format(PyExc_TypeError, #struct_elem " must be an integer"); \
             return -1;                                                         \
         }                                                                      \
-        pLog->dw##struct_elem = PyInt_AsLong(v);                               \
+        pLog->dw##struct_elem = PyLong_AsLong(v);                               \
         return 0;                                                              \
     }
 

--- a/isapi/src/PythonEng.cpp
+++ b/isapi/src/PythonEng.cpp
@@ -135,7 +135,7 @@ bool CPythonEngine::AddToPythonPath(LPCTSTR pPathName)
         len -= 4;
     }
 #if (PY_VERSION_HEX < 0x03000000)
-    PyObject *obNew = PyString_FromStringAndSize(pPathName, len);
+    PyObject *obNew = PyBytes_FromStringAndSize(pPathName, len);
 #else
     PyObject *obNew = PyUnicode_FromWideChar(pPathName, len);
 #endif

--- a/isapi/src/StdAfx.h
+++ b/isapi/src/StdAfx.h
@@ -63,7 +63,7 @@ typedef int Py_ssize_t;
 
 // Macros to handle PyObject layout changes in Py3k
 #define PYISAPI_OBJECT_HEAD PyObject_HEAD_INIT(&PyType_Type) 0,
-#define PYISAPI_ATTR_CONVERT PyString_AsString
+#define PYISAPI_ATTR_CONVERT PyBytes_AsString
 
 #else  // Py3k definitions
 
@@ -72,12 +72,12 @@ typedef int Py_ssize_t;
 #define PYISAPI_ATTR_CONVERT PyUnicode_AsUnicode
 
 // And some old py2k functions we can map to their new names...
-#define PyString_Check PyBytes_Check
-#define PyString_Size PyBytes_Size
-#define PyString_AsString PyBytes_AsString
-#define PyString_FromString PyBytes_FromString
-#define PyString_FromStringAndSize PyBytes_FromStringAndSize
-#define PyString_AS_STRING PyBytes_AS_STRING
+#define PyBytes_Check PyBytes_Check
+#define PyBytes_Size PyBytes_Size
+#define PyBytes_AsString PyBytes_AsString
+#define PyBytes_FromString PyBytes_FromString
+#define PyBytes_FromStringAndSize PyBytes_FromStringAndSize
+#define PyBytes_AS_STRING PyBytes_AS_STRING
 #define PyInt_AsLong PyLong_AsLong
 #define PyInt_FromLong PyLong_FromLong
 #define PyInt_Check PyLong_Check

--- a/isapi/src/StdAfx.h
+++ b/isapi/src/StdAfx.h
@@ -45,12 +45,6 @@
 // avoid anyone accidently using the wrong WRITE_RESTRICTED...
 #undef WRITE_RESTRICTED
 
-// See PEP-353 - this is the "official" test...
-#if PY_VERSION_HEX < 0x02050000 && !defined(PY_SSIZE_T_MIN)
-// 2.3 and before have no Py_ssize_t
-typedef int Py_ssize_t;
-#endif
-
 // ***** py3k support *****
 // Note that when built for py3k, 'UNICODE' is defined, which conveniently
 // means TCHAR is the same size as the native unicode object in all versions.
@@ -58,31 +52,9 @@ typedef int Py_ssize_t;
 // defined, most strings passed and received from ISAPI itself remain 'char *'
 // in all versions.
 
-// most of these taken from pywintypes...
-#if (PY_VERSION_HEX < 0x03000000)
-
-// Macros to handle PyObject layout changes in Py3k
-#define PYISAPI_OBJECT_HEAD PyObject_HEAD_INIT(&PyType_Type) 0,
-#define PYISAPI_ATTR_CONVERT PyBytes_AsString
-
-#else  // Py3k definitions
-
 // Macros to handle PyObject layout changes in Py3k
 #define PYISAPI_OBJECT_HEAD PyVarObject_HEAD_INIT(NULL, 0)
 #define PYISAPI_ATTR_CONVERT PyUnicode_AsUnicode
-
-// And some old py2k functions we can map to their new names...
-#define PyBytes_Check PyBytes_Check
-#define PyBytes_Size PyBytes_Size
-#define PyBytes_AsString PyBytes_AsString
-#define PyBytes_FromString PyBytes_FromString
-#define PyBytes_FromStringAndSize PyBytes_FromStringAndSize
-#define PyBytes_AS_STRING PyBytes_AS_STRING
-#define PyInt_AsLong PyLong_AsLong
-#define PyInt_FromLong PyLong_FromLong
-#define PyInt_Check PyLong_Check
-
-#endif
 
 // A helper that on py3k takes a str or unicode as input and returns a
 // string - exactly how the 's#' PyArg_ParseTuple format string does...

--- a/isapi/src/Utils.cpp
+++ b/isapi/src/Utils.cpp
@@ -45,13 +45,13 @@ const char *PyISAPIString_AsBytes(PyObject *ob, DWORD *psize /* = NULL */)
     }
 #endif
     // These 'PyString_' calls are all mapped to the bytes API in py3k...
-    if (!PyString_Check(ob)) {
+    if (!PyBytes_Check(ob)) {
         PyErr_Format(PyExc_ValueError, "Expected a string object (got %s)", ob->ob_type->tp_name);
         return NULL;
     }
     if (psize)
-        *psize = PyString_Size(ob);
-    const char *result = PyString_AsString(ob);
+        *psize = PyBytes_Size(ob);
+    const char *result = PyBytes_AsString(ob);
     Py_XDECREF(obNew);
     return result;
 }

--- a/isapi/src/pyISAPI.cpp
+++ b/isapi/src/pyISAPI.cpp
@@ -81,8 +81,8 @@ BOOL WINAPI GetExtensionVersion(HSE_VERSION_INFO *pVer)
     else {
         if (resultobject == Py_None)
             bRetStatus = TRUE;
-        else if (PyInt_Check(resultobject))
-            bRetStatus = PyInt_AsLong(resultobject) ? true : false;
+        else if (PyLong_Check(resultobject))
+            bRetStatus = PyLong_AsLong(resultobject) ? true : false;
         else {
             ExtensionError(NULL, "Filter init should return an int, or None");
             bRetStatus = FALSE;
@@ -111,8 +111,8 @@ DWORD WINAPI HttpExtensionProc(EXTENSION_CONTROL_BLOCK *pECB)
         result = HSE_STATUS_ERROR;
     }
     else {
-        if (PyInt_Check(resultobject))
-            result = PyInt_AsLong(resultobject);
+        if (PyLong_Check(resultobject))
+            result = PyLong_AsLong(resultobject);
         else {
             ExtensionError(pcb, "HttpExtensionProc should return an int");
             result = HSE_STATUS_ERROR;
@@ -136,8 +136,8 @@ BOOL WINAPI TerminateExtension(DWORD dwFlags)
     else {
         if (resultobject == Py_None)
             bRetStatus = TRUE;
-        else if (PyInt_Check(resultobject))
-            bRetStatus = PyInt_AsLong(resultobject) ? true : false;
+        else if (PyLong_Check(resultobject))
+            bRetStatus = PyLong_AsLong(resultobject) ? true : false;
         else {
             ExtensionError(NULL, "Extension term should return an int, or None");
             bRetStatus = FALSE;
@@ -167,8 +167,8 @@ BOOL WINAPI GetFilterVersion(HTTP_FILTER_VERSION *pVer)
     else {
         if (resultobject == Py_None)
             bRetStatus = TRUE;
-        else if (PyInt_Check(resultobject))
-            bRetStatus = PyInt_AsLong(resultobject) ? true : false;
+        else if (PyLong_Check(resultobject))
+            bRetStatus = PyLong_AsLong(resultobject) ? true : false;
         else {
             FilterError(NULL, "Filter init should return an int, or None");
             bRetStatus = FALSE;
@@ -204,8 +204,8 @@ DWORD WINAPI HttpFilterProc(HTTP_FILTER_CONTEXT *phfc, DWORD NotificationType, V
         DWORD action;
         if (resultobject == Py_None)
             action = SF_STATUS_REQ_NEXT_NOTIFICATION;
-        else if (PyInt_Check(resultobject))
-            action = PyInt_AsLong(resultobject);
+        else if (PyLong_Check(resultobject))
+            action = PyLong_AsLong(resultobject);
         else {
             FilterError(&fc, "Filter should return an int, or None");
             action = SF_STATUS_REQ_ERROR;
@@ -234,8 +234,8 @@ BOOL WINAPI TerminateFilter(DWORD status)
     else {
         if (resultobject == Py_None)
             bRetStatus = TRUE;
-        else if (PyInt_Check(resultobject))
-            bRetStatus = PyInt_AsLong(resultobject) ? true : false;
+        else if (PyLong_Check(resultobject))
+            bRetStatus = PyLong_AsLong(resultobject) ? true : false;
         else {
             FilterError(NULL, "Filter term should return an int, or None");
             bRetStatus = FALSE;

--- a/win32/help/security_directories.html
+++ b/win32/help/security_directories.html
@@ -100,7 +100,7 @@ in this extension are:
 <li>PyList_New(),PyList_Append -- make and add to a  python list</li>
 <li>PyDict_New(),PyDict_SetItem -- make a dictionary and add to a python dictionary</li>
 <li>PyArg_ParseTuple -- process arguments sent to module</li>
-<li>PyString_FromString/PyLong_FromUnsignedLong -- convert C datatypes to Python</li>
+<li>PyBytes_FromString/PyLong_FromUnsignedLong -- convert C datatypes to Python</li>
 <li>PyArg_ParseTuple -- accept data from python and convert to C</li>
 </ul>
 </p>
@@ -252,13 +252,13 @@ static PyObject *get_perms(PyObject *self, PyObject *args)
 		
 		//Dict
 		for (ULONG i=0;i<aclSize.AceCount;++i){
-			PyDict_SetItem( py_perms, PyString_FromString(fp[i].user_domain) , 
+			PyDict_SetItem( py_perms, PyBytes_FromString(fp[i].user_domain) , 
 				PyLong_FromUnsignedLong ((unsigned long) fp[i].user_mask));      
 		}
 		
 		//List
 		for (i=0;i<aclSize.AceCount;++i){
-			PyList_Append(py_perms,PyString_FromString(fp[i].user_domain));
+			PyList_Append(py_perms,PyBytes_FromString(fp[i].user_domain));
 		}
 
 	}

--- a/win32/src/PerfMon/PerfCounterDefn.cpp
+++ b/win32/src/PerfMon/PerfCounterDefn.cpp
@@ -87,7 +87,7 @@ PyObject *PyPERF_COUNTER_DEFINITION::Get(PyObject *self, PyObject *args)
     }
 
     DWORD *pVal = (DWORD *)(This->m_pCounterValue);
-    return PyInt_FromLong(*pVal);
+    return PyLong_FromLong(*pVal);
 }
 
 // @object PyPERF_COUNTER_DEFINITION|An object encapsulating a Windows NT Performance Monitor counter definition

--- a/win32/src/PyACL.cpp
+++ b/win32/src/PyACL.cpp
@@ -69,7 +69,7 @@ PyObject *PyACL::IsValid(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, ":IsValid"))
         return NULL;
     PyACL *This = (PyACL *)self;
-    return PyInt_FromLong(IsValidAcl(This->GetACL()));
+    return PyLong_FromLong(IsValidAcl(This->GetACL()));
 }
 
 BOOL _ReorderACL(PACL pacl)

--- a/win32/src/PyDEVMODE.cpp
+++ b/win32/src/PyDEVMODE.cpp
@@ -117,9 +117,9 @@ PyObject *PyDEVMODEA::get_DeviceName(PyObject *self, void *unused)
 {
     PDEVMODEA pdevmode = ((PyDEVMODEA *)self)->pdevmode;
     if (pdevmode->dmDeviceName[CCHDEVICENAME - 1] == 0)  // in case DeviceName fills space and has no trailing NULL
-        return PyString_FromString((char *)&pdevmode->dmDeviceName);
+        return PyBytes_FromString((char *)&pdevmode->dmDeviceName);
     else
-        return PyString_FromStringAndSize((char *)&pdevmode->dmDeviceName, CCHDEVICENAME);
+        return PyBytes_FromStringAndSize((char *)&pdevmode->dmDeviceName, CCHDEVICENAME);
 }
 
 int PyDEVMODEA::set_DeviceName(PyObject *self, PyObject *v, void *unused)
@@ -130,7 +130,7 @@ int PyDEVMODEA::set_DeviceName(PyObject *self, PyObject *v, void *unused)
     }
     char *value;
     Py_ssize_t valuelen;
-    if (PyString_AsStringAndSize(v, &value, &valuelen) == -1)
+    if (PyBytes_AsStringAndSize(v, &value, &valuelen) == -1)
         return -1;
     if (valuelen > CCHDEVICENAME) {
         PyErr_Format(PyExc_ValueError, "DeviceName must be a string of length %d or less", CCHDEVICENAME);
@@ -149,9 +149,9 @@ PyObject *PyDEVMODEA::get_FormName(PyObject *self, void *unused)
 {
     PDEVMODEA pdevmode = ((PyDEVMODEA *)self)->pdevmode;
     if (pdevmode->dmFormName[CCHFORMNAME - 1] == 0)  // If dmFormName occupies whole 32 chars, trailing NULL not present
-        return PyString_FromString((char *)&pdevmode->dmFormName);
+        return PyBytes_FromString((char *)&pdevmode->dmFormName);
     else
-        return PyString_FromStringAndSize((char *)&pdevmode->dmFormName, CCHFORMNAME);
+        return PyBytes_FromStringAndSize((char *)&pdevmode->dmFormName, CCHFORMNAME);
 }
 
 int PyDEVMODEA::set_FormName(PyObject *self, PyObject *v, void *unused)
@@ -162,7 +162,7 @@ int PyDEVMODEA::set_FormName(PyObject *self, PyObject *v, void *unused)
     }
     char *value;
     Py_ssize_t valuelen;
-    if (PyString_AsStringAndSize(v, &value, &valuelen) == -1)
+    if (PyBytes_AsStringAndSize(v, &value, &valuelen) == -1)
         return -1;
     if (valuelen > CCHFORMNAME) {
         PyErr_Format(PyExc_ValueError, "FormName must be a string of length %d or less", CCHFORMNAME);
@@ -184,7 +184,7 @@ PyObject *PyDEVMODEA::get_DriverData(PyObject *self, void *unused)
         Py_INCREF(Py_None);
         return Py_None;
     }
-    return PyString_FromStringAndSize((char *)((ULONG_PTR)pdevmode + pdevmode->dmSize), pdevmode->dmDriverExtra);
+    return PyBytes_FromStringAndSize((char *)((ULONG_PTR)pdevmode + pdevmode->dmSize), pdevmode->dmDriverExtra);
 }
 
 int PyDEVMODEA::set_DriverData(PyObject *self, PyObject *v, void *unused)
@@ -195,7 +195,7 @@ int PyDEVMODEA::set_DriverData(PyObject *self, PyObject *v, void *unused)
     }
     char *value;
     Py_ssize_t valuelen;
-    if (PyString_AsStringAndSize(v, &value, &valuelen) == -1)
+    if (PyBytes_AsStringAndSize(v, &value, &valuelen) == -1)
         return -1;
     PDEVMODEA pdevmode = ((PyDEVMODEA *)self)->pdevmode;
     if (valuelen > pdevmode->dmDriverExtra) {
@@ -585,7 +585,7 @@ PyObject *PyDEVMODEW::get_DriverData(PyObject *self, void *unused)
         Py_INCREF(Py_None);
         return Py_None;
     }
-    return PyString_FromStringAndSize((char *)((ULONG_PTR)pdevmode + pdevmode->dmSize), pdevmode->dmDriverExtra);
+    return PyBytes_FromStringAndSize((char *)((ULONG_PTR)pdevmode + pdevmode->dmSize), pdevmode->dmDriverExtra);
 }
 
 int PyDEVMODEW::set_DriverData(PyObject *self, PyObject *v, void *unused)
@@ -596,7 +596,7 @@ int PyDEVMODEW::set_DriverData(PyObject *self, PyObject *v, void *unused)
     }
     char *value;
     Py_ssize_t valuelen;
-    if (PyString_AsStringAndSize(v, &value, &valuelen) == -1)
+    if (PyBytes_AsStringAndSize(v, &value, &valuelen) == -1)
         return -1;
     PDEVMODEW pdevmode = ((PyDEVMODEW *)self)->pdevmode;
     if (valuelen > pdevmode->dmDriverExtra) {

--- a/win32/src/PyHANDLE.cpp
+++ b/win32/src/PyHANDLE.cpp
@@ -260,7 +260,7 @@ PyObject *PyHANDLE::richcompare(PyObject *other, int op)
     if (PyHANDLE_Check(other)) {
         hother = ((PyHANDLE *)other)->m_handle;
     }
-    else if (PyInt_Check(other) || PyLong_Check(other)) {
+    else if (PyLong_Check(other) || PyLong_Check(other)) {
         if (!PyWinLong_AsVoidPtr(other, &hother))
             return NULL;
     }

--- a/win32/src/PyLARGE_INTEGER.cpp
+++ b/win32/src/PyLARGE_INTEGER.cpp
@@ -22,9 +22,9 @@
 BOOL PyWinObject_AsLARGE_INTEGER(PyObject *ob, LARGE_INTEGER *pResult)
 {
 #if (PY_VERSION_HEX < 0x03000000)
-    if (PyInt_Check(ob)) {
+    if (PyLong_Check(ob)) {
         // 32 bit integer value.
-        int x = PyInt_AS_LONG(ob);
+        int x = PyLong_AS_LONG(ob);
         if (x == (int)-1 && PyErr_Occurred())
             return FALSE;
         LISet32(*pResult, x);
@@ -55,9 +55,9 @@ BOOL PyWinObject_AsULARGE_INTEGER(PyObject *ob, ULARGE_INTEGER *pResult)
 {
 #if (PY_VERSION_HEX < 0x03000000)
     // py2k - ints and longs are different, and we assume 'int' is 32bits.
-    if (PyInt_Check(ob)) {
+    if (PyLong_Check(ob)) {
         // 32 bit integer value.
-        int x = PyInt_AS_LONG(ob);
+        int x = PyLong_AS_LONG(ob);
         if (x == (int)-1 && PyErr_Occurred())
             return FALSE;
         // ### what to do with "negative" integers?  Nothing - they

--- a/win32/src/PySECURITY_DESCRIPTOR.cpp
+++ b/win32/src/PySECURITY_DESCRIPTOR.cpp
@@ -667,7 +667,7 @@ PyObject *PySECURITY_DESCRIPTOR::IsValid(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, ":IsValid"))
         return NULL;
     PySECURITY_DESCRIPTOR *This = (PySECURITY_DESCRIPTOR *)self;
-    return PyInt_FromLong(IsValidSecurityDescriptor(This->m_psd));
+    return PyLong_FromLong(IsValidSecurityDescriptor(This->m_psd));
 }
 
 // @pymethod |PySECURITY_DESCRIPTOR|GetLength|return length of security descriptor (GetSecurityDescriptorLenght).
@@ -676,7 +676,7 @@ PyObject *PySECURITY_DESCRIPTOR::GetLength(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, ":GetLength"))
         return NULL;
     PySECURITY_DESCRIPTOR *This = (PySECURITY_DESCRIPTOR *)self;
-    return PyInt_FromLong(GetSecurityDescriptorLength(This->m_psd));
+    return PyLong_FromLong(GetSecurityDescriptorLength(This->m_psd));
 }
 
 // @object PySECURITY_DESCRIPTOR|A Python object, representing a SECURITY_DESCRIPTOR structure

--- a/win32/src/PySID.cpp
+++ b/win32/src/PySID.cpp
@@ -126,7 +126,7 @@ PyObject *PySID::GetSubAuthority(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_ValueError, "The index is out of range");
         return NULL;
     }
-    return PyInt_FromLong(*GetSidSubAuthority(psid, subauthInd));
+    return PyLong_FromLong(*GetSidSubAuthority(psid, subauthInd));
 }
 
 // @pymethod int|PySID|GetLength|return length of SID (GetLengthSid).
@@ -135,7 +135,7 @@ PyObject *PySID::GetLength(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, ":GetLength"))
         return NULL;
     PySID *This = (PySID *)self;
-    return PyInt_FromLong(GetLengthSid(This->GetSID()));
+    return PyLong_FromLong(GetLengthSid(This->GetSID()));
 }
 
 // @pymethod int|PySID|GetSubAuthorityCount|return nbr of subauthorities from SID
@@ -144,7 +144,7 @@ PyObject *PySID::GetSubAuthorityCount(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, ":GetSubAuthorityCount"))
         return NULL;
     PySID *This = (PySID *)self;
-    return PyInt_FromLong(*::GetSidSubAuthorityCount(This->GetSID()));
+    return PyLong_FromLong(*::GetSidSubAuthorityCount(This->GetSID()));
 }
 
 // @pymethod |PySID|SetSubAuthority|Sets a SID SubAuthority

--- a/win32/src/PySID.cpp
+++ b/win32/src/PySID.cpp
@@ -375,7 +375,7 @@ BOOL GetTextualSid(
     DWORD bufSize = 0;
     GetTextualSid(psid, NULL, &bufSize);  // max size, NOT actual size!
     if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
-        return PyString_FromString("PySID: Invalid SID");
+        return PyBytes_FromString("PySID: Invalid SID");
     }
     // Space for the "PySID:" prefix.
     TCHAR *prefix = _T("PySID:");

--- a/win32/src/PyTime.cpp
+++ b/win32/src/PyTime.cpp
@@ -256,7 +256,7 @@ static BOOL gettmarg(PyObject *ob, struct tm *p, int *pmsec)
 static WORD SequenceIndexAsWORD(PyObject *seq, int index)
 {
     PyObject *t = PySequence_GetItem(seq, index);
-    int ret = t ? PyInt_AsLong(t) : -1;
+    int ret = t ? PyLong_AsLong(t) : -1;
     Py_XDECREF(t);
     return (WORD)ret;
 }

--- a/win32/src/PyWinTypes.h
+++ b/win32/src/PyWinTypes.h
@@ -73,16 +73,6 @@
     Definitions for the string functions are in stringobject.h,
     but comments indicate that this header is likely to go away in 3.1.
 */
-#define PyString_Check PyBytes_Check
-#define PyString_Size PyBytes_Size
-#define PyString_AsString PyBytes_AsString
-#define PyString_AsStringAndSize PyBytes_AsStringAndSize
-#define PyString_FromString PyBytes_FromString
-#define PyString_FromStringAndSize PyBytes_FromStringAndSize
-#define _PyString_Resize _PyBytes_Resize
-#define PyString_AS_STRING PyBytes_AS_STRING
-#define PyString_GET_SIZE PyBytes_GET_SIZE
-#define PyString_Concat PyBytes_Concat
 #define PyInt_Check PyLong_Check
 #define PyInt_FromLong PyLong_FromLong
 #define PyInt_AsLong PyLong_AsLong

--- a/win32/src/PyWinTypes.h
+++ b/win32/src/PyWinTypes.h
@@ -69,19 +69,6 @@
 */
 #define PYWIN_ATTR_CONVERT (char *)_PyUnicode_AsString
 
-/* Some API functions changed/removed in python 3.0
-    Definitions for the string functions are in stringobject.h,
-    but comments indicate that this header is likely to go away in 3.1.
-*/
-#define PyInt_Check PyLong_Check
-#define PyInt_FromLong PyLong_FromLong
-#define PyInt_AsLong PyLong_AsLong
-#define PyInt_AS_LONG PyLong_AS_LONG
-#define PyInt_FromSsize_t PyLong_FromSsize_t
-#define PyInt_AsSsize_t PyLong_AsSsize_t
-#define PyInt_AsUnsignedLongMask PyLong_AsUnsignedLongMask
-#define PyNumber_Int PyNumber_Long
-
 typedef Py_ssize_t Py_hash_t;
 
 // This only enables runtime checks in debug builds - so we use

--- a/win32/src/PyWinTypesmodule.cpp
+++ b/win32/src/PyWinTypesmodule.cpp
@@ -649,8 +649,8 @@ BOOL PyWinObject_AsPARAM(PyObject *ob, WPARAM *pparam)
     }
 #else
 #define TCHAR_DESC "String"
-    if (PyString_Check(ob)) {
-        *pparam = (WPARAM)PyString_AS_STRING(ob);
+    if (PyBytes_Check(ob)) {
+        *pparam = (WPARAM)PyBytes_AS_STRING(ob);
         return TRUE;
     }
 #endif
@@ -1226,8 +1226,8 @@ PYWINTYPES_EXPORT char *GetPythonTraceback(PyObject *exc_type, PyObject *exc_val
         GPEM_ERROR("getvalue() failed.");
 
     /* And it should be a string all ready to go - duplicate it. */
-    if (PyString_Check(obResult))
-        result = strdup(PyString_AsString(obResult));
+    if (PyBytes_Check(obResult))
+        result = strdup(PyBytes_AsString(obResult));
 #if (PY_VERSION_HEX >= 0x03000000)
     else if (PyUnicode_Check(obResult))
         result = strdup(_PyUnicode_AsString(obResult));

--- a/win32/src/PyWinTypesmodule.cpp
+++ b/win32/src/PyWinTypesmodule.cpp
@@ -493,7 +493,7 @@ BOOL PyWinObject_AsDWORDArray(PyObject *obdwords, DWORD **pdwords, DWORD *item_c
             // Doesn't check for overflow, but will accept a python long
             //  greater than INT_MAX (even on python 2.3).  Also accepts
             //  negatives and converts to the correct hex representation
-            (*pdwords)[tuple_index] = PyInt_AsUnsignedLongMask(tuple_item);
+            (*pdwords)[tuple_index] = PyLong_AsUnsignedLongMask(tuple_item);
             if (((*pdwords)[tuple_index] == -1) && PyErr_Occurred()) {
                 ret = FALSE;
                 break;
@@ -545,7 +545,7 @@ BOOL PyWinLong_AsVoidPtr(PyObject *ob, void **pptr)
                                 // longs that fit in 32bits if they are treated as unsigned - eg,
                                 // eg, the result of:
                                 // struct.unpack("P", struct.pack("P", -1)) -> (4294967295L,)
-                                // So, we do the PyInt_AsLong thing first, then fall back to the
+                                // So, we do the PyLong_AsLong thing first, then fall back to the
                                 // *_AsUnsignedLong[Long] versions.
 #ifdef _WIN64
 #define SIGNED_CONVERTER PyLong_AsLongLong
@@ -579,7 +579,7 @@ PyObject *PyWinLong_FromVoidPtr(const void *ptr)
 #ifdef _WIN64
     return PyLong_FromLongLong((LONG_PTR)ptr);
 #else
-    return PyInt_FromLong((LONG_PTR)ptr);
+    return PyLong_FromLong((LONG_PTR)ptr);
 #endif
 }
 

--- a/win32/src/PythonService.cpp
+++ b/win32/src/PythonService.cpp
@@ -955,7 +955,7 @@ DWORD WINAPI dispatchServiceCtrl(DWORD dwCtrlCode, DWORD dwEventType, LPVOID eve
                 if (dwEventType == PBT_POWERSETTINGCHANGE) {
                     POWERBROADCAST_SETTING *pbs = (POWERBROADCAST_SETTING *)eventData;
                     sub = Py_BuildValue("NN", PyWinObject_FromIID(pbs->PowerSetting),
-                                        PyString_FromStringAndSize((char *)pbs->Data, pbs->DataLength));
+                                        PyBytes_FromStringAndSize((char *)pbs->Data, pbs->DataLength));
                 }
                 else {
                     sub = Py_None;
@@ -1325,12 +1325,12 @@ static BOOL RegisterPythonServiceExe(void)
     CEnterLeavePython _celp;
     // Register this specific EXE against this specific DLL version
     PyObject *obVerString = PySys_GetObject("winver");
-    if (obVerString == NULL || !PyString_Check(obVerString)) {
+    if (obVerString == NULL || !PyBytes_Check(obVerString)) {
         Py_XDECREF(obVerString);
         printf("Registration failed as sys.winver is not available or not a string\n");
         return FALSE;
     }
-    char *szVerString = PyString_AsString(obVerString);
+    char *szVerString = PyBytes_AsString(obVerString);
     Py_DECREF(obVerString);
     // note wsprintf allows %hs to be "char *" even when UNICODE!
     TCHAR keyBuf[256];
@@ -1542,8 +1542,8 @@ int _tmain(int argc, TCHAR **argv)
         goto failed;
 
     // now get the handle to the DLL, and call the main function.
-    if (PyString_Check(f))
-        hmod = GetModuleHandleA(PyString_AsString(f));
+    if (PyBytes_Check(f))
+        hmod = GetModuleHandleA(PyBytes_AsString(f));
     else if (PyUnicode_Check(f))
         hmod = GetModuleHandleW(PyUnicode_AsUnicode(f));
     else {

--- a/win32/src/PythonService.cpp
+++ b/win32/src/PythonService.cpp
@@ -364,7 +364,7 @@ static PyObject *PyCoInitializeEx(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "l:CoInitializeEx", &flags))
         return NULL;
     HRESULT hr = CoInitializeEx(NULL, flags);
-    return PyInt_FromLong(hr);
+    return PyLong_FromLong(hr);
 }
 
 // @pymethod |servicemanager|CoUninitialize|Unitialize OLE
@@ -422,7 +422,7 @@ static PyObject *PyPumpWaitingMessages(PyObject *self, PyObject *args)
         // Otherwise, dispatch the message.
         DispatchMessage(&msg);
     }  // End of PeekMessage while loop
-    Py_END_ALLOW_THREADS return PyInt_FromLong(result);
+    Py_END_ALLOW_THREADS return PyLong_FromLong(result);
 }
 
 static PyObject *PyStartServiceCtrlDispatcher(PyObject *self)
@@ -987,7 +987,7 @@ DWORD WINAPI dispatchServiceCtrl(DWORD dwCtrlCode, DWORD dwEventType, LPVOID eve
     else if (result == Py_None)
         dwResult = NOERROR;
     else {
-        dwResult = PyInt_AsUnsignedLongMask(result);
+        dwResult = PyLong_AsUnsignedLongMask(result);
         if (dwResult == -1 && PyErr_Occurred()) {
             ReportPythonError(PYS_E_SERVICE_CONTROL_FAILED);
             dwResult = ERROR_SERVICE_SPECIFIC_ERROR;

--- a/win32/src/_win32sysloader.cpp
+++ b/win32/src/_win32sysloader.cpp
@@ -42,7 +42,7 @@ static PyObject *PyGetModuleFilename(PyObject *self, PyObject *args)
 #ifdef UNICODE
     return PyUnicode_FromUnicode(buf, wcslen(buf));
 #else
-    return PyString_FromString(buf);
+    return PyBytes_FromString(buf);
 #endif
 }
 
@@ -70,7 +70,7 @@ static PyObject *PyLoadModule(PyObject *self, PyObject *args)
 #ifdef UNICODE
     return PyUnicode_FromUnicode(buf, wcslen(buf));
 #else
-    return PyString_FromString(buf);
+    return PyBytes_FromString(buf);
 #endif
 }
 

--- a/win32/src/mmapfilemodule.cpp
+++ b/win32/src/mmapfilemodule.cpp
@@ -111,7 +111,7 @@ static PyObject *mmapfile_read_method(mmapfile_object *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "O",
                           &obnum_bytes))  // @pyparm int|num_bytes||Number of bytes to read
         return NULL;
-    num_bytes = PyInt_AsSsize_t(obnum_bytes);
+    num_bytes = PyLong_AsSsize_t(obnum_bytes);
     if (num_bytes == -1 && PyErr_Occurred())
         return NULL;
 
@@ -143,7 +143,7 @@ static PyObject *mmapfile_find_method(mmapfile_object *self, PyObject *args)
         return NULL;
 
     if (obstart != Py_None) {
-        start = PyInt_AsSsize_t(obstart);
+        start = PyLong_AsSsize_t(obstart);
         if (start == -1 && PyErr_Occurred())
             return NULL;
     }
@@ -161,7 +161,7 @@ static PyObject *mmapfile_find_method(mmapfile_object *self, PyObject *args)
         }
         p++;
     }
-    return PyInt_FromLong(-1);
+    return PyLong_FromLong(-1);
 }
 
 // @pymethod |Pymmapfile|write|Places data at current pos in buffer.
@@ -240,7 +240,7 @@ static PyObject *mmapfile_resize_method(mmapfile_object *self, PyObject *args, P
             &obview_size))  // @pyparm long|NumberOfBytesToMap|0|New view size.  Specify a multiple of system page size.
         return NULL;
     if (obview_size != Py_None) {
-        new_view_size = PyInt_AsSsize_t(obview_size);
+        new_view_size = PyLong_AsSsize_t(obview_size);
         if (new_view_size == -1 && PyErr_Occurred())
             return NULL;
     }
@@ -304,12 +304,12 @@ static PyObject *mmapfile_flush_method(mmapfile_object *self, PyObject *args)
             &obsize))   // @pyparm int|size|0|Number of bytes to flush, 0 to flush remainder of buffer past the offset
         return NULL;
     if (oboffset != Py_None) {
-        offset = PyInt_AsSsize_t(oboffset);
+        offset = PyLong_AsSsize_t(oboffset);
         if (offset == -1 && PyErr_Occurred())
             return NULL;
     }
     if (obsize != Py_None) {
-        size = PyInt_AsSsize_t(obsize);
+        size = PyLong_AsSsize_t(obsize);
         if (size == -1 && PyErr_Occurred())
             return NULL;
     }
@@ -320,7 +320,7 @@ static PyObject *mmapfile_flush_method(mmapfile_object *self, PyObject *args)
     if (!FlushViewOfFile(self->data + offset, size))
         return PyWin_SetAPIError("FlushViewOfFile");
     // Previously the BOOL result was returned without raising an error, return 1 on success
-    return PyInt_FromLong(1);
+    return PyLong_FromLong(1);
 }
 
 // @pymethod int|Pymmapfile|tell|Returns current position in buffer
@@ -341,7 +341,7 @@ static PyObject *mmapfile_seek_method(mmapfile_object *self, PyObject *args)
                           &obdist,  // @pyparm int|dist||Distance to seek
                           &how))    // @pyparm int|how|0|Pos from which to seek
         return (NULL);
-    dist = PyInt_AsSsize_t(obdist);
+    dist = PyLong_AsSsize_t(obdist);
     if (dist == -1 && PyErr_Occurred())
         return NULL;
 
@@ -384,13 +384,13 @@ static PyObject *mmapfile_move_method(mmapfile_object *self, PyObject *args)
                           &obsrc,     // @pyparm int|src||Source position in buffer
                           &obcount))  // @pyparm int|count||Number of bytes to move
         return NULL;
-    dest = PyInt_AsSsize_t(obdest);
+    dest = PyLong_AsSsize_t(obdest);
     if (dest == (size_t)-1 && PyErr_Occurred())
         return NULL;
-    src = PyInt_AsSsize_t(obsrc);
+    src = PyLong_AsSsize_t(obsrc);
     if (src == (size_t)-1 && PyErr_Occurred())
         return NULL;
-    count = PyInt_AsSsize_t(obcount);
+    count = PyLong_AsSsize_t(obcount);
     if (count == (size_t)-1 && PyErr_Occurred())
         return NULL;
 
@@ -533,7 +533,7 @@ static PyObject *new_mmapfile_object(PyObject *self, PyObject *args, PyObject *k
         return NULL;
     }
     if (obview_size != Py_None) {
-        m_obj->size = PyInt_AsSsize_t(obview_size);
+        m_obj->size = PyLong_AsSsize_t(obview_size);
         if (m_obj->size == -1 && PyErr_Occurred()) {
             Py_DECREF(m_obj);
             PyWinObject_FreeTCHAR(filename);

--- a/win32/src/mmapfilemodule.cpp
+++ b/win32/src/mmapfilemodule.cpp
@@ -72,7 +72,7 @@ static PyObject *mmapfile_read_byte_method(mmapfile_object *self, PyObject *args
     char *where = (self->data + self->pos);
     CHECK_VALID;
     if ((where >= 0) && (where < (self->data + self->size))) {
-        PyObject *ret = PyString_FromStringAndSize(where, 1);
+        PyObject *ret = PyBytes_FromStringAndSize(where, 1);
         if (ret)
             self->pos += 1;
         return ret;
@@ -96,7 +96,7 @@ static PyObject *mmapfile_read_line_method(mmapfile_object *self, PyObject *args
     for (eol = start; (eol < eof) && (*eol != '\n'); eol++) { /* do nothing */
     }
 
-    PyObject *result = PyString_FromStringAndSize(start, (++eol - start));
+    PyObject *result = PyBytes_FromStringAndSize(start, (++eol - start));
     if (result)
         self->pos += (eol - start);
     return (result);
@@ -119,7 +119,7 @@ static PyObject *mmapfile_read_method(mmapfile_object *self, PyObject *args)
     if ((self->pos + num_bytes) > self->size)
         num_bytes -= (self->pos + num_bytes) - self->size;
 
-    PyObject *result = PyString_FromStringAndSize(self->data + self->pos, num_bytes);
+    PyObject *result = PyBytes_FromStringAndSize(self->data + self->pos, num_bytes);
     if (result)
         self->pos += num_bytes;
     return (result);
@@ -139,7 +139,7 @@ static PyObject *mmapfile_find_method(mmapfile_object *self, PyObject *args)
             &obneedle,  // @pyparm str|needle||String to be located
             &obstart))  // @pyparm int|start||Pos at which to start search, current pos assumed if not specified
         return NULL;
-    if (PyString_AsStringAndSize(obneedle, &needle, &len) == -1)
+    if (PyBytes_AsStringAndSize(obneedle, &needle, &len) == -1)
         return NULL;
 
     if (obstart != Py_None) {
@@ -174,7 +174,7 @@ static PyObject *mmapfile_write_method(mmapfile_object *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "O",
                           &obdata))  // @pyparm str|data||Data to be written
         return NULL;
-    if (PyString_AsStringAndSize(obdata, &data, &length) == -1)
+    if (PyBytes_AsStringAndSize(obdata, &data, &length) == -1)
         return NULL;
 
     if ((self->pos + length) > self->size) {

--- a/win32/src/odbc.cpp
+++ b/win32/src/odbc.cpp
@@ -505,7 +505,7 @@ static PyObject *wcharCopy(const void *v, SQLLEN sz) { return PyWinObject_FromWC
 
 static PyObject *stringCopy(const void *v, SQLLEN sz) { return PyBytes_FromStringAndSize((char *)v, sz); }
 
-static PyObject *longCopy(const void *v, SQLLEN sz) { return PyInt_FromLong(*(unsigned long *)v); }
+static PyObject *longCopy(const void *v, SQLLEN sz) { return PyLong_FromLong(*(unsigned long *)v); }
 
 static PyObject *doubleCopy(const void *v, SQLLEN sz)
 {
@@ -611,7 +611,7 @@ static InputBinding *initInputBinding(cursorObject *cur, Py_ssize_t len)
 static int ibindInt(cursorObject *cur, int column, PyObject *item)
 {
     int len = sizeof(long);
-    long val = PyInt_AsLong(item);
+    long val = PyLong_AsLong(item);
 
     InputBinding *ib = initInputBinding(cur, len);
     if (!ib)
@@ -875,7 +875,7 @@ static int bindInput(cursorObject *cur, PyObject *vars, int columns)
         if (PyLong_Check(item)) {
             rv = ibindLong(cur, iCol, item);
         }
-        else if (PyInt_Check(item)) {
+        else if (PyLong_Check(item)) {
             rv = ibindInt(cur, iCol, item);
         }
         else if (PyBytes_Check(item)) {

--- a/win32/src/odbc.cpp
+++ b/win32/src/odbc.cpp
@@ -503,7 +503,7 @@ static BOOL bindOutputVar(cursorObject *cur, CopyFcn fcn, short vtype, SQLLEN vs
 
 static PyObject *wcharCopy(const void *v, SQLLEN sz) { return PyWinObject_FromWCHAR((WCHAR *)v, sz / sizeof(WCHAR)); }
 
-static PyObject *stringCopy(const void *v, SQLLEN sz) { return PyString_FromStringAndSize((char *)v, sz); }
+static PyObject *stringCopy(const void *v, SQLLEN sz) { return PyBytes_FromStringAndSize((char *)v, sz); }
 
 static PyObject *longCopy(const void *v, SQLLEN sz) { return PyInt_FromLong(*(unsigned long *)v); }
 
@@ -785,7 +785,7 @@ static int ibindFloat(cursorObject *cur, int column, PyObject *item)
 
 static int ibindString(cursorObject *cur, int column, PyObject *item)
 {
-    const char *val = PyString_AsString(item);
+    const char *val = PyBytes_AsString(item);
     size_t len = strlen(val);
 
     InputBinding *ib = initInputBinding(cur, len);
@@ -878,7 +878,7 @@ static int bindInput(cursorObject *cur, PyObject *vars, int columns)
         else if (PyInt_Check(item)) {
             rv = ibindInt(cur, iCol, item);
         }
-        else if (PyString_Check(item)) {
+        else if (PyBytes_Check(item)) {
             rv = ibindString(cur, iCol, item);
         }
         else if (PyUnicode_Check(item)) {
@@ -908,7 +908,7 @@ static int bindInput(cursorObject *cur, PyObject *vars, int columns)
             PyObject *sitem = PyObject_Str(item);
             if (sitem == NULL)
                 rv = 0;
-            else if (PyString_Check(sitem))
+            else if (PyBytes_Check(sitem))
                 rv = ibindString(cur, iCol, sitem);
             else if (PyUnicode_Check(sitem))
                 rv = ibindUnicode(cur, iCol, sitem);
@@ -1125,14 +1125,14 @@ static PyObject *odbcCurExec(PyObject *self, PyObject *args)
     }
 
     if (inputvars) {
-        if (PyString_Check(inputvars) || PyUnicode_Check(inputvars) || !PySequence_Check(inputvars))
+        if (PyBytes_Check(inputvars) || PyUnicode_Check(inputvars) || !PySequence_Check(inputvars))
             return PyErr_Format(odbcError, "Values must be a sequence, not %s", inputvars->ob_type->tp_name);
         if (PySequence_Length(inputvars) > 0) {
             PyObject *temp = PySequence_GetItem(inputvars, 0);
             if (temp == NULL)
                 return NULL;
             /* Strings don't count as a list in this case. */
-            if (PySequence_Check(temp) && !PyString_Check(temp) && !PyUnicode_Check(temp)) {
+            if (PySequence_Check(temp) && !PyBytes_Check(temp) && !PyUnicode_Check(temp)) {
                 rows = inputvars;
                 inputvars = NULL;
             }

--- a/win32/src/timermodule.cpp
+++ b/win32/src/timermodule.cpp
@@ -150,7 +150,7 @@ PYWIN_MODULE_INIT_FUNC(timer)
 
     if (PyDict_SetItemString(dict, "error", PyWinExc_ApiError) == -1)
         PYWIN_MODULE_INIT_RETURN_ERROR;
-    if (PyDict_SetItemString(dict, "__version__", PyString_FromString("0.2")) == -1)
+    if (PyDict_SetItemString(dict, "__version__", PyBytes_FromString("0.2")) == -1)
         PYWIN_MODULE_INIT_RETURN_ERROR;
 
     PYWIN_MODULE_INIT_RETURN_SUCCESS;

--- a/win32/src/win32apimodule.cpp
+++ b/win32/src/win32apimodule.cpp
@@ -725,7 +725,7 @@ static PyObject *PyFormatMessageA(PyObject *self, PyObject *args)
         // @pyseeapi FormatMessage
         if (::FormatMessageA(flags, hmodule, errCode, 0, buf, bufSize, NULL) <= 0)
             return ReturnAPIError("FormatMessage");
-        return PyString_FromString(buf);
+        return PyBytes_FromString(buf);
     }
     PyErr_Clear();
     // Support for "full" argument list
@@ -803,7 +803,7 @@ static PyObject *PyFormatMessageA(PyObject *self, PyObject *args)
     else if (lrc <= 0)
         PyWin_SetAPIError("FormatMessageA");
     else
-        rc = PyString_FromString(resultBuf);
+        rc = PyBytes_FromString(resultBuf);
 
 cleanup:
     if (pInserts) {
@@ -1455,8 +1455,8 @@ static PyObject *PyGetFileAttributes(PyObject *self, PyObject *args)
     rc = ::GetFileAttributesW(PathName);
     PyWinObject_FreeWCHAR(PathName);
 #else
-    if (PyString_Check(obPathName)) {
-        PyW32_BEGIN_ALLOW_THREADS rc = ::GetFileAttributesA(PyString_AS_STRING(obPathName));
+    if (PyBytes_Check(obPathName)) {
+        PyW32_BEGIN_ALLOW_THREADS rc = ::GetFileAttributesA(PyBytes_AS_STRING(obPathName));
         PyW32_END_ALLOW_THREADS
     }
     else if (PyUnicode_Check(obPathName)) {
@@ -1514,7 +1514,7 @@ static PyObject *PyGetKeyboardState(PyObject *self, PyObject *args)
         ok = GetKeyboardState(buf);
     PyW32_END_ALLOW_THREADS if (!ok) return PyWin_SetAPIError("GetKeyboardState");
 
-    return PyString_FromStringAndSize((char *)buf, 256);
+    return PyBytes_FromStringAndSize((char *)buf, 256);
     // @rdesc The return value is a string of exactly 256 characters.
     // Each character represents the bitmask for a key - see the Win32
     // documentation for more details.
@@ -1531,14 +1531,14 @@ static PyObject *PyVkKeyScan(PyObject *self, PyObject *args)
         return (NULL);
 
     int ret;
-    if (PyString_Check(obkey)) {
-        if (PyString_GET_SIZE(obkey) != 1) {
+    if (PyBytes_Check(obkey)) {
+        if (PyBytes_GET_SIZE(obkey) != 1) {
             PyErr_SetString(PyExc_TypeError, "must be a byte string of length 1");
             return NULL;
         }
         PyW32_BEGIN_ALLOW_THREADS
             // @pyseeapi VkKeyScanA
-            ret = VkKeyScanA(PyString_AS_STRING(obkey)[0]);
+            ret = VkKeyScanA(PyBytes_AS_STRING(obkey)[0]);
         PyW32_END_ALLOW_THREADS
     }
     else if (PyUnicode_Check(obkey)) {
@@ -1575,14 +1575,14 @@ static PyObject *PyVkKeyScanEx(PyObject *self, PyObject *args)
         return NULL;
 
     int ret;
-    if (PyString_Check(obkey)) {
-        if (PyString_GET_SIZE(obkey) != 1) {
+    if (PyBytes_Check(obkey)) {
+        if (PyBytes_GET_SIZE(obkey) != 1) {
             PyErr_SetString(PyExc_TypeError, "must be a byte string of length 1");
             return NULL;
         }
         PyW32_BEGIN_ALLOW_THREADS
             // @pyseeapi VkKeyScanExA
-            ret = VkKeyScanExA(PyString_AS_STRING(obkey)[0], hkl);
+            ret = VkKeyScanExA(PyBytes_AS_STRING(obkey)[0], hkl);
         PyW32_END_ALLOW_THREADS
     }
     else if (PyUnicode_Check(obkey)) {
@@ -1689,7 +1689,7 @@ static PyObject *PyGetModuleFileName(PyObject *self, PyObject *args)
             break;
         }
         if (reqdsize < bufsize) {
-            ret = PyString_FromString(buf);
+            ret = PyBytes_FromString(buf);
             break;
         }
         reqdsize++;
@@ -2232,7 +2232,7 @@ static PyObject *PyGetShortPathName(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "O:GetShortPathName", &obPath))
         return NULL;
 #ifndef UNICODE
-    if (PyString_Check(obPath)) {
+    if (PyBytes_Check(obPath)) {
         char *path;
         if (!PyWinObject_AsString(obPath, &path))
             return NULL;
@@ -2306,7 +2306,7 @@ static PyObject *PyGetLongPathNameA(PyObject *self, PyObject *args)
             break;
         }
         if (reqd_bufsize <= bufsize) {
-            ret = PyString_FromStringAndSize(pathBuf, reqd_bufsize);
+            ret = PyBytes_FromStringAndSize(pathBuf, reqd_bufsize);
             break;
         }
         bufsize = reqd_bufsize + 1;
@@ -3372,8 +3372,8 @@ static PyObject *PyRegEnumKeyEx(PyObject *self, PyObject *args)
                 break;
             }
             obretitem =
-                Py_BuildValue("NiNN", PyString_FromStringAndSize(key_name, key_len), 0,
-                              PyString_FromStringAndSize(class_name, class_len), PyWinObject_FromFILETIME(timestamp));
+                Py_BuildValue("NiNN", PyBytes_FromStringAndSize(key_name, key_len), 0,
+                              PyBytes_FromStringAndSize(class_name, class_len), PyWinObject_FromFILETIME(timestamp));
             if (obretitem == NULL) {
                 Py_DECREF(ret);
                 ret = NULL;
@@ -3673,7 +3673,7 @@ static PyObject *PyWinObject_FromRegistryValue(BYTE *retDataBuf, DWORD retDataSi
                 obData = Py_None;
             }
             else
-                obData = PyString_FromStringAndSize((char *)retDataBuf, retDataSize);
+                obData = PyBytes_FromStringAndSize((char *)retDataBuf, retDataSize);
             break;
     }
     return obData;
@@ -4673,8 +4673,8 @@ static PyObject *PyWinHelp(PyObject *self, PyObject *args)
         return NULL;
     if (dataOb == Py_None)
         data = 0;
-    else if (PyString_Check(dataOb))
-        data = (ULONG_PTR)PyString_AsString(dataOb);
+    else if (PyBytes_Check(dataOb))
+        data = (ULONG_PTR)PyBytes_AsString(dataOb);
     else if (!PyWinLong_AsVoidPtr(dataOb, (void **)&data))
         return NULL;
     if (!PyWinObject_AsTCHAR(obhlpFile, &hlpFile, FALSE))
@@ -5260,7 +5260,7 @@ static PyObject *PyLoadResource(PyObject *self, PyObject *args)
                     if (p == NULL)
                         PyWin_SetAPIError("LockResource");
                     else
-                        ret = PyString_FromStringAndSize((char *)p, size);
+                        ret = PyBytes_FromStringAndSize((char *)p, size);
                 }
             }
         }
@@ -6018,7 +6018,7 @@ PyObject *PyToAsciiEx(PyObject *self, PyObject *args)
         Py_INCREF(Py_None);
         return Py_None;
     }
-    return PyString_FromStringAndSize(result, nc);
+    return PyBytes_FromStringAndSize(result, nc);
 }
 
 // @pymethod int|win32api|MapVirtualKey|Translates (maps) a virtual-key code into a scan code or character value, or

--- a/win32/src/win32apimodule.cpp
+++ b/win32/src/win32apimodule.cpp
@@ -958,7 +958,7 @@ static PyObject *PyGetLogicalDrives(PyObject *self, PyObject *args)
     DWORD rc = GetLogicalDrives();
     if (rc == 0)
         return ReturnAPIError("GetLogicalDrives");
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod string|win32api|GetConsoleTitle|Returns the title for the current console.
@@ -1555,7 +1555,7 @@ static PyObject *PyVkKeyScan(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_TypeError, "must be a unicode or byte string of length 1");
         return NULL;
     }
-    return PyInt_FromLong(ret);
+    return PyLong_FromLong(ret);
 }
 
 // @pymethod int|win32api|VkKeyScanEx|Translates a character to the corresponding virtual-key code and shift state.
@@ -1599,7 +1599,7 @@ static PyObject *PyVkKeyScanEx(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_TypeError, "must be a unicode or byte string of length 1");
         return NULL;
     }
-    return PyInt_FromLong(ret);
+    return PyLong_FromLong(ret);
 }
 
 // @pymethod int|win32api|GetLastError|Retrieves the calling thread's last error code value.
@@ -2040,7 +2040,7 @@ static PyObject *PyGetProfileVal(PyObject *self, PyObject *args)
             &obiniName))  // @pyparm string|iniName|None|The name of the INI file.  If None, the system INI file is
                           // used.
         return NULL;
-    intDef = PyInt_AsLong(obDef);
+    intDef = PyLong_AsLong(obDef);
     if (intDef == -1 && PyErr_Occurred()) {
         PyErr_Clear();
         bHaveInt = FALSE;
@@ -3523,7 +3523,7 @@ static BOOL PyWinObject_AsRegistryValue(PyObject *value, DWORD typ, BYTE **retDa
                 *(DWORD *)*retDataBuf = 0;
                 return true;
             }
-            *(int *)*retDataBuf = PyInt_AsLong(value);
+            *(int *)*retDataBuf = PyLong_AsLong(value);
             if (*(int *)*retDataBuf == -1 && PyErr_Occurred()) {
                 PyErr_Clear();
                 *(DWORD *)*retDataBuf = PyLong_AsUnsignedLong(value);
@@ -3609,13 +3609,13 @@ static PyObject *PyWinObject_FromRegistryValue(BYTE *retDataBuf, DWORD retDataSi
     switch (typ) {
         case REG_DWORD:
             if (retDataSize == 0)
-                obData = PyInt_FromLong(0);
+                obData = PyLong_FromLong(0);
             else  // ??? Should be returned as unsigned ???
-                obData = PyInt_FromLong(*(int *)retDataBuf);
+                obData = PyLong_FromLong(*(int *)retDataBuf);
             break;
         case REG_QWORD:
             if (retDataSize == 0)
-                obData = PyInt_FromLong(0);
+                obData = PyLong_FromLong(0);
             else
                 obData = PyLong_FromUnsignedLongLong(*(ULONGLONG *)retDataBuf);
             break;
@@ -4555,7 +4555,7 @@ static PyObject *PySetErrorMode(PyObject *self, PyObject *args)
     PyW32_BEGIN_ALLOW_THREADS UINT ret = ::SetErrorMode(mode);
     PyW32_END_ALLOW_THREADS
         // @rdesc The result is an integer containing the old error flags.
-        return PyInt_FromLong(ret);
+        return PyLong_FromLong(ret);
 }
 
 // @pymethod int|win32api|ShowCursor|The ShowCursor method displays or hides the cursor.
@@ -4704,7 +4704,7 @@ static PyObject *PyWriteProfileVal(PyObject *self, PyObject *args)
                           &obiniFile))  // @pyparm string|iniName|None|The name of the INI file.  If None, the system
                                         // INI file is used.
         return NULL;
-    intVal = PyInt_AsLong(obVal);
+    intVal = PyLong_AsLong(obVal);
     if (intVal == -1 && PyErr_Occurred()) {
         PyErr_Clear();
         bHaveInt = FALSE;
@@ -5113,7 +5113,7 @@ static PyObject *PyGetThreadLocale(PyObject *self, PyObject *args)
 {
     if (!PyArg_ParseTuple(args, ":GetThreadLocale"))
         return NULL;
-    return PyInt_FromLong(GetThreadLocale());
+    return PyLong_FromLong(GetThreadLocale());
 }
 
 // @pymethod |win32api|OutputDebugString|Sends a string to the Windows debugging device.
@@ -5452,7 +5452,7 @@ BOOL CALLBACK EnumResourceLanguagesProc(HMODULE hmodule, WCHAR *typname, WCHAR *
 {
     long resid;
     resid = wIDLanguage;
-    PyObject *oblangid = PyInt_FromLong(resid);
+    PyObject *oblangid = PyLong_FromLong(resid);
     if ((oblangid == NULL) || (PyList_Append(ret, oblangid) == -1)) {
         Py_XDECREF(oblangid);
         return FALSE;
@@ -5542,8 +5542,8 @@ int PyApplyExceptionFilter(DWORD ExceptionCode, PEXCEPTION_POINTERS ExceptionInf
     int ret = EXCEPTION_CONTINUE_SEARCH;
     if (obRet) {
         // Simple integer return code
-        if (PyInt_Check(obRet)) {
-            ret = PyInt_AsLong(obRet);
+        if (PyLong_Check(obRet)) {
+            ret = PyLong_AsLong(obRet);
             // Exception instance to be raised.
         }
         else if (PyObject_IsSubclass(obRet, PyExc_Exception)) {
@@ -6045,7 +6045,7 @@ PyObject *PyMapVirtualKey(PyObject *self, PyObject *args)
             return NULL;
         rc = MapVirtualKeyExW(vk, typ, layout);
     }
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 }
 
 // @pymethod dict|win32api|GlobalMemoryStatus|Returns systemwide memory usage
@@ -6130,8 +6130,8 @@ PyObject *PyGetPwrCapabilities(PyObject *self, PyObject *args)
         PyBool_FromLong(spc.FullWake), "VideoDimPresent", PyBool_FromLong(spc.VideoDimPresent), "ApmPresent",
         PyBool_FromLong(spc.ApmPresent), "UpsPresent", PyBool_FromLong(spc.UpsPresent), "ThermalControl",
         PyBool_FromLong(spc.ThermalControl), "ProcessorThrottle", PyBool_FromLong(spc.ProcessorThrottle),
-        "ProcessorMinThrottle", PyInt_FromLong(spc.ProcessorMinThrottle), "ProcessorMaxThrottle",
-        PyInt_FromLong(spc.ProcessorMaxThrottle), "FastSystemS4", PyBool_FromLong(spc.FastSystemS4), "spare2",
+        "ProcessorMinThrottle", PyLong_FromLong(spc.ProcessorMinThrottle), "ProcessorMaxThrottle",
+        PyLong_FromLong(spc.ProcessorMaxThrottle), "FastSystemS4", PyBool_FromLong(spc.FastSystemS4), "spare2",
         Py_None,                                                               // reserved
         "DiskSpinDown", PyBool_FromLong(spc.DiskSpinDown), "spare3", Py_None,  // reserved
         "SystemBatteriesPresent", PyBool_FromLong(spc.SystemBatteriesPresent), "BatteriesAreShortTerm",
@@ -6139,9 +6139,9 @@ PyObject *PyGetPwrCapabilities(PyObject *self, PyObject *args)
         Py_BuildValue("NNN", PyWinObject_FromBATTERY_REPORTING_SCALE(&spc.BatteryScale[0]),
                       PyWinObject_FromBATTERY_REPORTING_SCALE(&spc.BatteryScale[1]),
                       PyWinObject_FromBATTERY_REPORTING_SCALE(&spc.BatteryScale[2])),
-        "AcOnLineWake", PyInt_FromLong(spc.AcOnLineWake), "SoftLidWake", PyInt_FromLong(spc.SoftLidWake), "RtcWake",
-        PyInt_FromLong(spc.RtcWake), "MinDeviceWakeState", PyInt_FromLong(spc.MinDeviceWakeState),
-        "DefaultLowLatencyWake", PyInt_FromLong(spc.DefaultLowLatencyWake));
+        "AcOnLineWake", PyLong_FromLong(spc.AcOnLineWake), "SoftLidWake", PyLong_FromLong(spc.SoftLidWake), "RtcWake",
+        PyLong_FromLong(spc.RtcWake), "MinDeviceWakeState", PyLong_FromLong(spc.MinDeviceWakeState),
+        "DefaultLowLatencyWake", PyLong_FromLong(spc.DefaultLowLatencyWake));
 }
 
 /* List of functions exported by this module */
@@ -6523,9 +6523,9 @@ PYWIN_MODULE_INIT_FUNC(win32api)
                               "Wraps general API functions that are not subsumed in the more specific modules");
 
     PyDict_SetItemString(dict, "error", PyWinExc_ApiError);
-    PyDict_SetItemString(dict, "STD_INPUT_HANDLE", PyInt_FromLong(STD_INPUT_HANDLE));
-    PyDict_SetItemString(dict, "STD_OUTPUT_HANDLE", PyInt_FromLong(STD_OUTPUT_HANDLE));
-    PyDict_SetItemString(dict, "STD_ERROR_HANDLE", PyInt_FromLong(STD_ERROR_HANDLE));
+    PyDict_SetItemString(dict, "STD_INPUT_HANDLE", PyLong_FromLong(STD_INPUT_HANDLE));
+    PyDict_SetItemString(dict, "STD_OUTPUT_HANDLE", PyLong_FromLong(STD_OUTPUT_HANDLE));
+    PyDict_SetItemString(dict, "STD_ERROR_HANDLE", PyLong_FromLong(STD_ERROR_HANDLE));
 
     if (PyType_Ready(&PyDISPLAY_DEVICEType) == -1 ||
         PyDict_SetItemString(dict, "PyDISPLAY_DEVICEType", (PyObject *)&PyDISPLAY_DEVICEType) == -1)

--- a/win32/src/win32clipboardmodule.cpp
+++ b/win32/src/win32clipboardmodule.cpp
@@ -670,7 +670,7 @@ static PyObject *py_getPriority_clipboard_format(PyObject *self, PyObject *args)
     Py_END_ALLOW_THREADS;
 
     free(format_list);
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
     // @pyseeapi GetPriorityClipboardFormat
     // @pyseeapi Standard Clipboard Formats
 
@@ -781,7 +781,7 @@ static PyObject *py_register_clipboard_format(PyObject *self, PyObject *args)
     PyWinObject_FreeTCHAR(name);
     if (!rc)
         return ReturnAPIError("RegisterClipboardFormat");
-    return PyInt_FromLong(rc);
+    return PyLong_FromLong(rc);
 
     // @comm If a registered format with the specified name already exists, a
     // new format is not registered and the return value identifies the existing

--- a/win32/src/win32clipboardmodule.cpp
+++ b/win32/src/win32clipboardmodule.cpp
@@ -400,7 +400,7 @@ static PyObject *py_get_clipboard_data(PyObject *self, PyObject *args)
         // For the text formats, strip the null!
         case CF_TEXT:
         case CF_OEMTEXT:
-            ret = PyString_FromStringAndSize((char *)cData, size - 1);
+            ret = PyBytes_FromStringAndSize((char *)cData, size - 1);
             GlobalUnlock(handle);
             break;
         default:
@@ -410,7 +410,7 @@ static PyObject *py_get_clipboard_data(PyObject *self, PyObject *args)
                 Py_INCREF(ret);
             }
             else
-                ret = PyString_FromStringAndSize((char *)cData, size);
+                ret = PyBytes_FromStringAndSize((char *)cData, size);
             GlobalUnlock(handle);
             break;
     }
@@ -467,7 +467,7 @@ static PyObject *py_get_global_memory(PyObject *self, PyObject *args)
     void *p = GlobalLock(hglobal);
     if (!p)
         return ReturnAPIError("GlobalAlloc");
-    PyObject *ret = PyString_FromStringAndSize((char *)p, size);
+    PyObject *ret = PyBytes_FromStringAndSize((char *)p, size);
     GlobalUnlock(hglobal);
     return ret;
 }
@@ -846,7 +846,7 @@ static PyObject *py_set_clipboard_data(PyObject *self, PyObject *args)
                 return NULL;
             buf = pybuf.ptr();
             bufSize = pybuf.len();
-            if (PyString_Check(obhandle))
+            if (PyBytes_Check(obhandle))
                 bufSize++;  // size doesnt include nulls!
                             // else assume buffer needs no terminator...
         }

--- a/win32/src/win32consolemodule.cpp
+++ b/win32/src/win32consolemodule.cpp
@@ -73,7 +73,7 @@ BOOL PyWinObject_AsUSHORTArray(PyObject *obushorts, USHORT **pushorts, DWORD *it
     else
         for (tuple_index = 0; tuple_index < *item_cnt; tuple_index++) {
             tuple_item = PyTuple_GET_ITEM(ushorts_tuple, tuple_index);
-            short_candidate = PyInt_AsLong(tuple_item);
+            short_candidate = PyLong_AsLong(tuple_item);
             if (short_candidate == -1 && PyErr_Occurred()) {
                 ret = FALSE;
                 break;
@@ -541,7 +541,7 @@ int PyINPUT_RECORD::tp_setattro(PyObject *self, PyObject *obname, PyObject *obva
             return -1;
         }
 
-        *dest_ptr = PyInt_AsUnsignedLongMask(obvalue);
+        *dest_ptr = PyLong_AsUnsignedLongMask(obvalue);
         if ((*dest_ptr == (DWORD)-1) && PyErr_Occurred())
             return -1;
         return 0;
@@ -993,7 +993,7 @@ PyObject *PyConsoleScreenBuffer::PyWriteConsole(PyObject *self, PyObject *args, 
     if (!WriteConsole(((PyConsoleScreenBuffer *)self)->m_handle, (LPVOID)buf, nbrtowrite, &nbrwritten, reserved))
         PyWin_SetAPIError("WriteConsole");
     else
-        ret = PyInt_FromLong(nbrwritten);
+        ret = PyLong_FromLong(nbrwritten);
     PyWinObject_FreeWCHAR(buf);
     return ret;
 }
@@ -1149,7 +1149,7 @@ PyObject *PyConsoleScreenBuffer::PyFillConsoleOutputCharacter(PyObject *self, Py
         return NULL;
     if (!FillConsoleOutputCharacter(((PyConsoleScreenBuffer *)self)->m_handle, fillchar, len, *pcoord, &nbrwritten))
         return PyWin_SetAPIError("FillConsoleOutputCharacter");
-    return PyInt_FromLong(nbrwritten);
+    return PyLong_FromLong(nbrwritten);
 }
 
 // @pymethod <o PyUnicode>|PyConsoleScreenBuffer|ReadConsoleOutputCharacter|Reads consecutive characters from a starting
@@ -1205,7 +1205,7 @@ PyObject *PyConsoleScreenBuffer::PyReadConsoleOutputAttribute(PyObject *self, Py
         ret = PyTuple_New(nbrread);
         if (ret != NULL)
             for (tuple_ind = 0; tuple_ind < nbrread; tuple_ind++) {
-                ret_item = PyInt_FromLong(buf[tuple_ind]);
+                ret_item = PyLong_FromLong(buf[tuple_ind]);
                 if (ret_item == NULL) {
                     Py_DECREF(ret);
                     ret = NULL;

--- a/win32/src/win32credmodule.cpp
+++ b/win32/src/win32credmodule.cpp
@@ -20,7 +20,7 @@ PyObject *PyWinObject_FromCREDENTIAL_ATTRIBUTEArray(PCREDENTIAL_ATTRIBUTE attrs,
     for (DWORD attr_ind = 0; attr_ind < attr_cnt; attr_ind++) {
         ret_item =
             Py_BuildValue("{s:u,s:k,s:N}", "Keyword", attrs[attr_ind].Keyword, "Flags", attrs[attr_ind].Flags, "Value",
-                          PyString_FromStringAndSize((char *)attrs[attr_ind].Value, attrs[attr_ind].ValueSize));
+                          PyBytes_FromStringAndSize((char *)attrs[attr_ind].Value, attrs[attr_ind].ValueSize));
         if (ret_item == NULL) {
             Py_DECREF(ret);
             ret = NULL;
@@ -132,7 +132,7 @@ PyObject *PyWinObject_FromCREDENTIAL(PCREDENTIAL credential)
     return Py_BuildValue("{s:k,s:k,s:u,s:u,s:N,s:N,s:k,s:N,s:u,s:u}", "Flags", credential->Flags, "Type",
                          credential->Type, "TargetName", credential->TargetName, "Comment", credential->Comment,
                          "LastWritten", PyWinObject_FromFILETIME(credential->LastWritten), "CredentialBlob",
-                         PyString_FromStringAndSize((char *)credential->CredentialBlob, credential->CredentialBlobSize),
+                         PyBytes_FromStringAndSize((char *)credential->CredentialBlob, credential->CredentialBlobSize),
                          "Persist", credential->Persist, "Attributes",
                          PyWinObject_FromCREDENTIAL_ATTRIBUTEArray(credential->Attributes, credential->AttributeCount),
                          "TargetAlias", credential->TargetAlias, "UserName", credential->UserName);
@@ -373,7 +373,7 @@ PyObject *PyCredMarshalCredential(PyObject *self, PyObject *args, PyObject *kwar
         case CertCredential: {
             Py_ssize_t hashlen;
             char *hash;
-            if (PyString_AsStringAndSize(obcredential, &hash, &hashlen) == -1)
+            if (PyBytes_AsStringAndSize(obcredential, &hash, &hashlen) == -1)
                 goto done;
             if (hashlen > CERT_HASH_LENGTH) {
                 PyErr_Format(PyExc_ValueError, "Certificate hash cannot be longer than %d characters",
@@ -437,7 +437,7 @@ PyObject *PyCredUnmarshalCredential(PyObject *self, PyObject *args, PyObject *kw
         // @flag CertCredential|Character string containing SHA1 hash of a certificate
         case CertCredential:
             ret = Py_BuildValue("kN", credtype,
-                                PyString_FromStringAndSize((char *)&((PCERT_CREDENTIAL_INFO)credential)->rgbHashOfCert,
+                                PyBytes_FromStringAndSize((char *)&((PCERT_CREDENTIAL_INFO)credential)->rgbHashOfCert,
                                                            CERT_HASH_LENGTH));
             break;
         // @flag UsernameTargetCredential|Unicode string containing username

--- a/win32/src/win32crypt/PyCERTSTORE.cpp
+++ b/win32/src/win32crypt/PyCERTSTORE.cpp
@@ -487,7 +487,7 @@ PyObject *PyCERTSTORE::PyPFXExportCertStoreEx(PyObject *self, PyObject *args, Py
     PyObject *ret = NULL;
     Py_BEGIN_ALLOW_THREADS bsuccess = PFXExportCertStoreEx(hcertstore, &out, password, NULL, flags);
     Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("PFXExportCertStoreEx");
-    else ret = PyString_FromStringAndSize((char *)out.pbData, out.cbData);
+    else ret = PyBytes_FromStringAndSize((char *)out.pbData, out.cbData);
     free(out.pbData);
     return ret;
 }
@@ -551,7 +551,7 @@ property id return NULL;
     if (!bsuccess)
         PyWin_SetAPIError("CertGetStoreProperty");
     else
-        ret = PyString_FromStringAndSize((char *)buf, bufsize);
+        ret = PyBytes_FromStringAndSize((char *)buf, bufsize);
     free(buf);
     return ret;
 }

--- a/win32/src/win32crypt/PyCERT_CONTEXT.cpp
+++ b/win32/src/win32crypt/PyCERT_CONTEXT.cpp
@@ -118,7 +118,7 @@ PyObject *PyWinObject_FromCERT_EXTENSIONArray(PCERT_EXTENSION pce, DWORD ext_cnt
     for (ext_ind = 0; ext_ind < ext_cnt; ext_ind++) {
         ret_item = Py_BuildValue(
             "{s:s,s:N,s:N}", "ObjId", pce[ext_ind].pszObjId, "Critical", PyBool_FromLong(pce[ext_ind].fCritical),
-            "Value", PyString_FromStringAndSize((char *)pce[ext_ind].Value.pbData, pce[ext_ind].Value.cbData));
+            "Value", PyBytes_FromStringAndSize((char *)pce[ext_ind].Value.pbData, pce[ext_ind].Value.cbData));
         if (ret_item == NULL) {
             Py_DECREF(ret);
             ret = NULL;
@@ -146,15 +146,15 @@ PyObject *PyCERT_CONTEXT::getattro(PyObject *self, PyObject *obname)
         return PyWinObject_FromCERTSTORE(h);
     }
     if (strcmp(name, "CertEncoded") == 0)
-        return PyString_FromStringAndSize((char *)pcc->pbCertEncoded, pcc->cbCertEncoded);
+        return PyBytes_FromStringAndSize((char *)pcc->pbCertEncoded, pcc->cbCertEncoded);
     if (strcmp(name, "CertEncodingType") == 0)
         return PyLong_FromUnsignedLong(pcc->dwCertEncodingType);
     if (strcmp(name, "Version") == 0)
         return PyLong_FromUnsignedLong(pcc->pCertInfo->dwVersion);
     if (strcmp(name, "Issuer") == 0)
-        return PyString_FromStringAndSize((char *)pcc->pCertInfo->Issuer.pbData, pcc->pCertInfo->Issuer.cbData);
+        return PyBytes_FromStringAndSize((char *)pcc->pCertInfo->Issuer.pbData, pcc->pCertInfo->Issuer.cbData);
     if (strcmp(name, "Subject") == 0)
-        return PyString_FromStringAndSize((char *)pcc->pCertInfo->Subject.pbData, pcc->pCertInfo->Subject.cbData);
+        return PyBytes_FromStringAndSize((char *)pcc->pCertInfo->Subject.pbData, pcc->pCertInfo->Subject.cbData);
     if (strcmp(name, "NotBefore") == 0)
         return PyWinObject_FromFILETIME(pcc->pCertInfo->NotBefore);
     if (strcmp(name, "NotAfter") == 0)
@@ -336,7 +336,7 @@ PyObject *PyCERT_CONTEXT::PyCertSerializeCertificateStoreElement(PyObject *self,
 
     Py_BEGIN_ALLOW_THREADS bsuccess = CertSerializeCertificateStoreElement(pccert_context, flags, buf, &bufsize);
     Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CertSerializeCertificateStoreElement");
-    else ret = PyString_FromStringAndSize((char *)buf, bufsize);
+    else ret = PyBytes_FromStringAndSize((char *)buf, bufsize);
     free(buf);
     return ret;
 }
@@ -438,7 +438,7 @@ PyObject *PyCERT_CONTEXT::PyCertGetCertificateContextProperty(PyObject *self, Py
         case CERT_SIGNATURE_HASH_PROP_ID:         // @flag CERT_SIGNATURE_HASH_PROP_ID|String containing a hash
         case CERT_KEY_IDENTIFIER_PROP_ID:         // @flag CERT_KEY_IDENTIFIER_PROP_ID|String containing a hash
         case CERT_SUBJECT_NAME_MD5_HASH_PROP_ID:  // @flag CERT_SUBJECT_NAME_MD5_HASH_PROP_ID|String containing a hash
-            ret = PyString_FromStringAndSize((char *)pvData, pcbData);
+            ret = PyBytes_FromStringAndSize((char *)pvData, pcbData);
             // all hashes treated as raw binary data
             break;
         case CERT_KEY_PROV_HANDLE_PROP_ID:  // @flag CERT_KEY_PROV_HANDLE_PROP_ID|<o PyCRYPTPROV>
@@ -448,14 +448,14 @@ PyObject *PyCERT_CONTEXT::PyCertGetCertificateContextProperty(PyObject *self, Py
                                                         // containing a hash
         case CERT_ISSUER_PUBLIC_KEY_MD5_HASH_PROP_ID:   // @flag CERT_ISSUER_PUBLIC_KEY_MD5_HASH_PROP_ID|String
                                                         // containing a hash
-            ret = PyString_FromStringAndSize((char *)pvData, pcbData);
+            ret = PyBytes_FromStringAndSize((char *)pvData, pcbData);
             /* MSDN claims these return a CRYPT_DATA_BLOB, but data is not valid when
                interpreted as such - cbdata is huge, and pbData is not a valid pointer.
                The returned pcbData exactly matches size of an MD5 hash, and it would
                actually have to be the size of the hash + sizeof(CRYPT_DATA_BLOB) since
                everything is returned in a single allocated block
             pcdb=(CRYPT_DATA_BLOB *)pvData;
-            ret=PyString_FromStringAndSize((char *)pcdb->pbData,pcdb->cbData);
+            ret=PyBytes_FromStringAndSize((char *)pcdb->pbData,pcdb->cbData);
             */
             break;
         // CERT_CTL_USAGE_PROP_ID is same value as CERT_ENHKEY_USAGE_PROP_ID
@@ -464,7 +464,7 @@ PyObject *PyCERT_CONTEXT::PyCertGetCertificateContextProperty(PyObject *self, Py
         // @flag CERT_ENHKEY_USAGE_PROP_ID|Encoded CTL_USAGE. Can be decoded using <om cryptoapi.CryptDecodeObjectEx>
         // with X509_ENHANCED_KEY_USAGE
         case CERT_ENHKEY_USAGE_PROP_ID:
-            ret = PyString_FromStringAndSize((char *)pvData, pcbData);
+            ret = PyBytes_FromStringAndSize((char *)pvData, pcbData);
             break;
         case CERT_KEY_PROV_INFO_PROP_ID:  // @flag CERT_KEY_PROV_INFO_PROP_ID|CRYPT_KEY_PROV_INFO dict
             ret = PyWinObject_FromCRYPT_KEY_PROV_INFO((PCRYPT_KEY_PROV_INFO)pvData);
@@ -476,7 +476,7 @@ PyObject *PyCERT_CONTEXT::PyCertGetCertificateContextProperty(PyObject *self, Py
         // @flag CERT_NEXT_UPDATE_LOCATION_PROP_ID|Encoded CERT_ALT_NAME_INFO, decode using <om
         // cryptoapi.CryptDecodeObjectEx> with szOID_NEXT_UPDATE_LOCATION
         case CERT_NEXT_UPDATE_LOCATION_PROP_ID:
-            ret = PyString_FromStringAndSize((char *)pvData, pcbData);
+            ret = PyBytes_FromStringAndSize((char *)pvData, pcbData);
             break;
         // case CERT_PUBKEY_ALG_PROP_ID: // ???? This constant does not exist in my header files ????
         case CERT_ENROLLMENT_PROP_ID:  // CRYPT_DATA_BLOB, data will apparently have to be split out manually

--- a/win32/src/win32crypt/PyCRYPTHASH.cpp
+++ b/win32/src/win32crypt/PyCRYPTHASH.cpp
@@ -192,7 +192,7 @@ PyObject *PyCRYPTHASH::PyCryptSignHash(PyObject *self, PyObject *args, PyObject 
     if (!CryptSignHash(hcrypthash, dwKeySpec, sDescription, dwFlags, pbSignature, &dwSigLen))
         PyWin_SetAPIError("PyCRYPTHASH::CryptSignHash", GetLastError());
     else
-        ret = PyString_FromStringAndSize((char *)pbSignature, dwSigLen);
+        ret = PyBytes_FromStringAndSize((char *)pbSignature, dwSigLen);
 
     if (pbSignature != NULL)
         free(pbSignature);
@@ -256,7 +256,7 @@ PyObject *PyCRYPTHASH::PyCryptGetHashParam(PyObject *self, PyObject *args, PyObj
                 ret = PyLong_FromUnsignedLong(*((unsigned long *)buf));
                 break;
             case HP_HASHVAL:
-                ret = PyString_FromStringAndSize((char *)buf, buflen);
+                ret = PyBytes_FromStringAndSize((char *)buf, buflen);
                 break;
             default:
                 PyErr_Format(PyExc_NotImplementedError, "Hash parameter %d is not yet supported", param);

--- a/win32/src/win32crypt/PyCRYPTKEY.cpp
+++ b/win32/src/win32crypt/PyCRYPTKEY.cpp
@@ -146,7 +146,7 @@ PyObject *PyCRYPTKEY::PyCryptExportKey(PyObject *self, PyObject *args, PyObject 
     if (pbData == NULL)
         return PyErr_Format(PyExc_MemoryError, "PyCRYPTKEY::CryptExportKey: Unable to allocate %d bytes", dwDataLen);
     if (CryptExportKey(hcryptkey, hcryptkeyexp, dwBlobType, dwFlags, pbData, &dwDataLen))
-        ret = PyString_FromStringAndSize((char *)pbData, dwDataLen);
+        ret = PyBytes_FromStringAndSize((char *)pbData, dwDataLen);
     else
         PyWin_SetAPIError("CryptExportKey");
     if (pbData != NULL)
@@ -196,7 +196,7 @@ PyObject *PyCRYPTKEY::PyCryptGetKeyParam(PyObject *self, PyObject *args, PyObjec
         case KP_G:
         case KP_IV:
         case KP_SALT:
-            ret = PyString_FromStringAndSize((char *)pbData, dwDataLen);
+            ret = PyBytes_FromStringAndSize((char *)pbData, dwDataLen);
             break;
         default:
             PyErr_SetString(PyExc_NotImplementedError, "The Param specified is not yet supported");
@@ -266,7 +266,7 @@ PyObject *PyCRYPTKEY::PyCryptEncrypt(PyObject *self, PyObject *args, PyObject *k
     if (!CryptEncrypt(hcryptkey, hcrypthash, Final, dwFlags, pbData, &dwDataLen, dwBufLen))
         PyWin_SetAPIError("CryptEncrypt");
     else
-        ret = PyString_FromStringAndSize((char *)pbData, dwDataLen);
+        ret = PyBytes_FromStringAndSize((char *)pbData, dwDataLen);
     free(pbData);
     return ret;
 }
@@ -305,7 +305,7 @@ PyObject *PyCRYPTKEY::PyCryptDecrypt(PyObject *self, PyObject *args, PyObject *k
     if (!CryptDecrypt(hcryptkey, hcrypthash, Final, dwFlags, pbData, &dwDataLen))
         PyWin_SetAPIError("CryptDecrypt");
     else
-        ret = PyString_FromStringAndSize((char *)pbData, dwDataLen);
+        ret = PyBytes_FromStringAndSize((char *)pbData, dwDataLen);
     free(pbData);
     return ret;
 }

--- a/win32/src/win32crypt/PyCRYPTPROV.cpp
+++ b/win32/src/win32crypt/PyCRYPTPROV.cpp
@@ -286,7 +286,7 @@ PyObject *PyCRYPTPROV::PyCryptGetProvParam(PyObject *self, PyObject *args, PyObj
                 case PP_KEYEXCHANGE_PIN:
                 case PP_SIGNATURE_PIN:
                 case PP_ADMIN_PIN:
-                    ret = PyString_FromString((char *)pbData);
+                    ret = PyBytes_FromString((char *)pbData);
                     break;
                 case PP_VERSION:  // return as string or tuple of 2 numbers ???????
                 default: {
@@ -343,7 +343,7 @@ PyObject *PyCRYPTPROV::PyCryptGenRandom(PyObject *self, PyObject *args, PyObject
     if (seeddata != NULL)
         memcpy(pbBuffer, seeddata, min(dwLen, seedlen));
     if (CryptGenRandom(hcryptprov, dwLen, pbBuffer))
-        ret = PyString_FromStringAndSize((char *)pbBuffer, dwLen);
+        ret = PyBytes_FromStringAndSize((char *)pbBuffer, dwLen);
     else
         PyWin_SetAPIError("PyCRYPTPROV::CryptGenRandom");
     if (pbBuffer != NULL)

--- a/win32/src/win32crypt/PyCTL_CONTEXT.cpp
+++ b/win32/src/win32crypt/PyCTL_CONTEXT.cpp
@@ -149,8 +149,8 @@ PyObject *PyCTL_CONTEXT::PyCertEnumSubjectInSortedCTL(PyObject *self, PyObject *
     if (ret == NULL)
         return NULL;
     while (CertEnumSubjectInSortedCTL(pctl, &ctxt, &subject, &attr)) {
-        ret_item = Py_BuildValue("NN", PyString_FromStringAndSize((char *)subject.pbData, subject.cbData),
-                                 PyString_FromStringAndSize((char *)attr.pbData, attr.cbData));
+        ret_item = Py_BuildValue("NN", PyBytes_FromStringAndSize((char *)subject.pbData, subject.cbData),
+                                 PyBytes_FromStringAndSize((char *)attr.pbData, attr.cbData));
         if ((ret_item == NULL) || (PyList_Append(ret, ret_item) == -1)) {
             Py_XDECREF(ret_item);
             Py_DECREF(ret);
@@ -191,7 +191,7 @@ PyObject *PyCTL_CONTEXT::PyCertSerializeCTLStoreElement(PyObject *self, PyObject
     if (!CertSerializeCTLStoreElement(pctl, flags, buf, &bufsize))
         PyWin_SetAPIError("CertSerializeCTLStoreElement");
     else
-        ret = PyString_FromStringAndSize((char *)buf, bufsize);
+        ret = PyBytes_FromStringAndSize((char *)buf, bufsize);
     free(buf);
     return ret;
 }

--- a/win32/src/win32crypt/win32crypt_structs.cpp
+++ b/win32/src/win32crypt/win32crypt_structs.cpp
@@ -14,7 +14,7 @@ BOOL PyWinObject_AsDATA_BLOB(PyObject *ob, DATA_BLOB *b)
     return TRUE;
 }
 
-PyObject *PyWinObject_FromDATA_BLOB(DATA_BLOB *b) { return PyString_FromStringAndSize((char *)b->pbData, b->cbData); }
+PyObject *PyWinObject_FromDATA_BLOB(DATA_BLOB *b) { return PyBytes_FromStringAndSize((char *)b->pbData, b->cbData); }
 
 // @object PyCRYPTPROTECT_PROMPTSTRUCT|A tuple representing a CRYPTPROTECT_PROMPTSTRUCT structure
 // @tupleitem 0|int|flags|Combination of CRYPTPROTECT_PROMPT_* flags
@@ -78,7 +78,7 @@ PyObject *PyWinObject_FromCRYPT_INTEGER_BLOB(PCRYPT_INTEGER_BLOB pcib)
         }
     return PyLong_FromString(hex_string, NULL, 16);
     */
-    return PyString_FromStringAndSize((char *)pcib->pbData, pcib->cbData);
+    return PyBytes_FromStringAndSize((char *)pcib->pbData, pcib->cbData);
 }
 
 PyObject *PyWinObject_FromCRYPT_KEY_PROV_INFO(PCRYPT_KEY_PROV_INFO pckpi)
@@ -104,13 +104,13 @@ PyObject *PyWinObject_FromCRYPT_KEY_PROV_INFO(PCRYPT_KEY_PROV_INFO pckpi)
             case PP_KEYEXCHANGE_PIN:
             case PP_SIGNATURE_PIN:
                 // both return pin as NULL-terminated string
-                data = PyString_FromString((char *)pckpi->rgProvParam[i].pbData);
+                data = PyBytes_FromString((char *)pckpi->rgProvParam[i].pbData);
                 break;
             default:
                 // Anything not handled specifically is dumped out as raw bytes
                 PyErr_Warn(PyExc_RuntimeWarning, "Unsupported PP_ parameter returned as raw data"),
                     data =
-                        PyString_FromStringAndSize((char *)pckpi->rgProvParam[i].pbData, pckpi->rgProvParam[i].cbData);
+                        PyBytes_FromStringAndSize((char *)pckpi->rgProvParam[i].pbData, pckpi->rgProvParam[i].cbData);
                 break;
         }
         if (data == NULL) {
@@ -144,7 +144,7 @@ PyObject *PyWinObject_FromCERT_OTHER_NAME(PCERT_OTHER_NAME pcon)
         - to be decoded with X509_UNICODE_NAME_VALUE
     */
     return Py_BuildValue("{s:s,s:N}", "ObjId", pcon->pszObjId, "Value",
-                         PyString_FromStringAndSize((char *)pcon->Value.pbData, pcon->Value.cbData));
+                         PyBytes_FromStringAndSize((char *)pcon->Value.pbData, pcon->Value.cbData));
 }
 
 // @object PyCERT_ALT_NAME_ENTRY|Represented as a 2-tuple
@@ -160,13 +160,13 @@ PyObject *PyWinObject_FromCERT_ALT_NAME_ENTRY(PCERT_ALT_NAME_ENTRY pcane)
         case CERT_ALT_NAME_EDI_PARTY_NAME:
             return Py_BuildValue("kN", pcane->dwAltNameChoice, PyWinObject_FromWCHAR(pcane->pwszRfc822Name));
         case CERT_ALT_NAME_REGISTERED_ID:
-            return Py_BuildValue("kN", pcane->dwAltNameChoice, PyString_FromString(pcane->pszRegisteredID));
+            return Py_BuildValue("kN", pcane->dwAltNameChoice, PyBytes_FromString(pcane->pszRegisteredID));
         // these 3 all resolve to a CRYPTOAPI_BLOB
         case CERT_ALT_NAME_IP_ADDRESS:
         case CERT_ALT_NAME_X400_ADDRESS:
         case CERT_ALT_NAME_DIRECTORY_NAME:
             return Py_BuildValue("kN", pcane->dwAltNameChoice,
-                                 PyString_FromStringAndSize((char *)pcane->IPAddress.pbData, pcane->IPAddress.cbData));
+                                 PyBytes_FromStringAndSize((char *)pcane->IPAddress.pbData, pcane->IPAddress.cbData));
         case CERT_ALT_NAME_OTHER_NAME:
             // pOtherName points to a CERT_OTHER_NAME
             return Py_BuildValue("kN", pcane->dwAltNameChoice, PyWinObject_FromCERT_OTHER_NAME(pcane->pOtherName));
@@ -213,7 +213,7 @@ PyObject *PyWinObject_FromCRYPT_ALGORITHM_IDENTIFIER(PCRYPT_ALGORITHM_IDENTIFIER
         err=GetLastError();
     */
     return Py_BuildValue("{s:s, s:N}", "ObjId", pcai->pszObjId, "Parameters",
-                         PyString_FromStringAndSize((char *)pcai->Parameters.pbData, pcai->Parameters.cbData));
+                         PyBytes_FromStringAndSize((char *)pcai->Parameters.pbData, pcai->Parameters.cbData));
 }
 
 // @object PyCRYPT_ALGORITHM_IDENTIFIER|Dictionary containing information that identifies an encryption
@@ -257,7 +257,7 @@ BOOL PyWinObject_AsCERT_PUBLIC_KEY_INFO(PyObject *obcpki, PCERT_PUBLIC_KEY_INFO 
 
 PyObject *PyWinObject_FromCRYPT_BIT_BLOB(PCRYPT_BIT_BLOB pcbb)
 {
-    return Py_BuildValue("{s:N,s:k}", "Data", PyString_FromStringAndSize((char *)pcbb->pbData, pcbb->cbData),
+    return Py_BuildValue("{s:N,s:k}", "Data", PyBytes_FromStringAndSize((char *)pcbb->pbData, pcbb->cbData),
                          "UnusedBits", pcbb->cUnusedBits);
 }
 
@@ -324,7 +324,7 @@ PyObject *PyWinObject_FromCERT_RDN_ATTR(PCERT_RDN_ATTR pcra)
         }
     }
     else  // all others treated as raw bytes
-        value = PyString_FromStringAndSize((char *)pcra->Value.pbData, pcra->Value.cbData);
+        value = PyBytes_FromStringAndSize((char *)pcra->Value.pbData, pcra->Value.cbData);
 
     if (value == NULL)
         return NULL;
@@ -371,7 +371,7 @@ PyObject *PyWinObject_FromCRYPT_OID_INFO(PCCRYPT_OID_INFO oid_info)
     return Py_BuildValue("{s:s,s:u,s:k,s:k,s:N}", "OID", oid_info->pszOID, "Name", oid_info->pwszName, "GroupId",
                          oid_info->dwGroupId, "Value", oid_info->dwValue,  // this is union, but all same size integers
                          "ExtraInfo",
-                         PyString_FromStringAndSize((char *)oid_info->ExtraInfo.pbData, oid_info->ExtraInfo.cbData));
+                         PyBytes_FromStringAndSize((char *)oid_info->ExtraInfo.pbData, oid_info->ExtraInfo.cbData));
 }
 
 void PyWinObject_FreeCRYPT_DECRYPT_MESSAGE_PARA(PCRYPT_DECRYPT_MESSAGE_PARA pcdmp)
@@ -500,7 +500,7 @@ PCCERT_CONTEXT WINAPI PyLocateCertificate(void *pvGetArg, DWORD dwCertEncodingTy
         TmpPyObject args = Py_BuildValue(
             "OkNN", callback_arg, dwCertEncodingType,
             Py_BuildValue("{s:N, s:N}", "Issuer",
-                          PyString_FromStringAndSize((char *)pSignerId->Issuer.pbData, pSignerId->Issuer.cbData),
+                          PyBytes_FromStringAndSize((char *)pSignerId->Issuer.pbData, pSignerId->Issuer.cbData),
                           "SerialNumber", PyWinObject_FromCRYPT_INTEGER_BLOB(&pSignerId->SerialNumber)),
             PyWinObject_FromCERTSTORE(hMsgCertStore));
         if (args == NULL)
@@ -879,7 +879,7 @@ BOOL PyWinObject_AsOIDArray(PyObject *str_seq, LPSTR **str_array, DWORD *str_cnt
 
     for (tuple_ind = 0; tuple_ind < *str_cnt; tuple_ind++) {
         PyObject *tuple_item = PyTuple_GET_ITEM((PyObject *)str_tuple, tuple_ind);
-        (*str_array)[tuple_ind] = PyString_AsString(tuple_item);
+        (*str_array)[tuple_ind] = PyBytes_AsString(tuple_item);
         if ((*str_array)[tuple_ind] != NULL)
             continue;
         PyErr_Clear();
@@ -910,7 +910,7 @@ PyObject *PyWinObject_FromCTL_USAGE(PCTL_USAGE pUsage)
     ret = PyTuple_New(pUsage->cUsageIdentifier);
     if (ret != NULL)
         for (usage_index = 0; usage_index < pUsage->cUsageIdentifier; usage_index++) {
-            ret_item = PyString_FromString(pUsage->rgpszUsageIdentifier[usage_index]);
+            ret_item = PyBytes_FromString(pUsage->rgpszUsageIdentifier[usage_index]);
             if (ret_item == NULL) {
                 Py_DECREF(ret);
                 ret = NULL;
@@ -957,7 +957,7 @@ PyObject *PyWinObject_FromCERT_KEY_ATTRIBUTES_INFO(PCERT_KEY_ATTRIBUTES_INFO pck
     }
 
     return Py_BuildValue("{s:N, s:N, s:N}", "KeyId",
-                         PyString_FromStringAndSize((char *)pckai->KeyId.pbData, pckai->KeyId.cbData),
+                         PyBytes_FromStringAndSize((char *)pckai->KeyId.pbData, pckai->KeyId.cbData),
                          "IntendedKeyUsage", PyWinObject_FromCRYPT_BIT_BLOB(&pckai->IntendedKeyUsage),
                          "PrivateKeyUsagePeriod", obusageperiod);
 }
@@ -973,7 +973,7 @@ PyObject *PyWinObject_FromCERT_BASIC_CONSTRAINTS_INFO(PCERT_BASIC_CONSTRAINTS_IN
     if (sc == NULL)
         return NULL;
     for (DWORD i = 0; i < pcbci->cSubtreesConstraint; i++) {
-        PyObject *nb = PyString_FromStringAndSize((char *)pcbci->rgSubtreesConstraint[i].pbData,
+        PyObject *nb = PyBytes_FromStringAndSize((char *)pcbci->rgSubtreesConstraint[i].pbData,
                                                   pcbci->rgSubtreesConstraint[i].cbData);
         if (nb == NULL) {
             Py_DECREF(sc);
@@ -1008,7 +1008,7 @@ PyObject *PyWinObject_FromCERT_POLICY_INFO(PCERT_POLICY_INFO pcpi)
     for (DWORD qual_ind = 0; qual_ind < pcpi->cPolicyQualifier; qual_ind++) {
         PyObject *qual = Py_BuildValue(
             "{s:s,s:N}", "PolicyQualifierId", pcpi->rgPolicyQualifier[qual_ind].pszPolicyQualifierId, "Qualifier",
-            PyString_FromStringAndSize((char *)pcpi->rgPolicyQualifier[qual_ind].Qualifier.pbData,
+            PyBytes_FromStringAndSize((char *)pcpi->rgPolicyQualifier[qual_ind].Qualifier.pbData,
                                        pcpi->rgPolicyQualifier[qual_ind].Qualifier.cbData));
         if (qual == NULL) {
             Py_DECREF(quals);
@@ -1042,7 +1042,7 @@ PyObject *PyWinObject_FromCERT_POLICIES_INFO(PCERT_POLICIES_INFO pcpi)
 PyObject *PyWinObject_FromCERT_AUTHORITY_KEY_ID_INFO(PCERT_AUTHORITY_KEY_ID_INFO pcaki)
 {
     return Py_BuildValue("{s:N, s:N, s:N}", "KeyId",
-                         PyString_FromStringAndSize((char *)pcaki->KeyId.pbData, pcaki->KeyId.cbData), "CertIssuer",
-                         PyString_FromStringAndSize((char *)pcaki->CertIssuer.pbData, pcaki->CertIssuer.cbData),
+                         PyBytes_FromStringAndSize((char *)pcaki->KeyId.pbData, pcaki->KeyId.cbData), "CertIssuer",
+                         PyBytes_FromStringAndSize((char *)pcaki->CertIssuer.pbData, pcaki->CertIssuer.cbData),
                          "CertSerialNumber", PyWinObject_FromCRYPT_INTEGER_BLOB(&pcaki->CertSerialNumber));
 }

--- a/win32/src/win32crypt/win32cryptmodule.cpp
+++ b/win32/src/win32crypt/win32cryptmodule.cpp
@@ -771,7 +771,7 @@ static PyObject *PyCryptFindOIDInfo(PyObject *self, PyObject *args, PyObject *kw
                 return NULL;
             break;
         case CRYPT_OID_INFO_ALGID_KEY:
-            alg_ids[0] = PyInt_AsLong(obkey);
+            alg_ids[0] = PyLong_AsLong(obkey);
             if (alg_ids[0] == (ALG_ID)-1 && PyErr_Occurred())
                 return NULL;
             key = (PVOID)&alg_ids[0];

--- a/win32/src/win32crypt/win32cryptmodule.cpp
+++ b/win32/src/win32crypt/win32cryptmodule.cpp
@@ -137,7 +137,7 @@ static PyObject *PyCertAlgIdToOID(PyObject *self, PyObject *args, PyObject *kwar
         Py_INCREF(Py_None);
         return Py_None;
     }
-    return PyString_FromString(szoid);
+    return PyBytes_FromString(szoid);
 }
 
 // @pymethod int|win32crypt|CertOIDToAlgId|Converts a string object identfier to a numeric algorith identifier
@@ -762,7 +762,7 @@ static PyObject *PyCryptFindOIDInfo(PyObject *self, PyObject *args, PyObject *kw
 
     switch (keytype) {
         case CRYPT_OID_INFO_OID_KEY:
-            key = PyString_AsString(obkey);
+            key = PyBytes_AsString(obkey);
             if (key == NULL)
                 return NULL;
             break;
@@ -874,7 +874,7 @@ BOOL WINAPI CryptEnumKeyIdentifierProperties_callback(const CRYPT_HASH_BLOB *key
             prop_data = PyWinObject_FromCRYPT_KEY_PROV_INFO((PCRYPT_KEY_PROV_INFO)rgpvData[prop_index]);
         else {
             PyErr_Warn(PyExc_RuntimeWarning, "Key identifier property returned as raw data"),
-                prop_data = PyString_FromStringAndSize((char *)rgpvData[prop_index], rgcbData[prop_index]);
+                prop_data = PyBytes_FromStringAndSize((char *)rgpvData[prop_index], rgcbData[prop_index]);
         }
         if (prop_data == NULL) {
             Py_DECREF(props);
@@ -890,7 +890,7 @@ BOOL WINAPI CryptEnumKeyIdentifierProperties_callback(const CRYPT_HASH_BLOB *key
     }
 
     ret_item = Py_BuildValue("{s:N, s:N}", "KeyIdentifier",
-                             PyString_FromStringAndSize((char *)key_id->pbData, key_id->cbData), "Props", props);
+                             PyBytes_FromStringAndSize((char *)key_id->pbData, key_id->cbData), "Props", props);
     if (ret_item == NULL) {
         Py_DECREF(props);
         return FALSE;
@@ -1195,7 +1195,7 @@ static PyObject *PyCryptDecodeMessage(PyObject *self, PyObject *args, PyObject *
             PyWin_SetAPIError("CryptDecodeMessage");
     }
     else ret = Py_BuildValue("{s:k,s:k,s:N,s:N,s:N}", "MsgType", msg_type, "InnerContentType", inner_type, "Decoded",
-                             PyString_FromStringAndSize((char *)output_buf, output_bufsize), "XchgCert",
+                             PyBytes_FromStringAndSize((char *)output_buf, output_bufsize), "XchgCert",
                              PyWinObject_FromCERT_CONTEXT(exchange_cert), "SignerCert",
                              PyWinObject_FromCERT_CONTEXT(signer_cert));
 
@@ -1249,7 +1249,7 @@ static PyObject *PyCryptEncryptMessage(PyObject *self, PyObject *args, PyObject 
                                                                   (BYTE*)pybuf.ptr(), pybuf.len(),
                                                                   outputbuf, &output_bufsize);
             Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptEncryptMessage");
-            else ret = PyString_FromStringAndSize((char *)outputbuf, output_bufsize);
+            else ret = PyBytes_FromStringAndSize((char *)outputbuf, output_bufsize);
         }
     }
 
@@ -1293,7 +1293,7 @@ static PyObject *PyCryptDecryptMessage(PyObject *self, PyObject *args, PyObject 
     Py_BEGIN_ALLOW_THREADS bsuccess =
         CryptDecryptMessage(&cdmp, (BYTE*)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize, &exchange_cert);
     Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptDecryptMessage");
-    else ret = Py_BuildValue("NN", PyString_FromStringAndSize((char *)output_buf, output_bufsize),
+    else ret = Py_BuildValue("NN", PyBytes_FromStringAndSize((char *)output_buf, output_bufsize),
                              PyWinObject_FromCERT_CONTEXT(exchange_cert));
     free(output_buf);
     return ret;
@@ -1351,7 +1351,7 @@ static PyObject *PyCryptSignAndEncryptMessage(PyObject *self, PyObject *args, Py
         PyWin_SetAPIError("CryptSignAndEncryptMessage");
         goto cleanup;
     }
-    ret = PyString_FromStringAndSize((char *)output_buf, output_bufsize);
+    ret = PyBytes_FromStringAndSize((char *)output_buf, output_bufsize);
 
 cleanup:
     PyWinObject_FreeCRYPT_SIGN_MESSAGE_PARA(&csmp);
@@ -1417,7 +1417,7 @@ static PyObject *PyCryptVerifyMessageSignature(PyObject *self, PyObject *args, P
                 PyWin_SetAPIError("CryptVerifyMessageSignature");
         }
         else ret = Py_BuildValue("{s:N, s:N}", "SignerCert", PyWinObject_FromCERT_CONTEXT(signer_cert), "Decoded",
-                                 PyString_FromStringAndSize((char *)output_buf, output_bufsize));
+                                 PyBytes_FromStringAndSize((char *)output_buf, output_bufsize));
     }
     if (output_buf)
         free(output_buf);
@@ -1521,7 +1521,7 @@ static PyObject *PyCryptSignMessage(PyObject *self, PyObject *args, PyObject *kw
         PyWin_SetAPIError("CryptSignMessage");
         goto cleanup;
     }
-    ret = PyString_FromStringAndSize((char *)output_buf, output_bufsize);
+    ret = PyBytes_FromStringAndSize((char *)output_buf, output_bufsize);
 
 cleanup:
     PyWinObject_FreeCRYPT_SIGN_MESSAGE_PARA(&csmp);
@@ -1615,7 +1615,7 @@ static PyObject *PyCryptDecryptAndVerifyMessageSignature(PyObject *self, PyObjec
         &cdmp, &cvmp, signer_ind, (BYTE*)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize, &exchange_cert, &signer_cert);
     Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptDecryptAndVerifyMessageSignature");
     else ret = Py_BuildValue(
-        "{s:N,s:N,s:N}", "Decrypted", PyString_FromStringAndSize((char *)output_buf, output_bufsize), "XchgCert",
+        "{s:N,s:N,s:N}", "Decrypted", PyBytes_FromStringAndSize((char *)output_buf, output_bufsize), "XchgCert",
         PyWinObject_FromCERT_CONTEXT(exchange_cert), "SignerCert", PyWinObject_FromCERT_CONTEXT(signer_cert));
 
     free(output_buf);
@@ -1628,7 +1628,7 @@ BOOL PyWinObject_AsOID(PyObject *oboid, LPSTR *objid, BOOLEAN *oid_is_str)
     *objid = (LPSTR)PyLong_AsVoidPtr(oboid);
     if (PyErr_Occurred()) {
         PyErr_Clear();
-        *objid = PyString_AsString(oboid);
+        *objid = PyBytes_AsString(oboid);
         if (*objid == NULL)
             return FALSE;
         *oid_is_str = TRUE;
@@ -1706,7 +1706,7 @@ static PyObject *PyCryptEncodeObjectEx(PyObject *self, PyObject *args, PyObject 
     Py_BEGIN_ALLOW_THREADS bsuccess =
         CryptEncodeObjectEx(encoding, structtype, input_buf, flags, NULL, &output_buf, &output_bufsize);
     Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptDecodeObjectEx");
-    else ret = PyString_FromStringAndSize((char *)output_buf, output_bufsize);
+    else ret = PyBytes_FromStringAndSize((char *)output_buf, output_bufsize);
 
 cleanup:
     if ((oid_is_str && (strcmp(structtype, szOID_ENHANCED_KEY_USAGE) == 0)) || (structtype == X509_ENHANCED_KEY_USAGE))
@@ -1813,7 +1813,7 @@ static PyObject *PyCryptDecodeObjectEx(PyObject *self, PyObject *args, PyObject 
         ret = PyWinObject_FromCERT_POLICIES_INFO((PCERT_POLICIES_INFO)output_buf);
     else if (oid_is_str && (strcmp(structtype, szOID_SUBJECT_KEY_IDENTIFIER) ==
                             0))  // @flag szOID_SUBJECT_KEY_IDENTIFIER|Binary string containing the key identifier
-        ret = PyString_FromStringAndSize((char *)((CRYPT_DATA_BLOB *)output_buf)->pbData,
+        ret = PyBytes_FromStringAndSize((char *)((CRYPT_DATA_BLOB *)output_buf)->pbData,
                                          ((CRYPT_DATA_BLOB *)output_buf)->cbData);
     else if ((oid_is_str && (strcmp(structtype, szOID_AUTHORITY_KEY_IDENTIFIER) ==
                              0)) ||  // @flag szOID_AUTHORITY_KEY_IDENTIFIER|<o PyCERT_AUTHORITY_KEY_ID_INFO>
@@ -2081,10 +2081,10 @@ static PyObject *PyCryptStringToBinary(PyObject *self, PyObject *args, PyObject 
     Py_BEGIN_ALLOW_THREADS bsuccess =
         CryptStringToBinary(input_buf, input_size, flags, output_buf, &output_size, &skip, &out_flags);
     Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptStringToBinary");
-    oboutput_buf = PyString_FromStringAndSize(NULL, output_size);
+    oboutput_buf = PyBytes_FromStringAndSize(NULL, output_size);
     if (oboutput_buf == NULL)
         return NULL;
-    output_buf = (BYTE *)PyString_AS_STRING(oboutput_buf);
+    output_buf = (BYTE *)PyBytes_AS_STRING(oboutput_buf);
     Py_BEGIN_ALLOW_THREADS bsuccess =
         CryptStringToBinary(input_buf, input_size, flags, output_buf, &output_size, &skip, &out_flags);
     Py_END_ALLOW_THREADS if (!bsuccess)

--- a/win32/src/win32dynamicdialog.cpp
+++ b/win32/src/win32dynamicdialog.cpp
@@ -417,7 +417,7 @@ static PyObject *MakeListFromDlgItem(LPVOID *tplin)
     // Parameter 6 - Extra data
     WORD datalen = *ptr++;
     if (datalen > 0) {
-        obitem = PyString_FromStringAndSize((char *)ptr, datalen);
+        obitem = PyBytes_FromStringAndSize((char *)ptr, datalen);
         ptr = (WCHAR *)(((char *)ptr) + datalen);
     }
     else {

--- a/win32/src/win32dynamicdialog.cpp
+++ b/win32/src/win32dynamicdialog.cpp
@@ -242,7 +242,7 @@ static PyObject *MakeResName(WCHAR **val)
     PyObject *obj = NULL;
     if (*ptr == (WORD)-1) {
         ptr++;
-        obj = PyInt_FromLong((WORD)*ptr++);
+        obj = PyLong_FromLong((WORD)*ptr++);
     }
     else if (*ptr != (WORD)0) {
         obj = PyWinObject_FromWCHAR(ptr);
@@ -359,7 +359,7 @@ static PyObject *MakeListFromDlgItem(LPVOID *tplin)
     WCHAR *ptr = (WCHAR *)((char *)tpl + sizeof(DLGITEMTEMPLATE));
     if (*ptr == (WCHAR)-1) {
         ptr++;
-        obitem = PyInt_FromLong((WORD)*ptr++);
+        obitem = PyLong_FromLong((WORD)*ptr++);
     }
     else {
         LPWSTR wc = LPWSTR(ptr);
@@ -383,7 +383,7 @@ static PyObject *MakeListFromDlgItem(LPVOID *tplin)
     PyList_SET_ITEM(ret, 1, obitem);
 
     // Parameter 2 - ID
-    obitem = PyInt_FromLong(tpl->id);
+    obitem = PyLong_FromLong(tpl->id);
     if (obitem == NULL) {
         Py_DECREF(ret);
         return NULL;

--- a/win32/src/win32event.i
+++ b/win32/src/win32event.i
@@ -198,7 +198,7 @@ static PyObject * MyMsgWaitForMultipleObjects(
 	if (rc==(DWORD)0xFFFFFFFF)
 		obrc = PyWin_SetAPIError("MsgWaitForMultipleObjects");
 	else
-		obrc = PyInt_FromLong(rc);
+		obrc = PyLong_FromLong(rc);
 	free(pItems);
 	return obrc;
 }
@@ -237,7 +237,7 @@ static PyObject * MyMsgWaitForMultipleObjectsEx(
 	if (rc==(DWORD)0xFFFFFFFF)
 		obrc = PyWin_SetAPIError("MsgWaitForMultipleObjectsEx");
 	else
-		obrc = PyInt_FromLong(rc);
+		obrc = PyLong_FromLong(rc);
 	free(pItems);
 	return obrc;
 }
@@ -340,7 +340,7 @@ static PyObject *MyWaitForMultipleObjects(
 	if (rc==WAIT_FAILED)
 		obrc = PyWin_SetAPIError("WaitForMultipleObjects");
 	else
-		obrc = PyInt_FromLong(rc);
+		obrc = PyLong_FromLong(rc);
 	free(pItems);
 	return obrc;
 }
@@ -374,7 +374,7 @@ static PyObject *MyWaitForMultipleObjectsEx(
 	if (rc==WAIT_FAILED)
 		obrc = PyWin_SetAPIError("WaitForMultipleObjectsEx");
 	else
-		obrc = PyInt_FromLong(rc);
+		obrc = PyLong_FromLong(rc);
 	free(pItems);
 	return obrc;
 }

--- a/win32/src/win32evtlog.i
+++ b/win32/src/win32evtlog.i
@@ -1261,7 +1261,7 @@ PyObject *PyList_FromEVT_VARIANTArray(PEVT_VARIANT val)
 				obval = PyWinObject_FromIID(val->GuidArr[i]);
 				break;
 			case EvtVarTypeSizeT:
-				obval = PyInt_FromSsize_t(val->SizeTArr[i]);
+				obval = PyLong_FromSsize_t(val->SizeTArr[i]);
 				break;
 			case EvtVarTypeFileTime:
 				{
@@ -1370,7 +1370,7 @@ PyObject *PyWinObject_FromEVT_VARIANT(PEVT_VARIANT val)
 			obval = PyWinObject_FromIID(*val->GuidVal);
 			break;
 		case EvtVarTypeSizeT:
-			obval = PyInt_FromSsize_t(val->SizeTVal);
+			obval = PyLong_FromSsize_t(val->SizeTVal);
 			break;
 		case EvtVarTypeFileTime:
 			{

--- a/win32/src/win32evtlog.i
+++ b/win32/src/win32evtlog.i
@@ -242,7 +242,7 @@ PyEventLogRecord::PyEventLogRecord(EVENTLOGRECORD *pEvt)
 		Sids = PyWinObject_FromSID( (PSID)(((BYTE *)pEvt) + pEvt->UserSidOffset));
 	}
 
-	Data = PyString_FromStringAndSize(((char *)pEvt)+pEvt->DataOffset, pEvt->DataLength);
+	Data = PyBytes_FromStringAndSize(((char *)pEvt)+pEvt->DataOffset, pEvt->DataLength);
 
 	WCHAR *szSourceName = (WCHAR *)(((BYTE *)pEvt) + sizeof(EVENTLOGRECORD));
 	SourceName = PyWinObject_FromWCHAR(szSourceName);
@@ -1364,7 +1364,7 @@ PyObject *PyWinObject_FromEVT_VARIANT(PEVT_VARIANT val)
 			obval = PyBool_FromLong(val->BooleanVal);
 			break;
 		case EvtVarTypeBinary:
-			obval = PyString_FromStringAndSize((char *)val->BinaryVal, val->Count);
+			obval = PyBytes_FromStringAndSize((char *)val->BinaryVal, val->Count);
 			break;
 		case EvtVarTypeGuid:
 			obval = PyWinObject_FromIID(*val->GuidVal);

--- a/win32/src/win32file.i
+++ b/win32/src/win32file.i
@@ -444,10 +444,10 @@ PyObject *py_DeviceIoControl(PyObject *self, PyObject *args, PyObject *kwargs)
 			OutBufferSize = out_buf.len();
 			}
 		else {
-			ret = PyString_FromStringAndSize(NULL, OutBufferSize);
+			ret = PyBytes_FromStringAndSize(NULL, OutBufferSize);
 			if (ret==NULL)
 				return NULL;
-			OutBuffer=PyString_AS_STRING(ret);
+			OutBuffer=PyBytes_AS_STRING(ret);
 			}
 		}
 	else {
@@ -504,7 +504,7 @@ PyObject *py_DeviceIoControl(PyObject *self, PyObject *args, PyObject *kwargs)
 			ret=resized;
 			}
 		else
-			_PyString_Resize(&ret, numRead);
+			_PyBytes_Resize(&ret, numRead);
 		}
 	return ret;
 }
@@ -964,10 +964,10 @@ PyObject *MyReadFile(PyObject *self, PyObject *args)
 			bufSize = pybuf.len();
 			}
 		else{
-			obRet=PyString_FromStringAndSize(NULL, bufSize);
+			obRet=PyBytes_FromStringAndSize(NULL, bufSize);
 			if (obRet==NULL)
 				return NULL;
-			buf=PyString_AS_STRING(obRet);
+			buf=PyBytes_AS_STRING(obRet);
 			bBufMallocd=TRUE;
 			}
 		}
@@ -1003,9 +1003,9 @@ PyObject *MyReadFile(PyObject *self, PyObject *args)
 		}
 	}
 	if (obRet==NULL)
-		obRet=PyString_FromStringAndSize((char *)buf, numRead);
+		obRet=PyBytes_FromStringAndSize((char *)buf, numRead);
 	else if (bBufMallocd && (numRead < bufSize))
-		_PyString_Resize(&obRet, numRead);
+		_PyBytes_Resize(&obRet, numRead);
 	if (obRet==NULL)
 		return NULL;
 	return Py_BuildValue("iN", err, obRet);
@@ -1853,9 +1853,9 @@ static PyObject *py_ConnectEx( PyObject *self, PyObject *args, PyObject *kwargs 
 		host_idna = PyObject_CallMethod(hobj, "encode", "s", "idna");
 		if (!host_idna)
 			return NULL;
-		hptr = PyString_AsString(host_idna);
-	} else if (PyString_Check(hobj)) {
-		hptr = PyString_AsString(hobj);
+		hptr = PyBytes_AsString(host_idna);
+	} else if (PyBytes_Check(hobj)) {
+		hptr = PyBytes_AsString(hobj);
 	} else {
 		PyErr_SetString(PyExc_TypeError,
 				"getaddrinfo() argument 1 must be string or None");
@@ -1868,9 +1868,9 @@ static PyObject *py_ConnectEx( PyObject *self, PyObject *args, PyObject *kwargs 
 		port_idna = PyObject_CallMethod(pobj, "encode", "s", "idna");
 		if (!port_idna)
 			return NULL;
-		pptr = PyString_AsString(port_idna);
-	} else if (PyString_Check(pobj)) {
-		pptr = PyString_AsString(pobj);
+		pptr = PyBytes_AsString(port_idna);
+	} else if (PyBytes_Check(pobj)) {
+		pptr = PyBytes_AsString(pobj);
 	} else if (PyInt_Check(pobj)) {
 		PyOS_snprintf(pbuf, sizeof(pbuf), "%ld", PyInt_AsLong(pobj));
 		pptr = pbuf;
@@ -2042,7 +2042,7 @@ MyMakeIPAddr(SOCKADDR_IN *addr)
 	sprintf(buf, "%d.%d.%d.%d",
 		(int) (x>>24) & 0xff, (int) (x>>16) & 0xff,
 		(int) (x>> 8) & 0xff, (int) (x>> 0) & 0xff);
-	return PyString_FromString(buf);
+	return PyBytes_FromString(buf);
 }
 
 static PyObject *
@@ -2075,7 +2075,7 @@ MyMakeSockaddr(SOCKADDR *addr, INT cbAddr)
 		   exception -- return it as a tuple. */
 		return Py_BuildValue("iN",
 			addr->sa_family,
-			PyString_FromStringAndSize(addr->sa_data,sizeof(addr->sa_data)));
+			PyBytes_FromStringAndSize(addr->sa_data,sizeof(addr->sa_data)));
 
 	}
 }
@@ -3486,7 +3486,7 @@ PyObject *PyWinObject_FromPENCRYPTION_CERTIFICATE_LIST(PENCRYPTION_CERTIFICATE_L
 	for (user_cnt=0; user_cnt < pecl->nUsers; user_cnt++){
 		ret_item=Py_BuildValue("NN", 
 			PyWinObject_FromSID((*user_item)->pUserSid), 
-			PyString_FromStringAndSize((char *)(*user_item)->pCertBlob->pbData, (*user_item)->pCertBlob->cbData));
+			PyBytes_FromStringAndSize((char *)(*user_item)->pCertBlob->pbData, (*user_item)->pCertBlob->cbData));
 		// ??? This doesn't return EFS_CERTIFICATE_BLOB.dwCertEncodingType ???
 		if (!ret_item){
 			Py_DECREF(ret);
@@ -3510,7 +3510,7 @@ PyObject *PyWinObject_FromPENCRYPTION_CERTIFICATE_HASH_LIST(PENCRYPTION_CERTIFIC
 	for (user_cnt=0; user_cnt < pechl->nCert_Hash; user_cnt++){
 		ret_item=Py_BuildValue("NNu",
 			PyWinObject_FromSID((*user_item)->pUserSid),
-			PyString_FromStringAndSize((char *)(*user_item)->pHash->pbData, (*user_item)->pHash->cbData),
+			PyBytes_FromStringAndSize((char *)(*user_item)->pHash->pbData, (*user_item)->pHash->cbData),
 			(*user_item)->lpDisplayInformation);
 		if (!ret_item){
 			Py_DECREF(ret);
@@ -3593,7 +3593,7 @@ BOOL PyWinObject_AsPENCRYPTION_CERTIFICATE_LIST(PyObject *obcert_list, PENCRYPTI
 		if (bSuccess){
 			obcert_member=PySequence_GetItem(obcert,2);
 			Py_ssize_t cbData;
-			if (PyString_AsStringAndSize(obcert_member, 
+			if (PyBytes_AsStringAndSize(obcert_member, 
 					(char **)&((*ppec)->pCertBlob->pbData), 
 					&cbData)==-1){
 				PyErr_SetString(PyExc_TypeError,"Third item of ENCRYPTION_CERTIFICATE must be a string containing encoded certificate data");
@@ -3672,7 +3672,7 @@ BOOL PyWinObject_AsPENCRYPTION_CERTIFICATE_HASH_LIST(PyObject *obhash_list, PENC
 			ZeroMemory((*ppech)->pHash,sizeof(EFS_HASH_BLOB));
 			obhash_item=PySequence_GetItem(obhash,1);
 			Py_ssize_t cbData;
-			if (PyString_AsStringAndSize(obhash_item, 
+			if (PyBytes_AsStringAndSize(obhash_item, 
 				(char **)&((*ppech)->pHash->pbData), 
 				&cbData)==-1){
 				PyErr_SetString(PyExc_TypeError,"Second item of ENCRYPTION_CERTIFICATE_HASH tuple must be a string containing encoded certificate data");
@@ -5430,7 +5430,7 @@ static PyObject *py_GetFullPathName(PyObject *self, PyObject *args, PyObject *kw
 
 	PyErr_Clear();
 	char *cpathin;
-	if (cpathin=PyString_AsString(obpathin)){
+	if (cpathin=PyBytes_AsString(obpathin)){
 		if (htrans)
 			CHECK_PFN(GetFullPathNameTransactedA);
 		char *cpathret=NULL, *cfilepart, *cpathsave=NULL;
@@ -5458,7 +5458,7 @@ static PyObject *py_GetFullPathName(PyObject *self, PyObject *args, PyObject *kw
 				break;
 				}
 			if (retlen<=pathlen){
-				ret=PyString_FromStringAndSize(cpathret,retlen);
+				ret=PyBytes_FromStringAndSize(cpathret,retlen);
 				break;
 				}
 			pathlen=retlen;

--- a/win32/src/win32file.i
+++ b/win32/src/win32file.i
@@ -949,7 +949,7 @@ PyObject *MyReadFile(PyObject *self, PyObject *args)
 	void *buf = NULL;
 	PyWinBufferView pybuf;
 
-	bufSize = PyInt_AsLong(obBuf);
+	bufSize = PyLong_AsLong(obBuf);
 	if ((bufSize!=(DWORD)-1) || !PyErr_Occurred()){
 		if (pOverlapped){	// guaranteed to be NULL on CE
 			obRet = PyBuffer_New(bufSize);
@@ -1690,7 +1690,7 @@ PyObject *myopen_osfhandle (PyHANDLE osfhandle, int flags)
   if (result == -1)
     return PyErr_SetFromErrno(PyExc_IOError);
 
-  return PyInt_FromLong(result);
+  return PyLong_FromLong(result);
 }
 
 %}
@@ -1784,7 +1784,7 @@ static PyObject *py_TransmitFile( PyObject *self, PyObject *args, PyObject *kwar
 	Py_END_ALLOW_THREADS;
 
 	if (rc == 0 || rc == ERROR_IO_PENDING || rc == WSA_IO_PENDING)
-		return PyInt_FromLong(rc);
+		return PyLong_FromLong(rc);
 	return PyWin_SetAPIError("TransmitFile", rc);
 }
 PyCFunction pfnpy_TransmitFile=(PyCFunction)py_TransmitFile;
@@ -1871,8 +1871,8 @@ static PyObject *py_ConnectEx( PyObject *self, PyObject *args, PyObject *kwargs 
 		pptr = PyBytes_AsString(port_idna);
 	} else if (PyBytes_Check(pobj)) {
 		pptr = PyBytes_AsString(pobj);
-	} else if (PyInt_Check(pobj)) {
-		PyOS_snprintf(pbuf, sizeof(pbuf), "%ld", PyInt_AsLong(pobj));
+	} else if (PyLong_Check(pobj)) {
+		PyOS_snprintf(pbuf, sizeof(pbuf), "%ld", PyLong_AsLong(pobj));
 		pptr = pbuf;
 	} else {
 		PyErr_SetString(PyExc_TypeError, "Port must be int, string, or None");
@@ -2031,7 +2031,7 @@ static PyObject *MyAcceptEx
 		if (rc != ERROR_IO_PENDING)
 			return PyWin_SetAPIError("AcceptEx", WSAGetLastError());
 	}
-	return PyInt_FromLong(rc);
+	return PyLong_FromLong(rc);
 }
 
 static PyObject *
@@ -2111,7 +2111,7 @@ PyObject *MyCalculateSocketEndPointSize(PyObject *self, PyObject *args)
 		PyWin_SetAPIError("getsockopt", WSAGetLastError());
 		return NULL;
 	}
-	return PyInt_FromLong((wsProtInfo.iMaxSockAddr + 16) * 2);
+	return PyLong_FromLong((wsProtInfo.iMaxSockAddr + 16) * 2);
 }
 %}
 
@@ -2209,7 +2209,7 @@ PyObject *MyGetAcceptExSockaddrs
 	//@comm and they should be unpacked with the struct module.
 
 	// Stick in sa_family.
-	obTemp = PyInt_FromLong((LONG)psaddrLocal->sa_family);
+	obTemp = PyLong_FromLong((LONG)psaddrLocal->sa_family);
 	if (obTemp == NULL)
 	{
 		goto Error;
@@ -2289,12 +2289,12 @@ MyCopyEvent(PyObject *dict, WSANETWORKEVENTS *events, long event, int eventbit)
 	{
 		PyObject *key, *value;
 
-		key = PyInt_FromLong(event);
+		key = PyLong_FromLong(event);
 		if (key == NULL)
 		{
 			return -1;
 		}
-		value = PyInt_FromLong(events->iErrorCode[eventbit]);
+		value = PyLong_FromLong(events->iErrorCode[eventbit]);
 		if (value == NULL)
 		{
 			Py_DECREF(key);
@@ -2477,7 +2477,7 @@ PyObject *MyWSASend
 		goto Error;
 	}
 
-	obTemp = PyInt_FromLong(rc);
+	obTemp = PyLong_FromLong(rc);
 	if (obTemp == NULL)
 	{
 		goto Error;
@@ -2485,7 +2485,7 @@ PyObject *MyWSASend
 	PyTuple_SET_ITEM(rv, 0, obTemp);
 	obTemp = NULL;
 
-	obTemp = PyInt_FromLong(cbSent);
+	obTemp = PyLong_FromLong(cbSent);
 	if (obTemp == NULL)
 	{
 		goto Error;
@@ -2575,7 +2575,7 @@ PyObject *MyWSARecv
 		goto Error;
 	}
 
-	obTemp = PyInt_FromLong(rc);
+	obTemp = PyLong_FromLong(rc);
 	if (obTemp == NULL)
 	{
 		goto Error;
@@ -2583,7 +2583,7 @@ PyObject *MyWSARecv
 	PyTuple_SET_ITEM(rv, 0, obTemp);
 	obTemp = NULL;
 
-	obTemp = PyInt_FromLong(cbRecvd);
+	obTemp = PyLong_FromLong(cbRecvd);
 	if (obTemp == NULL)
 	{
 		goto Error;
@@ -3581,12 +3581,12 @@ BOOL PyWinObject_AsPENCRYPTION_CERTIFICATE_LIST(PyObject *obcert_list, PENCRYPTI
 		if (bSuccess){
 			ZeroMemory((*ppec)->pCertBlob,sizeof(EFS_CERTIFICATE_BLOB));
 			obcert_member=PySequence_GetItem(obcert,1);
-			if (!PyInt_Check(obcert_member)){
+			if (!PyLong_Check(obcert_member)){
 				PyErr_SetString(PyExc_TypeError,"Second item (dwCertEncodingType) of ENCRYPTION_CERTIFICATE must be an integer");
 				bSuccess=FALSE;
 				}
 			else
-				(*ppec)->pCertBlob->dwCertEncodingType=PyInt_AsLong(obcert_member);
+				(*ppec)->pCertBlob->dwCertEncodingType=PyLong_AsLong(obcert_member);
 			Py_DECREF(obcert_member);
 			}
 
@@ -4059,7 +4059,7 @@ DWORD CALLBACK CopyFileEx_ProgressRoutine(
 		if (ret==NULL)
 			retcode=PROGRESS_CANCEL;
 		else{
-			retcode=PyInt_AsLong(ret);
+			retcode=PyLong_AsLong(ret);
 			if ((retcode==(DWORD)-1) && PyErr_Occurred())
 				retcode=PROGRESS_CANCEL;
 			}
@@ -4565,7 +4565,7 @@ static PyObject *py_CreateFileW(PyObject *self, PyObject *args, PyObject *kwargs
 			PyErr_SetString(PyExc_ValueError, "MiniVersion can only be used with a transacted operation");
 			return NULL;
 			}
-		long longversion=PyInt_AsLong(obminiversion);
+		long longversion=PyLong_AsLong(obminiversion);
 		if (longversion==-1 && PyErr_Occurred())
 			return NULL;
 		if ((longversion > USHRT_MAX) || (longversion < 0))
@@ -5849,7 +5849,7 @@ static PyObject *py_SetFileInformationByHandle(PyObject *self, PyObject *args, P
 			if (piohi == NULL)
 				break;
 			buf = piohi;
-			piohi->PriorityHint = (PRIORITY_HINT)PyInt_AsLong(info);
+			piohi->PriorityHint = (PRIORITY_HINT)PyLong_AsLong(info);
 			rc = piohi->PriorityHint != -1 || !PyErr_Occurred();
 			break;
 			}

--- a/win32/src/win32file_comm.cpp
+++ b/win32/src/win32file_comm.cpp
@@ -163,7 +163,7 @@ PyDCB::PyDCB(const DCB &other)
 PyDCB::~PyDCB(void) {}
 
 #define GET_BITFIELD_ENTRY(bitfield_name) \
-    else if (strcmp(name, #bitfield_name) == 0) { return PyInt_FromLong(pydcb->m_DCB.##bitfield_name); }
+    else if (strcmp(name, #bitfield_name) == 0) { return PyLong_FromLong(pydcb->m_DCB.##bitfield_name); }
 
 PyObject *PyDCB::getattro(PyObject *self, PyObject *obname)
 {
@@ -194,11 +194,11 @@ PyObject *PyDCB::getattro(PyObject *self, PyObject *obname)
 #define SET_BITFIELD_ENTRY(bitfield_name)                                 \
     else if (strcmp(name, #bitfield_name) == 0)                           \
     {                                                                     \
-        if (!PyInt_Check(v)) {                                            \
+        if (!PyLong_Check(v)) {                                            \
             PyErr_Format(PyExc_TypeError, szNeedIntAttr, #bitfield_name); \
             return -1;                                                    \
         }                                                                 \
-        pydcb->m_DCB.##bitfield_name = PyInt_AsLong(v);                   \
+        pydcb->m_DCB.##bitfield_name = PyLong_AsLong(v);                   \
         return 0;                                                         \
     }
 
@@ -362,7 +362,7 @@ PyCOMSTAT::~PyCOMSTAT(void) {}
 
 #undef GET_BITFIELD_ENTRY
 #define GET_BITFIELD_ENTRY(bitfield_name) \
-    else if (strcmp(name, #bitfield_name) == 0) { return PyInt_FromLong(pyCOMSTAT->m_COMSTAT.##bitfield_name); }
+    else if (strcmp(name, #bitfield_name) == 0) { return PyLong_FromLong(pyCOMSTAT->m_COMSTAT.##bitfield_name); }
 
 PyObject *PyCOMSTAT::getattro(PyObject *self, PyObject *obname)
 {
@@ -387,11 +387,11 @@ PyObject *PyCOMSTAT::getattro(PyObject *self, PyObject *obname)
 #define SET_BITFIELD_ENTRY(bitfield_name)                                 \
     else if (strcmp(name, #bitfield_name) == 0)                           \
     {                                                                     \
-        if (!PyInt_Check(v)) {                                            \
+        if (!PyLong_Check(v)) {                                            \
             PyErr_Format(PyExc_TypeError, szNeedIntAttr, #bitfield_name); \
             return -1;                                                    \
         }                                                                 \
-        pyCOMSTAT->m_COMSTAT.##bitfield_name = PyInt_AsLong(v);           \
+        pyCOMSTAT->m_COMSTAT.##bitfield_name = PyLong_AsLong(v);           \
         return 0;                                                         \
     }
 

--- a/win32/src/win32gui.i
+++ b/win32/src/win32gui.i
@@ -586,7 +586,7 @@ typedef int UINT;
                 $source->rcPaint.left, $source->rcPaint.top, $source->rcPaint.right, $source->rcPaint.bottom,
                 $source->fRestore,
                 $source->fIncUpdate,
-                PyString_FromStringAndSize((char *)$source->rgbReserved,sizeof($source->rgbReserved)));
+                PyBytes_FromStringAndSize((char *)$source->rgbReserved,sizeof($source->rgbReserved)));
     if (!$target) {
       $target = o;
     } else if ($target == Py_None) {
@@ -625,7 +625,7 @@ typedef int UINT;
 			return NULL;
 		if (!PyWinObject_AsHANDLE(obdc, (HANDLE *)&ps_input.hdc))
 			return NULL;
-		if (PyString_AsStringAndSize(obReserved, &szReserved, &lenReserved)==-1)
+		if (PyBytes_AsStringAndSize(obReserved, &szReserved, &lenReserved)==-1)
 			return NULL;
         if (lenReserved != sizeof(ps_input.rgbReserved))
             return PyErr_Format(PyExc_ValueError, "%s: last element must be string of %d bytes",
@@ -1022,14 +1022,14 @@ int SetTCHAR(PyObject *v, PyObject **m, LPCTSTR *ret)
 	*ret = PyUnicode_AsUnicode(v);
 	return 0;
 #else
-	if (!PyString_Check(v)) {
+	if (!PyBytes_Check(v)) {
 		PyErr_SetString(PyExc_TypeError, "Object must be a string");
 		return -1;
 	}
 	Py_XDECREF(*m);
 	*m = v;
 	Py_INCREF(v);
-	*ret = PyString_AsString(v);
+	*ret = PyBytes_AsString(v);
 	return 0;
 #endif
 }
@@ -3712,7 +3712,7 @@ PyObject *Pylpstr(PyObject *self, PyObject *args) {
 		return NULL;
 	if (!PyWinLong_AsVoidPtr(obaddress, (void **)&address))
 		return NULL;
-	return PyString_FromString(address);
+	return PyBytes_FromString(address);
 }
 %}
 %native (lpstr) Pylpstr;
@@ -3722,17 +3722,17 @@ DWORD CommDlgExtendedError(void);
 
 %typemap (python, in) OPENFILENAME *INPUT (int size){
 	size = sizeof(OPENFILENAME);
-	if (!PyString_Check($source)) {
+	if (!PyBytes_Check($source)) {
 		PyErr_Format(PyExc_TypeError, "Argument must be a %d-byte string (got type %s)",
 		             size, $source->ob_type->tp_name);
 		return NULL;
 	}
-	if (size != PyString_GET_SIZE($source)) {
+	if (size != PyBytes_GET_SIZE($source)) {
 		PyErr_Format(PyExc_TypeError, "Argument must be a %d-byte string (got string of %d bytes)",
-		             size, PyString_GET_SIZE($source));
+		             size, PyBytes_GET_SIZE($source));
 		return NULL;
 	}
-	$target = ( OPENFILENAME *)PyString_AS_STRING($source);
+	$target = ( OPENFILENAME *)PyBytes_AS_STRING($source);
 }
 
 #ifndef MS_WINCE

--- a/win32/src/win32gui.i
+++ b/win32/src/win32gui.i
@@ -699,7 +699,7 @@ BOOL PyWndProc_Call(PyObject *obFuncOrMap, HWND hWnd, UINT uMsg, WPARAM wParam, 
 	PyObject *obFunc = NULL;
 	if (obFuncOrMap!=NULL) {
 		if (PyDict_Check(obFuncOrMap)) {
-			PyObject *key = PyInt_FromLong(uMsg);
+			PyObject *key = PyLong_FromLong(uMsg);
 			if (key==NULL){
 				HandleError("Internal error converting Msg param of window procedure");
 				return FALSE;
@@ -1405,7 +1405,7 @@ BOOL CALLBACK EnumFontFamProc(const LOGFONT FAR *lpelf, const TEXTMETRIC *lpntm,
 	PyObject *ret = PyObject_CallObject(obFunc, params);
 	Py_XDECREF(params);
 	if (ret) {
-		iret = PyInt_AsLong(ret);
+		iret = PyLong_AsLong(ret);
 		Py_DECREF(ret);
 	}
 	return iret;
@@ -1443,7 +1443,7 @@ static PyObject *PyEnumFontFamilies(PyObject *self, PyObject *args)
 	int rc = EnumFontFamilies(hdc, szFamily, EnumFontFamProc, (LPARAM)lparam);
 	Py_XDECREF(lparam);
 	PyWinObject_FreeTCHAR(szFamily);
-	return PyInt_FromLong(rc);
+	return PyLong_FromLong(rc);
 
 }
 %}
@@ -1742,7 +1742,7 @@ static PyObject *PyGetArraySignedLong(PyObject *self, PyObject *args)
 		PyErr_SetString(PyExc_ValueError,"array index out of bounds");
 		return NULL;
 		}
-	return PyInt_FromLong(l[offset]);
+	return PyLong_FromLong(l[offset]);
 }
 %}
 %native (PyGetArraySignedLong) PyGetArraySignedLong;
@@ -1760,7 +1760,7 @@ static PyObject *PyGetBufferAddressAndLen(PyObject *self, PyObject *args)
 	PyWinBufferView pybuf(ob);
 	if (!pybuf.ok())
 		return NULL;
-	return Py_BuildValue("NN", PyWinLong_FromVoidPtr(pybuf.ptr()), PyInt_FromSsize_t(pybuf.len()));
+	return Py_BuildValue("NN", PyWinLong_FromVoidPtr(pybuf.ptr()), PyLong_FromSsize_t(pybuf.len()));
 }
 %}
 %native (PyGetBufferAddressAndLen) PyGetBufferAddressAndLen;
@@ -2072,7 +2072,7 @@ BOOL CALLBACK PyEnumWindowsProc(
 	if (ret == NULL)		
 		return FALSE;
 	if (ret != Py_None){
-		result = PyInt_AsLong(ret);
+		result = PyLong_AsLong(ret);
 		if (result == -1 && PyErr_Occurred())
 			result = FALSE;
 		}
@@ -2239,7 +2239,7 @@ static PyObject *PyDialogBoxIndirect(PyObject *self, PyObject *args)
 	if (!PyWinObject_AsHANDLE(obhwnd, (HANDLE *)&hwnd))
 		return NULL;
 	// We unpack the object in the dlgproc - but check validity now
-	if (obParam != Py_None && !PyInt_Check(obParam) && !PyLong_Check(obParam)) {
+	if (obParam != Py_None && !PyLong_Check(obParam) && !PyLong_Check(obParam)) {
 		return PyErr_Format(PyExc_TypeError, "optional param must be None, or an integer (got %s)",
 		                    obParam->ob_type->tp_name);
 	}
@@ -3254,7 +3254,7 @@ static PyObject *PyRegisterClass(PyObject *self, PyObject *args)
 
 	// Save atom/PyWNDCLASS and name/atom pairs in global dict.  These are used in
 	// CreateWindow to lookup the python window proc function for the class
-	PyObject *ret = PyInt_FromLong(at);
+	PyObject *ret = PyLong_FromLong(at);
 	if (ret==NULL)
 		return NULL;
 	if (PyDict_SetItem(g_AtomMap, ((PyWNDCLASS *)obwc)->m_obClassName, ret)==-1){
@@ -3413,7 +3413,7 @@ PyHIWORD(PyObject *self, PyObject *args)
 {	int n;
 	if(!PyArg_ParseTuple(args, "i:HIWORD", &n))
 		return NULL;
-	return PyInt_FromLong(HIWORD(n));
+	return PyLong_FromLong(HIWORD(n));
 }
 %}
 %native (HIWORD) PyHIWORD;
@@ -3424,7 +3424,7 @@ PyLOWORD(PyObject *self, PyObject *args)
 {	int n;
 	if(!PyArg_ParseTuple(args, "i:LOWORD", &n))
 		return NULL;
-	return PyInt_FromLong(LOWORD(n));
+	return PyLong_FromLong(LOWORD(n));
 }
 %}
 %native (LOWORD) PyLOWORD;
@@ -3767,7 +3767,7 @@ static PyObject *PyExtractIconEx(PyObject *self, PyObject *args)
     if (index==-1) {
         nicons = (int)ExtractIconEx(fname, index, NULL, NULL, 0);
         PyWinObject_FreeTCHAR(fname);
-        return PyInt_FromLong(nicons);
+        return PyLong_FromLong(nicons);
     }
 #endif // MS_WINCE
     if (nicons<=0) {
@@ -3930,7 +3930,7 @@ static PyObject *PyGetTextCharacterExtra(PyObject *self, PyObject *args)
 	ret=GetTextCharacterExtra(hdc);
 	if (ret==0x80000000)
 		return PyWin_SetAPIError("GetTextCharacterExtra");
-	return PyInt_FromLong(ret);
+	return PyLong_FromLong(ret);
 }
 
 // @pyswig int|SetTextCharacterExtra|Sets the spacing between characters
@@ -3949,7 +3949,7 @@ static PyObject *PySetTextCharacterExtra(PyObject *self, PyObject *args)
 	prevspacing=SetTextCharacterExtra(hdc, newspacing);
 	if (prevspacing==0x80000000)
 		return PyWin_SetAPIError("SetTextCharacterExtra");
-	return PyInt_FromLong(prevspacing);
+	return PyLong_FromLong(prevspacing);
 }
 
 // @pyswig int|GetTextAlign|Returns horizontal and vertical alignment for text in a device context
@@ -3967,7 +3967,7 @@ static PyObject *PyGetTextAlign(PyObject *self, PyObject *args)
 	prevalign=GetTextAlign(hdc);
 	if (prevalign==GDI_ERROR)
 		return PyWin_SetAPIError("GetTextAlign");
-	return PyInt_FromLong(prevalign);
+	return PyLong_FromLong(prevalign);
 }
 
 // @pyswig int|SetTextAlign|Sets horizontal and vertical alignment for text in a device context
@@ -3986,7 +3986,7 @@ static PyObject *PySetTextAlign(PyObject *self, PyObject *args)
 	prevalign=SetTextAlign(hdc, newalign);
 	if (prevalign==GDI_ERROR)
 		return PyWin_SetAPIError("SetTextAlign");
-	return PyInt_FromLong(prevalign);
+	return PyLong_FromLong(prevalign);
 }
 
 // @pyswig <o PyUnicode>|GetTextFace|Retrieves the name of the font currently selected in a DC
@@ -4024,7 +4024,7 @@ static PyObject *PyGetMapMode(PyObject *self, PyObject *args)
 	ret=GetMapMode(hdc);
 	if (ret==0)
 		return PyWin_SetAPIError("GetMapMode");
-	return PyInt_FromLong(ret);
+	return PyLong_FromLong(ret);
 }
 
 // @pyswig int|SetMapMode|Sets the method used for translating logical units to device units
@@ -4043,7 +4043,7 @@ static PyObject *PySetMapMode(PyObject *self, PyObject *args)
 	prevmode=SetMapMode(hdc, newmode);
 	if (prevmode==0)
 		return PyWin_SetAPIError("SetMapMode");
-	return PyInt_FromLong(prevmode);
+	return PyLong_FromLong(prevmode);
 }
 
 // @pyswig int|GetGraphicsMode|Determines if advanced GDI features are enabled for a device context
@@ -4061,7 +4061,7 @@ static PyObject *PyGetGraphicsMode(PyObject *self, PyObject *args)
 	ret=GetGraphicsMode(hdc);
 	if (ret==0)
 		return PyWin_SetAPIError("GetGraphicsMode");
-	return PyInt_FromLong(ret);
+	return PyLong_FromLong(ret);
 }
 
 // @pyswig int|SetGraphicsMode|Enables or disables advanced graphics features for a DC
@@ -4080,7 +4080,7 @@ static PyObject *PySetGraphicsMode(PyObject *self, PyObject *args)
 	prevmode=SetGraphicsMode(hdc, newmode);
 	if (prevmode==0)
 		return PyWin_SetAPIError("SetGraphicsMode");
-	return PyInt_FromLong(prevmode);
+	return PyLong_FromLong(prevmode);
 }
 
 // @pyswig int|GetLayout|Retrieves the layout mode of a device context
@@ -4137,7 +4137,7 @@ static PyObject *PyGetPolyFillMode(PyObject *self, PyObject *args)
 	ret=GetPolyFillMode(hdc);
 	if (ret==0)
 		return PyWin_SetAPIError("GetPolyFillMode");
-	return PyInt_FromLong(ret);
+	return PyLong_FromLong(ret);
 }
 
 // @pyswig int|SetPolyFillMode|Sets the polygon filling mode for a device context
@@ -4156,7 +4156,7 @@ static PyObject *PySetPolyFillMode(PyObject *self, PyObject *args)
 	prevmode=SetPolyFillMode(hdc, newmode);
 	if (prevmode==0)
 		return PyWin_SetAPIError("SetPolyFillMode");
-	return PyInt_FromLong(prevmode);
+	return PyLong_FromLong(prevmode);
 }
 %}
 %native (GetTextExtentPoint32) PyGetTextExtentPoint32;
@@ -5050,7 +5050,7 @@ static PyObject *PyGetROP2(PyObject *self, PyObject *args)
 	ret=GetROP2(hdc);
 	if (ret==0)
 		return PyWin_SetAPIError("GetROP2");
-	return PyInt_FromLong(ret);
+	return PyLong_FromLong(ret);
 }
 
 // @pyswig int|SetROP2|Sets the foreground mixing mode of a DC
@@ -5069,7 +5069,7 @@ static PyObject *PySetROP2(PyObject *self, PyObject *args)
 	oldmode=SetROP2(hdc, newmode);
 	if (oldmode==0)
 		return PyWin_SetAPIError("SetROP2");
-	return PyInt_FromLong(oldmode);
+	return PyLong_FromLong(oldmode);
 }
 %}
 %native (SetPixel) PySetPixel;
@@ -5396,10 +5396,10 @@ static PyObject *PyExtTextOut(PyObject *self, PyObject *args)
 				widths = new int[len + 1];
 				for (int i = 0; i < len; i++) {
 					PyObject *item = PyTuple_GetItem(widthObject, i);
-					if (!PyInt_Check(item))
+					if (!PyLong_Check(item))
 						error = TRUE;
 					else 
-						widths[i] = PyInt_AsLong(item);
+						widths[i] = PyLong_AsLong(item);
 				}
 			}
 		}
@@ -5770,7 +5770,7 @@ static PyObject *PyGetPath(PyObject *self, PyObject *args)
 		if (tuple_item==NULL)
 			goto cleanup;
 		PyTuple_SET_ITEM(obpoints, point_ind, tuple_item);
-		tuple_item=PyInt_FromLong(types[point_ind]);
+		tuple_item=PyLong_FromLong(types[point_ind]);
 		if (tuple_item==NULL)
 			goto cleanup;
 		PyTuple_SET_ITEM(obtypes, point_ind, tuple_item);
@@ -5958,24 +5958,24 @@ BOOL ParseSCROLLINFOTuple( PyObject *args, SCROLLINFO *pInfo)
 		return FALSE;
 	}
 	if (obMin!=Py_None){
-		if (((pInfo->nMin=PyInt_AsLong(obMin))==-1)&&PyErr_Occurred())
+		if (((pInfo->nMin=PyLong_AsLong(obMin))==-1)&&PyErr_Occurred())
 			return FALSE;
-		if (((pInfo->nMax=PyInt_AsLong(obMax))==-1)&&PyErr_Occurred())
+		if (((pInfo->nMax=PyLong_AsLong(obMax))==-1)&&PyErr_Occurred())
 			return FALSE;
 		pInfo->fMask |= SIF_RANGE;
 	}
 	if (obPage!=Py_None){
-		if (((pInfo->nPage=PyInt_AsLong(obPage))==-1)&&PyErr_Occurred())
+		if (((pInfo->nPage=PyLong_AsLong(obPage))==-1)&&PyErr_Occurred())
 			return FALSE;
 		pInfo->fMask |= SIF_PAGE;
 	}
 	if (obPos!=Py_None){
-		if (((pInfo->nPos=PyInt_AsLong(obPos))==-1)&&PyErr_Occurred())
+		if (((pInfo->nPos=PyLong_AsLong(obPos))==-1)&&PyErr_Occurred())
 			return FALSE;
 		pInfo->fMask |= SIF_POS;
 	}
 	if (obTrackPos!=Py_None){
-		if (((pInfo->nTrackPos=PyInt_AsLong(obTrackPos))==-1)&&PyErr_Occurred())
+		if (((pInfo->nTrackPos=PyLong_AsLong(obTrackPos))==-1)&&PyErr_Occurred())
 			return FALSE;
 		pInfo->fMask |= SIF_TRACKPOS;
 	}
@@ -5986,10 +5986,10 @@ PyObject *MakeSCROLLINFOTuple(SCROLLINFO *pInfo)
 {
 	PyObject *ret = PyTuple_New(6);
 	if (ret==NULL) return NULL;
-	PyTuple_SET_ITEM(ret, 0, PyInt_FromLong(0));
+	PyTuple_SET_ITEM(ret, 0, PyLong_FromLong(0));
 	if (pInfo->fMask & SIF_RANGE) {
-		PyTuple_SET_ITEM(ret, 1, PyInt_FromLong(pInfo->nMin));
-		PyTuple_SET_ITEM(ret, 2, PyInt_FromLong(pInfo->nMax));
+		PyTuple_SET_ITEM(ret, 1, PyLong_FromLong(pInfo->nMin));
+		PyTuple_SET_ITEM(ret, 2, PyLong_FromLong(pInfo->nMax));
 	} else {
 		Py_INCREF(Py_None);
 		Py_INCREF(Py_None);
@@ -5997,18 +5997,18 @@ PyObject *MakeSCROLLINFOTuple(SCROLLINFO *pInfo)
 		PyTuple_SET_ITEM(ret, 2, Py_None);
 	}
 	if (pInfo->fMask & SIF_PAGE) {
-		PyTuple_SET_ITEM(ret, 3, PyInt_FromLong(pInfo->nPage));
+		PyTuple_SET_ITEM(ret, 3, PyLong_FromLong(pInfo->nPage));
 	} else {
 		Py_INCREF(Py_None);
 		PyTuple_SET_ITEM(ret, 3, Py_None);
 	}
 	if (pInfo->fMask & SIF_POS) {
-		PyTuple_SET_ITEM(ret, 4, PyInt_FromLong(pInfo->nPos));
+		PyTuple_SET_ITEM(ret, 4, PyLong_FromLong(pInfo->nPos));
 	} else {
 		Py_INCREF(Py_None);
 		PyTuple_SET_ITEM(ret, 4, Py_None);
 	}
-	PyTuple_SET_ITEM(ret, 5, PyInt_FromLong(pInfo->nTrackPos));
+	PyTuple_SET_ITEM(ret, 5, PyLong_FromLong(pInfo->nTrackPos));
 	return ret;
 }
 
@@ -6037,7 +6037,7 @@ static PyObject *PySetScrollInfo(PyObject *self, PyObject *args) {
 	GUI_BGN_SAVE;
 	int rc = SetScrollInfo(hwnd, nBar, &info, bRedraw);
 	GUI_END_SAVE;
-	return PyInt_FromLong(rc);
+	return PyLong_FromLong(rc);
 }
 %}
 %native (SetScrollInfo) PySetScrollInfo;
@@ -6146,11 +6146,11 @@ static int CALLBACK PySortFunc(
 	result = PyEval_CallObject(pc->fn, args);
 	// API says must return 0, but there might be a good reason.
 	if (!result) goto done;
-	if (!PyInt_Check(result)) {
+	if (!PyLong_Check(result)) {
 		PyErr_SetString(PyExc_TypeError, "The sort function must return an integer");
 		goto done;
 	}
-	rc = PyInt_AsLong(result);
+	rc = PyLong_AsLong(result);
 done:
 	if (PyErr_Occurred())
 		HandleError("ListView sort callback failed!");
@@ -6942,7 +6942,7 @@ static PyObject *PySystemParametersInfo(PyObject *self, PyObject *args, PyObject
 		// @flag SPI_SETDEFAULTINPUTLANG|Param is an int containing a locale id
 		case SPI_SETDEFAULTINPUTLANG:
 			// input is a HKL, which is actually a HANDLE, which can be treated as a long
-			longParam=PyInt_AsLong(obParam);
+			longParam=PyLong_AsLong(obParam);
 			if (longParam==-1 && PyErr_Occurred())
 				goto done;
 			pvParam=&longParam;
@@ -6961,7 +6961,7 @@ static PyObject *PySystemParametersInfo(PyObject *self, PyObject *args, PyObject
 			uiParam=buflen;
 			((ANIMATIONINFO *)pvParam)->cbSize=buflen;
 			if (Action==SPI_SETANIMATION){
-				((ANIMATIONINFO *)pvParam)->iMinAnimate=PyInt_AsLong(obParam);
+				((ANIMATIONINFO *)pvParam)->iMinAnimate=PyLong_AsLong(obParam);
 				if (((ANIMATIONINFO *)pvParam)->iMinAnimate==-1 && PyErr_Occurred())
 					goto done;
 				}
@@ -7152,7 +7152,7 @@ static PyObject *PySystemParametersInfo(PyObject *self, PyObject *args, PyObject
 			break;
 #ifndef MS_WINCE
 		case SPI_GETANIMATION:
-			ret=PyInt_FromLong(((ANIMATIONINFO *)pvParam)->iMinAnimate);
+			ret=PyLong_FromLong(((ANIMATIONINFO *)pvParam)->iMinAnimate);
 			break;
 		// these 2 can be a get or set, use Param==Py_None to mean a get
 		case SPI_ICONHORIZONTALSPACING:

--- a/win32/src/win32helpmodule.cpp
+++ b/win32/src/win32helpmodule.cpp
@@ -759,14 +759,14 @@ PyHH_POPUP::PyHH_POPUP(const HH_POPUP *pPOPUP)
     m_pszFont = pPOPUP->pszFont ? PyWinObject_FromTCHAR((TCHAR *)pPOPUP->pszFont) : NULL;
 
     m_pt = PyTuple_New(2);
-    PyTuple_SetItem(m_pt, 0, PyInt_FromLong(pPOPUP->pt.x));
-    PyTuple_SetItem(m_pt, 1, PyInt_FromLong(pPOPUP->pt.y));
+    PyTuple_SetItem(m_pt, 0, PyLong_FromLong(pPOPUP->pt.x));
+    PyTuple_SetItem(m_pt, 1, PyLong_FromLong(pPOPUP->pt.y));
 
     m_rcMargins = PyTuple_New(4);
-    PyTuple_SetItem(m_rcMargins, 0, PyInt_FromLong(pPOPUP->rcMargins.left));
-    PyTuple_SetItem(m_rcMargins, 1, PyInt_FromLong(pPOPUP->rcMargins.right));
-    PyTuple_SetItem(m_rcMargins, 2, PyInt_FromLong(pPOPUP->rcMargins.top));
-    PyTuple_SetItem(m_rcMargins, 3, PyInt_FromLong(pPOPUP->rcMargins.bottom));
+    PyTuple_SetItem(m_rcMargins, 0, PyLong_FromLong(pPOPUP->rcMargins.left));
+    PyTuple_SetItem(m_rcMargins, 1, PyLong_FromLong(pPOPUP->rcMargins.right));
+    PyTuple_SetItem(m_rcMargins, 2, PyLong_FromLong(pPOPUP->rcMargins.top));
+    PyTuple_SetItem(m_rcMargins, 3, PyLong_FromLong(pPOPUP->rcMargins.bottom));
 }
 
 PyHH_POPUP::~PyHH_POPUP(void)
@@ -2404,11 +2404,11 @@ in the Html Help engine yet.");
                 PyErr_SetString(PyExc_TypeError, "HH_HELP_CONTEXT file must be a string");
                 return NULL;
             }
-            if (!PyInt_Check(dataOb)) {
+            if (!PyLong_Check(dataOb)) {
                 PyErr_SetString(PyExc_TypeError, "HH_HELP_CONTEXT data must be an integer");
                 return NULL;
             }
-            data = (DWORD_PTR)PyInt_AsLong(dataOb);
+            data = (DWORD_PTR)PyLong_AsLong(dataOb);
             break;
 
         case HH_INITIALIZE:
@@ -2457,10 +2457,10 @@ in the Html Help engine yet.");
             ctlIDs = new DWORD[len + 1];
             for (i = 0; i < len; i++) {
                 item = PyTuple_GetItem(dataOb, i);
-                if (!PyInt_Check(item))
+                if (!PyLong_Check(item))
                     error = TRUE;
                 else
-                    ctlIDs[i] = PyInt_AsLong(item);
+                    ctlIDs[i] = PyLong_AsLong(item);
             }
             if (error) {
                 delete[] ctlIDs;
@@ -2474,11 +2474,11 @@ data tuple items must be integers");
 
         case HH_UNINITIALIZE:
             file = NULL;
-            if (!PyInt_Check(dataOb)) {
+            if (!PyLong_Check(dataOb)) {
                 PyErr_SetString(PyExc_TypeError, "HH_UNINITIALIZE data must be an integer");
                 return NULL;
             }
-            data = (DWORD_PTR)PyInt_AsLong(dataOb);
+            data = (DWORD_PTR)PyLong_AsLong(dataOb);
             break;
 
         default:

--- a/win32/src/win32inet.i
+++ b/win32/src/win32inet.i
@@ -176,7 +176,7 @@ PyObject *PyWinObject_FromStatusInformation(DWORD status, void *buf, DWORD bufsi
 		//	but it appears to be a plain string ??? 
 		case INTERNET_STATUS_CONNECTED_TO_SERVER:
 		case INTERNET_STATUS_CONNECTING_TO_SERVER:
-			return PyString_FromString((char *)buf);
+			return PyBytes_FromString((char *)buf);
 		case INTERNET_STATUS_COOKIE_HISTORY:{	// InternetCookieHistory struct
 			InternetCookieHistory *ich=(InternetCookieHistory *)buf;
 			return Py_BuildValue("{s:N, s:N, s:N, s:N}",
@@ -198,7 +198,7 @@ PyObject *PyWinObject_FromStatusInformation(DWORD status, void *buf, DWORD bufsi
 			//	useless to calling python app, as it may be a pointer to anything.  Should
 			//	probably just throw an error to avoid confusion in the future if more statuses
 			//	are recognized.
-			return PyString_FromStringAndSize((char *)buf, bufsize);
+			return PyBytes_FromStringAndSize((char *)buf, bufsize);
 	}
 }
 
@@ -737,7 +737,7 @@ PyObject *PyInternetReadFile(PyObject *self, PyObject *args)
         PyWin_SetAPIError("InternetReadFile");
         goto done;
     }
-    ret = PyString_FromStringAndSize(buf, read);
+    ret = PyBytes_FromStringAndSize(buf, read);
     // @rdesc The result will be a string of zero bytes when the end is reached.
 done:
     if (buf) free(buf);

--- a/win32/src/win32lzmodule.cpp
+++ b/win32/src/win32lzmodule.cpp
@@ -112,7 +112,7 @@ static PyObject *PyLZCopy(PyObject *self, PyObject *args)
     long ret = LZCopy(hSrc, hDest);
     if (ret < 0)
         return ReturnLZError("LZCopy", ret);
-    return PyInt_FromLong(ret);
+    return PyLong_FromLong(ret);
 }
 
 // @pymethod |win32lz|Init|Allocates memory for the internal data structures required to decompress files, and then
@@ -127,7 +127,7 @@ static PyObject *PyLZInit(PyObject *self, PyObject *args)
     INT ret = LZInit(h);
     if (ret < 0)
         return ReturnLZError("LZInit", ret);
-    return PyInt_FromLong(ret);
+    return PyLong_FromLong(ret);
 }
 
 // @pymethod int,(tuple)|win32lz|OpenFile|Creates, opens, reopens, or deletes the specified file.

--- a/win32/src/win32net/win32netmisc.cpp
+++ b/win32/src/win32net/win32netmisc.cpp
@@ -1612,7 +1612,7 @@ static PyObject *PyObject_FromNET_VALIDATE_PERSISTED_FIELDS(NET_VALIDATE_PERSIST
         if (f->PasswordHistory) {
             SAFE_INSERT_NEW_REF(
                 ret, "PasswordHistory",
-                PyString_FromStringAndSize((char *)f->PasswordHistory->Hash, f->PasswordHistory->Length));
+                PyBytes_FromStringAndSize((char *)f->PasswordHistory->Hash, f->PasswordHistory->Length));
         }
         else
             PyDict_SetItemString(ret, "PasswordHistory", Py_None);

--- a/win32/src/win32net/win32netmodule.cpp
+++ b/win32/src/win32net/win32netmodule.cpp
@@ -151,7 +151,7 @@ BOOL PyObject_AsNET_STRUCT(PyObject *ob, PyNET_STRUCT *pI, BYTE **ppRet)
                     break;
                 case NSI_HOURS:
                     if (subob != Py_None) {
-                        if (!PyString_Check(subob) || PyString_Size(subob) != 21) {
+                        if (!PyBytes_Check(subob) || PyBytes_Size(subob) != 21) {
                             PyErr_Format(PyExc_TypeError,
                                          "The mapping attribute '%s' must be a string of exactly length 21",
                                          pItem->attrname);
@@ -159,7 +159,7 @@ BOOL PyObject_AsNET_STRUCT(PyObject *ob, PyNET_STRUCT *pI, BYTE **ppRet)
                             goto done;
                         }
                         *((char **)(buf + pItem->off)) = (char *)malloc(21);
-                        memcpy(*((char **)(buf + pItem->off)), PyString_AsString(subob), 21);
+                        memcpy(*((char **)(buf + pItem->off)), PyBytes_AsString(subob), 21);
                     }
                     break;
                 case NSI_SID: {
@@ -230,7 +230,7 @@ PyObject *PyObject_FromNET_STRUCT(PyNET_STRUCT *pI, BYTE *buf)
             case NSI_HOURS: {
                 char *data = *((char **)(buf + pItem->off));
                 if (data) {
-                    newObj = PyString_FromStringAndSize(data, 21);
+                    newObj = PyBytes_FromStringAndSize(data, 21);
                 }
                 else {
                     newObj = Py_None;

--- a/win32/src/win32net/win32netmodule.cpp
+++ b/win32/src/win32net/win32netmodule.cpp
@@ -121,7 +121,7 @@ BOOL PyObject_AsNET_STRUCT(PyObject *ob, PyNET_STRUCT *pI, BYTE **ppRet)
                     *((WCHAR **)(buf + pItem->off)) = wsz;
                     break;
                 case NSI_DWORD:
-                    *((DWORD *)(buf + pItem->off)) = PyInt_AsUnsignedLongMask(subob);
+                    *((DWORD *)(buf + pItem->off)) = PyLong_AsUnsignedLongMask(subob);
                     if (*((DWORD *)(buf + pItem->off)) == -1 && PyErr_Occurred()) {
                         PyErr_Clear();
                         PyErr_Format(PyExc_TypeError, "The mapping attribute '%s' must be an unsigned 32 bit int",
@@ -131,7 +131,7 @@ BOOL PyObject_AsNET_STRUCT(PyObject *ob, PyNET_STRUCT *pI, BYTE **ppRet)
                     }
                     break;
                 case NSI_LONG:
-                    *((LONG *)(buf + pItem->off)) = PyInt_AsLong(subob);
+                    *((LONG *)(buf + pItem->off)) = PyLong_AsLong(subob);
                     if (*((LONG *)(buf + pItem->off)) == -1 && PyErr_Occurred()) {
                         PyErr_Clear();
                         PyErr_Format(PyExc_TypeError, "The mapping attribute '%s' must be an integer", pItem->attrname);
@@ -221,7 +221,7 @@ PyObject *PyObject_FromNET_STRUCT(PyNET_STRUCT *pI, BYTE *buf)
                 newObj = PyLong_FromUnsignedLong(*((DWORD *)(buf + pItem->off)));
                 break;
             case NSI_LONG:
-                newObj = PyInt_FromLong(*((LONG *)(buf + pItem->off)));
+                newObj = PyLong_FromLong(*((LONG *)(buf + pItem->off)));
                 break;
             case NSI_BOOL:
                 newObj = *((BOOL *)(buf + pItem->off)) ? Py_True : Py_False;
@@ -1195,7 +1195,7 @@ static struct PyMethodDef win32net_functions[] = {
 
 static void AddConstant(PyObject *dict, char *name, long val)
 {
-    PyObject *nv = PyInt_FromLong(val);
+    PyObject *nv = PyLong_FromLong(val);
     PyDict_SetItemString(dict, name, nv);
     Py_XDECREF(nv);
 }

--- a/win32/src/win32pdhmodule.cpp
+++ b/win32/src/win32pdhmodule.cpp
@@ -233,7 +233,7 @@ BOOL CheckCounterStatusOK(DWORD status)
 {
     if (status == 0)
         return TRUE;
-    PyObject *v = PyInt_FromLong(status);
+    PyObject *v = PyLong_FromLong(status);
     PyErr_SetObject(win32pdh_counter_error, v);
     Py_DECREF(v);
     return FALSE;
@@ -669,7 +669,7 @@ static PyObject *PyGetFormattedCounterValue(PyObject *self, PyObject *args)
     if (format & PDH_FMT_DOUBLE)
         rc = PyFloat_FromDouble(result.doubleValue);
     else if (format & PDH_FMT_LONG)
-        rc = PyInt_FromLong(result.longValue);
+        rc = PyLong_FromLong(result.longValue);
     else if (format & PDH_FMT_LARGE)
         rc = PyLong_FromLongLong(result.largeValue);
     else {
@@ -731,7 +731,7 @@ static PyObject *PyPdhGetFormattedCounterArray(PyObject *self, PyObject *args)
         if (format & PDH_FMT_DOUBLE)
             value = PyFloat_FromDouble(pItems[i].FmtValue.doubleValue);
         else if (format & PDH_FMT_LONG)
-            value = PyInt_FromLong(pItems[i].FmtValue.longValue);
+            value = PyLong_FromLong(pItems[i].FmtValue.longValue);
         else if (format & PDH_FMT_LARGE)
             value = PyLong_FromLongLong(pItems[i].FmtValue.largeValue);
         else {
@@ -786,7 +786,7 @@ static PyObject *PyValidatePath(PyObject *self, PyObject *args)
 
     PyWinObject_FreeTCHAR(path);
 
-    return PyInt_FromLong(pdhStatus);
+    return PyLong_FromLong(pdhStatus);
     // @comm This method returns an integer result code.  No exception is
     // ever thrown.  Zero result indicates success.
 }
@@ -987,7 +987,7 @@ PDH_STATUS __stdcall PyCounterPathCallback(DWORD_PTR dwArg)
         else if (result == Py_None)
             rc = ERROR_SUCCESS;
         else {
-            rc = PyInt_AsLong(result);
+            rc = PyLong_AsLong(result);
             if (rc == -1 && PyErr_Occurred()) {
                 PyErr_Print();  // *Don't* leave exception hanging
                 rc = PDH_INVALID_DATA;
@@ -1160,7 +1160,7 @@ static PyObject *PyLookupPerfIndexByName(PyObject *self, PyObject *args)
     Py_END_ALLOW_THREADS
 
         if (pdhStatus != 0) return PyWin_SetAPIError("LookupPerfIndexByName", pdhStatus);
-    return PyInt_FromLong(dwIndex);
+    return PyLong_FromLong(dwIndex);
 }
 
 // @pymethod string|win32pdh|LookupPerfNameByIndex|Returns the performance object name corresponding to the specified

--- a/win32/src/win32pipe.i
+++ b/win32/src/win32pipe.i
@@ -129,8 +129,8 @@ PyObject *MyGetNamedPipeHandleState(PyObject *self, PyObject *args)
 		return PyWin_SetAPIError("GetNamedPipeHandleState");
 	PyObject *obName = PyWinObject_FromTCHAR(buf);
 	if (getCollectData) {
-		obMaxCollectionCount = PyInt_FromLong(MaxCollectionCount);
-		obCollectDataTimeout = PyInt_FromLong(CollectDataTimeout);
+		obMaxCollectionCount = PyLong_FromLong(MaxCollectionCount);
+		obCollectDataTimeout = PyLong_FromLong(CollectDataTimeout);
 	} else {
 		obMaxCollectionCount = Py_None; Py_INCREF(Py_None);
 		obCollectDataTimeout = Py_None; Py_INCREF(Py_None);
@@ -167,21 +167,21 @@ PyObject *MySetNamedPipeHandleState(PyObject *self, PyObject *args)
 	if (!PyWinObject_AsHANDLE(obhNamedPipe, &hNamedPipe))
 		return NULL;
     if (obMode!=Py_None) {
-        if (!PyInt_Check(obMode))
+        if (!PyLong_Check(obMode))
             return PyErr_Format(PyExc_TypeError, "mode param must be None or an integer (got %s)", obMode->ob_type->tp_name);
-        Mode = PyInt_AsLong(obMode);
+        Mode = PyLong_AsLong(obMode);
         pMode = &Mode;
     }
     if (obMaxCollectionCount!=Py_None) {
-        if (!PyInt_Check(obMaxCollectionCount))
+        if (!PyLong_Check(obMaxCollectionCount))
             return PyErr_Format(PyExc_TypeError, "maxCollectionCount param must be None or an integer (got %s)", obMaxCollectionCount->ob_type->tp_name);
-        MaxCollectionCount = PyInt_AsLong(obMaxCollectionCount);
+        MaxCollectionCount = PyLong_AsLong(obMaxCollectionCount);
         pMaxCollectionCount = &MaxCollectionCount;
     }
     if (obCollectDataTimeout!=Py_None) {
-        if (!PyInt_Check(obCollectDataTimeout))
+        if (!PyLong_Check(obCollectDataTimeout))
             return PyErr_Format(PyExc_TypeError, "collectDataTimeout param must be None or an integer (got %s)", obCollectDataTimeout->ob_type->tp_name);
-        CollectDataTimeout = PyInt_AsLong(obCollectDataTimeout);
+        CollectDataTimeout = PyLong_AsLong(obCollectDataTimeout);
         pCollectDataTimeout = &CollectDataTimeout;
     }
 
@@ -225,7 +225,7 @@ PyObject *MyConnectNamedPipe(PyObject *self, PyObject *args)
 	// the function has still worked.
 	if (!ok && rc != ERROR_IO_PENDING && rc != ERROR_PIPE_CONNECTED)
 		return PyWin_SetAPIError("ConnectNamedPipe");
-	return PyInt_FromLong(rc);
+	return PyLong_FromLong(rc);
 }
 
 // @pyswig string/buffer|TransactNamedPipe|Combines the functions that write a
@@ -265,7 +265,7 @@ PyObject *MyTransactNamedPipe(PyObject *self, PyObject *args)
 	BOOL bIsNewString=FALSE;
 	PyObject *obRet = NULL;
 	// process the tricky read buffer.
-	cbReadData = PyInt_AsLong(obReadData);
+	cbReadData = PyLong_AsLong(obReadData);
 	if ((cbReadData!=(DWORD)-1) || !PyErr_Occurred()){
 		if (pOverlapped){	// guaranteed to be NULL on CE
 			obRet = PyBuffer_New(cbReadData);

--- a/win32/src/win32pipe.i
+++ b/win32/src/win32pipe.i
@@ -279,10 +279,10 @@ PyObject *MyTransactNamedPipe(PyObject *self, PyObject *args)
 			    }
 			readData = read_buf.ptr();
 		} else {
-			obRet=PyString_FromStringAndSize(NULL, cbReadData);
+			obRet=PyBytes_FromStringAndSize(NULL, cbReadData);
 			if (obRet==NULL)
 				return NULL;
-			readData=PyString_AS_STRING(obRet);
+			readData=PyBytes_AS_STRING(obRet);
 			bIsNewString=TRUE;
 		}
 	} else {
@@ -314,9 +314,9 @@ PyObject *MyTransactNamedPipe(PyObject *self, PyObject *args)
 		}
 	}
 	if (obRet==NULL)
-		obRet=PyString_FromStringAndSize((char *)readData, numRead);
+		obRet=PyBytes_FromStringAndSize((char *)readData, numRead);
 	else if (bIsNewString && (numRead < cbReadData))
-		_PyString_Resize(&obRet, numRead);
+		_PyBytes_Resize(&obRet, numRead);
 	if (obRet==NULL)
 		return NULL;
 	return Py_BuildValue("iN", err, obRet);
@@ -359,7 +359,7 @@ PyObject *MyCallNamedPipe(PyObject *self, PyObject *args)
 		free(readBuf);
 		return PyWin_SetAPIError("CallNamedPipe");
 	}
-	PyObject *rc = PyString_FromStringAndSize( (char *)readBuf, numRead);
+	PyObject *rc = PyBytes_FromStringAndSize( (char *)readBuf, numRead);
 	PyWinObject_FreeTCHAR(szPipeName);
 	free(readBuf);
 	return rc;
@@ -481,7 +481,7 @@ PyObject *MyPeekNamedPipe(PyObject *self, PyObject *args)
 	PyObject *rc = NULL;
 	if (PeekNamedPipe(hNamedPipe, buf, size, &bytesRead, &totalAvail, &bytesLeft)) {
 		rc = Py_BuildValue("Nii", 
-			PyString_FromStringAndSize((char *)buf, bytesRead),
+			PyBytes_FromStringAndSize((char *)buf, bytesRead),
 			totalAvail, bytesLeft);
 	} else
 		PyWin_SetAPIError("PeekNamedPipe");

--- a/win32/src/win32popen.cpp
+++ b/win32/src/win32popen.cpp
@@ -399,7 +399,7 @@ static PyObject *_PyPopen(char *cmdstring, int mode, int n)
 
         procObj = PyList_New(2);
         hProcessObj = PyLong_FromVoidPtr(hProcess);
-        intObj = PyInt_FromLong(file_count);
+        intObj = PyLong_FromLong(file_count);
 
         if (procObj && hProcessObj && intObj) {
             PyList_SetItem(procObj, 0, hProcessObj);
@@ -508,12 +508,12 @@ static int _PyPclose(FILE *file)
             (procObj = PyDict_GetItem(_PyPopenProcs, fileObj)) != NULL &&
             (hProcessObj = PyList_GetItem(procObj, 0)) != NULL && (intObj = PyList_GetItem(procObj, 1)) != NULL) {
             hProcess = PyLong_AsVoidPtr(hProcessObj);
-            file_count = PyInt_AsLong(intObj);
+            file_count = PyLong_AsLong(intObj);
 
             if (file_count > 1) {
                 /* Still other files referencing process */
                 file_count--;
-                PyList_SetItem(procObj, 1, PyInt_FromLong(file_count));
+                PyList_SetItem(procObj, 1, PyLong_FromLong(file_count));
             }
             else {
                 Py_BEGIN_ALLOW_THREADS

--- a/win32/src/win32print/win32print.cpp
+++ b/win32/src/win32print/win32print.cpp
@@ -2520,7 +2520,7 @@ static PyObject *PyFlushPrinter(PyObject *self, PyObject *args)
                           &obbuf,      // @pyparm str|Buf||Data to be sent to printer
                           &sleep_ms))  // @pyparm int|Sleep||Number of milliseconds to suspend printer
         return NULL;
-    if (PyString_AsStringAndSize(obbuf, (char **)&buf, &bufsize) == -1)
+    if (PyBytes_AsStringAndSize(obbuf, (char **)&buf, &bufsize) == -1)
         return NULL;
     if (!(*pfnFlushPrinter)(hprinter, buf, PyWin_SAFE_DOWNCAST(bufsize, Py_ssize_t, DWORD), &bytes_written, sleep_ms))
         return PyWin_SetAPIError("FlushPrinter");

--- a/win32/src/win32print/win32print.cpp
+++ b/win32/src/win32print/win32print.cpp
@@ -338,7 +338,7 @@ BOOL PyWinObject_AsPRINTER_INFO(DWORD level, PyObject *obinfo, LPBYTE *pbuf)
         if (obinfo == Py_None)
             return TRUE;
         else {
-            *pbuf = (LPBYTE)PyInt_AsLong(obinfo);
+            *pbuf = (LPBYTE)PyLong_AsLong(obinfo);
             if ((*pbuf == (LPBYTE)-1) && PyErr_Occurred()) {
                 PyErr_Clear();
                 PyErr_SetString(PyExc_TypeError, "Info must be None or a PRINTER_STATUS_* integer when level is 0.");
@@ -1317,7 +1317,7 @@ static PyObject *PyDocumentProperties(PyObject *self, PyObject *args)
         else {
             if (obdmoutput != Py_None)
                 ((PyDEVMODE *)obdmoutput)->modify_in_place();
-            ret = PyInt_FromLong(rc);
+            ret = PyLong_FromLong(rc);
         }
     }
     PyWinObject_FreeTCHAR(devicename);
@@ -2597,7 +2597,7 @@ static struct PyMethodDef win32print_functions[] = {
 
 static void AddConstant(PyObject *dict, char *name, long val)
 {
-    PyObject *nv = PyInt_FromLong(val);
+    PyObject *nv = PyLong_FromLong(val);
     PyDict_SetItemString(dict, name, nv);
     Py_XDECREF(nv);
 }

--- a/win32/src/win32process.i
+++ b/win32/src/win32process.i
@@ -382,8 +382,8 @@ unsigned __stdcall ThreadEntryPoint( void *arg )
 		return -1;
 	}
 	int rc = 0;
-	if (PyInt_Check(pyrc))
-		rc = PyInt_AsLong(pyrc);
+	if (PyLong_Check(pyrc))
+		rc = PyLong_AsLong(pyrc);
 	Py_XDECREF(pyrc);
 	return rc;
 }
@@ -655,8 +655,8 @@ PyObject *MyCreateProcess(
 	PyObject *ret = PyTuple_New(4);
 	PyTuple_SET_ITEM(ret, 0, PyWinObject_FromHANDLE(pi.hProcess));
 	PyTuple_SET_ITEM(ret, 1, PyWinObject_FromHANDLE(pi.hThread));
-	PyTuple_SET_ITEM(ret, 2, PyInt_FromLong(pi.dwProcessId));
-	PyTuple_SET_ITEM(ret, 3, PyInt_FromLong(pi.dwThreadId));
+	PyTuple_SET_ITEM(ret, 2, PyLong_FromLong(pi.dwProcessId));
+	PyTuple_SET_ITEM(ret, 3, PyLong_FromLong(pi.dwThreadId));
 	return ret;
 }
 %}
@@ -749,8 +749,8 @@ PyObject *MyCreateProcessAsUser(
 	PyObject *ret = PyTuple_New(4);
 	PyTuple_SET_ITEM(ret, 0, PyWinObject_FromHANDLE(pi.hProcess));
 	PyTuple_SET_ITEM(ret, 1, PyWinObject_FromHANDLE(pi.hThread));
-	PyTuple_SET_ITEM(ret, 2, PyInt_FromLong(pi.dwProcessId));
-	PyTuple_SET_ITEM(ret, 3, PyInt_FromLong(pi.dwThreadId));
+	PyTuple_SET_ITEM(ret, 2, PyLong_FromLong(pi.dwProcessId));
+	PyTuple_SET_ITEM(ret, 3, PyLong_FromLong(pi.dwThreadId));
 	return ret;
 }
 %}
@@ -1003,7 +1003,7 @@ static PyObject *MySetThreadIdealProcessor( HANDLE hThread, DWORD dwIdealProc )
 	DWORD rc = (*pfnSetThreadIdealProcessor)(hThread, dwIdealProc);
 	if (rc==-1)
 		return PyWin_SetAPIError("SetThreadIdealProcessor");
-	return PyInt_FromLong(rc);
+	return PyLong_FromLong(rc);
 }
 %}
 
@@ -1095,7 +1095,7 @@ static PyObject *MySetThreadAffinityMask(PyObject *self, PyObject *args)
 // Special result handling for SuspendThread and ResumeThread
 %typedef DWORD DWORD_SR_THREAD
 %typemap(python,out) DWORD_SR_THREAD {
-	$target = PyInt_FromLong($source);
+	$target = PyLong_FromLong($source);
 }
 %typemap(python,except) DWORD_SR_THREAD {
       Py_BEGIN_ALLOW_THREADS

--- a/win32/src/win32process.i
+++ b/win32/src/win32process.i
@@ -511,9 +511,9 @@ static BOOL CreateEnvironmentString(PyObject *env, LPVOID *ppRet, BOOL *pRetIsUn
 		PyObject *key = PyList_GetItem(keys, i); // no reference
 		PyObject *val = PyList_GetItem(vals, i); // no ref.
 		if (i==0) {
-			if (PyString_Check(key)) {
+			if (PyBytes_Check(key)) {
 				bIsUnicode = FALSE;
-				bufLen += PyString_Size(key) + 1;
+				bufLen += PyBytes_Size(key) + 1;
 			} else if (PyUnicode_Check(key)) {
 				bIsUnicode = TRUE;
 				bufLen += PyUnicode_GET_SIZE(key) + 1;
@@ -530,12 +530,12 @@ static BOOL CreateEnvironmentString(PyObject *env, LPVOID *ppRet, BOOL *pRetIsUn
 				bufLen += PyUnicode_GET_SIZE(key) + 1;
 			}
 			else {
-				if (!PyString_Check(key)) {
+				if (!PyBytes_Check(key)) {
 					PyErr_SetString(PyExc_TypeError, "All dictionary items must be strings, or all must be unicode");
 					goto done;
 
 				}
-				bufLen += PyString_Size(key) + 1;
+				bufLen += PyBytes_Size(key) + 1;
 			}
 		}
 		if (bIsUnicode) {
@@ -546,11 +546,11 @@ static BOOL CreateEnvironmentString(PyObject *env, LPVOID *ppRet, BOOL *pRetIsUn
 			bufLen += PyUnicode_GET_SIZE(val) + 2; // For the '=' and '\0'
 		}
 		else {
-			if (!PyString_Check(val)) {
+			if (!PyBytes_Check(val)) {
 				PyErr_SetString(PyExc_TypeError, "All dictionary items must be strings, or all must be unicode");
 				goto done;
 			}
-			bufLen += PyString_Size(val) + 2; // For the '=' and '\0'
+			bufLen += PyBytes_Size(val) + 2; // For the '=' and '\0'
 		}
 	}
 	result = (LPVOID)malloc( (bIsUnicode ? sizeof(WCHAR) : sizeof(char)) * (bufLen + 1) );
@@ -572,7 +572,7 @@ static BOOL CreateEnvironmentString(PyObject *env, LPVOID *ppRet, BOOL *pRetIsUn
 			pUCur += wcslen(pTemp);
 			PyWinObject_FreeWCHAR(pTemp);
 		} else {
-			char *pTemp = PyString_AsString(key);
+			char *pTemp = PyBytes_AsString(key);
 			strcpy(pACur, pTemp);
 			pACur += strlen(pTemp);
 		}
@@ -588,7 +588,7 @@ static BOOL CreateEnvironmentString(PyObject *env, LPVOID *ppRet, BOOL *pRetIsUn
 			pUCur += wcslen(pTemp);
 			PyWinObject_FreeWCHAR(pTemp);
 		} else {
-			char *pTemp = PyString_AsString(val);
+			char *pTemp = PyBytes_AsString(val);
 			strcpy(pACur, pTemp);
 			pACur += strlen(pTemp);
 		}

--- a/win32/src/win32rasmodule.cpp
+++ b/win32/src/win32rasmodule.cpp
@@ -278,7 +278,7 @@ PyObject *PyRASDIALEXTENSIONS::getattro(PyObject *self, PyObject *obname)
     PyRASDIALEXTENSIONS *py = (PyRASDIALEXTENSIONS *)self;
     // @prop integer|dwfOptions|(fOptions may also be used)
     if (strcmp(name, "dwfOptions") == 0 || strcmp(name, "fOptions") == 0)
-        return PyInt_FromLong(py->m_ext.dwfOptions);
+        return PyLong_FromLong(py->m_ext.dwfOptions);
     // @prop integer|hwndParent|
     if (strcmp(name, "hwndParent") == 0)
         return PyLong_FromVoidPtr(py->m_ext.hwndParent);
@@ -309,7 +309,7 @@ int PyRASDIALEXTENSIONS::setattro(PyObject *self, PyObject *obname, PyObject *va
         return -1;
     PyRASDIALEXTENSIONS *py = (PyRASDIALEXTENSIONS *)self;
     if (strcmp(name, "dwfOptions") == 0 || strcmp(name, "fOptions") == 0) {
-        int i = PyInt_AsLong(val);
+        int i = PyLong_AsLong(val);
         if (i == -1 && PyErr_Occurred())
             return -1;
         py->m_ext.dwfOptions = i;
@@ -323,7 +323,7 @@ int PyRASDIALEXTENSIONS::setattro(PyObject *self, PyObject *obname, PyObject *va
         return 0;
     }
     if (strcmp(name, "reserved") == 0) {
-        long v = PyInt_AsLong(val);
+        long v = PyLong_AsLong(val);
         if (v == -1 && PyErr_Occurred())
             return -1;
         py->m_ext.reserved = v;
@@ -552,7 +552,7 @@ static PyObject *PyRasDial(PyObject *self, PyObject *args)
         pNotification = PyRasDialFunc1;
         notType = 1;
     }
-    else if (PyInt_Check(obCallback)) {
+    else if (PyLong_Check(obCallback)) {
         if (!PyWinLong_AsVoidPtr(obCallback, &pNotification))
             return NULL;
         notType = 0xFFFFFFFF;

--- a/win32/src/win32security.i
+++ b/win32/src/win32security.i
@@ -2639,7 +2639,7 @@ static PyObject *PyLsaSetInformationPolicy(PyObject *self, PyObject *args)
 
 			for (option_ind=0; option_ind<info.MaximumAuditEventCount; option_ind++){
 				obauditing_option = PyTuple_GET_ITEM(options_tuple, option_ind);
-				info.EventAuditingOptions[option_ind] = PyInt_AsLong(obauditing_option);
+				info.EventAuditingOptions[option_ind] = PyLong_AsLong(obauditing_option);
 				if (info.EventAuditingOptions[option_ind] == (ULONG)-1 && PyErr_Occurred())
 					goto done;
 				}

--- a/win32/src/win32security.i
+++ b/win32/src/win32security.i
@@ -435,7 +435,7 @@ BOOL PyWinObject_AsLUID_AND_ATTRIBUTESArray(PyObject *obluids, PLUID_AND_ATTRIBU
 BOOL PyWinObject_AsLSA_STRING(PyObject *obname, PLSA_STRING plsas)
 {
 	Py_ssize_t len;
-	if (PyString_AsStringAndSize(obname, &plsas->Buffer, &len)==-1)
+	if (PyBytes_AsStringAndSize(obname, &plsas->Buffer, &len)==-1)
 		return FALSE;
 	if (len>USHRT_MAX){
 		PyErr_Format(PyExc_ValueError,"String can be at most %d characters", USHRT_MAX);
@@ -622,8 +622,8 @@ void PyWinObject_FreeTOKEN_PRIVILEGES(TOKEN_PRIVILEGES *pPriv)
 	ADD_UNICODE_CONSTANT(SE_CREATE_SYMBOLIC_LINK_NAME);
 	#endif
 
-	PyDict_SetItemString(d,"MSV1_0_PACKAGE_NAME",PyString_FromString(MSV1_0_PACKAGE_NAME));
-	PyDict_SetItemString(d,"MICROSOFT_KERBEROS_NAME_A",PyString_FromString(MICROSOFT_KERBEROS_NAME_A));
+	PyDict_SetItemString(d,"MSV1_0_PACKAGE_NAME",PyBytes_FromString(MSV1_0_PACKAGE_NAME));
+	PyDict_SetItemString(d,"MICROSOFT_KERBEROS_NAME_A",PyBytes_FromString(MICROSOFT_KERBEROS_NAME_A));
 
 	// TOKEN_INFORMATION_CLASS, used with Get/SetTokenInformation
 	PyModule_AddIntConstant(m,"TokenUser", TokenUser);
@@ -1101,7 +1101,7 @@ PyObject *PyLogonUserEx(PyObject *self, PyObject *args, PyObject *kwargs)
 			ret=Py_BuildValue("NNNN",
 				PyWinObject_FromHANDLE(htoken),
 				PyWinObject_FromSID(psid),
-				PyString_FromStringAndSize((char *)profile, profilelen),
+				PyBytes_FromStringAndSize((char *)profile, profilelen),
 				PyWinObject_FromQUOTA_LIMITS(&quota_limits));
 		}
 
@@ -1947,7 +1947,7 @@ static PyObject *PyGetTokenInformation(PyObject *self, PyObject *args)
 			TOKEN_SOURCE *ts = (TOKEN_SOURCE *)buf;
 			PLUID pluid = &ts->SourceIdentifier;
 			ret = Py_BuildValue("NN",
-				PyString_FromStringAndSize(ts->SourceName,8),
+				PyBytes_FromStringAndSize(ts->SourceName,8),
 				PyWinObject_FromLARGE_INTEGER(*((LARGE_INTEGER *) pluid)));
 			break;
 			}

--- a/win32/src/win32security_ds.cpp
+++ b/win32/src/win32security_ds.cpp
@@ -140,7 +140,7 @@ extern PyObject *PyDsGetSpn(PyObject *self, PyObject *args)
             tuple_item = PyTuple_GET_ITEM(obInstancePorts_tuple, tuple_index);
             // convert a python int to a USHORT
             // ??? any API function to do this other than H format of PyArg_ParseTuple ???
-            port_nbr = PyInt_AsLong(tuple_item);
+            port_nbr = PyLong_AsLong(tuple_item);
             if ((port_nbr == (unsigned long)-1 && PyErr_Occurred()) || (port_nbr < 0)) {
                 PyErr_Clear();
                 PyErr_Format(PyExc_TypeError, "InstancePorts must be a sequence of ints in the range 0-%d", USHRT_MAX);

--- a/win32/src/win32security_sspi.cpp
+++ b/win32/src/win32security_sspi.cpp
@@ -412,7 +412,7 @@ PyObject *PySecBuffer::getattro(PyObject *self, PyObject *obname)
     if (name == NULL)
         return NULL;
     if (strcmp(name, "Buffer") == 0)
-        return PyString_FromStringAndSize((char *)psecbuffer->pvBuffer, psecbuffer->cbBuffer);
+        return PyBytes_FromStringAndSize((char *)psecbuffer->pvBuffer, psecbuffer->cbBuffer);
     return PyObject_GenericGetAttr(self, obname);
 }
 
@@ -848,7 +848,7 @@ PyObject *PyCtxtHandle::QueryContextAttributes(PyObject *self, PyObject *args)
         case SECPKG_ATTR_SESSION_KEY:
             PSecPkgContext_SessionKey sk;
             sk = (PSecPkgContext_SessionKey)&buf;
-            ret = PyString_FromStringAndSize((const char *)sk->SessionKey, sk->SessionKeyLength);
+            ret = PyBytes_FromStringAndSize((const char *)sk->SessionKey, sk->SessionKeyLength);
             (*psecurityfunctiontable->FreeContextBuffer)(sk->SessionKey);
             break;
         // @flag SECPKG_ATTR_ISSUER_LIST_EX|(int, string) - Returns names of trusted certificate issuers
@@ -856,7 +856,7 @@ PyObject *PyCtxtHandle::QueryContextAttributes(PyObject *self, PyObject *args)
             PSecPkgContext_IssuerListInfoEx li;
             li = (PSecPkgContext_IssuerListInfoEx)&buf;
             ret = Py_BuildValue("lN", li->cIssuers,
-                                PyString_FromStringAndSize((char *)li->aIssuers->pbData, li->aIssuers->cbData));
+                                PyBytes_FromStringAndSize((char *)li->aIssuers->pbData, li->aIssuers->cbData));
             (*psecurityfunctiontable->FreeContextBuffer)(li->aIssuers);
             break;
         // @flag SECPKG_ATTR_FLAGS|int - returns flags negotiated when context was established
@@ -914,7 +914,7 @@ PyObject *PyCtxtHandle::QueryContextAttributes(PyObject *self, PyObject *args)
         case SECPKG_ATTR_TARGET_INFORMATION:
             PSecPkgContext_TargetInformation ti;
             ti = (PSecPkgContext_TargetInformation)&buf;
-            ret = PyString_FromStringAndSize((const char *)ti->MarshalledTargetInfo, ti->MarshalledTargetInfoLength);
+            ret = PyBytes_FromStringAndSize((const char *)ti->MarshalledTargetInfo, ti->MarshalledTargetInfoLength);
             (*psecurityfunctiontable->FreeContextBuffer)(ti->MarshalledTargetInfo);
             break;
         // @flag SECPKG_ATTR_STREAM_SIZES|dict (see SecPkgContext_StreamSizes) containing message buffer sizes

--- a/win32/src/win32service.i
+++ b/win32/src/win32service.i
@@ -792,7 +792,7 @@ PyObject *MyChangeServiceConfig(
 						 lpDisplayName))
 		rc = PyWin_SetAPIError("ChangeServiceConfig");
 	else if (bFetchTag)
-		rc = PyInt_FromLong(tagID);
+		rc = PyLong_FromLong(tagID);
 	else {
 		rc = Py_None;
 		Py_INCREF(rc);

--- a/win32/src/win32trace.cpp
+++ b/win32/src/win32trace.cpp
@@ -141,7 +141,7 @@ static PyObject *PyTraceObject_read(PyObject *self, PyObject *args)
     if (!ok)
         return NULL;
 #if (PY_VERSION_HEX < 0x03000000)
-    PyObject *result = PyString_FromStringAndSize(data, len);
+    PyObject *result = PyBytes_FromStringAndSize(data, len);
 #else
     PyObject *result = PyUnicode_DecodeLatin1(data, len, "replace");
 #endif
@@ -160,7 +160,7 @@ static PyObject *PyTraceObject_blockingread(PyObject *self, PyObject *args)
     if (!ok)
         return NULL;
 #if (PY_VERSION_HEX < 0x03000000)
-    PyObject *result = PyString_FromStringAndSize(data, len);
+    PyObject *result = PyBytes_FromStringAndSize(data, len);
 #else
     PyObject *result = PyUnicode_DecodeLatin1(data, len, "replace");
 #endif

--- a/win32/src/win32tsmodule.cpp
+++ b/win32/src/win32tsmodule.cpp
@@ -396,7 +396,7 @@ static PyObject *PyWTSQuerySessionInformation(PyObject *self, PyObject *args, Py
         case WTSClientProtocolType:  // @flag WTSClientProtocolType|Int, one of
                                      // WTS_PROTOCOL_TYPE_CONSOLE,WTS_PROTOCOL_TYPE_ICA,WTS_PROTOCOL_TYPE_RDP
         case WTSClientProductId:     // @flag WTSClientProductId|Int
-            ret = PyInt_FromLong(*(USHORT *)buf);
+            ret = PyLong_FromLong(*(USHORT *)buf);
             break;
         // ULONGs
         case WTSClientBuildNumber:  // @flag WTSClientBuildNumber|Int
@@ -405,7 +405,7 @@ static PyObject *PyWTSQuerySessionInformation(PyObject *self, PyObject *args, Py
             ret = PyLong_FromUnsignedLong(*(ULONG *)buf);
             break;
         case WTSConnectState:  // @flag WTSConnectState|Int, from WTS_CONNECTSTATE_CLASS
-            ret = PyInt_FromLong(*(INT *)buf);
+            ret = PyLong_FromLong(*(INT *)buf);
             break;
         case WTSClientDisplay: {  // @flag WTSClientDisplay|Dict containing client's display settings
             WTS_CLIENT_DISPLAY *wcd = (WTS_CLIENT_DISPLAY *)buf;
@@ -430,7 +430,7 @@ static PyObject *PyWTSQuerySessionInformation(PyObject *self, PyObject *args, Py
             obaddress = PyTuple_New(address_cnt);
             if (obaddress != NULL)
                 for (address_ind = 0; address_ind < address_cnt; address_ind++) {
-                    PyObject *obaddress_element = PyInt_FromLong(wca->Address[address_ind]);
+                    PyObject *obaddress_element = PyLong_FromLong(wca->Address[address_ind]);
                     if (obaddress_element == NULL) {
                         Py_DECREF(obaddress);
                         obaddress = NULL;

--- a/win32/src/win32wnet/win32wnet.cpp
+++ b/win32/src/win32wnet/win32wnet.cpp
@@ -575,7 +575,7 @@ PyObject *PyWinMethod_Netbios(PyObject *self, PyObject *args)
     PyNCB *pyncb = (PyNCB *)obncb;
     UCHAR rc;
     Py_BEGIN_ALLOW_THREADS rc = Netbios(&pyncb->m_ncb);
-    Py_END_ALLOW_THREADS return PyInt_FromLong((long)rc);
+    Py_END_ALLOW_THREADS return PyLong_FromLong((long)rc);
 }
 
 // @pymethod buffer|win32wnet|NCBBuffer|Creates an NCB buffer of the relevant size.

--- a/win32/src/wincerapi.i
+++ b/win32/src/wincerapi.i
@@ -297,8 +297,8 @@ PyObject *MyCreateProcess(
 	PyObject *ret = PyTuple_New(4);
 	PyTuple_SET_ITEM(ret, 0, PyWinObject_FromCEHANDLE(pi.hProcess));
 	PyTuple_SET_ITEM(ret, 1, PyWinObject_FromCEHANDLE(pi.hThread));
-	PyTuple_SET_ITEM(ret, 2, PyInt_FromLong(pi.dwProcessId));
-	PyTuple_SET_ITEM(ret, 3, PyInt_FromLong(pi.dwThreadId));
+	PyTuple_SET_ITEM(ret, 2, PyLong_FromLong(pi.dwProcessId));
+	PyTuple_SET_ITEM(ret, 3, PyLong_FromLong(pi.dwThreadId));
 	return ret;
 }
 %}
@@ -699,7 +699,7 @@ PyCeGetFileAttributes(PyObject * self, PyObject * args)
 	if (rc==(DWORD)-1)
 		return PyWin_SetAPIError("CeGetFileAttributes", GetLastCEError());
 
-	return PyInt_FromLong(rc);
+	return PyLong_FromLong(rc);
 }
 %}
 %native (CeGetFileAttributes) PyCeGetFileAttributes;
@@ -845,9 +845,9 @@ BOOL PyWinObject_CloseCEHANDLE(PyObject *obHandle)
 	BOOL ok;
 	if (PyHANDLE_Check(obHandle))
 		ok = ((PyCEHANDLE *)obHandle)->Close();
-	else if PyInt_Check(obHandle) {
+	else if PyLong_Check(obHandle) {
 		PyW32_BEGIN_ALLOW_THREADS
-		long rc = ::CeCloseHandle((HANDLE)PyInt_AsLong(obHandle));
+		long rc = ::CeCloseHandle((HANDLE)PyLong_AsLong(obHandle));
 		PyW32_END_ALLOW_THREADS
 		ok = (rc==ERROR_SUCCESS);
 		if (!ok)

--- a/win32/src/wincerapi.i
+++ b/win32/src/wincerapi.i
@@ -160,9 +160,9 @@ static BOOL CreateEnvironmentString(PyObject *env, LPVOID *ppRet, BOOL *pRetIsUn
 		PyObject *key = PyList_GetItem(keys, i);
 		PyObject *val = PyList_GetItem(vals, i);
 		if (i==0) {
-			if (PyString_Check(key)) {
+			if (PyBytes_Check(key)) {
 				bIsUnicode = FALSE;
-				bufLen += PyString_Size(key) + 1;
+				bufLen += PyBytes_Size(key) + 1;
 			} else if (PyUnicode_Check(key)) {
 				bIsUnicode = TRUE;
 				bufLen += PyUnicode_Size(key) + 1;
@@ -183,13 +183,13 @@ static BOOL CreateEnvironmentString(PyObject *env, LPVOID *ppRet, BOOL *pRetIsUn
 				bufLen += PyUnicode_Size(key) + 1;
 			}
 			else {
-				if (!PyString_Check(key)) {
+				if (!PyBytes_Check(key)) {
 					PyErr_SetString(PyExc_TypeError, "All dictionary items must be strings, or all must be unicode");
 					Py_DECREF(keys);
 					Py_DECREF(vals);
 					return FALSE;
 				}
-				bufLen += PyString_Size(key) + 1;
+				bufLen += PyBytes_Size(key) + 1;
 			}
 		}
 		if (bIsUnicode) {
@@ -202,13 +202,13 @@ static BOOL CreateEnvironmentString(PyObject *env, LPVOID *ppRet, BOOL *pRetIsUn
 			bufLen += PyUnicode_Size(val) + 2; // For the '=' and '\0'
 		}
 		else {
-			if (!PyString_Check(val)) {
+			if (!PyBytes_Check(val)) {
 				PyErr_SetString(PyExc_TypeError, "All dictionary items must be strings, or all must be unicode");
 				Py_DECREF(keys);
 				Py_DECREF(vals);
 				return FALSE;
 			}
-			bufLen += PyString_Size(val) + 2; // For the '=' and '\0'
+			bufLen += PyBytes_Size(val) + 2; // For the '=' and '\0'
 		}
 	}
 	LPVOID result = (LPVOID)malloc( (bIsUnicode ? sizeof(WCHAR) : sizeof(char)) * (bufLen + 1) );
@@ -225,7 +225,7 @@ static BOOL CreateEnvironmentString(PyObject *env, LPVOID *ppRet, BOOL *pRetIsUn
 			pUCur += wcslen(pTemp);
 			PyWinObject_FreeBstr(pTemp);
 		} else {
-			char *pTemp = PyString_AsString(key);
+			char *pTemp = PyBytes_AsString(key);
 			strcpy(pACur, pTemp);
 			pACur += strlen(pTemp);
 		}
@@ -240,7 +240,7 @@ static BOOL CreateEnvironmentString(PyObject *env, LPVOID *ppRet, BOOL *pRetIsUn
 			pUCur += wcslen(pTemp);
 			PyWinObject_FreeBstr(pTemp);
 		} else {
-			char *pTemp = PyString_AsString(val);
+			char *pTemp = PyBytes_AsString(val);
 			strcpy(pACur, pTemp);
 			pACur += strlen(pTemp);
 		}
@@ -765,7 +765,7 @@ PyObject *PyCeReadFile(PyObject *self, PyObject *args)
 		free(buf);
 		return PyWin_SetAPIError("CeReadFile", GetLastCEError());
 	}
-	return PyString_FromStringAndSize((char *)buf, numRead);
+	return PyBytes_FromStringAndSize((char *)buf, numRead);
 }
 %}
 %native (CeReadFile) PyCeReadFile;

--- a/win32/src/wincerapi_reg.cpp
+++ b/win32/src/wincerapi_reg.cpp
@@ -40,9 +40,9 @@ BOOL PyWinObject_CloseCEHKEY(PyObject *obHandle)
         // Python error already set.
         ok = ((PyCEHKEY *)obHandle)->Close();
     else if
-        PyInt_Check(obHandle)
+        PyLong_Check(obHandle)
         {
-            PyW32_BEGIN_ALLOW_THREADS long rc = ::CeRegCloseKey((HKEY)PyInt_AsLong(obHandle));
+            PyW32_BEGIN_ALLOW_THREADS long rc = ::CeRegCloseKey((HKEY)PyLong_AsLong(obHandle));
             PyW32_END_ALLOW_THREADS ok = (rc == ERROR_SUCCESS);
             if (!ok)
                 PyWin_SetAPIError("CeRegCloseKey", rc);
@@ -237,7 +237,7 @@ static int Py2Reg(PyObject *value, DWORD typ, BYTE **retDataBuf, DWORD *retDataS
     int i, j;
     switch (typ) {
         case REG_DWORD:
-            if (value != Py_None && !PyInt_Check(value))
+            if (value != Py_None && !PyLong_Check(value))
                 return 0;
             *retDataBuf = (BYTE *)PyMem_NEW(DWORD, 1);
             *retDataSize = sizeof(DWORD);
@@ -246,7 +246,7 @@ static int Py2Reg(PyObject *value, DWORD typ, BYTE **retDataBuf, DWORD *retDataS
                 memcpy(*retDataBuf, &zero, sizeof(DWORD));
             }
             else
-                memcpy(*retDataBuf, &PyInt_AS_LONG((PyIntObject *)value), sizeof(DWORD));
+                memcpy(*retDataBuf, &PyLong_AS_LONG((PyIntObject *)value), sizeof(DWORD));
             break;
         case REG_SZ:
         case REG_EXPAND_SZ: {

--- a/win32/src/wincerapi_reg.cpp
+++ b/win32/src/wincerapi_reg.cpp
@@ -312,11 +312,11 @@ static int Py2Reg(PyObject *value, DWORD typ, BYTE **retDataBuf, DWORD *retDataS
             if (value == Py_None)
                 *retDataSize = 0;
             else {
-                if (!PyString_Check(value))
+                if (!PyBytes_Check(value))
                     return 0;
-                *retDataSize = PyString_Size(value);
+                *retDataSize = PyBytes_Size(value);
                 *retDataBuf = (BYTE *)PyMem_NEW(char, *retDataSize);
-                memcpy(*retDataBuf, PyString_AS_STRING((PyStringObject *)value), *retDataSize);
+                memcpy(*retDataBuf, PyBytes_AS_STRING((PyStringObject *)value), *retDataSize);
             }
             break;
     }


### PR DESCRIPTION
Lots of the code was still using py2k-isms with typedefs to use the correct names. This is no longer necessary and can cause confusion, so this removes that.