### PR TITLE
Enable support for Windows on arm64 targets

### DIFF
--- a/Pythonwin/Win32uiHostGlue.h
+++ b/Pythonwin/Win32uiHostGlue.h
@@ -133,6 +133,8 @@ inline BOOL Win32uiHostGlue::DynamicApplicationInit(const TCHAR *cmd, const TCHA
         _T("..\\..\\.."),  // lib\site-packages\pythonwin
 #ifdef _M_X64
         _T("..\\..\\..\\PCBuild\\amd64"),
+#elif defined(_M_ARM64)
+        _T("..\\..\\..\\PCBuild\\arm64"),
 #else
         _T("..\\..\\..\\PCBuild"),
 #endif
@@ -140,6 +142,8 @@ inline BOOL Win32uiHostGlue::DynamicApplicationInit(const TCHAR *cmd, const TCHA
         _T(""),
 #ifdef _M_X64
         _T("PCBuild\\amd64"),
+#elif defined(_M_ARM64)
+        _T("PCBuild\\arm64"),
 #else
         _T("PCBuild"),
 #endif

--- a/Pythonwin/win32uiExt.h
+++ b/Pythonwin/win32uiExt.h
@@ -316,7 +316,7 @@ class CPythonWndFramework : public T {
         }
     }
     afx_msg
-#ifdef _M_X64  // add one more thing to things I don't understand..
+#ifdef _WIN64  // add one more thing to things I don't understand..
         LRESULT
 #else
         UINT

--- a/Pythonwin/win32uiole.cpp
+++ b/Pythonwin/win32uiole.cpp
@@ -10,7 +10,7 @@
 // (although replacing transact.h with a later Platform SDK
 // version does *not* give the error.  Whatever.
 #include "transact.h"
-#ifndef _M_X64
+#if !defined(_M_X64) && !defined(_M_ARM64)
 #include "afxdao.h"
 #endif
 
@@ -88,7 +88,7 @@ static PyObject *DaoGetEngine(PyObject *self, PyObject *args)
 {
     CHECK_NO_ARGS2(args, "DaoGetEngine");
 
-#ifdef _M_X64
+#if defined(_M_X64) || defined(_M_ARM64)
     return NULL;
 #else
     AfxDaoInit();

--- a/com/win32com/src/univgw_dataconv.cpp
+++ b/com/win32com/src/univgw_dataconv.cpp
@@ -152,7 +152,7 @@ static inline bool SizeOfVT(VARTYPE vt, int *pitem_size, int *pstack_size)
     }
 #ifdef _M_IX86
     int stack_size = (item_size < 4) ? 4 : item_size;
-#elif _M_X64
+#elif defined(_M_X64) || defined(_M_ARM64)
     // params > 64bits passed by address, and only VT_VARIANT is > 64bits.
     assert((item_size <= 8) || ((vt & VT_TYPEMASK) == VT_VARIANT));
     if (item_size > 8)
@@ -596,7 +596,7 @@ PyObject *dataconv_ReadFromInTuple(PyObject *self, PyObject *args)
         vtArgType = (VARTYPE)PyLong_AS_LONG(obArgType);
 #ifdef _M_IX86
         bIsByRef = vtArgType & VT_BYREF;
-#elif _M_X64
+#elif defined(_M_X64) || defined(_M_ARM64)
         // params > 64bits always passed by address - and the only
         // arg we support > 64 bits is a VARIANT structure.
         bIsByRef = (vtArgType == VT_VARIANT) || (vtArgType & VT_BYREF);

--- a/com/win32comext/mapi/src/mapi_headers/MAPIUtil.h
+++ b/com/win32comext/mapi/src/mapi_headers/MAPIUtil.h
@@ -860,7 +860,7 @@ STDAPI_(VOID)			DeinitMapiUtil(VOID);
  *	it easier to write code which uses them optionally.
  */
 
-#if defined (_WIN64) && defined(_AMD64_)
+#if defined (_WIN64) && (defined (_AMD64_) || defined(_ARM64_))
 #define szHrDispatchNotifications "HrDispatchNotifications"
 #elif defined (_WIN32) && defined (_X86_)
 #define szHrDispatchNotifications "_HrDispatchNotifications@4"
@@ -871,7 +871,7 @@ STDAPI_(VOID)			DeinitMapiUtil(VOID);
 typedef HRESULT (STDAPICALLTYPE DISPATCHNOTIFICATIONS)(ULONG ulFlags);
 typedef DISPATCHNOTIFICATIONS FAR * LPDISPATCHNOTIFICATIONS;
 
-#if defined (_WIN64) && defined (_AMD64_)
+#if defined (_WIN64) && (defined (_AMD64_) || defined(_ARM64_))
 #define szScCreateConversationIndex "ScCreateConversationIndex"
 #elif defined (_WIN32) && defined (_X86_)
 #define szScCreateConversationIndex "_ScCreateConversationIndex@16"

--- a/com/win32comext/mapi/src/mapi_headers/MAPIVal.h
+++ b/com/win32comext/mapi/src/mapi_headers/MAPIVal.h
@@ -1957,7 +1957,7 @@ __ValidateParameters(METHODS eMethod, LPVOID ppThis);
 #define CheckParameters_IMAPIAdviseSink_OnNotify( a1, a2, a3 ) \
 			 CheckParameters3( IMAPIAdviseSink_OnNotify, a1, a2, a3 )
 
-#if defined (_AMD64_) || defined(_X86_)
+#if defined(_AMD64_) || defined(_ARM64_) || defined(_X86_)
 STDAPI	HrValidateParameters( METHODS eMethod, LPVOID FAR *ppFirstArg );
 #elif defined(DOS) || defined(_MAC) 
 STDAPIV	HrValidateParametersV( METHODS eMethod, ... );

--- a/com/win32comext/mapi/src/mapi_stub_library/MapiStubLibrary.cpp
+++ b/com/win32comext/mapi/src/mapi_stub_library/MapiStubLibrary.cpp
@@ -25,7 +25,7 @@
 #error Outlook 2010 MAPI headers or higher must be installed
 #endif
 
-#if defined(_M_X64) || defined(_M_ARM)
+#if defined(_M_X64) || defined(_M_ARM) || defined(_M_ARM64)
 #define ExpandFunction(fn, c) #fn
 #elif defined(_M_IX86)
 #define ExpandFunction(fn, c) #fn "@" #c

--- a/win32/test/test_sspi.py
+++ b/win32/test/test_sspi.py
@@ -13,7 +13,10 @@ def applyHandlingSkips(func, *args):
     try:
         return func(*args)
     except win32api.error as exc:
-        if exc.winerror in [sspicon.SEC_E_NO_CREDENTIALS, sspicon.SEC_E_NO_AUTHENTICATING_AUTHORITY]:
+        if exc.winerror in [
+            sspicon.SEC_E_NO_CREDENTIALS,
+            sspicon.SEC_E_NO_AUTHENTICATING_AUTHORITY,
+        ]:
             raise TestSkipped(exc)
         raise
 

--- a/win32/test/test_sspi.py
+++ b/win32/test/test_sspi.py
@@ -13,7 +13,7 @@ def applyHandlingSkips(func, *args):
     try:
         return func(*args)
     except win32api.error as exc:
-        if exc.winerror == sspicon.SEC_E_NO_CREDENTIALS:
+        if exc.winerror in [sspicon.SEC_E_NO_CREDENTIALS, sspicon.SEC_E_NO_AUTHENTICATING_AUTHORITY]:
             raise TestSkipped(exc)
         raise
 


### PR DESCRIPTION
This patch enables building pywin32 and extensions for windows on arm64 targets.

### Test Results

```
python .\pywin32_testall.py -skip-adodbapi

.................................................SSSSSSSSSSSSSSS............SS....SSSSSSSSS.S.S..SSS..................................................................................Connected - response info is (0, '200 Switching to ASCII mode.\r\n200 PORT command successful. Consider using PASV.\r\n150 Here comes the directory listing.\r\n')
Read 238 bytes
..................SSSSSSSSSSSSSSS..........................
SKIPPED: 15 tests - Can't find a DB engine
SKIPPED: 2 tests - No 'Administrator' account is available
SKIPPED: 8 tests - (1355, 'DsBind', 'The specified domain either does not exist or could not be contacted.')
SKIPPED: 6 tests - (-2146893039, 'AcquireCredentialsHandle', 'No authority could be contacted for authentication.')
SKIPPED: 15 tests - We skip this test on CI
----------------------------------------------------------------------
Ran 242 tests in 49.182s

OK
*** Test script 'C:\Users\niysai01\Workspace\pywin32\win32\test\testall.py' exited with 0
Executing level 1 tests - 70 test cases will be run
SSS.............................SSSSSSSSSS....F........................
======================================================================
FAIL: testIsCurrentClipboard (win32com.test.testClipboard.ClipboardTester)
----------------------------------------------------------------------
AssertionError: 0 interface objects and 2 gateway objects leaked

SKIPPED: 13 tests - (-2147221005, 'Invalid class string', None, None)
----------------------------------------------------------------------
Ran 70 tests in 48.599s

FAILED (failures=1)
******************** - unittest tests FAILED
*** Test script 'C:\Users\niysai01\Workspace\pywin32\com\win32com\test\testall.py' exited with 1
The following scripts failed
> C:\Users\niysai01\Workspace\pywin32\com\win32com\test\testall.py
```

`testIsCurrentClipboard` seems to be an intermittent failure. It passes on some runs.

I also had to skip win32trace tests by setting the environment variable CI. Otherwise, the tests seem to get stuck during the run. This looks like a more general issue and I haven't debugged it further.


