### PR TITLE
Fixed support for unicode as a `win32crypt.CREDENTIAL_ATTRIBUTE.Value`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,8 @@ Note that build 228 was the last version supporting Python 2.
 
 Since build 301:
 ----------------
+* Fixed support for unicode as a `win32crypt.CREDENTIAL_ATTRIBUTE.Value`
+
 * Support for Python 10, dropped support for Python 3.5 (3.5 security support
   ended 13 Sep 2020)
 

--- a/win32/Demos/win32cred_demo.py
+++ b/win32/Demos/win32cred_demo.py
@@ -22,7 +22,7 @@ target, pwd, save = win32cred.CredUIPromptForCredentials(
 
 attrs = [
     {"Keyword": "attr1", "Flags": 0, "Value": "unicode data"},
-    {"Keyword": "attr2", "Flags": 0, "Value": "character data"},
+    {"Keyword": "attr2", "Flags": 0, "Value": b"character data"},
 ]
 cred = {
     "Comment": "Created by win32cred_demo.py",
@@ -41,29 +41,38 @@ print(win32cred.CredRead(target, win32cred.CRED_TYPE_DOMAIN_PASSWORD))
 
 ## Marshal saved credential and use it to log on
 mc = win32cred.CredMarshalCredential(win32cred.UsernameTargetCredential, target)
-th = win32security.LogonUser(
-    mc, None, "", win32con.LOGON32_LOGON_INTERACTIVE, win32con.LOGON32_PROVIDER_DEFAULT
-)
-win32security.ImpersonateLoggedOnUser(th)
-print("GetUserName:", win32api.GetUserName())
-win32security.RevertToSelf()
 
-## Load user's profile.  (first check if user has a roaming profile)
-username, domain = win32cred.CredUIParseUserName(target)
-user_info_4 = win32net.NetUserGetInfo(None, username, 4)
-profilepath = user_info_4["profile"]
-## LoadUserProfile apparently doesn't like an empty string
-if not profilepath:
-    profilepath = None
+# As of pywin32 301 this no longer works for markh and unclear when it stopped, or
+# even if it ever did! # Fails in Python 2.7 too, so not a 3.x regression.
+try:
+    th = win32security.LogonUser(
+        mc,
+        None,
+        "",
+        win32con.LOGON32_LOGON_INTERACTIVE,
+        win32con.LOGON32_PROVIDER_DEFAULT,
+    )
+    win32security.ImpersonateLoggedOnUser(th)
+    print("GetUserName:", win32api.GetUserName())
+    win32security.RevertToSelf()
 
-## leave Flags in since 2.3 still chokes on some types of optional keyword args
-hk = win32profile.LoadUserProfile(
-    th, {"UserName": username, "Flags": 0, "ProfilePath": profilepath}
-)
-## Get user's environment variables in a form that can be passed to win32process.CreateProcessAsUser
-env = win32profile.CreateEnvironmentBlock(th, False)
+    ## Load user's profile.  (first check if user has a roaming profile)
+    username, domain = win32cred.CredUIParseUserName(target)
+    user_info_4 = win32net.NetUserGetInfo(None, username, 4)
+    profilepath = user_info_4["profile"]
+    ## LoadUserProfile apparently doesn't like an empty string
+    if not profilepath:
+        profilepath = None
 
+    ## leave Flags in since 2.3 still chokes on some types of optional keyword args
+    hk = win32profile.LoadUserProfile(
+        th, {"UserName": username, "Flags": 0, "ProfilePath": profilepath}
+    )
+    ## Get user's environment variables in a form that can be passed to win32process.CreateProcessAsUser
+    env = win32profile.CreateEnvironmentBlock(th, False)
 
-## Cleanup should probably be in a finally block
-win32profile.UnloadUserProfile(th, hk)
-th.Close()
+    ## Cleanup should probably be in a finally block
+    win32profile.UnloadUserProfile(th, hk)
+    th.Close()
+except win32security.error as exc:
+    print("Failed to login for some reason", exc)


### PR DESCRIPTION
Should fix #1710 