### PR TITLE
Add PRINTER_INFO_6 support in Set/GetPrinter

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,8 @@ Note that build 228 was the last version supporting Python 2.
 
 Since build 303:
 ----------------
+* Add `PRINTER_INFO_6` support for Set/GetPrinter (#1853, @CristiFati)
+
 * Fixed codepage/mojibake issues when non-ascii characters were included in
   COM exceptions raised by Python apps. This should be invisible, but might
   break any workarounds which were used, such as using specific encodings in

--- a/win32/src/win32print/win32print.cpp
+++ b/win32/src/win32print/win32print.cpp
@@ -332,12 +332,12 @@ void PyWinObject_FreePRINTER_INFO(DWORD level, LPBYTE pbuf)
     free(pbuf);
 }
 
-#define AsPRINTER_INFO__INIT_PRINTER_INFO_X(_PRINTER_INFO_X, _PIX_PTR, _BREAK_ON_ERROR) \
+#define AsPRINTER_INFO__INIT_PRINTER_INFO_X(_PRINTER_INFO_X, _PIX_PTR) \
     _PRINTER_INFO_X *_PIX_PTR; \
     bufsize = sizeof(_PRINTER_INFO_X); \
     if ((*pbuf = (LPBYTE)malloc(bufsize)) == NULL) { \
         PyErr_Format(PyExc_MemoryError, "Malloc failed for %d bytes", bufsize); \
-        if (_BREAK_ON_ERROR) break; \
+        break; \
     } \
     ZeroMemory(*pbuf, bufsize); \
     _PIX_PTR = (_PRINTER_INFO_X*)*pbuf;
@@ -489,7 +489,7 @@ BOOL PyWinObject_AsPRINTER_INFO(DWORD level, PyObject *obinfo, LPBYTE *pbuf)
                 "Status",
                 NULL };
             static char *pi6_format = "k:PRINTER_INFO_6";
-            AsPRINTER_INFO__INIT_PRINTER_INFO_X(PRINTER_INFO_6, pi6, TRUE);
+            AsPRINTER_INFO__INIT_PRINTER_INFO_X(PRINTER_INFO_6, pi6);
             ret = PyArg_ParseTupleAndKeywords(dummy_tuple, obinfo, pi6_format, pi6_keys, &pi6->dwStatus);
             break;
         }

--- a/win32/src/win32print/win32print.cpp
+++ b/win32/src/win32print/win32print.cpp
@@ -395,15 +395,7 @@ BOOL PyWinObject_AsPRINTER_INFO(DWORD level, PyObject *obinfo, LPBYTE *pbuf)
                      *obDriverName = Py_None, *obComment = Py_None, *obLocation = Py_None, *obDevMode = Py_None,
                      *obSepFile = Py_None, *obPrintProcessor = Py_None, *obDatatype = Py_None, *obParameters = Py_None,
                      *obSecurityDescriptor = Py_None;
-            PRINTER_INFO_2 *pi2;
-            bufsize = sizeof(PRINTER_INFO_2);
-            if (NULL == (*pbuf = (LPBYTE)malloc(bufsize))) {
-                PyErr_Format(PyExc_MemoryError, "Malloc failed for %d bytes", bufsize);
-                break;
-            }
-            ZeroMemory(*pbuf, bufsize);
-            pi2 = (PRINTER_INFO_2 *)*pbuf;
-
+            AsPRINTER_INFO__INIT_PRINTER_INFO_X(PRINTER_INFO_2, pi2);
             ret = PyArg_ParseTupleAndKeywords(dummy_tuple, obinfo, pi2_format, pi2_keys, &obServerName, &obPrinterName,
                                               &obShareName, &obPortName, &obDriverName, &obComment, &obLocation,
                                               &obDevMode, &obSepFile, &obPrintProcessor, &obDatatype, &obParameters,
@@ -429,14 +421,7 @@ BOOL PyWinObject_AsPRINTER_INFO(DWORD level, PyObject *obinfo, LPBYTE *pbuf)
             static char *pi3_keys[] = {"pSecurityDescriptor", NULL};
             static char *pi3_format = "O:PRINTER_INFO_3";
             PyObject *obSecurityDescriptor;
-            PRINTER_INFO_3 *pi3;
-            bufsize = sizeof(PRINTER_INFO_3);
-            if (NULL == (*pbuf = (LPBYTE)malloc(bufsize))) {
-                PyErr_Format(PyExc_MemoryError, "Malloc failed for %d bytes", bufsize);
-                break;
-            }
-            ZeroMemory(*pbuf, bufsize);
-            pi3 = (PRINTER_INFO_3 *)*pbuf;
+            AsPRINTER_INFO__INIT_PRINTER_INFO_X(PRINTER_INFO_3, pi3);
             ret = PyArg_ParseTupleAndKeywords(dummy_tuple, obinfo, pi3_format, pi3_keys, &obSecurityDescriptor) &&
                   PyWinObject_AsSECURITY_DESCRIPTOR(obSecurityDescriptor, &pi3->pSecurityDescriptor, FALSE);
             break;
@@ -445,14 +430,7 @@ BOOL PyWinObject_AsPRINTER_INFO(DWORD level, PyObject *obinfo, LPBYTE *pbuf)
             static char *pi4_keys[] = {"pPrinterName", "pServerName", "Attributes", NULL};
             static char *pi4_format = "OOk:PRINTER_INFO_4";
             PyObject *obPrinterName = Py_None, *obServerName = Py_None;
-            PRINTER_INFO_4 *pi4;
-            bufsize = sizeof(PRINTER_INFO_4);
-            if (NULL == (*pbuf = (LPBYTE)malloc(bufsize))) {
-                PyErr_Format(PyExc_MemoryError, "Malloc failed for %d bytes", bufsize);
-                break;
-            }
-            ZeroMemory(*pbuf, bufsize);
-            pi4 = (PRINTER_INFO_4 *)*pbuf;
+            AsPRINTER_INFO__INIT_PRINTER_INFO_X(PRINTER_INFO_4, pi4);
             ret = PyArg_ParseTupleAndKeywords(dummy_tuple, obinfo, pi4_format, pi4_keys, &obPrinterName, &obServerName,
                                               &pi4->Attributes) &&
                   PyWinObject_AsTCHAR(obPrinterName, &pi4->pPrinterName, TRUE) &&
@@ -468,15 +446,7 @@ BOOL PyWinObject_AsPRINTER_INFO(DWORD level, PyObject *obinfo, LPBYTE *pbuf)
                                        NULL};
             static char *pi5_format = "OOkkk:PRINTER_INFO_5";
             PyObject *obPrinterName = Py_None, *obPortName = Py_None;
-
-            PRINTER_INFO_5 *pi5;
-            bufsize = sizeof(PRINTER_INFO_5);
-            if (NULL == (*pbuf = (LPBYTE)malloc(bufsize))) {
-                PyErr_Format(PyExc_MemoryError, "Malloc failed for %d bytes", bufsize);
-                break;
-            }
-            ZeroMemory(*pbuf, bufsize);
-            pi5 = (PRINTER_INFO_5 *)*pbuf;
+            AsPRINTER_INFO__INIT_PRINTER_INFO_X(PRINTER_INFO_5, pi5);
             ret = PyArg_ParseTupleAndKeywords(dummy_tuple, obinfo, pi5_format, pi5_keys, &obPrinterName, &obPortName,
                                               &pi5->Attributes, &pi5->DeviceNotSelectedTimeout,
                                               &pi5->TransmissionRetryTimeout) &&
@@ -497,14 +467,7 @@ BOOL PyWinObject_AsPRINTER_INFO(DWORD level, PyObject *obinfo, LPBYTE *pbuf)
             static char *pi7_keys[] = {"ObjectGUID", "Action", NULL};
             static char *pi7_format = "Ok:PRINTER_INFO_7";
             PyObject *obObjectGUID = Py_None;
-            PRINTER_INFO_7 *pi7;
-            bufsize = sizeof(PRINTER_INFO_7);
-            if (NULL == (*pbuf = (LPBYTE)malloc(bufsize))) {
-                PyErr_Format(PyExc_MemoryError, "Malloc failed for %d bytes", bufsize);
-                break;
-            }
-            ZeroMemory(*pbuf, bufsize);
-            pi7 = (PRINTER_INFO_7 *)*pbuf;
+            AsPRINTER_INFO__INIT_PRINTER_INFO_X(PRINTER_INFO_7, pi7);
             ret =
                 PyArg_ParseTupleAndKeywords(dummy_tuple, obinfo, pi7_format, pi7_keys, &obObjectGUID, &pi7->dwAction) &&
                 PyWinObject_AsTCHAR(obObjectGUID, &pi7->pszObjectGUID, TRUE);
@@ -515,14 +478,7 @@ BOOL PyWinObject_AsPRINTER_INFO(DWORD level, PyObject *obinfo, LPBYTE *pbuf)
             static char *pi8_keys[] = {"pDevMode", NULL};
             static char *pi8_format = "O:PRINTER_INFO_8";
             PyObject *obDevMode;
-            PRINTER_INFO_8 *pi8;
-            bufsize = sizeof(PRINTER_INFO_8);
-            if (NULL == (*pbuf = (LPBYTE)malloc(bufsize))) {
-                PyErr_Format(PyExc_MemoryError, "Malloc failed for %d bytes", bufsize);
-                break;
-            }
-            ZeroMemory(*pbuf, bufsize);
-            pi8 = (PRINTER_INFO_8 *)*pbuf;
+            AsPRINTER_INFO__INIT_PRINTER_INFO_X(PRINTER_INFO_8, pi8);
             ret = PyArg_ParseTupleAndKeywords(dummy_tuple, obinfo, pi8_format, pi8_keys, &obDevMode) &&
                   PyWinObject_AsDEVMODE(obDevMode, &pi8->pDevMode, FALSE);
             break;

--- a/win32/test/test_win32print.py
+++ b/win32/test/test_win32print.py
@@ -1,0 +1,25 @@
+# Tests (scarce) for win32print module
+
+import os
+import unittest
+
+import win32print as wprn
+
+
+class Win32PrintTestCase(unittest.TestCase):
+    def setUp(self):
+        self.printer_idx = 0
+        self.printer_levels_all = list(range(1, 10))
+        self.local_printers = wprn.EnumPrinters(wprn.PRINTER_ENUM_LOCAL, None, 1)
+
+    def test_printer_levels_read_dummy(self):
+        if not self.local_printers:
+            print("Test didn't run (no local printers)!")
+            return
+        ph = wprn.OpenPrinter(self.local_printers[self.printer_idx][2])
+        for level in self.printer_levels_all:
+            wprn.GetPrinter(ph, level)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
According to [\[MS.Docs\]: GetPrinter function](https://docs.microsoft.com/en-us/windows/win32/printdocs/getprinter), *PRINTER\_INFO\_6* (and thus level 6), is a valid choice.

Note: there's not much extra real value, as the status is also included in *PRINTER\_INFO\_2*.


