### PR TITLE
Allow tests to run on Python 3.11.

### DIFF
--- a/com/win32com/test/testArrays.py
+++ b/com/win32com/test/testArrays.py
@@ -58,7 +58,7 @@ class ArrayTest(util.TestCase):
 
     def _doTest(self, array):
         self.arr.Array = array
-        self.failUnlessEqual(_normalize_array(self.arr.Array), array)
+        self.assertEqual(_normalize_array(self.arr.Array), array)
 
     def testZeroD(self):
         self._doTest(ZeroD)

--- a/com/win32com/test/testMarshal.py
+++ b/com/win32com/test/testMarshal.py
@@ -138,11 +138,11 @@ class ThreadInterpCase(InterpCase):
                 break
         for t in threads:
             t.join(2)
-            self.failIf(t.is_alive(), "thread failed to stop!?")
+            self.assertFalse(t.is_alive(), "thread failed to stop!?")
         threads = None  # threads hold references to args
         # Seems to be a leak here I can't locate :(
-        # self.failUnlessEqual(pythoncom._GetInterfaceCount(), 0)
-        # self.failUnlessEqual(pythoncom._GetGatewayCount(), 0)
+        # self.assertEqual(pythoncom._GetInterfaceCount(), 0)
+        # self.assertEqual(pythoncom._GetGatewayCount(), 0)
 
     def testSimpleMarshal(self):
         self._DoTestMarshal(self.BeginThreadsSimpleMarshal)

--- a/com/win32com/test/testShell.py
+++ b/com/win32com/test/testShell.py
@@ -243,26 +243,26 @@ class FileOperationTester(win32com.test.util.TestCase):
         s = (0, FO_COPY, self.src_name, self.dest_name)  # hwnd,  # operation
 
         rc, aborted = shell.SHFileOperation(s)
-        self.failUnless(not aborted)
-        self.failUnlessEqual(0, rc)
-        self.failUnless(os.path.isfile(self.src_name))
-        self.failUnless(os.path.isfile(self.dest_name))
+        self.assertTrue(not aborted)
+        self.assertEqual(0, rc)
+        self.assertTrue(os.path.isfile(self.src_name))
+        self.assertTrue(os.path.isfile(self.dest_name))
 
     def testRename(self):
         s = (0, FO_RENAME, self.src_name, self.dest_name)  # hwnd,  # operation
         rc, aborted = shell.SHFileOperation(s)
-        self.failUnless(not aborted)
-        self.failUnlessEqual(0, rc)
-        self.failUnless(os.path.isfile(self.dest_name))
-        self.failUnless(not os.path.isfile(self.src_name))
+        self.assertTrue(not aborted)
+        self.assertEqual(0, rc)
+        self.assertTrue(os.path.isfile(self.dest_name))
+        self.assertTrue(not os.path.isfile(self.src_name))
 
     def testMove(self):
         s = (0, FO_MOVE, self.src_name, self.dest_name)  # hwnd,  # operation
         rc, aborted = shell.SHFileOperation(s)
-        self.failUnless(not aborted)
-        self.failUnlessEqual(0, rc)
-        self.failUnless(os.path.isfile(self.dest_name))
-        self.failUnless(not os.path.isfile(self.src_name))
+        self.assertTrue(not aborted)
+        self.assertEqual(0, rc)
+        self.assertTrue(os.path.isfile(self.dest_name))
+        self.assertTrue(not os.path.isfile(self.src_name))
 
     def testDelete(self):
         s = (
@@ -273,9 +273,9 @@ class FileOperationTester(win32com.test.util.TestCase):
             FOF_NOCONFIRMATION,
         )
         rc, aborted = shell.SHFileOperation(s)
-        self.failUnless(not aborted)
-        self.failUnlessEqual(0, rc)
-        self.failUnless(not os.path.isfile(self.src_name))
+        self.assertTrue(not aborted)
+        self.assertEqual(0, rc)
+        self.assertTrue(not os.path.isfile(self.src_name))
 
 
 if __name__ == "__main__":

--- a/com/win32com/test/testStreams.py
+++ b/com/win32com/test/testStreams.py
@@ -141,8 +141,8 @@ class StreamTest(win32com.test.util.TestCase):
         win32com.test.util.restore_test_logger(old_log)
         # expecting 2 pythoncom errors to have been raised by the gateways.
         self.assertEqual(len(records), 2)
-        self.failUnless(records[0].msg.startswith("pythoncom error"))
-        self.failUnless(records[1].msg.startswith("pythoncom error"))
+        self.assertTrue(records[0].msg.startswith("pythoncom error"))
+        self.assertTrue(records[1].msg.startswith("pythoncom error"))
 
 
 if __name__ == "__main__":

--- a/com/win32com/test/testWMI.py
+++ b/com/win32com/test/testWMI.py
@@ -11,7 +11,7 @@ class Simple(win32com.test.util.TestCase):
         for cs in cses:
             val = cs.Properties_("Caption").Value
             vals.append(val)
-        self.failIf(len(vals) < 5, "We only found %d processes!" % len(vals))
+        self.assertFalse(len(vals) < 5, "We only found %d processes!" % len(vals))
 
 
 if __name__ == "__main__":

--- a/com/win32comext/axscript/test/testHost.py
+++ b/com/win32comext/axscript/test/testHost.py
@@ -180,12 +180,12 @@ class EngineTester(win32com.test.util.TestCase):
             engine.AddCode(code)
             engine.Start()
             _CheckEngineState(site, engineName, axscript.SCRIPTSTATE_STARTED)
-            self.failUnless(not echoer.fail_called, "Fail should not have been called")
+            self.assertTrue(not echoer.fail_called, "Fail should not have been called")
             # Now call into the scripts IDispatch
             ob = Dispatch(engine.GetScriptDispatch())
             try:
                 ob.hello("Goober")
-                self.failUnless(
+                self.assertTrue(
                     expected_exc is None,
                     "Expected %r, but no exception seen" % (expected_exc,),
                 )
@@ -205,7 +205,7 @@ class EngineTester(win32com.test.util.TestCase):
 
             self.assertEqual(str(ob.prop), "Property Value")
             ob.testcollection()
-            self.failUnless(not echoer.fail_called, "Fail should not have been called")
+            self.assertTrue(not echoer.fail_called, "Fail should not have been called")
 
             # Now make sure my engines can evaluate stuff.
             result = engine.eParse.ParseScriptText(

--- a/win32/Lib/pywin32_testutil.py
+++ b/win32/Lib/pywin32_testutil.py
@@ -198,9 +198,15 @@ class TestSkipped(Exception):
     pass
 
 
+# This appears to have been "upgraded" to non-private in 3.11
+try:
+    TextTestResult = unittest._TextTestResult
+except AttributeError:
+    TextTestResult = unittest.TextTestResult
+
 # The 'TestResult' subclass that records the failures and has the special
 # handling for the TestSkipped exception.
-class TestResult(unittest._TextTestResult):
+class TestResult(TextTestResult):
     def __init__(self, *args, **kw):
         super(TestResult, self).__init__(*args, **kw)
         self.skips = {}  # count of skips for each reason.

--- a/win32/test/handles.py
+++ b/win32/test/handles.py
@@ -87,7 +87,7 @@ class PyHandleTestCase(unittest.TestCase):
     def testOtherHandle(self):
         h = pywintypes.HANDLE(1)
         h2 = pywintypes.HANDLE(h)
-        self.failUnlessEqual(h, h2)
+        self.assertEqual(h, h2)
         # but the above doesn't really test everything - we want a way to
         # pass the handle directly into PyWinLong_AsVoidPtr.  One way to
         # to that is to abuse win32api.GetProcAddress() - the 2nd param
@@ -99,41 +99,41 @@ class PyHandleTestCase(unittest.TestCase):
     def testHandleInDict(self):
         h = pywintypes.HANDLE(1)
         d = dict(foo=h)
-        self.failUnlessEqual(d["foo"], h)
+        self.assertEqual(d["foo"], h)
 
     def testHandleInDictThenInt(self):
         h = pywintypes.HANDLE(1)
         d = dict(foo=h)
-        self.failUnlessEqual(d["foo"], 1)
+        self.assertEqual(d["foo"], 1)
 
     def testHandleCompareNone(self):
         h = pywintypes.HANDLE(1)
-        self.failIfEqual(h, None)
-        self.failIfEqual(None, h)
+        self.assertNotEqual(h, None)
+        self.assertNotEqual(None, h)
         # ensure we use both __eq__ and __ne__ ops
-        self.failIf(h == None)
-        self.failUnless(h != None)
+        self.assertFalse(h == None)
+        self.assertTrue(h != None)
 
     def testHandleCompareInt(self):
         h = pywintypes.HANDLE(1)
-        self.failIfEqual(h, 0)
-        self.failUnlessEqual(h, 1)
+        self.assertNotEqual(h, 0)
+        self.assertEqual(h, 1)
         # ensure we use both __eq__ and __ne__ ops
-        self.failUnless(h == 1)
-        self.failUnless(1 == h)
-        self.failIf(h != 1)
-        self.failIf(1 != h)
-        self.failIf(h == 0)
-        self.failIf(0 == h)
-        self.failUnless(h != 0)
-        self.failUnless(0 != h)
+        self.assertTrue(h == 1)
+        self.assertTrue(1 == h)
+        self.assertFalse(h != 1)
+        self.assertFalse(1 != h)
+        self.assertFalse(h == 0)
+        self.assertFalse(0 == h)
+        self.assertTrue(h != 0)
+        self.assertTrue(0 != h)
 
     def testHandleNonZero(self):
         h = pywintypes.HANDLE(0)
-        self.failIf(h)
+        self.assertFalse(h)
 
         h = pywintypes.HANDLE(1)
-        self.failUnless(h)
+        self.assertTrue(h)
 
     def testLong(self):
         # sys.maxint+1 should always be a 'valid' handle, treated as an

--- a/win32/test/test_clipboard.py
+++ b/win32/test/test_clipboard.py
@@ -38,12 +38,12 @@ class TestBitmap(unittest.TestCase):
         self.bmp_name = os.path.join(
             os.path.abspath(this_dir), "..", "Demos", "images", "smiley.bmp"
         )
-        self.failUnless(os.path.isfile(self.bmp_name), self.bmp_name)
+        self.assertTrue(os.path.isfile(self.bmp_name), self.bmp_name)
         flags = win32con.LR_DEFAULTSIZE | win32con.LR_LOADFROMFILE
         self.bmp_handle = win32gui.LoadImage(
             0, self.bmp_name, win32con.IMAGE_BITMAP, 0, 0, flags
         )
-        self.failUnless(self.bmp_handle, "Failed to get a bitmap handle")
+        self.assertTrue(self.bmp_handle, "Failed to get a bitmap handle")
 
     def tearDown(self):
         if self.bmp_handle:
@@ -54,7 +54,7 @@ class TestBitmap(unittest.TestCase):
         try:
             SetClipboardData(win32con.CF_BITMAP, self.bmp_handle)
             got_handle = GetClipboardDataHandle(win32con.CF_BITMAP)
-            self.failUnlessEqual(got_handle, self.bmp_handle)
+            self.assertEqual(got_handle, self.bmp_handle)
         finally:
             CloseClipboard()
 
@@ -69,7 +69,7 @@ class TestStrings(unittest.TestCase):
     def test_unicode(self):
         val = "test-\a9har"
         SetClipboardData(win32con.CF_UNICODETEXT, val)
-        self.failUnlessEqual(GetClipboardData(win32con.CF_UNICODETEXT), val)
+        self.assertEqual(GetClipboardData(win32con.CF_UNICODETEXT), val)
 
     def test_unicode_text(self):
         val = "test-val"
@@ -77,14 +77,14 @@ class TestStrings(unittest.TestCase):
         # GetClipboardData doesn't to auto string conversions - so on py3k,
         # CF_TEXT returns bytes.
         expected = str2bytes(val)
-        self.failUnlessEqual(GetClipboardData(win32con.CF_TEXT), expected)
+        self.assertEqual(GetClipboardData(win32con.CF_TEXT), expected)
         SetClipboardText(val, win32con.CF_UNICODETEXT)
-        self.failUnlessEqual(GetClipboardData(win32con.CF_UNICODETEXT), val)
+        self.assertEqual(GetClipboardData(win32con.CF_UNICODETEXT), val)
 
     def test_string(self):
         val = str2bytes("test")
         SetClipboardData(win32con.CF_TEXT, val)
-        self.failUnlessEqual(GetClipboardData(win32con.CF_TEXT), val)
+        self.assertEqual(GetClipboardData(win32con.CF_TEXT), val)
 
 
 class TestGlobalMemory(unittest.TestCase):
@@ -100,26 +100,26 @@ class TestGlobalMemory(unittest.TestCase):
         SetClipboardData(win32con.CF_TEXT, val)
         # Get the raw data - this will include the '\0'
         raw_data = GetGlobalMemory(GetClipboardDataHandle(win32con.CF_TEXT))
-        self.failUnlessEqual(expected, raw_data)
+        self.assertEqual(expected, raw_data)
 
     def test_bad_mem(self):
-        self.failUnlessRaises(pywintypes.error, GetGlobalMemory, 0)
-        self.failUnlessRaises(pywintypes.error, GetGlobalMemory, -1)
+        self.assertRaises(pywintypes.error, GetGlobalMemory, 0)
+        self.assertRaises(pywintypes.error, GetGlobalMemory, -1)
         if sys.getwindowsversion()[0] <= 5:
             # For some reason, the value '1' dies from a 64bit process, but
             # "works" (ie, gives the correct exception) from a 32bit process.
             # just silently skip this value on Vista.
-            self.failUnlessRaises(pywintypes.error, GetGlobalMemory, 1)
+            self.assertRaises(pywintypes.error, GetGlobalMemory, 1)
 
     def test_custom_mem(self):
         test_data = str2bytes("hello\x00\xff")
         test_buffer = array.array("b", test_data)
         cf = RegisterClipboardFormat(custom_format_name)
-        self.failUnlessEqual(custom_format_name, GetClipboardFormatName(cf))
+        self.assertEqual(custom_format_name, GetClipboardFormatName(cf))
         SetClipboardData(cf, test_buffer)
         hglobal = GetClipboardDataHandle(cf)
         data = GetGlobalMemory(hglobal)
-        self.failUnlessEqual(data, test_data)
+        self.assertEqual(data, test_data)
 
 
 if __name__ == "__main__":

--- a/win32/test/test_exceptions.py
+++ b/win32/test/test_exceptions.py
@@ -10,9 +10,9 @@ class TestBase(unittest.TestCase):
     def _testExceptionIndex(self, exc, index, expected):
         # check the exception itself can be indexed if not py3k
         if sys.version_info < (3,):
-            self.failUnlessEqual(exc[index], expected)
+            self.assertEqual(exc[index], expected)
         # and that exception.args can is the same.
-        self.failUnlessEqual(exc.args[index], expected)
+        self.assertEqual(exc.args[index], expected)
 
 
 class TestAPISimple(TestBase):
@@ -44,19 +44,19 @@ class TestAPISimple(TestBase):
             win32api.CloseHandle(1)
             self.fail("expected exception!")
         except win32api.error as exc:
-            self.failUnlessEqual(exc.winerror, winerror.ERROR_INVALID_HANDLE)
-            self.failUnlessEqual(exc.funcname, "CloseHandle")
+            self.assertEqual(exc.winerror, winerror.ERROR_INVALID_HANDLE)
+            self.assertEqual(exc.funcname, "CloseHandle")
             expected_msg = win32api.FormatMessage(
                 winerror.ERROR_INVALID_HANDLE
             ).rstrip()
-            self.failUnlessEqual(exc.strerror, expected_msg)
+            self.assertEqual(exc.strerror, expected_msg)
 
     def testAsStr(self):
         exc = self._getInvalidHandleException()
         err_msg = win32api.FormatMessage(winerror.ERROR_INVALID_HANDLE).rstrip()
         # early on the result actually *was* a tuple - it must always look like one
         err_tuple = (winerror.ERROR_INVALID_HANDLE, "CloseHandle", err_msg)
-        self.failUnlessEqual(str(exc), str(err_tuple))
+        self.assertEqual(str(exc), str(err_tuple))
 
     def testAsTuple(self):
         exc = self._getInvalidHandleException()
@@ -64,28 +64,28 @@ class TestAPISimple(TestBase):
         # early on the result actually *was* a tuple - it must be able to be one
         err_tuple = (winerror.ERROR_INVALID_HANDLE, "CloseHandle", err_msg)
         if sys.version_info < (3,):
-            self.failUnlessEqual(tuple(exc), err_tuple)
+            self.assertEqual(tuple(exc), err_tuple)
         else:
-            self.failUnlessEqual(exc.args, err_tuple)
+            self.assertEqual(exc.args, err_tuple)
 
     def testClassName(self):
         exc = self._getInvalidHandleException()
         # The error class has always been named 'error'.  That's not ideal :(
-        self.failUnlessEqual(exc.__class__.__name__, "error")
+        self.assertEqual(exc.__class__.__name__, "error")
 
     def testIdentity(self):
         exc = self._getInvalidHandleException()
-        self.failUnless(exc.__class__ is pywintypes.error)
+        self.assertTrue(exc.__class__ is pywintypes.error)
 
     def testBaseClass(self):
-        self.failUnlessEqual(pywintypes.error.__bases__, (Exception,))
+        self.assertEqual(pywintypes.error.__bases__, (Exception,))
 
     def testAttributes(self):
         exc = self._getInvalidHandleException()
         err_msg = win32api.FormatMessage(winerror.ERROR_INVALID_HANDLE).rstrip()
-        self.failUnlessEqual(exc.winerror, winerror.ERROR_INVALID_HANDLE)
-        self.failUnlessEqual(exc.strerror, err_msg)
-        self.failUnlessEqual(exc.funcname, "CloseHandle")
+        self.assertEqual(exc.winerror, winerror.ERROR_INVALID_HANDLE)
+        self.assertEqual(exc.strerror, err_msg)
+        self.assertEqual(exc.funcname, "CloseHandle")
 
     # some tests for 'insane' args.
     def testStrangeArgsNone(self):
@@ -93,10 +93,10 @@ class TestAPISimple(TestBase):
             raise pywintypes.error()
             self.fail("Expected exception")
         except pywintypes.error as exc:
-            self.failUnlessEqual(exc.args, ())
-            self.failUnlessEqual(exc.winerror, None)
-            self.failUnlessEqual(exc.funcname, None)
-            self.failUnlessEqual(exc.strerror, None)
+            self.assertEqual(exc.args, ())
+            self.assertEqual(exc.winerror, None)
+            self.assertEqual(exc.funcname, None)
+            self.assertEqual(exc.strerror, None)
 
     def testStrangeArgsNotEnough(self):
         try:
@@ -105,20 +105,20 @@ class TestAPISimple(TestBase):
         except pywintypes.error as exc:
             assert exc.args[0] == "foo"
             # 'winerror' always args[0]
-            self.failUnlessEqual(exc.winerror, "foo")
-            self.failUnlessEqual(exc.funcname, None)
-            self.failUnlessEqual(exc.strerror, None)
+            self.assertEqual(exc.winerror, "foo")
+            self.assertEqual(exc.funcname, None)
+            self.assertEqual(exc.strerror, None)
 
     def testStrangeArgsTooMany(self):
         try:
             raise pywintypes.error("foo", "bar", "you", "never", "kn", 0)
             self.fail("Expected exception")
         except pywintypes.error as exc:
-            self.failUnlessEqual(exc.args[0], "foo")
-            self.failUnlessEqual(exc.args[-1], 0)
-            self.failUnlessEqual(exc.winerror, "foo")
-            self.failUnlessEqual(exc.funcname, "bar")
-            self.failUnlessEqual(exc.strerror, "you")
+            self.assertEqual(exc.args[0], "foo")
+            self.assertEqual(exc.args[-1], 0)
+            self.assertEqual(exc.winerror, "foo")
+            self.assertEqual(exc.funcname, "bar")
+            self.assertEqual(exc.strerror, "you")
 
 
 class TestCOMSimple(TestBase):
@@ -130,7 +130,7 @@ class TestCOMSimple(TestBase):
         self.fail("Didn't get storage exception.")
 
     def testIs(self):
-        self.failUnless(pythoncom.com_error is pywintypes.com_error)
+        self.assertTrue(pythoncom.com_error is pywintypes.com_error)
 
     def testSimple(self):
         self.assertRaises(pythoncom.com_error, pythoncom.StgOpenStorage, "foo", None, 0)
@@ -149,7 +149,7 @@ class TestCOMSimple(TestBase):
         err_msg = win32api.FormatMessage(winerror.STG_E_INVALIDFLAG).rstrip()
         # early on the result actually *was* a tuple - it must always look like one
         err_tuple = (winerror.STG_E_INVALIDFLAG, err_msg, None, None)
-        self.failUnlessEqual(str(exc), str(err_tuple))
+        self.assertEqual(str(exc), str(err_tuple))
 
     def testAsTuple(self):
         exc = self._getException()
@@ -157,63 +157,63 @@ class TestCOMSimple(TestBase):
         # early on the result actually *was* a tuple - it must be able to be one
         err_tuple = (winerror.STG_E_INVALIDFLAG, err_msg, None, None)
         if sys.version_info < (3,):
-            self.failUnlessEqual(tuple(exc), err_tuple)
+            self.assertEqual(tuple(exc), err_tuple)
         else:
-            self.failUnlessEqual(exc.args, err_tuple)
+            self.assertEqual(exc.args, err_tuple)
 
     def testClassName(self):
         exc = self._getException()
-        self.failUnlessEqual(exc.__class__.__name__, "com_error")
+        self.assertEqual(exc.__class__.__name__, "com_error")
 
     def testIdentity(self):
         exc = self._getException()
-        self.failUnless(exc.__class__ is pywintypes.com_error)
+        self.assertTrue(exc.__class__ is pywintypes.com_error)
 
     def testBaseClass(self):
         exc = self._getException()
-        self.failUnlessEqual(pywintypes.com_error.__bases__, (Exception,))
+        self.assertEqual(pywintypes.com_error.__bases__, (Exception,))
 
     def testAttributes(self):
         exc = self._getException()
         err_msg = win32api.FormatMessage(winerror.STG_E_INVALIDFLAG).rstrip()
-        self.failUnlessEqual(exc.hresult, winerror.STG_E_INVALIDFLAG)
-        self.failUnlessEqual(exc.strerror, err_msg)
-        self.failUnlessEqual(exc.argerror, None)
-        self.failUnlessEqual(exc.excepinfo, None)
+        self.assertEqual(exc.hresult, winerror.STG_E_INVALIDFLAG)
+        self.assertEqual(exc.strerror, err_msg)
+        self.assertEqual(exc.argerror, None)
+        self.assertEqual(exc.excepinfo, None)
 
     def testStrangeArgsNone(self):
         try:
             raise pywintypes.com_error()
             self.fail("Expected exception")
         except pywintypes.com_error as exc:
-            self.failUnlessEqual(exc.args, ())
-            self.failUnlessEqual(exc.hresult, None)
-            self.failUnlessEqual(exc.strerror, None)
-            self.failUnlessEqual(exc.argerror, None)
-            self.failUnlessEqual(exc.excepinfo, None)
+            self.assertEqual(exc.args, ())
+            self.assertEqual(exc.hresult, None)
+            self.assertEqual(exc.strerror, None)
+            self.assertEqual(exc.argerror, None)
+            self.assertEqual(exc.excepinfo, None)
 
     def testStrangeArgsNotEnough(self):
         try:
             raise pywintypes.com_error("foo")
             self.fail("Expected exception")
         except pywintypes.com_error as exc:
-            self.failUnlessEqual(exc.args[0], "foo")
-            self.failUnlessEqual(exc.hresult, "foo")
-            self.failUnlessEqual(exc.strerror, None)
-            self.failUnlessEqual(exc.excepinfo, None)
-            self.failUnlessEqual(exc.argerror, None)
+            self.assertEqual(exc.args[0], "foo")
+            self.assertEqual(exc.hresult, "foo")
+            self.assertEqual(exc.strerror, None)
+            self.assertEqual(exc.excepinfo, None)
+            self.assertEqual(exc.argerror, None)
 
     def testStrangeArgsTooMany(self):
         try:
             raise pywintypes.com_error("foo", "bar", "you", "never", "kn", 0)
             self.fail("Expected exception")
         except pywintypes.com_error as exc:
-            self.failUnlessEqual(exc.args[0], "foo")
-            self.failUnlessEqual(exc.args[-1], 0)
-            self.failUnlessEqual(exc.hresult, "foo")
-            self.failUnlessEqual(exc.strerror, "bar")
-            self.failUnlessEqual(exc.excepinfo, "you")
-            self.failUnlessEqual(exc.argerror, "never")
+            self.assertEqual(exc.args[0], "foo")
+            self.assertEqual(exc.args[-1], 0)
+            self.assertEqual(exc.hresult, "foo")
+            self.assertEqual(exc.strerror, "bar")
+            self.assertEqual(exc.excepinfo, "you")
+            self.assertEqual(exc.argerror, "never")
 
 
 if __name__ == "__main__":

--- a/win32/test/test_odbc.py
+++ b/win32/test/test_odbc.py
@@ -174,9 +174,9 @@ class TestStuff(unittest.TestCase):
                 ["Frank"],
             )
             rows = self.cur.fetchmany()
-            self.failUnlessEqual(1, len(rows))
+            self.assertEqual(1, len(rows))
             row = rows[0]
-            self.failUnlessEqual(row[0], value)
+            self.assertEqual(row[0], value)
 
     def testBit(self):
         self._test_val("bitfield", 1)

--- a/win32/test/test_pywintypes.py
+++ b/win32/test/test_pywintypes.py
@@ -34,25 +34,25 @@ class TestCase(unittest.TestCase):
     def testTimeInDict(self):
         d = {}
         d["t1"] = pywintypes.Time(1)
-        self.failUnlessEqual(d["t1"], pywintypes.Time(1))
+        self.assertEqual(d["t1"], pywintypes.Time(1))
 
     def testPyTimeCompare(self):
         t1 = pywintypes.Time(100)
         t1_2 = pywintypes.Time(100)
         t2 = pywintypes.Time(101)
 
-        self.failUnlessEqual(t1, t1_2)
-        self.failUnless(t1 <= t1_2)
-        self.failUnless(t1_2 >= t1)
+        self.assertEqual(t1, t1_2)
+        self.assertTrue(t1 <= t1_2)
+        self.assertTrue(t1_2 >= t1)
 
-        self.failIfEqual(t1, t2)
-        self.failUnless(t1 < t2)
-        self.failUnless(t2 > t1)
+        self.assertNotEqual(t1, t2)
+        self.assertTrue(t1 < t2)
+        self.assertTrue(t2 > t1)
 
     def testPyTimeCompareOther(self):
         t1 = pywintypes.Time(100)
         t2 = None
-        self.failIfEqual(t1, t2)
+        self.assertNotEqual(t1, t2)
 
     def testTimeTuple(self):
         now = datetime.datetime.now()  # has usec...
@@ -60,7 +60,7 @@ class TestCase(unittest.TestCase):
         pt = pywintypes.Time(now.timetuple())
         # *sob* - only if we have a datetime object can we compare like this.
         if isinstance(pt, datetime.datetime):
-            self.failUnless(pt <= now)
+            self.assertTrue(pt <= now)
 
     def testTimeTuplems(self):
         now = datetime.datetime.now()  # has usec...
@@ -74,12 +74,12 @@ class TestCase(unittest.TestCase):
 
     def testPyTimeFromTime(self):
         t1 = pywintypes.Time(time.time())
-        self.failUnless(pywintypes.Time(t1) is t1)
+        self.assertTrue(pywintypes.Time(t1) is t1)
 
     def testPyTimeTooLarge(self):
         MAX_TIMESTAMP = 0x7FFFFFFFFFFFFFFF  # used by some API function to mean "never"
         ts = pywintypes.TimeStamp(MAX_TIMESTAMP)
-        self.failUnlessEqual(ts, datetime.datetime.max)
+        self.assertEqual(ts, datetime.datetime.max)
 
     def testGUID(self):
         s = "{00020400-0000-0000-C000-000000000046}"
@@ -94,10 +94,10 @@ class TestCase(unittest.TestCase):
     def testGUIDRichCmp(self):
         s = "{00020400-0000-0000-C000-000000000046}"
         iid = pywintypes.IID(s)
-        self.failIf(s == None)
-        self.failIf(None == s)
-        self.failUnless(s != None)
-        self.failUnless(None != s)
+        self.assertFalse(s == None)
+        self.assertFalse(None == s)
+        self.assertTrue(s != None)
+        self.assertTrue(None != s)
         if sys.version_info > (3, 0):
             self.assertRaises(TypeError, operator.gt, None, s)
             self.assertRaises(TypeError, operator.gt, s, None)
@@ -108,7 +108,7 @@ class TestCase(unittest.TestCase):
         s = "{00020400-0000-0000-C000-000000000046}"
         iid = pywintypes.IID(s)
         d = dict(item=iid)
-        self.failUnlessEqual(d["item"], iid)
+        self.assertEqual(d["item"], iid)
 
 
 if __name__ == "__main__":

--- a/win32/test/test_security.py
+++ b/win32/test/test_security.py
@@ -25,31 +25,31 @@ class SecurityTests(unittest.TestCase):
     def testEqual(self):
         if self.admin_sid is None:
             raise TestSkipped("No 'Administrator' account is available")
-        self.failUnlessEqual(
+        self.assertEqual(
             win32security.LookupAccountName("", "Administrator")[0],
             win32security.LookupAccountName("", "Administrator")[0],
         )
 
     def testNESID(self):
-        self.failUnless(self.pwr_sid == self.pwr_sid)
+        self.assertTrue(self.pwr_sid == self.pwr_sid)
         if self.admin_sid:
-            self.failUnless(self.pwr_sid != self.admin_sid)
+            self.assertTrue(self.pwr_sid != self.admin_sid)
 
     def testNEOther(self):
-        self.failUnless(self.pwr_sid != None)
-        self.failUnless(None != self.pwr_sid)
-        self.failIf(self.pwr_sid == None)
-        self.failIf(None == self.pwr_sid)
-        self.failIfEqual(None, self.pwr_sid)
+        self.assertTrue(self.pwr_sid != None)
+        self.assertTrue(None != self.pwr_sid)
+        self.assertFalse(self.pwr_sid == None)
+        self.assertFalse(None == self.pwr_sid)
+        self.assertNotEqual(None, self.pwr_sid)
 
     def testSIDInDict(self):
         d = dict(foo=self.pwr_sid)
-        self.failUnlessEqual(d["foo"], self.pwr_sid)
+        self.assertEqual(d["foo"], self.pwr_sid)
 
     def testBuffer(self):
         if self.admin_sid is None:
             raise TestSkipped("No 'Administrator' account is available")
-        self.failUnlessEqual(
+        self.assertEqual(
             ob2memory(win32security.LookupAccountName("", "Administrator")[0]),
             ob2memory(win32security.LookupAccountName("", "Administrator")[0]),
         )
@@ -121,7 +121,7 @@ class TestDS(DomainTests):
         fmt_offered = ntsecuritycon.DS_FQDN_1779_NAME
         name = win32api.GetUserNameEx(fmt_offered)
         result = win32security.DsCrackNames(h, 0, fmt_offered, fmt_offered, (name,))
-        self.failUnlessEqual(name, result[0][2])
+        self.assertEqual(name, result[0][2])
 
     def testDsCrackNamesSyntax(self):
         # Do a syntax check only - that allows us to avoid binding.
@@ -136,7 +136,7 @@ class TestDS(DomainTests):
             ntsecuritycon.DS_CANONICAL_NAME,
             (name,),
         )
-        self.failUnlessEqual(expected, result[0][2])
+        self.assertEqual(expected, result[0][2])
 
 
 class TestTranslate(DomainTests):
@@ -144,7 +144,7 @@ class TestTranslate(DomainTests):
         name = win32api.GetUserNameEx(fmt_from)
         expected = win32api.GetUserNameEx(fmt_to)
         got = win32security.TranslateName(name, fmt_from, fmt_to)
-        self.failUnlessEqual(got, expected)
+        self.assertEqual(got, expected)
 
     def testTranslate1(self):
         self._testTranslate(win32api.NameFullyQualifiedDN, win32api.NameSamCompatible)

--- a/win32/test/test_sspi.py
+++ b/win32/test/test_sspi.py
@@ -24,7 +24,7 @@ class TestSSPI(unittest.TestCase):
             return func(*args)
             raise RuntimeError("expecting %s failure" % (hr,))
         except win32security.error as exc:
-            self.failUnlessEqual(exc.winerror, hr)
+            self.assertEqual(exc.winerror, hr)
 
     def _doAuth(self, pkg_name):
         sspiclient = sspi.ClientAuth(pkg_name, targetspn=win32api.GetUserName())
@@ -67,7 +67,7 @@ class TestSSPI(unittest.TestCase):
         encbuf[0].Buffer = msg
         sspiclient.ctxt.EncryptMessage(0, encbuf, 1)
         sspiserver.ctxt.DecryptMessage(encbuf, 1)
-        self.failUnlessEqual(msg, encbuf[0].Buffer)
+        self.assertEqual(msg, encbuf[0].Buffer)
         # and test the higher-level functions
         data_in = str2bytes("hello")
         data, sig = sspiclient.encrypt(data_in)
@@ -109,7 +109,7 @@ class TestSSPI(unittest.TestCase):
         decbuf[0].Buffer = encmsg
 
         sspiserver.ctxt.DecryptMessage(decbuf, 1)
-        self.failUnlessEqual(msg, decbuf[1].Buffer)
+        self.assertEqual(msg, decbuf[1].Buffer)
 
     def testEncryptNTLM(self):
         self._doTestEncrypt("NTLM")

--- a/win32/test/test_win32api.py
+++ b/win32/test/test_win32api.py
@@ -12,7 +12,7 @@ import datetime
 class CurrentUserTestCase(unittest.TestCase):
     def testGetCurrentUser(self):
         name = "%s\\%s" % (win32api.GetDomainName(), win32api.GetUserName())
-        self.failUnless(name == win32api.GetUserNameEx(win32api.NameSamCompatible))
+        self.assertTrue(name == win32api.GetUserNameEx(win32api.NameSamCompatible))
 
 
 class TestTime(unittest.TestCase):
@@ -123,11 +123,11 @@ class Registry(unittest.TestCase):
         )
         ret_code = win32event.WaitForSingleObject(evt, 0)
         # Should be no change.
-        self.failUnless(ret_code == win32con.WAIT_TIMEOUT)
+        self.assertTrue(ret_code == win32con.WAIT_TIMEOUT)
         change()
         # Our event should now be in a signalled state.
         ret_code = win32event.WaitForSingleObject(evt, 0)
-        self.failUnless(ret_code == win32con.WAIT_OBJECT_0)
+        self.assertTrue(ret_code == win32con.WAIT_OBJECT_0)
 
 
 class FileNames(unittest.TestCase):
@@ -139,17 +139,17 @@ class FileNames(unittest.TestCase):
         fname = os.path.abspath(me).lower()
         short_name = win32api.GetShortPathName(fname).lower()
         long_name = win32api.GetLongPathName(short_name).lower()
-        self.failUnless(
+        self.assertTrue(
             long_name == fname,
             "Expected long name ('%s') to be original name ('%s')" % (long_name, fname),
         )
-        self.failUnlessEqual(long_name, win32api.GetLongPathNameW(short_name).lower())
+        self.assertEqual(long_name, win32api.GetLongPathNameW(short_name).lower())
         long_name = win32api.GetLongPathNameW(short_name).lower()
-        self.failUnless(
+        self.assertTrue(
             type(long_name) == str,
             "GetLongPathNameW returned type '%s'" % (type(long_name),),
         )
-        self.failUnless(
+        self.assertTrue(
             long_name == fname,
             "Expected long name ('%s') to be original name ('%s')" % (long_name, fname),
         )
@@ -162,19 +162,19 @@ class FileNames(unittest.TestCase):
         fname = os.path.abspath(me).lower()
         # passing unicode should cause GetShortPathNameW to be called.
         short_name = win32api.GetShortPathName(str(fname)).lower()
-        self.failUnless(isinstance(short_name, str))
+        self.assertTrue(isinstance(short_name, str))
         long_name = win32api.GetLongPathName(short_name).lower()
-        self.failUnless(
+        self.assertTrue(
             long_name == fname,
             "Expected long name ('%s') to be original name ('%s')" % (long_name, fname),
         )
-        self.failUnlessEqual(long_name, win32api.GetLongPathNameW(short_name).lower())
+        self.assertEqual(long_name, win32api.GetLongPathNameW(short_name).lower())
         long_name = win32api.GetLongPathNameW(short_name).lower()
-        self.failUnless(
+        self.assertTrue(
             type(long_name) == str,
             "GetLongPathNameW returned type '%s'" % (type(long_name),),
         )
-        self.failUnless(
+        self.assertTrue(
             long_name == fname,
             "Expected long name ('%s') to be original name ('%s')" % (long_name, fname),
         )
@@ -205,10 +205,10 @@ class FileNames(unittest.TestCase):
                     raise
 
             attr = win32api.GetFileAttributes(str(fname))
-            self.failUnless(attr & win32con.FILE_ATTRIBUTE_DIRECTORY, attr)
+            self.assertTrue(attr & win32con.FILE_ATTRIBUTE_DIRECTORY, attr)
 
             long_name = win32api.GetLongPathNameW(fname)
-            self.failUnlessEqual(long_name.lower(), fname.lower())
+            self.assertEqual(long_name.lower(), fname.lower())
         finally:
             win32file.RemoveDirectory(fname)
 
@@ -231,15 +231,15 @@ class Misc(unittest.TestCase):
     def test_last_error(self):
         for x in (0, 1, -1, winerror.TRUST_E_PROVIDER_UNKNOWN):
             win32api.SetLastError(x)
-            self.failUnlessEqual(x, win32api.GetLastError())
+            self.assertEqual(x, win32api.GetLastError())
 
     def testVkKeyScan(self):
         # hopefully ' ' doesn't depend on the locale!
-        self.failUnlessEqual(win32api.VkKeyScan(" "), 32)
+        self.assertEqual(win32api.VkKeyScan(" "), 32)
 
     def testVkKeyScanEx(self):
         # hopefully ' ' doesn't depend on the locale!
-        self.failUnlessEqual(win32api.VkKeyScanEx(" ", 0), 32)
+        self.assertEqual(win32api.VkKeyScanEx(" ", 0), 32)
 
 
 if __name__ == "__main__":

--- a/win32/test/test_win32crypt.py
+++ b/win32/test/test_win32crypt.py
@@ -16,8 +16,8 @@ class Crypt(unittest.TestCase):
         got_desc, got_data = win32crypt.CryptUnprotectData(
             blob, entropy, None, ps, flags
         )
-        self.failUnlessEqual(data, got_data)
-        self.failUnlessEqual(desc, got_desc)
+        self.assertEqual(data, got_data)
+        self.assertEqual(desc, got_desc)
 
     def testEntropy(self):
         data = str2bytes("My test data")
@@ -29,8 +29,8 @@ class Crypt(unittest.TestCase):
         got_desc, got_data = win32crypt.CryptUnprotectData(
             blob, entropy, None, ps, flags
         )
-        self.failUnlessEqual(data, got_data)
-        self.failUnlessEqual(desc, got_desc)
+        self.assertEqual(data, got_data)
+        self.assertEqual(desc, got_desc)
 
 
 if __name__ == "__main__":

--- a/win32/test/test_win32event.py
+++ b/win32/test/test_win32event.py
@@ -12,7 +12,7 @@ class TestWaitableTimer(unittest.TestCase):
         dt = -160  # 160 ns.
         win32event.SetWaitableTimer(h, dt, 0, None, None, 0)
         rc = win32event.WaitForSingleObject(h, 1000)
-        self.failUnlessEqual(rc, win32event.WAIT_OBJECT_0)
+        self.assertEqual(rc, win32event.WAIT_OBJECT_0)
 
     def testWaitableTrigger(self):
         h = win32event.CreateWaitableTimer(None, 0, None)
@@ -20,7 +20,7 @@ class TestWaitableTimer(unittest.TestCase):
         dt = -2000000000
         win32event.SetWaitableTimer(h, dt, 0, None, None, 0)
         rc = win32event.WaitForSingleObject(h, 10)  # 10 ms.
-        self.failUnlessEqual(rc, win32event.WAIT_TIMEOUT)
+        self.assertEqual(rc, win32event.WAIT_TIMEOUT)
 
     def testWaitableError(self):
         h = win32event.CreateWaitableTimer(None, 0, None)

--- a/win32/test/test_win32file.py
+++ b/win32/test/test_win32file.py
@@ -22,7 +22,7 @@ except NameError:
 class TestReadBuffer(unittest.TestCase):
     def testLen(self):
         buffer = win32file.AllocateReadBuffer(1)
-        self.failUnlessEqual(len(buffer), 1)
+        self.assertEqual(len(buffer), 1)
 
     def testSimpleIndex(self):
         buffer = win32file.AllocateReadBuffer(1)
@@ -33,7 +33,7 @@ class TestReadBuffer(unittest.TestCase):
         buffer = win32file.AllocateReadBuffer(2)
         val = str2bytes("\0\0")
         buffer[:2] = val
-        self.failUnlessEqual(buffer[0:2], val)
+        self.assertEqual(buffer[0:2], val)
 
 
 class TestSimpleOps(unittest.TestCase):
@@ -89,7 +89,7 @@ class TestSimpleOps(unittest.TestCase):
 
         win32file.WriteFile(h, data)
 
-        self.failUnless(
+        self.assertTrue(
             win32file.GetFileSize(h) == len(data),
             "WARNING: Written file does not have the same size as the length of the data in it!",
         )
@@ -99,35 +99,35 @@ class TestSimpleOps(unittest.TestCase):
         hr, read_data = win32file.ReadFile(
             h, len(data) + 10
         )  # + 10 to get anything extra
-        self.failUnless(hr == 0, "Readfile returned %d" % hr)
+        self.assertTrue(hr == 0, "Readfile returned %d" % hr)
 
-        self.failUnless(read_data == data, "Read data is not what we wrote!")
+        self.assertTrue(read_data == data, "Read data is not what we wrote!")
 
         # Now truncate the file at 1/2 its existing size.
         newSize = len(data) // 2
         win32file.SetFilePointer(h, newSize, win32file.FILE_BEGIN)
         win32file.SetEndOfFile(h)
-        self.failUnlessEqual(win32file.GetFileSize(h), newSize)
+        self.assertEqual(win32file.GetFileSize(h), newSize)
 
         # GetFileAttributesEx/GetFileAttributesExW tests.
-        self.failUnlessEqual(
+        self.assertEqual(
             win32file.GetFileAttributesEx(testName),
             win32file.GetFileAttributesExW(testName),
         )
 
         attr, ct, at, wt, size = win32file.GetFileAttributesEx(testName)
-        self.failUnless(
+        self.assertTrue(
             size == newSize,
             "Expected GetFileAttributesEx to return the same size as GetFileSize()",
         )
-        self.failUnless(
+        self.assertTrue(
             attr == win32file.GetFileAttributes(testName),
             "Expected GetFileAttributesEx to return the same attributes as GetFileAttributes",
         )
 
         h = None  # Close the file by removing the last reference to the handle!
 
-        self.failUnless(
+        self.assertTrue(
             not os.path.isfile(testName), "After closing the file, it still exists!"
         )
 
@@ -151,22 +151,22 @@ class TestSimpleOps(unittest.TestCase):
             data = str2bytes("Some data")
             (res, written) = win32file.WriteFile(f, data)
 
-            self.failIf(res)
+            self.assertFalse(res)
             self.assertEqual(written, len(data))
 
             # Move at the beginning and read the data
             win32file.SetFilePointer(f, 0, win32file.FILE_BEGIN)
             (res, s) = win32file.ReadFile(f, len(data))
 
-            self.failIf(res)
+            self.assertFalse(res)
             self.assertEqual(s, data)
 
             # Move at the end and read the data
             win32file.SetFilePointer(f, -len(data), win32file.FILE_END)
             (res, s) = win32file.ReadFile(f, len(data))
 
-            self.failIf(res)
-            self.failUnlessEqual(s, data)
+            self.assertFalse(res)
+            self.assertEqual(s, data)
         finally:
             f.Close()
             os.unlink(filename)
@@ -189,15 +189,15 @@ class TestSimpleOps(unittest.TestCase):
         try:
             win32file.SetFileTime(h, now_utc, now_utc, now_utc)
             ct, at, wt = win32file.GetFileTime(h)
-            self.failUnlessEqual(now_local, ct)
-            self.failUnlessEqual(now_local, at)
-            self.failUnlessEqual(now_local, wt)
+            self.assertEqual(now_local, ct)
+            self.assertEqual(now_local, at)
+            self.assertEqual(now_local, wt)
             # and the reverse - set local, check against utc
             win32file.SetFileTime(h, now_local, now_local, now_local)
             ct, at, wt = win32file.GetFileTime(h)
-            self.failUnlessEqual(now_utc, ct)
-            self.failUnlessEqual(now_utc, at)
-            self.failUnlessEqual(now_utc, wt)
+            self.assertEqual(now_utc, ct)
+            self.assertEqual(now_utc, at)
+            self.assertEqual(now_utc, wt)
         finally:
             h.close()
             os.unlink(filename)
@@ -226,16 +226,16 @@ class TestSimpleOps(unittest.TestCase):
         )
         try:
             ct, at, wt = win32file.GetFileTime(f)
-            self.failUnless(
+            self.assertTrue(
                 ct >= now,
                 "File was created in the past - now=%s, created=%s" % (now, ct),
             )
-            self.failUnless(now <= ct <= nowish, (now, ct))
-            self.failUnless(
+            self.assertTrue(now <= ct <= nowish, (now, ct))
+            self.assertTrue(
                 wt >= now,
                 "File was written-to in the past now=%s, written=%s" % (now, wt),
             )
-            self.failUnless(now <= wt <= nowish, (now, wt))
+            self.assertTrue(now <= wt <= nowish, (now, wt))
 
             # Now set the times.
             win32file.SetFileTime(f, later, later, later, UTCTimes=True)
@@ -243,9 +243,9 @@ class TestSimpleOps(unittest.TestCase):
             ct, at, wt = win32file.GetFileTime(f)
             # XXX - the builtin PyTime type appears to be out by a dst offset.
             # just ignore that type here...
-            self.failUnlessEqual(ct, later)
-            self.failUnlessEqual(at, later)
-            self.failUnlessEqual(wt, later)
+            self.assertEqual(ct, later)
+            self.assertEqual(at, later)
+            self.assertEqual(wt, later)
 
         finally:
             f.Close()
@@ -361,7 +361,7 @@ class TestOverlapped(unittest.TestCase):
             win32file.CloseHandle(hv)
             raise RuntimeError("Expected close to fail!")
         except win32file.error as details:
-            self.failUnlessEqual(details.winerror, winerror.ERROR_INVALID_HANDLE)
+            self.assertEqual(details.winerror, winerror.ERROR_INVALID_HANDLE)
 
     def testCompletionPortsQueued(self):
         class Foo:
@@ -374,8 +374,8 @@ class TestOverlapped(unittest.TestCase):
         errCode, bytes, key, overlapped = win32file.GetQueuedCompletionStatus(
             io_req_port, win32event.INFINITE
         )
-        self.failUnlessEqual(errCode, 0)
-        self.failUnless(isinstance(overlapped.object, Foo))
+        self.assertEqual(errCode, 0)
+        self.assertTrue(isinstance(overlapped.object, Foo))
 
     def _IOCPServerThread(self, handle, port, drop_overlapped_reference):
         overlapped = pywintypes.OVERLAPPED()
@@ -388,7 +388,7 @@ class TestOverlapped(unittest.TestCase):
             # even if we fail, be sure to close the handle; prevents hangs
             # on Vista 64...
             try:
-                self.failUnlessRaises(
+                self.assertRaises(
                     RuntimeError, win32file.GetQueuedCompletionStatus, port, -1
                 )
             finally:
@@ -397,7 +397,7 @@ class TestOverlapped(unittest.TestCase):
 
         result = win32file.GetQueuedCompletionStatus(port, -1)
         ol2 = result[-1]
-        self.failUnless(ol2 is overlapped)
+        self.assertTrue(ol2 is overlapped)
         data = win32file.ReadFile(handle, 512)[1]
         win32file.WriteFile(handle, data)
 
@@ -444,7 +444,7 @@ class TestOverlapped(unittest.TestCase):
             if not test_overlapped_death:
                 handle.Close()
             t.join(3)
-            self.failIf(t.is_alive(), "thread didn't finish")
+            self.assertFalse(t.is_alive(), "thread didn't finish")
 
     def testCompletionPortsNonQueuedBadReference(self):
         self.testCompletionPortsNonQueued(True)
@@ -453,29 +453,29 @@ class TestOverlapped(unittest.TestCase):
         overlapped = pywintypes.OVERLAPPED()
         d = {}
         d[overlapped] = "hello"
-        self.failUnlessEqual(d[overlapped], "hello")
+        self.assertEqual(d[overlapped], "hello")
 
     def testComparable(self):
         overlapped = pywintypes.OVERLAPPED()
-        self.failUnlessEqual(overlapped, overlapped)
+        self.assertEqual(overlapped, overlapped)
         # ensure we explicitly test the operators.
-        self.failUnless(overlapped == overlapped)
-        self.failIf(overlapped != overlapped)
+        self.assertTrue(overlapped == overlapped)
+        self.assertFalse(overlapped != overlapped)
 
     def testComparable2(self):
         # 2 overlapped objects compare equal if their contents are the same.
         overlapped1 = pywintypes.OVERLAPPED()
         overlapped2 = pywintypes.OVERLAPPED()
-        self.failUnlessEqual(overlapped1, overlapped2)
+        self.assertEqual(overlapped1, overlapped2)
         # ensure we explicitly test the operators.
-        self.failUnless(overlapped1 == overlapped2)
-        self.failIf(overlapped1 != overlapped2)
+        self.assertTrue(overlapped1 == overlapped2)
+        self.assertFalse(overlapped1 != overlapped2)
         # now change something in one of them - should no longer be equal.
         overlapped1.hEvent = 1
-        self.failIfEqual(overlapped1, overlapped2)
+        self.assertNotEqual(overlapped1, overlapped2)
         # ensure we explicitly test the operators.
-        self.failIf(overlapped1 == overlapped2)
-        self.failUnless(overlapped1 != overlapped2)
+        self.assertFalse(overlapped1 == overlapped2)
+        self.assertTrue(overlapped1 != overlapped2)
 
 
 class TestSocketExtensions(unittest.TestCase):
@@ -500,7 +500,7 @@ class TestSocketExtensions(unittest.TestCase):
         # This is the correct way to allocate the buffer...
         buffer = win32file.AllocateReadBuffer(1024)
         rc = win32file.AcceptEx(listener, accepter, buffer, overlapped)
-        self.failUnlessEqual(rc, winerror.ERROR_IO_PENDING)
+        self.assertEqual(rc, winerror.ERROR_IO_PENDING)
         # Set the event to say we are all ready
         running_event.set()
         # and wait for the connection.
@@ -535,7 +535,7 @@ class TestSocketExtensions(unittest.TestCase):
         win32file.WSARecv(s, buffer, overlapped)
         nbytes = win32file.GetOverlappedResult(s.fileno(), overlapped, True)
         got = buffer[:nbytes]
-        self.failUnlessEqual(got, str2bytes("hello"))
+        self.assertEqual(got, str2bytes("hello"))
         # thread should have stopped
         stopped.wait(2)
         if not stopped.isSet():
@@ -552,7 +552,7 @@ class TestFindFiles(unittest.TestCase):
         for file in win32file.FindFilesIterator(dir):
             set2.add(file)
         assert len(set2) > 5, "This directory has less than 5 files!?"
-        self.failUnlessEqual(set1, set2)
+        self.assertEqual(set1, set2)
 
     def testBadDir(self):
         dir = os.path.join(os.getcwd(), "a dir that doesnt exist", "*")
@@ -563,7 +563,7 @@ class TestFindFiles(unittest.TestCase):
         num = 0
         for i in win32file.FindFilesIterator(spec):
             num += 1
-        self.failUnlessEqual(0, num)
+        self.assertEqual(0, num)
 
     def testEmptyDir(self):
         test_path = os.path.join(win32api.GetTempPath(), "win32file_test_directory")
@@ -580,7 +580,7 @@ class TestFindFiles(unittest.TestCase):
             for i in win32file.FindFilesIterator(os.path.join(test_path, "*")):
                 num += 1
             # Expecting "." and ".." only
-            self.failUnlessEqual(2, num)
+            self.assertEqual(2, num)
         finally:
             os.rmdir(test_path)
 
@@ -697,7 +697,7 @@ class TestDirectoryChanges(unittest.TestCase):
 
         self.stablize()
         changes = self.watcher_thread_changes[0]
-        self.failUnlessEqual(changes, [(1, "test_file")])
+        self.assertEqual(changes, [(1, "test_file")])
 
     def testSmall(self):
         self.stablize()
@@ -707,7 +707,7 @@ class TestDirectoryChanges(unittest.TestCase):
 
         self.stablize()
         changes = self.watcher_thread_changes[0]
-        self.failUnlessEqual(changes, [(1, "x")])
+        self.assertEqual(changes, [(1, "x")])
 
 
 class TestEncrypt(unittest.TestCase):
@@ -803,7 +803,7 @@ class TestConnect(unittest.TestCase):
         self.assertEqual(self.response, str2bytes("some expected response"))
         self.assertEqual(self.request, str2bytes("some expected request"))
         t.join(5)
-        self.failIf(t.is_alive(), "worker thread didn't terminate")
+        self.assertFalse(t.is_alive(), "worker thread didn't terminate")
 
     def test_connect_without_payload(self):
         giveup_event = win32event.CreateEvent(None, 0, 0, None)
@@ -838,7 +838,7 @@ class TestConnect(unittest.TestCase):
         self.response = buff[:length]
         self.assertEqual(self.response, str2bytes("some expected response"))
         t.join(5)
-        self.failIf(t.is_alive(), "worker thread didn't terminate")
+        self.assertFalse(t.is_alive(), "worker thread didn't terminate")
 
 
 class TestTransmit(unittest.TestCase):

--- a/win32/test/test_win32guistruct.py
+++ b/win32/test/test_win32guistruct.py
@@ -10,13 +10,13 @@ class TestBase(unittest.TestCase):
     def assertDictEquals(self, d, **kw):
         checked = dict()
         for n, v in kw.items():
-            self.failUnlessEqual(v, d[n], "'%s' doesn't match: %r != %r" % (n, v, d[n]))
+            self.assertEqual(v, d[n], "'%s' doesn't match: %r != %r" % (n, v, d[n]))
             checked[n] = True
         checked_keys = list(checked.keys())
         passed_keys = list(kw.keys())
         checked_keys.sort()
         passed_keys.sort()
-        self.failUnlessEqual(checked_keys, passed_keys)
+        self.assertEqual(checked_keys, passed_keys)
 
 
 class TestMenuItemInfo(TestBase):
@@ -76,19 +76,19 @@ class TestMenuItemInfo(TestBase):
             text,
             hbmpItem,
         ) = win32gui_struct.UnpackMENUITEMINFO(mii)
-        self.failUnlessEqual(fType, 0)
-        self.failUnlessEqual(fState, 0)
-        self.failUnlessEqual(wID, 0)
-        self.failUnlessEqual(hSubMenu, 0)
-        self.failUnlessEqual(hbmpChecked, 0)
-        self.failUnlessEqual(hbmpUnchecked, 0)
-        self.failUnlessEqual(dwItemData, 0)
-        self.failUnlessEqual(hbmpItem, 0)
+        self.assertEqual(fType, 0)
+        self.assertEqual(fState, 0)
+        self.assertEqual(wID, 0)
+        self.assertEqual(hSubMenu, 0)
+        self.assertEqual(hbmpChecked, 0)
+        self.assertEqual(hbmpUnchecked, 0)
+        self.assertEqual(dwItemData, 0)
+        self.assertEqual(hbmpItem, 0)
         # it's not clear if UnpackMENUITEMINFO() should ignore cch, instead
         # assuming it is a buffer size rather than 'current length' - but it
         # never has (and this gives us every \0 in the string), and actually
         # helps us test the unicode/str semantics.
-        self.failUnlessEqual(text, "\0" * len(text))
+        self.assertEqual(text, "\0" * len(text))
 
 
 class TestMenuInfo(TestBase):
@@ -122,11 +122,11 @@ class TestMenuInfo(TestBase):
             dwContextHelpID,
             dwMenuData,
         ) = win32gui_struct.UnpackMENUINFO(mi)
-        self.failUnlessEqual(dwStyle, 0)
-        self.failUnlessEqual(cyMax, 0)
-        self.failUnlessEqual(hbrBack, 0)
-        self.failUnlessEqual(dwContextHelpID, 0)
-        self.failUnlessEqual(dwMenuData, 0)
+        self.assertEqual(dwStyle, 0)
+        self.assertEqual(cyMax, 0)
+        self.assertEqual(hbrBack, 0)
+        self.assertEqual(dwContextHelpID, 0)
+        self.assertEqual(dwMenuData, 0)
 
 
 class TestTreeViewItem(TestBase):
@@ -184,14 +184,14 @@ class TestTreeViewItem(TestBase):
             citems,
             param,
         ) = win32gui_struct.UnpackTVITEM(ti)
-        self.failUnlessEqual(hitem, 0)
-        self.failUnlessEqual(state, 0)
-        self.failUnlessEqual(stateMask, 0)
-        self.failUnlessEqual(text, "")
-        self.failUnlessEqual(image, 0)
-        self.failUnlessEqual(selimage, 0)
-        self.failUnlessEqual(citems, 0)
-        self.failUnlessEqual(param, 0)
+        self.assertEqual(hitem, 0)
+        self.assertEqual(state, 0)
+        self.assertEqual(stateMask, 0)
+        self.assertEqual(text, "")
+        self.assertEqual(image, 0)
+        self.assertEqual(selimage, 0)
+        self.assertEqual(citems, 0)
+        self.assertEqual(param, 0)
 
 
 class TestListViewItem(TestBase):
@@ -252,14 +252,14 @@ class TestListViewItem(TestBase):
             param,
             indent,
         ) = win32gui_struct.UnpackLVITEM(ti)
-        self.failUnlessEqual(item, 1)
-        self.failUnlessEqual(subItem, 2)
-        self.failUnlessEqual(state, 0)
-        self.failUnlessEqual(stateMask, 0)
-        self.failUnlessEqual(text, "")
-        self.failUnlessEqual(image, 0)
-        self.failUnlessEqual(param, 0)
-        self.failUnlessEqual(indent, 0)
+        self.assertEqual(item, 1)
+        self.assertEqual(subItem, 2)
+        self.assertEqual(state, 0)
+        self.assertEqual(stateMask, 0)
+        self.assertEqual(text, "")
+        self.assertEqual(image, 0)
+        self.assertEqual(param, 0)
+        self.assertEqual(indent, 0)
 
 
 class TestLVColumn(TestBase):
@@ -282,12 +282,12 @@ class TestLVColumn(TestBase):
     def testEmpty(self):
         ti, extras = win32gui_struct.EmptyLVCOLUMN()
         fmt, cx, text, subItem, image, order = win32gui_struct.UnpackLVCOLUMN(ti)
-        self.failUnlessEqual(fmt, 0)
-        self.failUnlessEqual(cx, 0)
-        self.failUnlessEqual(text, "")
-        self.failUnlessEqual(subItem, 0)
-        self.failUnlessEqual(image, 0)
-        self.failUnlessEqual(order, 0)
+        self.assertEqual(fmt, 0)
+        self.assertEqual(cx, 0)
+        self.assertEqual(text, "")
+        self.assertEqual(subItem, 0)
+        self.assertEqual(image, 0)
+        self.assertEqual(order, 0)
 
 
 class TestDEV_BROADCAST_HANDLE(TestBase):
@@ -295,14 +295,14 @@ class TestDEV_BROADCAST_HANDLE(TestBase):
         s = win32gui_struct.PackDEV_BROADCAST_HANDLE(123)
         c = array.array("b", s)
         got = win32gui_struct.UnpackDEV_BROADCAST(c.buffer_info()[0])
-        self.failUnlessEqual(got.handle, 123)
+        self.assertEqual(got.handle, 123)
 
     def testGUID(self):
         s = win32gui_struct.PackDEV_BROADCAST_HANDLE(123, guid=pythoncom.IID_IUnknown)
         c = array.array("b", s)
         got = win32gui_struct.UnpackDEV_BROADCAST(c.buffer_info()[0])
-        self.failUnlessEqual(got.handle, 123)
-        self.failUnlessEqual(got.eventguid, pythoncom.IID_IUnknown)
+        self.assertEqual(got.handle, 123)
+        self.assertEqual(got.eventguid, pythoncom.IID_IUnknown)
 
 
 class TestDEV_BROADCAST_DEVICEINTERFACE(TestBase):
@@ -312,8 +312,8 @@ class TestDEV_BROADCAST_DEVICEINTERFACE(TestBase):
         )
         c = array.array("b", s)
         got = win32gui_struct.UnpackDEV_BROADCAST(c.buffer_info()[0])
-        self.failUnlessEqual(got.classguid, pythoncom.IID_IUnknown)
-        self.failUnlessEqual(got.name, "hello")
+        self.assertEqual(got.classguid, pythoncom.IID_IUnknown)
+        self.assertEqual(got.name, "hello")
 
 
 class TestDEV_BROADCAST_VOLUME(TestBase):
@@ -321,8 +321,8 @@ class TestDEV_BROADCAST_VOLUME(TestBase):
         s = win32gui_struct.PackDEV_BROADCAST_VOLUME(123, 456)
         c = array.array("b", s)
         got = win32gui_struct.UnpackDEV_BROADCAST(c.buffer_info()[0])
-        self.failUnlessEqual(got.unitmask, 123)
-        self.failUnlessEqual(got.flags, 456)
+        self.assertEqual(got.unitmask, 123)
+        self.assertEqual(got.flags, 456)
 
 
 if __name__ == "__main__":

--- a/win32/test/test_win32pipe.py
+++ b/win32/test/test_win32pipe.py
@@ -18,11 +18,11 @@ class PipeTests(unittest.TestCase):
     def _serverThread(self, pipe_handle, event, wait_time):
         # just do one connection and terminate.
         hr = win32pipe.ConnectNamedPipe(pipe_handle)
-        self.failUnless(
+        self.assertTrue(
             hr in (0, winerror.ERROR_PIPE_CONNECTED), "Got error code 0x%x" % (hr,)
         )
         hr, got = win32file.ReadFile(pipe_handle, 100)
-        self.failUnlessEqual(got, str2bytes("foo\0bar"))
+        self.assertEqual(got, str2bytes("foo\0bar"))
         time.sleep(wait_time)
         win32file.WriteFile(pipe_handle, str2bytes("bar\0foo"))
         pipe_handle.Close()
@@ -57,9 +57,9 @@ class PipeTests(unittest.TestCase):
         got = win32pipe.CallNamedPipe(
             self.pipename, str2bytes("foo\0bar"), 1024, win32pipe.NMPWAIT_WAIT_FOREVER
         )
-        self.failUnlessEqual(got, str2bytes("bar\0foo"))
+        self.assertEqual(got, str2bytes("bar\0foo"))
         event.wait(5)
-        self.failUnless(event.isSet(), "Pipe server thread didn't terminate")
+        self.assertTrue(event.isSet(), "Pipe server thread didn't terminate")
 
     def testTransactNamedPipeBlocking(self):
         event = threading.Event()
@@ -82,9 +82,9 @@ class PipeTests(unittest.TestCase):
         )
 
         hr, got = win32pipe.TransactNamedPipe(hpipe, str2bytes("foo\0bar"), 1024, None)
-        self.failUnlessEqual(got, str2bytes("bar\0foo"))
+        self.assertEqual(got, str2bytes("bar\0foo"))
         event.wait(5)
-        self.failUnless(event.isSet(), "Pipe server thread didn't terminate")
+        self.assertTrue(event.isSet(), "Pipe server thread didn't terminate")
 
     def testTransactNamedPipeBlockingBuffer(self):
         # Like testTransactNamedPipeBlocking, but a pre-allocated buffer is
@@ -112,9 +112,9 @@ class PipeTests(unittest.TestCase):
         hr, got = win32pipe.TransactNamedPipe(
             hpipe, str2bytes("foo\0bar"), buffer, None
         )
-        self.failUnlessEqual(got, str2bytes("bar\0foo"))
+        self.assertEqual(got, str2bytes("bar\0foo"))
         event.wait(5)
-        self.failUnless(event.isSet(), "Pipe server thread didn't terminate")
+        self.assertTrue(event.isSet(), "Pipe server thread didn't terminate")
 
     def testTransactNamedPipeAsync(self):
         event = threading.Event()
@@ -142,12 +142,12 @@ class PipeTests(unittest.TestCase):
         hr, got = win32pipe.TransactNamedPipe(
             hpipe, str2bytes("foo\0bar"), buffer, overlapped
         )
-        self.failUnlessEqual(hr, winerror.ERROR_IO_PENDING)
+        self.assertEqual(hr, winerror.ERROR_IO_PENDING)
         nbytes = win32file.GetOverlappedResult(hpipe, overlapped, True)
         got = buffer[:nbytes]
-        self.failUnlessEqual(got, str2bytes("bar\0foo"))
+        self.assertEqual(got, str2bytes("bar\0foo"))
         event.wait(5)
-        self.failUnless(event.isSet(), "Pipe server thread didn't terminate")
+        self.assertTrue(event.isSet(), "Pipe server thread didn't terminate")
 
 
 if __name__ == "__main__":

--- a/win32/test/test_win32rcparser.py
+++ b/win32/test/test_win32rcparser.py
@@ -39,12 +39,12 @@ class TestParser(unittest.TestCase):
             style = cdef[-2]
             styleex = cdef[-1]
             if cid in tabstop_ids:
-                self.failUnlessEqual(style & win32con.WS_TABSTOP, win32con.WS_TABSTOP)
+                self.assertEqual(style & win32con.WS_TABSTOP, win32con.WS_TABSTOP)
                 num_ok += 1
             elif cid in notabstop_ids:
-                self.failUnlessEqual(style & win32con.WS_TABSTOP, 0)
+                self.assertEqual(style & win32con.WS_TABSTOP, 0)
                 num_ok += 1
-        self.failUnlessEqual(num_ok, len(tabstop_ids) + len(notabstop_ids))
+        self.assertEqual(num_ok, len(tabstop_ids) + len(notabstop_ids))
 
 
 class TestGenerated(TestParser):

--- a/win32/test/test_win32trace.py
+++ b/win32/test/test_win32trace.py
@@ -83,7 +83,7 @@ class TestInitOps(unittest.TestCase):
         # test for either the correct data or an empty string
         win32trace.TermWrite()
         win32trace.InitRead()
-        self.failUnless(win32trace.read() in ["Ta da", ""])
+        self.assertTrue(win32trace.read() in ["Ta da", ""])
         win32trace.TermRead()
 
         # we keep the data because we init read before terminating write

--- a/win32/test/test_win32wnet.py
+++ b/win32/test/test_win32wnet.py
@@ -59,14 +59,14 @@ class TestCase(unittest.TestCase):
         for attr, typ in attrs:
             val = getattr(item, attr)
             if typ is int:
-                self.failUnless(
+                self.assertTrue(
                     type(val) in (int,), "Attr %r has value %r" % (attr, val)
                 )
                 new_val = val + 1
             elif typ is str:
                 if val is not None:
                     # on py2k, must be string or unicode.  py3k must be string or bytes.
-                    self.failUnless(
+                    self.assertTrue(
                         type(val) in (str, str), "Attr %r has value %r" % (attr, val)
                     )
                     new_val = val + " new value"
@@ -104,13 +104,13 @@ class TestCase(unittest.TestCase):
         la_enum = netbios.LANA_ENUM()
         ncb.Buffer = la_enum
         rc = win32wnet.Netbios(ncb)
-        self.failUnlessEqual(rc, 0)
+        self.assertEqual(rc, 0)
         for i in range(la_enum.length):
             ncb.Reset()
             ncb.Command = netbios.NCBRESET
             ncb.Lana_num = netbios.byte_to_int(la_enum.lana[i])
             rc = Netbios(ncb)
-            self.failUnlessEqual(rc, 0)
+            self.assertEqual(rc, 0)
             ncb.Reset()
             ncb.Command = netbios.NCBASTAT
             ncb.Lana_num = byte_to_int(la_enum.lana[i])
@@ -119,7 +119,7 @@ class TestCase(unittest.TestCase):
             ncb.Buffer = adapter
             Netbios(ncb)
             # expect 6 bytes in the mac address.
-            self.failUnless(len(adapter.adapter_address), 6)
+            self.assertTrue(len(adapter.adapter_address), 6)
 
     def iterConnectableShares(self):
         nr = win32wnet.NETRESOURCE()


### PR DESCRIPTION
All the unittest deprecated `fail*` methods now all the equivalent
`assert*` functions.

TextTestResult was renamed in Python 3.11.