### PR TITLE
Fix PythonService.exe initialization when starting as NT_AUTHORITY/SYSTEM

### DIFF
--- a/pywin32_postinstall.py
+++ b/pywin32_postinstall.py
@@ -488,9 +488,10 @@ def install(lib_dir):
     base = "python%d%d.dll" % (sys.version_info.major, sys.version_info.minor)
     fname = os.path.join(sys.prefix, base)
     dst = os.path.join(get_system_dir(), base)
-    CopyTo("installing %s" % base, fname, dst)
-    if verbose:
-        print("Copied %s to %s" % (base, dst))
+    if not os.path.exists(dst):
+        CopyTo("installing %s" % base, fname, dst)
+        if verbose:
+            print("Copied %s to %s" % (base, dst))
     # unlike for pywintypes and pycomtypes, we don't register pythonXXX.dll with the uninstaller
 
     # Pythonwin 'compiles' config files - record them for uninstall.

--- a/pywin32_postinstall.py
+++ b/pywin32_postinstall.py
@@ -484,6 +484,15 @@ def install(lib_dir):
             "You don't have enough permissions to install the system files"
         )
 
+    # Also copies the pythonXXX.dll to system32 if not already present
+    base = "python%d%d.dll" % (sys.version_info.major, sys.version_info.minor)
+    fname = os.path.join(sys.prefix, base)
+    dst = os.path.join(get_system_dir(), base)
+    CopyTo("installing %s" % base, fname, dst)
+    if verbose:
+        print("Copied %s to %s" % (base, dst))
+    # unlike for pywintypes and pycomtypes, we don't register pythonXXX.dll with the uninstaller
+
     # Pythonwin 'compiles' config files - record them for uninstall.
     pywin_dir = os.path.join(lib_dir, "Pythonwin", "pywin")
     for fname in glob.glob(os.path.join(pywin_dir, "*.cfg")):


### PR DESCRIPTION
Since the advent of Python3, the python windows installer now install
python "as a user" (in the ``%LocalAppData%`` folder) and optionnally adds ``sys.prefix``
to the **user's PATH**.

However, PythonService.exe by default runs as NT_AUTHORITY/SYSTEM which
does not share the same %PATH% environment variables (in order to
prevent privilege escalations paths based on DLL hijacking). Currently,
on a fresh install, PythonService.exe can not launch since it rely on
pythonXXX.dll which is not present on SYSTEM's path :

![image](https://user-images.githubusercontent.com/2520861/141449864-c19fcfbd-4378-4764-b40d-08a854a29192.png)

This commit aims to fix this situation by ensuring PythonXXX.dll is in
%System32%, a folder both on the DLL loading path for any users or
SYSTEM.

it should fix this issue : https://github.com/mhammond/pywin32/issues/1771

PS : there are several other ways to fix this issue, for example by copying ``PythonXXX.dll`` in the folder where ``PythonService.exe`` is located, or modifying SYSTEM's PATH env var to add ``sys.prefix``