### PR TITLE
Add entry_point console scripts for postinstall and testall

### DIFF
--- a/pywin32_postinstall.py
+++ b/pywin32_postinstall.py
@@ -684,7 +684,7 @@ def verify_destination(location):
     return location
 
 
-if __name__ == "__main__":
+def main():
     import argparse
 
     parser = argparse.ArgumentParser(
@@ -765,3 +765,7 @@ if __name__ == "__main__":
     if args.remove:
         if not is_bdist_wininst:
             uninstall(args.destination)
+
+
+if __name__ == "__main__":
+    main()

--- a/pywin32_testall.py
+++ b/pywin32_testall.py
@@ -38,7 +38,7 @@ def find_and_run(possible_locations, extras):
         )
 
 
-if __name__ == "__main__":
+def main():
     import argparse
 
     code_directories = [this_dir] + site_packages
@@ -113,3 +113,7 @@ if __name__ == "__main__":
             print(">", failure)
         sys.exit(1)
     print("All tests passed \o/")
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -2476,6 +2476,12 @@ dist = setup(
         },
     },
     scripts=["pywin32_postinstall.py", "pywin32_testall.py"],
+    entry_points={
+        "console_scripts": [
+            "pywin32_postinstall=pywin32_postinstall:main",
+            "pywin32_testall=pywin32_testall:main",
+        ]
+    },
     ext_modules=ext_modules,
     package_dir={
         "win32com": "com/win32com",


### PR DESCRIPTION
When I try to naively follow the instructions for running the post install script from the readme 
I will end up with an error like `C:\Users\myuser\Miniconda3\envs\qcodespip38\python.exe: can't open file 'Scripts/pywin32_postinstall.py': [Errno 2] No such file or directory`
unless I execute the script from exactly the folder where Scripts is a subdir. 
(following a pip install of pywin32)

These days it seems like setuptools recommend using `console-script entry points` rather than scripts. 
This pr enables that by refactoring the scripts to create an entry point that setuptools can generate exes that call.

With the changes in this pr I am able to run the post install scripts using 
`pywin32_postinstall.exe -install` from any folder which imho makes it much easier for end users to run the post install script. 

Note that I have left the existing scripts as is for backwards compatibility. One could also move the logic from `pywin32_postinstall.py` into the package and drop the script entry. 
That means that both pwwin32_postinstall.exe and pywin32_postinstall.py will be on path. 

I have not updated the readme since I figured that doing that would create more confusion if done before this is part of 
an official release.

I have also done the same for the test all script since it seems to fill a similar role. 

