### PR TITLE
_win32sysloader now uses the same LoadLibrary flags as Python itself …

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,9 @@ Note that build 228 was the last version supporting Python 2.
 
 Since build 302:
 ----------------
+* Tweaks to how DLLs are loaded and our installation found, which should
+  improve virtualenv support and version mismatch issues (#1787, #1794)
+
 * Binary installers for 32-bit 3.10+ are no longer released (#1805)
 
 Since build 301:

--- a/win32/src/_win32sysloader.cpp
+++ b/win32/src/_win32sysloader.cpp
@@ -56,8 +56,17 @@ static PyObject *PyLoadModule(PyObject *self, PyObject *args)
     TCHAR *modName = NULL;
     if (!PyArg_ParseTuple(args, fmt, &modName))
         return NULL;
-    HINSTANCE hinst = LoadLibrary(modName);
 
+    // Python 3.7 vs 3.8 use different flags for LoadLibraryEx and we match them.
+    // See github issue 1787.
+#if (PY_VERSION_HEX < 0x03080000)
+    HINSTANCE hinst = LoadLibraryEx(modName, NULL,
+                                    LOAD_WITH_ALTERED_SEARCH_PATH);
+#else
+    HINSTANCE hinst = LoadLibraryEx(modName, NULL,
+                                    LOAD_LIBRARY_SEARCH_DEFAULT_DIRS |
+                                    LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
+#endif
     if (hinst == NULL) {
         Py_INCREF(Py_None);
         return Py_None;


### PR DESCRIPTION
…(fixes #1787)

@davidkhess and @tshemeng, it would be great if you could try the artifacts from this PR and see if it addresses your problems.