### PR TITLE
Remove faulty assertion when loading pywintypes.py

### DIFF
--- a/win32/Lib/pywintypes.py
+++ b/win32/Lib/pywintypes.py
@@ -119,7 +119,6 @@ def __import_pywin32_system_module__(modname, globs):
     spec.loader.exec_module(mod)
 
     # Check the sys.modules[] behaviour we describe above is true...
-    assert sys.modules[modname] is not old_mod
     assert sys.modules[modname] is mod
     # as above - re-reset to the *old* module object then update globs.
     sys.modules[modname] = old_mod


### PR DESCRIPTION
Fixes the following issues:
#452 
#582
#1209
#1773

Rationale:
The above issues are caused when pywintypes is reloaded, usually by third party code that indiscriminately reloads all modules.

The intention of the removed assertion was to make sure that the loaded "pywintypes" in `sys.modules` is pywintypesXX.dll. However, re-running `__import_pywin32_system_module__` means that `sys.modules["pywintypes"]` will actually be pywintypesXX.dll instead of pywintypes.py, which this logic does not account for.

Just `assert sys.modules[modname] is mod` by itself appears to be sufficient to ensure that the DLL has been appropriately loaded, even after reloads, with the only side effect being that `__import_pywin32_system_module__` will end up loaded at a different address.

The following code was used to determine whether any side effects are visible in the module's dict:
```python
import pywintypes
import importlib

a = pywintypes.__dict__.copy()
importlib.reload(pywintypes)
b = pywintypes.__dict__.copy()

assert list(a.keys()) == list(b.keys())
for key in a.keys():
    if a[key] != b[key]:
        print(f"key {key} - {a[key]} != {b[key]}")
```

Output:
```
(venv) C:\Users\wchill\PycharmProjects\pywin32>python test.py
key __import_pywin32_system_module__ - <function __import_pywin32_system_module__ at 0x0000024E6083C9D0> != <function __import_pywin32_system_module__ at 0x0000024E6084DE50>
```