### PR TITLE
Call Py_SetProgramName() so that Py_Initialize() has more information to work with.

### DIFF
--- a/win32/src/PythonService.cpp
+++ b/win32/src/PythonService.cpp
@@ -1535,6 +1535,7 @@ int _tmain(int argc, TCHAR **argv)
     wchar_t **program = CommandLineToArgvW(GetCommandLineW(), &dummy);
     if (program != NULL) {
         Py_SetProgramName(program[0]);
+        // do not free `program` since Py_SetProgramName does not copy it.
     }
     Py_Initialize();
     PyEval_InitThreads();


### PR DESCRIPTION
Which is usefull if PythonService.exe is placed next to Python.exe and that folder is not on the PATH.
Which in turn is usefull if one is using pyenv-win.