### PR TITLE
Publish documentation to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: '3.9'
 
     - name: Install latest release
-      run: pip install --user pywin32
+      run: pip install --user --upgrade pywin32
 
     - name: Set Python user site directory
       run: python -c "import os,site;open(os.environ['GITHUB_ENV'], 'a').write(f'USER_DIR={site.USER_SITE}\n')"


### PR DESCRIPTION
This makes it so release tags or any tag starting with `publish-docs` (for manual triggers if needed) will publish the documentation for the latest release on PyPI to [GitHub Pages](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages). Docs are also decompiled on pushes to master but not published just in case any errors eventually arise.

After the potential merge and manual trigger, you'd then go to https://github.com/mhammond/pywin32/settings/pages and choose the `gh-pages` branch in the dropdown. At that point you're all done and the docs will be available for viewing for free at https://mhammond.github.io/pywin32/.

Notes:

1. Unlike http://timgolden.me.uk/pywin32-docs/, I made the root be http://timgolden.me.uk/pywin32-docs/PyWin32.html and there is no table of contents like http://timgolden.me.uk/pywin32-docs/contents.html. I assume he adds those.
2. ~For some reason unlike my other sites, omitting the trailing slash at the end of the URL will not automatically redirect, so you may want to document it as https://mhammond.github.io/pywin32/index.html.~ fixed