### PR TITLE
Fix: win32print.SetJob sending ANSI to UNICODE API

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,9 @@ Since build 303:
   break any workarounds which were used, such as using specific encodings in
   these strings. (#1823, #1833)
 
+* Fixed a bug triggering `win32print.SetJob` to fail due to data type
+  (`char*` / `wchar_t*`) mismatch (#1849, @CristiFati)
+
 Since build 302:
 ----------------
 * Tweaks to how DLLs are loaded and our installation found, which should

--- a/win32/src/win32print/win32print.cpp
+++ b/win32/src/win32print/win32print.cpp
@@ -1160,14 +1160,14 @@ BOOL PytoJob(DWORD level, PyObject *pyjobinfo, LPBYTE *pbuf)
     static char *job1_keys[] = {"JobId",      "pPrinterName", "pMachineName", "pUserName", "pDocument",
                                 "pDatatype",  "pStatus",      "Status",       "Priority",  "Position",
                                 "TotalPages", "PagesPrinted", "Submitted",    NULL};
-    static char *job1_format = "kzzzzzzkkkkk|O:JOB_INFO_1";
+    static char *job1_format = "kZZZZZZkkkkk|O:JOB_INFO_1";
 
     static char *job2_keys[] = {"JobId",       "pPrinterName", "pMachineName",        "pUserName",   "pDocument",
                                 "pNotifyName", "pDatatype",    "pPrintProcessor",     "pParameters", "pDriverName",
                                 "pDevMode",    "pStatus",      "pSecurityDescriptor", "Status",      "Priority",
                                 "Position",    "StartTime",    "UntilTime",           "TotalPages",  "Size",
                                 "Submitted",   "Time",         "PagesPrinted",        NULL};
-    static char *job2_format = "kzzzzzzzzzOzOkkkkkkkOkk:JOB_INFO_2";
+    static char *job2_format = "kZZZZZZZZZOZOkkkkkkkOkk:JOB_INFO_2";
 
     static char *job3_keys[] = {"JobId", "NextJobId", "Reserved", NULL};
     static char *job3_format = "kk|k:JOB_INFO_3";


### PR DESCRIPTION
Fix for  #1281.

Confirmed when investigating [\[SO\]: How to change username of job in print queue using python & win32print](https://stackoverflow.com/questions/71612616/how-to-change-username-of-job-in-print-queue-using-python-win32print).

Modified the script in the bug. The scenario is even easier to reproduce: simply pass the dictionary returned by *GetJob* to *SetJob*, and the error pops up (actually there are different errors depending on level (1, 2) - as also encountered in the *SO* *URL*).

The cause is straightforward: *JOB\_INFO\_\** structures have *LPTSTR* (*wchar\_t\** when built with *-DUNICODE* *-D\_UNICODE*) members, while *PyArg\_ParseTupleAndKeywords*, fills *char\** s for ***z*** format specifiers. Check [\[Python.Docs\]: Parsing arguments and building values](https://docs.python.org/3/c-api/arg.html#parsing-arguments-and-building-values).

The fix is to specify the Unicode format specifier (***Z***).

After rebuilding the *.pyd* (and placing it in the *site-packages* *dir*), the error no longer pops up, and changing existing jobs string properties is possible (tried setting *pUserName* to random strings and the change is reflected in the print queue).


Environment: *Python 3.9.9* (*pc064*) with *PyWin32 303*.
