### PR TITLE
Lots of UNICODE cleanups

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,9 @@ However contributors are encouraged to add their own entries for their work.
 
 Note that build 228 was the last version supporting Python 2.
 
+Since build 304:
+----------------
+
 Since build 303:
 ----------------
 * Fixed Unicode issues in the `dde` module (#1861, @markuskimius )

--- a/com/win32comext/mapi/src/PyIAddrBook.i
+++ b/com/win32comext/mapi/src/PyIAddrBook.i
@@ -107,10 +107,10 @@ PyObject *PyIAddrBook::CompareEntryIDs(PyObject *self, PyObject *args)
 		&flags)) // @pyparm int|flags|0|Reserved - must be zero.
         goto done;
 
-	if (!PyWinObject_AsString(obE1, (char **)&peid1, FALSE, &cb1))
+	if (!PyWinObject_AsChars(obE1, (char **)&peid1, FALSE, &cb1))
         goto done;
 
-	if (!PyWinObject_AsString(obE2, (char **)&peid2, FALSE, &cb2))
+	if (!PyWinObject_AsChars(obE2, (char **)&peid2, FALSE, &cb2))
         goto done;
 
 	Py_BEGIN_ALLOW_THREADS
@@ -121,8 +121,8 @@ PyObject *PyIAddrBook::CompareEntryIDs(PyObject *self, PyObject *args)
 	else
 		rc = PyLong_FromLong(ulResult);
 done:
-	PyWinObject_FreeString((char *)peid1);
-	PyWinObject_FreeString((char *)peid2);
+	PyWinObject_FreeChars((char *)peid1);
+	PyWinObject_FreeChars((char *)peid2);
 	return rc;
 }
 %}

--- a/com/win32comext/mapi/src/PyIExchangeManageStore.i
+++ b/com/win32comext/mapi/src/PyIExchangeManageStore.i
@@ -67,7 +67,7 @@ PyObject *PyIExchangeManageStore::CreateStoreEntryID(PyObject *self, PyObject *a
 	char *serverDN = NULL;
 	char *userDN = NULL;
 	unsigned long flags = 0;
-	SBinary sbEID = {0, NULL};	
+	SBinary sbEID = {0, NULL};
 	PyObject *result = NULL;
 
 	IExchangeManageStore *_swig_self;
@@ -79,11 +79,11 @@ PyObject *PyIExchangeManageStore::CreateStoreEntryID(PyObject *self, PyObject *a
 		&flags))
 		return NULL;
 
-	if (!PyWinObject_AsString(obServerDN, &serverDN, FALSE))
+	if (!PyWinObject_AsChars(obServerDN, &serverDN, FALSE))
 		goto done;
-	if (!PyWinObject_AsString(obUserDN, &userDN, TRUE))
+	if (!PyWinObject_AsChars(obUserDN, &userDN, TRUE))
 		goto done;
-	
+
 	Py_BEGIN_ALLOW_THREADS
 	hRes = _swig_self->CreateStoreEntryID(serverDN, userDN, flags, &sbEID.cb, (LPENTRYID *) &sbEID.lpb);
 	Py_END_ALLOW_THREADS
@@ -91,19 +91,13 @@ PyObject *PyIExchangeManageStore::CreateStoreEntryID(PyObject *self, PyObject *a
 	if (FAILED(hRes))
 		result = OleSetOleError(hRes);
 	else
-		result = Py_BuildValue(
-#if PY_MAJOR_VERSION >= 3
-								"y#",
-#else
-								"s#",
-#endif
-								sbEID.lpb, (Py_ssize_t)sbEID.cb);
+		result = Py_BuildValue("y#", sbEID.lpb, (Py_ssize_t)sbEID.cb);
 
 done:
 	MAPIFreeBuffer((LPENTRYID)sbEID.lpb);
-	PyWinObject_FreeString(serverDN);
-	PyWinObject_FreeString(userDN);
-	
+	PyWinObject_FreeChars(serverDN);
+	PyWinObject_FreeChars(userDN);
+
 	return result;
 }
 

--- a/com/win32comext/mapi/src/PyIExchangeManageStoreEx.i
+++ b/com/win32comext/mapi/src/PyIExchangeManageStoreEx.i
@@ -72,7 +72,7 @@ PyObject *PyIExchangeManageStoreEx::CreateStoreEntryID2(PyObject *self, PyObject
 
 	if (!PyArg_ParseTuple(args, "O|l:CreateStoreEntryID2", &obs, &flags))
 		return NULL;
-	
+
 	if (!PySequence_Check(obs))
 	{
 		PyErr_SetString(PyExc_TypeError, "Properties must be a sequence of tuples");
@@ -85,21 +85,15 @@ PyObject *PyIExchangeManageStoreEx::CreateStoreEntryID2(PyObject *self, PyObject
 	Py_BEGIN_ALLOW_THREADS
 	hRes = _swig_self->CreateStoreEntryID2(seqLen, pPV, flags, &sbEID.cb, (LPENTRYID *) &sbEID.lpb);
 	Py_END_ALLOW_THREADS
-	
+
 	if (FAILED(hRes))
 		result = OleSetOleError(hRes);
 	else
-		result = Py_BuildValue(
-#if PY_MAJOR_VERSION >= 3
-								"y#",
-#else
-								"s#",
-#endif
-								sbEID.lpb, (Py_ssize_t)sbEID.cb);
-								
+		result = Py_BuildValue("y#", sbEID.lpb, (Py_ssize_t)sbEID.cb);
+
 	MAPIFreeBuffer((LPENTRYID)sbEID.lpb);
 	MAPIFreeBuffer(pPV);
-	
+
 	return result;
 }
 %}

--- a/com/win32comext/mapi/src/PyIMAPIFolder.i
+++ b/com/win32comext/mapi/src/PyIMAPIFolder.i
@@ -114,8 +114,8 @@ PyObject *PyIMAPIFolder::CreateFolder(PyObject *self, PyObject *args)
 		MAKE_OUTPUT_INTERFACE(&lpFolder, result, IID_IMAPIFolder);
 
 done:
-	PyWinObject_FreeString(lpszFolderName);
-	PyWinObject_FreeString(lpszFolderComment);
+	PyWinObject_FreeMAPIStr(lpszFolderName, ulFlags & MAPI_UNICODE);
+	PyWinObject_FreeMAPIStr(lpszFolderComment, ulFlags & MAPI_UNICODE);
 	
 	return result;
 }

--- a/com/win32comext/mapi/src/PyIMAPISession.i
+++ b/com/win32comext/mapi/src/PyIMAPISession.i
@@ -229,10 +229,10 @@ PyObject *PyIMAPISession::CompareEntryIDs(PyObject *self, PyObject *args)
 		&flags)) // @pyparm int|flags|0|Reserved - must be zero.
         goto done;
 
-	if (!PyWinObject_AsString(obE1, (char **)&peid1, FALSE, &cb1))
+	if (!PyWinObject_AsChars(obE1, (char **)&peid1, FALSE, &cb1))
         goto done;
 
-	if (!PyWinObject_AsString(obE2, (char **)&peid2, FALSE, &cb2))
+	if (!PyWinObject_AsChars(obE2, (char **)&peid2, FALSE, &cb2))
         goto done;
 
 	Py_BEGIN_ALLOW_THREADS
@@ -243,8 +243,8 @@ PyObject *PyIMAPISession::CompareEntryIDs(PyObject *self, PyObject *args)
 	else
 		rc = PyLong_FromLong(ulResult);
 done:
-	PyWinObject_FreeString((char *)peid1);
-	PyWinObject_FreeString((char *)peid2);
+	PyWinObject_FreeChars((char *)peid1);
+	PyWinObject_FreeChars((char *)peid2);
 	return rc;
 }
 %}

--- a/com/win32comext/mapi/src/PyIMsgServiceAdmin.i
+++ b/com/win32comext/mapi/src/PyIMsgServiceAdmin.i
@@ -101,8 +101,8 @@ PyObject *PyIMsgServiceAdmin::CreateMsgService(PyObject *self, PyObject *args)
 		result = Py_BuildValue("");
 
 done:
-	PyWinObject_FreeString(lpszService);
-	PyWinObject_FreeString(lpszDisplayName);
+	PyWinObject_FreeMAPIStr(lpszService, ulFlags & MAPI_UNICODE);
+	PyWinObject_FreeMAPIStr(lpszDisplayName, ulFlags & MAPI_UNICODE);
 	
 	return result;
 }

--- a/com/win32comext/mapi/src/PyIMsgServiceAdmin2.i
+++ b/com/win32comext/mapi/src/PyIMsgServiceAdmin2.i
@@ -71,8 +71,8 @@ PyObject *PyIMsgServiceAdmin2::CreateMsgServiceEx(PyObject *self, PyObject *args
 		result = PyWinObject_FromIID(reinterpret_cast<GUID &>(uidService));
 
 done:
-	PyWinObject_FreeString(lpszService);
-	PyWinObject_FreeString(lpszDisplayName);
+	PyWinObject_FreeMAPIStr(lpszService, ulFlags & MAPI_UNICODE);
+	PyWinObject_FreeMAPIStr(lpszDisplayName, ulFlags & MAPI_UNICODE);
 
 	return result;
 }

--- a/com/win32comext/mapi/src/PyIMsgStore.i
+++ b/com/win32comext/mapi/src/PyIMsgStore.i
@@ -150,10 +150,10 @@ PyObject *PyIMsgStore::CompareEntryIDs(PyObject *self, PyObject *args)
 		&flags)) // @pyparm int|flags|0|Reserved - must be zero.
         goto done;
 
-	if (!PyWinObject_AsString(obE1, (char **)&peid1, FALSE, &cb1))
+	if (!PyWinObject_AsChars(obE1, (char **)&peid1, FALSE, &cb1))
         goto done;
 
-	if (!PyWinObject_AsString(obE2, (char **)&peid2, FALSE, &cb2))
+	if (!PyWinObject_AsChars(obE2, (char **)&peid2, FALSE, &cb2))
         goto done;
 
 	Py_BEGIN_ALLOW_THREADS
@@ -164,8 +164,8 @@ PyObject *PyIMsgStore::CompareEntryIDs(PyObject *self, PyObject *args)
 	else
 		rc = PyLong_FromLong(ulResult);
 done:
-	PyWinObject_FreeString((char *)peid1);
-	PyWinObject_FreeString((char *)peid2);
+	PyWinObject_FreeChars((char *)peid1);
+	PyWinObject_FreeChars((char *)peid2);
 	return rc;
 }
 %}
@@ -221,7 +221,7 @@ PyObject *PyIMsgStore::AbortSubmit(PyObject *self, PyObject *args)
 		&flags)) // @pyparm int|flags|0|Reserved - must be zero.
 		goto done;
 
-	if (!PyWinObject_AsString(obE, (char **)&peid, FALSE, &cb))
+	if (!PyWinObject_AsChars(obE, (char **)&peid, FALSE, &cb))
 		goto done;
 
 	Py_BEGIN_ALLOW_THREADS
@@ -234,7 +234,7 @@ PyObject *PyIMsgStore::AbortSubmit(PyObject *self, PyObject *args)
 		Py_INCREF(Py_None);
 	}
 done:
-	PyWinObject_FreeString((char *)peid);
+	PyWinObject_FreeChars((char *)peid);
 	return rc;
 }
 %}

--- a/com/win32comext/mapi/src/PyIProfAdmin.i
+++ b/com/win32comext/mapi/src/PyIProfAdmin.i
@@ -101,8 +101,8 @@ PyObject *PyIProfAdmin::CreateProfile(PyObject *self, PyObject *args)
 		result = Py_BuildValue("");
 
 done:
-	PyWinObject_FreeString(lpszProfileName);
-	PyWinObject_FreeString(lpszPassword);
+	PyWinObject_FreeMAPIStr(lpszProfileName, ulFlags & MAPI_UNICODE);
+	PyWinObject_FreeMAPIStr(lpszPassword, ulFlags & MAPI_UNICODE);
 	
 	return result;
 }
@@ -122,10 +122,10 @@ PyObject *PyIProfAdmin::DeleteProfile(PyObject *self, PyObject *args)
 	PyObject *obProfileName;
 	LPTSTR lpszProfileName;
 	ULONG ulFlags = 0;
-	
+
 	IProfAdmin *_swig_self;
 	if ((_swig_self=GetI(self))==NULL) return NULL;
-	
+
 	if (!PyArg_ParseTuple(args, "O|l",
 		&obProfileName, // @pyparm string|oldProfileName||The name of the profile to be deleted. 
 		&ulFlags)) // @pyparm int|flags|0|
@@ -133,15 +133,15 @@ PyObject *PyIProfAdmin::DeleteProfile(PyObject *self, PyObject *args)
 
 	if (!PyWinObject_AsMAPIStr(obProfileName, &lpszProfileName, ulFlags & MAPI_UNICODE, FALSE))
 		return NULL;
-	
-	Py_BEGIN_ALLOW_THREADS
+
+	Py_BEGIN_ALLOW_THREADS;
 	hRes = _swig_self->DeleteProfile(lpszProfileName, ulFlags);
-	Py_END_ALLOW_THREADS
-	
-	PyWinObject_FreeString(lpszProfileName);
+	Py_END_ALLOW_THREADS;
+
+	PyWinObject_FreeMAPIStr(lpszProfileName, ulFlags & MAPI_UNICODE);
 	if (FAILED(hRes))
 		return OleSetOleError(hRes);
-	
+
 	return Py_BuildValue("");
 }
 %}
@@ -199,9 +199,9 @@ PyObject *PyIProfAdmin::CopyProfile(PyObject *self, PyObject *args)
 		result = Py_BuildValue("");
 
 done:
-	PyWinObject_FreeString(lpszOldProfileName);
-	PyWinObject_FreeString(lpszOldPassword);
-	PyWinObject_FreeString(lpszNewProfileName);
+	PyWinObject_FreeMAPIStr(lpszOldProfileName, ulFlags & MAPI_UNICODE);
+	PyWinObject_FreeMAPIStr(lpszOldPassword, ulFlags & MAPI_UNICODE);
+	PyWinObject_FreeMAPIStr(lpszNewProfileName, ulFlags & MAPI_UNICODE);
 	
 	return result;
 }
@@ -251,9 +251,9 @@ PyObject *PyIProfAdmin::RenameProfile(PyObject *self, PyObject *args)
 		result = Py_BuildValue("");
 
 done:
-	PyWinObject_FreeString(lpszOldProfileName);
-	PyWinObject_FreeString(lpszOldPassword);
-	PyWinObject_FreeString(lpszNewProfileName);
+	PyWinObject_FreeMAPIStr(lpszOldProfileName, ulFlags & MAPI_UNICODE);
+	PyWinObject_FreeMAPIStr(lpszOldPassword, ulFlags & MAPI_UNICODE);
+	PyWinObject_FreeMAPIStr(lpszNewProfileName, ulFlags & MAPI_UNICODE);
 	
 	return result;
 }
@@ -284,7 +284,7 @@ PyObject *PyIProfAdmin::SetDefaultProfile(PyObject *self, PyObject *args)
 	hRes = _swig_self->SetDefaultProfile(lpszProfileName, ulFlags);
 	Py_END_ALLOW_THREADS
 	
-	PyWinObject_FreeString(lpszProfileName);
+	PyWinObject_FreeMAPIStr(lpszProfileName, ulFlags & MAPI_UNICODE);
 	
 	if (FAILED(hRes))
 		return OleSetOleError(hRes);
@@ -333,8 +333,8 @@ PyObject *PyIProfAdmin::AdminServices(PyObject *self, PyObject *args)
 		MAKE_OUTPUT_INTERFACE(&lpServiceAdmin, result, IID_IMsgServiceAdmin);
 
 done:
-	PyWinObject_FreeString(lpszProfileName);
-	PyWinObject_FreeString(lpszPassword);
+	PyWinObject_FreeMAPIStr(lpszProfileName, ulFlags & MAPI_UNICODE);
+	PyWinObject_FreeMAPIStr(lpszPassword, ulFlags & MAPI_UNICODE);
 	
 	return result;
 }

--- a/com/win32comext/mapi/src/PyMAPIUtil.h
+++ b/com/win32comext/mapi/src/PyMAPIUtil.h
@@ -63,3 +63,4 @@ PyObject *PyMAPIObject_FromSPropProblemArray(SPropProblemArray *ppa);
 PyObject *PyWinObject_FromMAPIStr(LPTSTR str, BOOL isUnicode);
 BOOL PyWinObject_AsMAPIStr(PyObject *stringObject, LPTSTR *pResult, BOOL asUnicode, BOOL bNoneOK = FALSE,
                            DWORD *pResultLen = NULL);
+void PyWinObject_FreeMAPIStr(LPTSTR pResult, BOOL wasUnicode);

--- a/com/win32comext/mapi/src/exchange.i
+++ b/com/win32comext/mapi/src/exchange.i
@@ -359,12 +359,12 @@ static PyObject *PyHrCreateProfileName(PyObject *self, PyObject *args)
 	// @pyparm string/<o PyUnicode>|profPrefix||A prefix for the new profile.
 	if (!PyArg_ParseTuple(args, "O:HrCreateProfileName", &obPrefix))
 		return NULL;
-	if (!PyWinObject_AsString(obPrefix, &prefix))
+	if (!PyWinObject_AsChars(obPrefix, &prefix))
 		return NULL;
 	const int bufSize = MAX_PATH + 1;
 	char buf[bufSize];
 	_result = HrCreateProfileName(prefix, bufSize, buf);
-	PyWinObject_FreeString(prefix);
+	PyWinObject_FreeChars(prefix);
 	if (FAILED(_result))
 		return OleSetOleError(_result);
 	return PyWinCoreString_FromString(buf);
@@ -388,7 +388,7 @@ PyObject *PyHrCreateDirEntryIdEx(PyObject *self, PyObject *args)
 		&obDN))		 // @pyparm string|distinguishedName||The dn of the object to obtain the entry ID for.
 		return NULL;
 
-	if (!PyWinObject_AsString(obDN, &szdn, FALSE))
+	if (!PyWinObject_AsChars(obDN, &szdn, FALSE))
         goto done;
 
 	if (!PyCom_InterfaceFromPyInstanceOrObject(obAddrBook, IID_IAddrBook, (void **)&pAddrBook, /*BOOL bNoneOK=*/FALSE))
@@ -400,7 +400,7 @@ PyObject *PyHrCreateDirEntryIdEx(PyObject *self, PyObject *args)
 
 	ret = PyBytes_FromStringAndSize((char *)entryId, cbEntryId);
 done:
-	PyWinObject_FreeString(szdn);
+	PyWinObject_FreeChars(szdn);
 	if (pAddrBook) pAddrBook->Release();
 	return ret;
 }

--- a/com/win32comext/mapi/src/mapi.i
+++ b/com/win32comext/mapi/src/mapi.i
@@ -635,8 +635,8 @@ PyObject *PyMAPILogonEx(PyObject *self, PyObject *args)
 		MAKE_OUTPUT_INTERFACE(&lpSession, result, IID_IMAPISession);
 	
 done:
-	PyWinObject_FreeString(lpszProfileName);
-	PyWinObject_FreeString(lpszPassword);
+	PyWinObject_FreeMAPIStr(lpszProfileName, ulFlags & MAPI_UNICODE);
+	PyWinObject_FreeMAPIStr(lpszPassword, ulFlags & MAPI_UNICODE);
 	
 	return result;
 }
@@ -1017,7 +1017,7 @@ exit:
 %native(OpenStreamOnFile) PyOpenStreamOnFile;
 %{
 PyObject *PyOpenStreamOnFile(PyObject *self, PyObject *args)
-{	
+{
 		HRESULT hRes;
 		unsigned long flags = 0;
 		IStream *pStream;
@@ -1025,17 +1025,17 @@ PyObject *PyOpenStreamOnFile(PyObject *self, PyObject *args)
 		char *filename = NULL;
 		PyObject *obPrefix = Py_None;
 		char *prefix = NULL;
-		
+
 		if (!PyArg_ParseTuple(args, "O|lO:OpenStreamOnFile",
 			&obFileName, // @pyparm string|filename||
 			&flags, // @pyparm int|flags|0|
 			&obPrefix)) // @pyparm string|prefix|None|
 			return NULL;
 
-		if (!PyWinObject_AsString(obFileName, &filename, TRUE))
+		if (!PyWinObject_AsChars(obFileName, &filename, TRUE))
 			goto done;
 
-		if (!PyWinObject_AsString(obPrefix, &prefix, TRUE))
+		if (!PyWinObject_AsChars(obPrefix, &prefix, TRUE))
 			goto done;
 
 		{
@@ -1046,16 +1046,16 @@ PyObject *PyOpenStreamOnFile(PyObject *self, PyObject *args)
 		}
 
 	done:
-		PyWinObject_FreeString(filename);
-		PyWinObject_FreeString(prefix);
+		PyWinObject_FreeChars(filename);
+		PyWinObject_FreeChars(prefix);
 
 		if (PyErr_Occurred())
 			return NULL;
 
 		if (FAILED(hRes))
-			return OleSetOleError(hRes);	
-				
-		return PyCom_PyObjectFromIUnknown(pStream, IID_IStream, FALSE);	
+			return OleSetOleError(hRes);
+
+		return PyCom_PyObjectFromIUnknown(pStream, IID_IStream, FALSE);
 }
 %}
 

--- a/com/win32comext/shell/src/PyIContextMenu.cpp
+++ b/com/win32comext/shell/src/PyIContextMenu.cpp
@@ -185,9 +185,9 @@ STDMETHODIMP PyGContextMenu::GetCommandString(
         }
         else {
             char *szResult;
-            if (PyWinObject_AsString(result, &szResult, FALSE, NULL)) {
+            if (PyWinObject_AsChars(result, &szResult, FALSE, NULL)) {
                 strncpy(pszName, szResult, cchMax);
-                PyWinObject_FreeString(szResult);
+                PyWinObject_FreeChars(szResult);
             }
         }
         hr = S_OK;

--- a/com/win32comext/shell/src/PyICopyHook.cpp
+++ b/com/win32comext/shell/src/PyICopyHook.cpp
@@ -45,17 +45,17 @@ PyObject *PyICopyHookA::CopyCallback(PyObject *self, PyObject *args)
     if (!PyWinObject_AsHANDLE(obhwnd, (HANDLE *)&hwnd))
         return NULL;
     BOOL bPythonIsHappy = TRUE;
-    if (bPythonIsHappy && !PyWinObject_AsString(obsrcFile, &srcFile))
+    if (bPythonIsHappy && !PyWinObject_AsChars(obsrcFile, &srcFile))
         bPythonIsHappy = FALSE;
-    if (bPythonIsHappy && !PyWinObject_AsString(obdestFile, &destFile))
+    if (bPythonIsHappy && !PyWinObject_AsChars(obdestFile, &destFile))
         bPythonIsHappy = FALSE;
     if (!bPythonIsHappy)
         return NULL;
     HRESULT hr;
     PY_INTERFACE_PRECALL;
     hr = pICH->CopyCallback(hwnd, wFunc, wFlags, srcFile, srcAttribs, destFile, destAttribs);
-    PyWinObject_FreeString(srcFile);
-    PyWinObject_FreeString(destFile);
+    PyWinObject_FreeChars(srcFile);
+    PyWinObject_FreeChars(destFile);
 
     PY_INTERFACE_POSTCALL;
 

--- a/com/win32comext/shell/src/PyIExtractIcon.cpp
+++ b/com/win32comext/shell/src/PyIExtractIcon.cpp
@@ -31,14 +31,14 @@ PyObject *PyIExtractIcon::Extract(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "Oii:Extract", &obpszFile, &nIconIndex, &nIconSize))
         return NULL;
     BOOL bPythonIsHappy = TRUE;
-    if (!PyWinObject_AsString(obpszFile, &pszFile))
+    if (!PyWinObject_AsChars(obpszFile, &pszFile))
         bPythonIsHappy = FALSE;
     if (!bPythonIsHappy)
         return NULL;
     HRESULT hr;
     PY_INTERFACE_PRECALL;
     hr = pIEI->Extract(pszFile, nIconIndex, &hiconLarge, &hiconSmall, nIconSize);
-    PyWinObject_FreeString(pszFile);
+    PyWinObject_FreeChars(pszFile);
     PY_INTERFACE_POSTCALL;
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pIEI, IID_IExtractIcon);
@@ -145,9 +145,9 @@ STDMETHODIMP PyGExtractIcon::GetIconLocation(
     else {
         if (PyArg_ParseTuple(result, "Oii", &obFileName, piIndex, pflags)) {
             char *filename;
-            if (PyWinObject_AsString(obFileName, &filename)) {
+            if (PyWinObject_AsChars(obFileName, &filename)) {
                 strncpy(szIconFile, filename, cchMax);
-                PyWinObject_FreeString(filename);
+                PyWinObject_FreeChars(filename);
             }
         }
         hr = MAKE_PYCOM_GATEWAY_FAILURE_CODE("GetIconLocation");

--- a/com/win32comext/shell/src/shell.cpp
+++ b/com/win32comext/shell/src/shell.cpp
@@ -595,7 +595,9 @@ BOOL PyObject_AsCMINVOKECOMMANDINFO(PyObject *ob, CMINVOKECOMMANDINFO *pci)
         return FALSE;
     return TRUE;
 }
-void PyObject_FreeCMINVOKECOMMANDINFO(CMINVOKECOMMANDINFO *pci) { PyWinObject_FreeResourceId((char *)pci->lpVerb); }
+void PyObject_FreeCMINVOKECOMMANDINFO(CMINVOKECOMMANDINFO *pci) {
+    PyWinObject_FreeResourceIdA((char *)pci->lpVerb);
+}
 
 static PyObject *PyString_FromMaybeNullString(const char *sz)
 {
@@ -1507,12 +1509,12 @@ static PyObject *PySHAddToRecentDocs(PyObject *self, PyObject *args)
         case SHARD_PATHA: {
             // @flag SHARD_PATHA|String containing a file path
             char *buf;
-            if (!PyWinObject_AsString(ob, &buf, FALSE))
+            if (!PyWinObject_AsChars(ob, &buf, FALSE))
                 return NULL;
             PY_INTERFACE_PRECALL;
             SHAddToRecentDocs(flags, buf);
             PY_INTERFACE_POSTCALL;
-            PyWinObject_FreeString(buf);
+            PyWinObject_FreeChars(buf);
             break;
         }
         case SHARD_PATHW: {
@@ -2340,10 +2342,10 @@ static PyObject *PyFILEGROUPDESCRIPTORAsString(PyObject *self, PyObject *args)
             }
             else {
                 char *t;
-                ok = PyWinObject_AsString(attr, &t);
+                ok = PyWinObject_AsChars(attr, &t);
                 if (ok) {
                     strncpy(fd->cFileName, t, sizeof(fd->cFileName) / sizeof(char));
-                    PyWinObject_FreeString(t);
+                    PyWinObject_FreeChars(t);
                 }
             }
         }
@@ -2606,11 +2608,11 @@ static PyObject *PyShellExecuteEx(PyObject *self, PyObject *args, PyObject *kw)
         PyWin_SetAPIError("ShellExecuteEx");
 
 done:
-    PyWinObject_FreeString((char *)info.lpVerb);
-    PyWinObject_FreeString((char *)info.lpFile);
-    PyWinObject_FreeString((char *)info.lpParameters);
-    PyWinObject_FreeString((char *)info.lpDirectory);
-    PyWinObject_FreeString((char *)info.lpClass);
+    PyWinObject_FreeChars((char *)info.lpVerb);
+    PyWinObject_FreeChars((char *)info.lpFile);
+    PyWinObject_FreeChars((char *)info.lpParameters);
+    PyWinObject_FreeChars((char *)info.lpDirectory);
+    PyWinObject_FreeChars((char *)info.lpClass);
     PyObject_FreePIDL((ITEMIDLIST *)info.lpIDList);
     return ret;
 }

--- a/win32/src/PyDEVMODE.cpp
+++ b/win32/src/PyDEVMODE.cpp
@@ -4,357 +4,6 @@
 #include "structmember.h"
 #include "PyWinObjects.h"
 
-#ifdef MS_WINCE
-#define DM_SPECVERSION 0
-#endif
-
-// @object PyDEVMODE|Python object wrapping a DEVMODE structure
-struct PyMethodDef PyDEVMODEA::methods[] = {
-    {"Clear", PyDEVMODEA::Clear, 1},  // @pymeth Clear|Resets all members of the structure
-    {NULL}};
-
-#define OFF(e) offsetof(PyDEVMODEA, e)
-struct PyMemberDef PyDEVMODEA::members[] = {
-    // @prop int|SpecVersion|Should always be set to DM_SPECVERSION
-    {"SpecVersion", T_USHORT, OFF(devmode.dmSpecVersion), 0, "Should always be set to DM_SPECVERSION"},
-    // @prop int|DriverVersion|Version nbr assigned to printer driver by vendor
-    {"DriverVersion", T_USHORT, OFF(devmode.dmDriverVersion), 0, "Version nbr assigned to printer driver by vendor"},
-    // @prop int|Size|Size of structure
-    {"Size", T_USHORT, OFF(devmode.dmSize), READONLY, "Size of structure"},
-    // @prop int|DriverExtra|Number of extra bytes allocated for driver data, can only be set when new object is created
-    {"DriverExtra", T_USHORT, OFF(devmode.dmDriverExtra), READONLY,
-     "Number of extra bytes allocated for driver data, can only be set when new object is created"},
-    // @prop int|Fields|Bitmask of win32con.DM_* constants indicating which members are set
-    {"Fields", T_ULONG, OFF(devmode.dmFields), 0,
-     "Bitmask of win32con.DM_* constants indicating which members are set"},
-    // @prop int|Orientation|Only applies to printers, DMORIENT_PORTRAIT or DMORIENT_LANDSCAPE
-    {"Orientation", T_SHORT, OFF(devmode.dmOrientation), 0,
-     "Only applies to printers, DMORIENT_PORTRAIT or DMORIENT_LANDSCAPE"},
-    // @prop int|PaperSize|Use 0 if PaperWidth and PaperLength are set, otherwise win32con.DMPAPER_* constant
-    {"PaperSize", T_SHORT, OFF(devmode.dmPaperSize), 0,
-     "Use 0 if PaperWidth and PaperLength are set, otherwise win32con.DMPAPER_* constant"},
-    // @prop int|PaperLength|Specified in 1/10 millimeters
-    {"PaperLength", T_SHORT, OFF(devmode.dmPaperLength), 0, "Specified in 1/10 millimeters"},
-    // @prop int|PaperWidth|Specified in 1/10 millimeters
-    {"PaperWidth", T_SHORT, OFF(devmode.dmPaperWidth), 0, "Specified in 1/10 millimeters"},
-#ifndef MS_WINCE
-    // @prop int|Position_x|Position of display relative to desktop
-    {"Position_x", T_LONG, OFF(devmode.dmPosition.x), 0, "Position of display relative to desktop"},
-    // @prop int|Position_y|Position of display relative to desktop
-    {"Position_y", T_LONG, OFF(devmode.dmPosition.y), 0, "Position of display relative to desktop"},
-#endif
-    // @prop int|DisplayOrientation|Display rotation: DMDO_DEFAULT,DMDO_90, DMDO_180, DMDO_270
-    {"DisplayOrientation", T_ULONG, OFF(devmode.dmDisplayOrientation), 0,
-     "Display rotation: DMDO_DEFAULT,DMDO_90, DMDO_180, DMDO_270"},
-    // @prop int|DisplayFixedOutput|DMDFO_DEFAULT, DMDFO_CENTER, DMDFO_STRETCH
-    {"DisplayFixedOutput", T_ULONG, OFF(devmode.dmDisplayFixedOutput), 0, "DMDFO_DEFAULT, DMDFO_CENTER, DMDFO_STRETCH"},
-    // @prop int|Scale|Specified as percentage, eg 50 means half size of original
-    {"Scale", T_SHORT, OFF(devmode.dmScale), 0, "Specified as percentage, eg 50 means half size of original"},
-    // @prop int|Copies|Nbr of copies to print
-    {"Copies", T_SHORT, OFF(devmode.dmCopies), 0, "Nbr of copies to print"},
-    // @prop int|DefaultSource|DMBIN_* constant, or can be a printer-specific value
-    {"DefaultSource", T_SHORT, OFF(devmode.dmDefaultSource), 0, "DMBIN_* constant, or can be a printer-specific value"},
-    // @prop int|PrintQuality|DMRES_* constant, interpreted as DPI if positive
-    {"PrintQuality", T_SHORT, OFF(devmode.dmPrintQuality), 0, "DMRES_* constant, interpreted as DPI if positive"},
-    // @prop int|Color|DMCOLOR_COLOR or DMCOLOR_MONOCHROME
-    {"Color", T_SHORT, OFF(devmode.dmColor), 0, "DMCOLOR_COLOR or DMCOLOR_MONOCHROME"},
-    // @prop int|Duplex|For printers that do two-sided printing: DMDUP_SIMPLEX, DMDUP_HORIZONTAL, DMDUP_VERTICAL
-    {"Duplex", T_SHORT, OFF(devmode.dmDuplex), 0,
-     "For printers that do two-sided printing: DMDUP_SIMPLEX, DMDUP_HORIZONTAL, DMDUP_VERTICAL"},
-    // @prop int|YResolution|Vertical printer resolution in DPI - if this is set, PrintQuality indicates horizontal DPI
-    {"YResolution", T_SHORT, OFF(devmode.dmYResolution), 0,
-     "Vertical printer resolution in DPI - if this is set, PrintQuality indicates horizontal DPI"},
-    // @prop int|TTOption|TrueType options: DMTT_BITMAP, DMTT_DOWNLOAD, DMTT_DOWNLOAD_OUTLINE, DMTT_SUBDEV
-    {"TTOption", T_SHORT, OFF(devmode.dmTTOption), 0,
-     "TrueType options: DMTT_BITMAP, DMTT_DOWNLOAD, DMTT_DOWNLOAD_OUTLINE, DMTT_SUBDEV"},
-    // @prop int|Collate|DMCOLLATE_TRUE or DMCOLLATE_FALSE
-    {"Collate", T_SHORT, OFF(devmode.dmCollate), 0, "DMCOLLATE_TRUE or DMCOLLATE_FALSE"},
-    // @prop int|LogPixels|Pixels per inch (only for display devices
-    {"LogPixels", T_USHORT, OFF(devmode.dmLogPixels), 0, "Pixels per inch (only for display devices)"},
-    // @prop int|BitsPerPel|Color resolution in bits per pixel
-    {"BitsPerPel", T_ULONG, OFF(devmode.dmBitsPerPel), 0, "Color resolution in bits per pixel"},
-    // @prop int|PelsWidth|Pixel width of display
-    {"PelsWidth", T_ULONG, OFF(devmode.dmPelsWidth), 0, "Pixel width of display"},
-    // @prop int|PelsHeight|Pixel height of display
-    {"PelsHeight", T_ULONG, OFF(devmode.dmPelsHeight), 0, "Pixel height of display"},
-    // @prop int|DisplayFlags|Combination of DM_GRAYSCALE and DM_INTERLACED
-    {"DisplayFlags", T_ULONG, OFF(devmode.dmDisplayFlags), 0, "Combination of DM_GRAYSCALE and DM_INTERLACED"},
-    // @prop int|DisplayFrequency|Refresh rate
-    {"DisplayFrequency", T_ULONG, OFF(devmode.dmDisplayFrequency), 0, "Refresh rate"},
-#ifdef MS_WINCE
-    // @prop int|DisplayOrientation|Display rotation: DMDO_DEFAULT,DMDO_90, DMDO_180, DMDO_270
-    {"DisplayOrientation", T_ULONG, OFF(devmode.dmDisplayOrientation), 0,
-     "Display rotation: DMDO_DEFAULT,DMDO_90, DMDO_180, DMDO_270"},
-#else
-    // @prop int|ICMMethod|Indicates where ICM is performed, one of win32con.DMICMMETHOD_* values
-    {"ICMMethod", T_ULONG, OFF(devmode.dmICMMethod), 0,
-     "Indicates where ICM is performed, one of win32con.DMICMMETHOD_* values"},
-    // @prop int|ICMIntent|Intent of ICM, one of win32con.DMICM_* values
-    {"ICMIntent", T_ULONG, OFF(devmode.dmICMIntent), 0, "Intent of ICM, one of win32con.DMICM_* values"},
-    // @prop int|MediaType|win32con.DMMEDIA_*, can also be a printer-specific value greater then DMMEDIA_USER
-    {"MediaType", T_ULONG, OFF(devmode.dmMediaType), 0,
-     "win32con.DMMEDIA_*, can also be a printer-specific value greater then DMMEDIA_USER"},
-    // @prop int|DitherType|Dithering option, win32con.DMDITHER_*
-    {"DitherType", T_ULONG, OFF(devmode.dmDitherType), 0, "Dithering options, win32con.DMDITHER_*"},
-    // @prop int|Reserved1|Reserved, use only 0
-    {"Reserved1", T_ULONG, OFF(devmode.dmReserved1), 0, "Reserved, use only 0"},
-    // @prop int|Reserved2|Reserved, use only 0
-    {"Reserved2", T_ULONG, OFF(devmode.dmReserved2), 0, "Reserved, use only 0"},
-#if WINVER >= 0x0500
-    // @prop int|Nup|Controls printing of multiple logical pages per physical page, DMNUP_SYSTEM or DMNUP_ONEUP
-    {"Nup", T_ULONG, OFF(devmode.dmNup), 0,
-     "Controls printing of multiple logical pages per physical page, DMNUP_SYSTEM or DMNUP_ONEUP"},
-    // @prop int|PanningWidth|Not used, leave as 0
-    {"PanningWidth", T_ULONG, OFF(devmode.dmPanningWidth), 0, "Not used, leave as 0"},
-    // @prop int|PanningHeight|Not used, leave as 0
-    {"PanningHeight", T_ULONG, OFF(devmode.dmPanningHeight), 0, "Not used, leave as 0"},
-#endif  // WINVER >= 0x0500
-#endif  // !MS_WINCE
-    {NULL}};
-
-// @prop str|DeviceName|String of at most 32 chars
-PyObject *PyDEVMODEA::get_DeviceName(PyObject *self, void *unused)
-{
-    PDEVMODEA pdevmode = ((PyDEVMODEA *)self)->pdevmode;
-    if (pdevmode->dmDeviceName[CCHDEVICENAME - 1] == 0)  // in case DeviceName fills space and has no trailing NULL
-        return PyBytes_FromString((char *)&pdevmode->dmDeviceName);
-    else
-        return PyBytes_FromStringAndSize((char *)&pdevmode->dmDeviceName, CCHDEVICENAME);
-}
-
-int PyDEVMODEA::set_DeviceName(PyObject *self, PyObject *v, void *unused)
-{
-    if (v == NULL) {
-        PyErr_SetString(PyExc_AttributeError, "Attributes of PyDEVMODE can't be deleted");
-        return -1;
-    }
-    char *value;
-    Py_ssize_t valuelen;
-    if (PyBytes_AsStringAndSize(v, &value, &valuelen) == -1)
-        return -1;
-    if (valuelen > CCHDEVICENAME) {
-        PyErr_Format(PyExc_ValueError, "DeviceName must be a string of length %d or less", CCHDEVICENAME);
-        return -1;
-    }
-    PDEVMODEA pdevmode = &((PyDEVMODEA *)self)->devmode;
-    ZeroMemory(&pdevmode->dmDeviceName, CCHDEVICENAME);
-    memcpy(&pdevmode->dmDeviceName, value, valuelen);
-    // update variable length DEVMODE with same value
-    memcpy(((PyDEVMODEA *)self)->pdevmode, pdevmode, pdevmode->dmSize);
-    return 0;
-}
-
-// @prop str|FormName|Name of form as returned by <om win32print.EnumForms>, at most 32 chars
-PyObject *PyDEVMODEA::get_FormName(PyObject *self, void *unused)
-{
-    PDEVMODEA pdevmode = ((PyDEVMODEA *)self)->pdevmode;
-    if (pdevmode->dmFormName[CCHFORMNAME - 1] == 0)  // If dmFormName occupies whole 32 chars, trailing NULL not present
-        return PyBytes_FromString((char *)&pdevmode->dmFormName);
-    else
-        return PyBytes_FromStringAndSize((char *)&pdevmode->dmFormName, CCHFORMNAME);
-}
-
-int PyDEVMODEA::set_FormName(PyObject *self, PyObject *v, void *unused)
-{
-    if (v == NULL) {
-        PyErr_SetString(PyExc_AttributeError, "Attributes of PyDEVMODE can't be deleted");
-        return -1;
-    }
-    char *value;
-    Py_ssize_t valuelen;
-    if (PyBytes_AsStringAndSize(v, &value, &valuelen) == -1)
-        return -1;
-    if (valuelen > CCHFORMNAME) {
-        PyErr_Format(PyExc_ValueError, "FormName must be a string of length %d or less", CCHFORMNAME);
-        return -1;
-    }
-    PDEVMODEA pdevmode = &((PyDEVMODEA *)self)->devmode;
-    ZeroMemory(&pdevmode->dmFormName, CCHFORMNAME);
-    memcpy(&pdevmode->dmFormName, value, valuelen);
-    // update variable length PDEVMODE with same value
-    memcpy(((PyDEVMODEA *)self)->pdevmode, pdevmode, pdevmode->dmSize);
-    return 0;
-}
-
-// @prop str|DriverData|Driver data appended to end of structure
-PyObject *PyDEVMODEA::get_DriverData(PyObject *self, void *unused)
-{
-    PDEVMODEA pdevmode = ((PyDEVMODEA *)self)->pdevmode;
-    if (pdevmode->dmDriverExtra == 0) {  // No extra space allocated
-        Py_INCREF(Py_None);
-        return Py_None;
-    }
-    return PyBytes_FromStringAndSize((char *)((ULONG_PTR)pdevmode + pdevmode->dmSize), pdevmode->dmDriverExtra);
-}
-
-int PyDEVMODEA::set_DriverData(PyObject *self, PyObject *v, void *unused)
-{
-    if (v == NULL) {
-        PyErr_SetString(PyExc_AttributeError, "Attributes of PyDEVMODE can't be deleted");
-        return -1;
-    }
-    char *value;
-    Py_ssize_t valuelen;
-    if (PyBytes_AsStringAndSize(v, &value, &valuelen) == -1)
-        return -1;
-    PDEVMODEA pdevmode = ((PyDEVMODEA *)self)->pdevmode;
-    if (valuelen > pdevmode->dmDriverExtra) {
-        PyErr_Format(PyExc_ValueError, "Length of DriverData cannot be longer that DriverExtra (%d bytes)",
-                     pdevmode->dmDriverExtra);
-        return -1;
-    }
-    // This is not a real struct member, calculate address after end of fixed part of structure
-    char *driverdata = (char *)((ULONG_PTR)pdevmode + pdevmode->dmSize);
-    ZeroMemory(driverdata, pdevmode->dmDriverExtra);
-    memcpy(driverdata, value, valuelen);
-    return 0;
-}
-
-PyGetSetDef PyDEVMODEA::getset[] = {
-    {"DeviceName", PyDEVMODEA::get_DeviceName, PyDEVMODEA::set_DeviceName, "String of at most 32 chars"},
-    {"FormName", PyDEVMODEA::get_FormName, PyDEVMODEA::set_FormName,
-     "Name of form as returned by EnumForms, at most 32 chars"},
-    {"DriverData", PyDEVMODEA::get_DriverData, PyDEVMODEA::set_DriverData, "Driver data appended to end of structure"},
-    {NULL}};
-
-PYWINTYPES_EXPORT PyTypeObject PyDEVMODEAType = {
-    PYWIN_OBJECT_HEAD "PyDEVMODEA",
-    sizeof(PyDEVMODEA),
-    0,
-    PyDEVMODEA::deallocFunc,
-    0,                                         // tp_print;
-    0,                                         // tp_getattr
-    0,                                         // tp_setattr
-    0,                                         // tp_compare
-    0,                                         // tp_repr
-    0,                                         // tp_as_number
-    0,                                         // tp_as_sequence
-    0,                                         // tp_as_mapping
-    0,                                         // tp_hash
-    0,                                         // tp_call
-    0,                                         // tp_str
-    0,                                         // tp_getattro
-    0,                                         // tp_setattro
-    0,                                         // tp_as_buffer
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,  // tp_flags;
-    0,                                         // tp_doc; /* Documentation string */
-    0,                                         // traverseproc tp_traverse;
-    0,                                         // tp_clear;
-    0,                                         // tp_richcompare;
-    0,                                         // tp_weaklistoffset;
-    0,                                         // tp_iter
-    0,                                         // iternextfunc tp_iternext
-    PyDEVMODEA::methods,
-    PyDEVMODEA::members,
-    PyDEVMODEA::getset,  // tp_getset;
-    0,                   // tp_base;
-    0,                   // tp_dict;
-    0,                   // tp_descr_get;
-    0,                   // tp_descr_set;
-    0,                   // tp_dictoffset;
-    0,                   // tp_init;
-    0,                   // tp_alloc;
-    PyDEVMODEA::tp_new   // newfunc tp_new;
-};
-
-PyDEVMODEA::PyDEVMODEA(PDEVMODEA pdm)
-{
-    ob_type = &PyDEVMODEAType;
-    memcpy(&devmode, pdm, pdm->dmSize);
-    pdevmode = (PDEVMODEA)malloc(pdm->dmSize + pdm->dmDriverExtra);
-    if (pdevmode == NULL)
-        PyErr_Format(PyExc_MemoryError, "PyDEVMODEA::PyDEVMODE - Unable to allocate DEVMODE of size %d",
-                     pdm->dmSize + pdm->dmDriverExtra);
-    else
-        memcpy(pdevmode, pdm, pdm->dmSize + pdm->dmDriverExtra);
-    _Py_NewReference(this);
-}
-
-PyDEVMODEA::PyDEVMODEA(void)
-{
-    ob_type = &PyDEVMODEAType;
-    static WORD dmSize = sizeof(DEVMODEA);
-    pdevmode = (PDEVMODEA)malloc(dmSize);
-    ZeroMemory(pdevmode, dmSize);
-    pdevmode->dmSize = dmSize;
-    pdevmode->dmSpecVersion = DM_SPECVERSION;
-    ZeroMemory(&devmode, dmSize);
-    devmode.dmSize = dmSize;
-    devmode.dmSpecVersion = DM_SPECVERSION;
-    _Py_NewReference(this);
-}
-
-PyDEVMODEA::PyDEVMODEA(USHORT dmDriverExtra)
-{
-    ob_type = &PyDEVMODEAType;
-    static WORD dmSize = sizeof(DEVMODEA);
-    pdevmode = (PDEVMODEA)malloc(dmSize + dmDriverExtra);
-    ZeroMemory(pdevmode, dmSize + dmDriverExtra);
-    pdevmode->dmSize = dmSize;
-    pdevmode->dmSpecVersion = DM_SPECVERSION;
-    pdevmode->dmDriverExtra = dmDriverExtra;
-    ZeroMemory(&devmode, dmSize);
-    devmode.dmSize = dmSize;
-    devmode.dmSpecVersion = DM_SPECVERSION;
-    devmode.dmDriverExtra = dmDriverExtra;
-    _Py_NewReference(this);
-}
-
-PyDEVMODEA::~PyDEVMODEA()
-{
-    if (pdevmode != NULL)
-        free(pdevmode);
-}
-
-BOOL PyDEVMODE_Check(PyObject *ob)
-{
-    if (ob->ob_type != &PyDEVMODEAType) {
-        PyErr_SetString(PyExc_TypeError, "Object must be a PyDEVMODE");
-        return FALSE;
-    }
-    return TRUE;
-}
-
-void PyDEVMODEA::deallocFunc(PyObject *ob) { delete (PyDEVMODEA *)ob; }
-
-PDEVMODEA PyDEVMODEA::GetDEVMODE(void)
-{
-    // Propagate any changes made by python attribute logic from the fixed length DEVMODE
-    // to the externally visible variable length DEVMODE before handing it off to anyone else
-    memcpy(pdevmode, &devmode, devmode.dmSize);
-    return pdevmode;
-}
-
-// @pymethod |PyDEVMODE|Clear|Resets all members of the structure
-PyObject *PyDEVMODEA::Clear(PyObject *self, PyObject *args)
-{
-    PDEVMODEA pdevmode = ((PyDEVMODEA *)self)->pdevmode;
-    USHORT dmDriverExtra = pdevmode->dmDriverExtra;
-    WORD dmSize = pdevmode->dmSize;
-    DWORD totalsize = dmSize + dmDriverExtra;
-    ZeroMemory(pdevmode, totalsize);
-    pdevmode->dmDriverExtra = dmDriverExtra;
-    pdevmode->dmSize = dmSize;
-    pdevmode->dmSpecVersion = DM_SPECVERSION;
-
-    pdevmode = &((PyDEVMODEA *)self)->devmode;
-    ZeroMemory(pdevmode, dmSize);
-    pdevmode->dmDriverExtra = dmDriverExtra;
-    pdevmode->dmSize = dmSize;
-    pdevmode->dmSpecVersion = DM_SPECVERSION;
-    Py_INCREF(Py_None);
-    return Py_None;
-}
-
-PyObject *PyDEVMODEA::tp_new(PyTypeObject *typ, PyObject *args, PyObject *kwargs)
-{
-    USHORT DriverExtra = 0;
-    static char *keywords[] = {"DriverExtra", NULL};
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|H", keywords, &DriverExtra))
-        return NULL;
-    return new PyDEVMODEA(DriverExtra);
-}
-
 // DEVMODEW support
 // @object PyDEVMODEW|Unicode version of <o PyDEVMODE> object
 
@@ -386,12 +35,10 @@ struct PyMemberDef PyDEVMODEW::members[] = {
     {"PaperLength", T_SHORT, OFFW(devmode.dmPaperLength), 0, "Specified in 1/10 millimeters"},
     // @prop int|PaperWidth|Specified in 1/10 millimeters
     {"PaperWidth", T_SHORT, OFFW(devmode.dmPaperWidth), 0, "Specified in 1/10 millimeters"},
-#ifndef MS_WINCE
     // @prop int|Position_x|Position of display relative to desktop
     {"Position_x", T_LONG, OFFW(devmode.dmPosition.x), 0, "Position of display relative to desktop"},
     // @prop int|Position_y|Position of display relative to desktop
     {"Position_y", T_LONG, OFFW(devmode.dmPosition.y), 0, "Position of display relative to desktop"},
-#endif
     // @prop int|DisplayOrientation|Display rotation: DMDO_DEFAULT,DMDO_90, DMDO_180, DMDO_270
     {"DisplayOrientation", T_ULONG, OFFW(devmode.dmDisplayOrientation), 0,
      "Display rotation: DMDO_DEFAULT,DMDO_90, DMDO_180, DMDO_270"},
@@ -432,11 +79,6 @@ struct PyMemberDef PyDEVMODEW::members[] = {
     {"DisplayFlags", T_ULONG, OFFW(devmode.dmDisplayFlags), 0, "Combination of DM_GRAYSCALE and DM_INTERLACED"},
     // @prop int|DisplayFrequency|Refresh rate
     {"DisplayFrequency", T_ULONG, OFFW(devmode.dmDisplayFrequency), 0, "Refresh rate"},
-#ifdef MS_WINCE
-    // @prop int|DisplayOrientation|Display rotation: DMDO_DEFAULT,DMDO_90, DMDO_180, DMDO_270
-    {"DisplayOrientation", T_ULONG, OFFW(devmode.dmDisplayOrientation), 0,
-     "Display rotation: DMDO_DEFAULT,DMDO_90, DMDO_180, DMDO_270"},
-#else
     // @prop int|ICMMethod|Indicates where ICM is performed, one of win32con.DMICMMETHOD_* values
     {"ICMMethod", T_ULONG, OFFW(devmode.dmICMMethod), 0,
      "Indicates where ICM is performed, one of win32con.DMICMMETHOD_* values"},
@@ -451,7 +93,6 @@ struct PyMemberDef PyDEVMODEW::members[] = {
     {"Reserved1", T_ULONG, OFFW(devmode.dmReserved1), 0, "Reserved, use only 0"},
     // @prop int|Reserved2|Reserved, use only 0
     {"Reserved2", T_ULONG, OFFW(devmode.dmReserved2), 0, "Reserved, use only 0"},
-#if WINVER >= 0x0500
     // @prop int|Nup|Controls printing of multiple logical pages per physical page, DMNUP_SYSTEM or DMNUP_ONEUP
     {"Nup", T_ULONG, OFFW(devmode.dmNup), 0,
      "Controls printing of multiple logical pages per physical page, DMNUP_SYSTEM or DMNUP_ONEUP"},
@@ -459,8 +100,6 @@ struct PyMemberDef PyDEVMODEW::members[] = {
     {"PanningWidth", T_ULONG, OFFW(devmode.dmPanningWidth), 0, "Not used, leave as 0"},
     // @prop int|PanningHeight|Not used, leave as 0
     {"PanningHeight", T_ULONG, OFFW(devmode.dmPanningHeight), 0, "Not used, leave as 0"},
-#endif  // WINVER >= 0x0500
-#endif  // !MS_WINCE
     {NULL}};
 
 // @prop string|DeviceName|String of at most 32 chars
@@ -616,7 +255,7 @@ PyDEVMODEW::PyDEVMODEW(PDEVMODEW pdm)
     memcpy(&devmode, pdm, pdm->dmSize);
     pdevmode = (PDEVMODEW)malloc(pdm->dmSize + pdm->dmDriverExtra);
     if (pdevmode == NULL)
-        PyErr_Format(PyExc_MemoryError, "PyDEVMODEA::PyDEVMODE - Unable to allocate DEVMODE of size %d",
+        PyErr_Format(PyExc_MemoryError, "PyDEVMODE::PyDEVMODE - Unable to allocate DEVMODE of size %d",
                      pdm->dmSize + pdm->dmDriverExtra);
     else
         memcpy(pdevmode, pdm, pdm->dmSize + pdm->dmDriverExtra);

--- a/win32/src/PyWinObjects.h
+++ b/win32/src/PyWinObjects.h
@@ -126,37 +126,6 @@ class PYWINTYPES_EXPORT PyHKEY : public PyHANDLE {
     virtual const char *GetTypeName() { return "PyHKEY"; }
 };
 
-class PYWINTYPES_EXPORT PyDEVMODEA : public PyObject {
-   public:
-    static struct PyMemberDef members[];
-    static struct PyMethodDef methods[];
-
-    static PyObject *get_DeviceName(PyObject *self, void *unused);
-    static int set_DeviceName(PyObject *self, PyObject *obsd, void *unused);
-    static PyObject *get_FormName(PyObject *self, void *unused);
-    static int set_FormName(PyObject *self, PyObject *obsd, void *unused);
-    static PyObject *get_DriverData(PyObject *self, void *unused);
-    static int set_DriverData(PyObject *self, PyObject *obsd, void *unused);
-    static PyGetSetDef getset[];
-
-    static void deallocFunc(PyObject *ob);
-    PyDEVMODEA(PDEVMODEA);
-    PyDEVMODEA(void);
-    PyDEVMODEA(USHORT);
-    static PyObject *Clear(PyObject *self, PyObject *args);
-    static PyObject *tp_new(PyTypeObject *, PyObject *, PyObject *);
-    // use this where a function modifies a passed-in PyDEVMODE to make changes visible to Python
-    void modify_in_place(void) { memcpy(&devmode, pdevmode, pdevmode->dmSize); }
-    PDEVMODEA GetDEVMODE(void);
-
-   protected:
-    // Pointer to variable length DEVMODE with dmDriverExtra bytes allocated at end, always use this externally
-    PDEVMODEA pdevmode;
-    // copy of fixed portion of DEVMODE for structmember api to access
-    DEVMODEA devmode;
-    ~PyDEVMODEA();
-};
-
 // Unicode version of DEVMODE
 class PYWINTYPES_EXPORT PyDEVMODEW : public PyObject {
    public:
@@ -189,10 +158,6 @@ class PYWINTYPES_EXPORT PyDEVMODEW : public PyObject {
     ~PyDEVMODEW();
 };
 
-#ifdef UNICODE
 #define PyDEVMODE PyDEVMODEW
-#else
-#define PyDEVMODE PyDEVMODEA
-#endif
 
 #endif /* __PYWINOBJECTS_H__ */

--- a/win32/src/stddde.h
+++ b/win32/src/stddde.h
@@ -56,12 +56,10 @@ class CDDEAllocator {
         LPBYTE p = (LPBYTE)(const TCHAR *)cs;
         DWORD cb = (cs.GetLength() + 1) * sizeof(TCHAR);
 
-#if defined(UNICODE)
         if(m_wFmt == CF_TEXT) {
             p = (LPBYTE)(const char*)CT2CA(cs);
             cb = (cs.GetLength() + 1) * sizeof(const char);
         }
-#endif
 
         return Alloc(p, cb);
     }
@@ -397,10 +395,6 @@ class CDDEServer : public CObject {
     CDDESystemItem_FormatList m_SystemItemFormats;
 };
 
-#ifdef UNICODE
 #define DDE_STRING_CODEPAGE CP_WINUNICODE
-#else
-#define DDE_STRING_CODEPAGE CP_WINANSI
-#endif
 
 #endif  // _STDDDE_

--- a/win32/src/win32api_display.h
+++ b/win32/src/win32api_display.h
@@ -2,13 +2,6 @@
     if (pfn##fname == NULL) \
         return PyErr_Format(PyExc_NotImplementedError, "%s is not available on this platform", #fname);
 
-// Macro to allow loading the correct ANSI/wide-character version of a function from a .dll
-#ifdef UNICODE
-#define A_OR_W "W"
-#else
-#define A_OR_W "A"
-#endif
-
 PyObject *PyChangeDisplaySettings(PyObject *self, PyObject *args);
 PyObject *PyChangeDisplaySettingsEx(PyObject *self, PyObject *args, PyObject *kwargs);
 PyObject *PyEnumDisplayDevices(PyObject *self, PyObject *args, PyObject *kwargs);

--- a/win32/src/win32clipboardmodule.cpp
+++ b/win32/src/win32clipboardmodule.cpp
@@ -915,7 +915,7 @@ static PyObject *py_set_clipboard_text(PyObject *self, PyObject *args)
     DWORD cb = 0;  // number of bytes *excluding* NULL
     size_t size_null = 0;
     if (format == CF_TEXT) {
-        if (!PyWinObject_AsString(obtext, (char **)&src, FALSE, &cb))
+        if (!PyWinObject_AsChars(obtext, (char **)&src, FALSE, &cb))
             return NULL;
         size_null = sizeof(char);
     }
@@ -953,7 +953,7 @@ static PyObject *py_set_clipboard_text(PyObject *self, PyObject *args)
             ret = PyWinLong_FromHANDLE(data);
     }
     if (format == CF_TEXT)
-        PyWinObject_FreeString((char *)src);
+        PyWinObject_FreeChars((char *)src);
     else
         PyWinObject_FreeWCHAR((WCHAR *)src);
     return ret;

--- a/win32/src/win32dynamicdialog.cpp
+++ b/win32/src/win32dynamicdialog.cpp
@@ -507,9 +507,9 @@ static CPythonDialogTemplate *ParseDlgHdrList(PyObject *tmpl)
 
     if (!PyWinObject_AsWCHAR(obcaption, &caption, FALSE))
         goto cleanup;
-    if (!PyWinObject_AsResourceIdW(obmenu, &menu, TRUE))
+    if (!PyWinObject_AsResourceId(obmenu, &menu, TRUE))
         goto cleanup;
-    if (!PyWinObject_AsResourceIdW(obwclass, &wclass, TRUE))
+    if (!PyWinObject_AsResourceId(obwclass, &wclass, TRUE))
         goto cleanup;
     if (obexstyle != Py_None) {
         tpl.dwExtendedStyle = PyLong_AsUnsignedLong(obexstyle);
@@ -592,7 +592,7 @@ static BOOL ParseDlgItemList(CPythonDialogTemplate *dlg, PyObject *tmpl)
     if (!PyArg_ParseTuple(obitem, "OOH|(hhhh)kkO:DLGITEMTEMPLATE", &obwclass, &obcaption, &tpl.id, &tpl.x, &tpl.y,
                           &tpl.cx, &tpl.cy, &tpl.style, &tpl.dwExtendedStyle, &obdata))
         goto cleanup;
-    if (!PyWinObject_AsResourceIdW(obwclass, &wclass, FALSE))
+    if (!PyWinObject_AsResourceId(obwclass, &wclass, FALSE))
         goto cleanup;
     if (!PyWinObject_AsWCHAR(obcaption, &caption, TRUE))
         goto cleanup;

--- a/win32/src/win32event.i
+++ b/win32/src/win32event.i
@@ -4,7 +4,6 @@
 %module win32event // A module which provides an interface to the win32 event/wait API
 
 %{
-//#define UNICODE
 #define _WIN32_WINNT 0x0501
 %}
 
@@ -84,9 +83,9 @@
 
 #define EVENT_ALL_ACCESS EVENT_ALL_ACCESS // Specifies all possible access flags for the event object. 
  
-#define EVENT_MODIFY_STATE EVENT_MODIFY_STATE // Enables use of the event handle in the SetEvent and ResetEvent functions to modify the event’s state. 
+#define EVENT_MODIFY_STATE EVENT_MODIFY_STATE // Enables use of the event handle in the SetEvent and ResetEventï¿½functions to modify the eventï¿½s state. 
  
-#define SYNCHRONIZE SYNCHRONIZE // Windows NT only: Enables use of the event handle in any of the wait functions to wait for the event’s state to be signaled.
+#define SYNCHRONIZE SYNCHRONIZE // Windows NT only:ï¿½Enables use of the event handle in any of the wait functionsï¿½to wait for the eventï¿½s state to be signaled.
 
 #ifndef MS_WINCE
 // @pyswig |CancelWaitableTimer|Cancels a waiting timer.

--- a/win32/src/win32file.i
+++ b/win32/src/win32file.i
@@ -4654,7 +4654,7 @@ static PyObject *py_GetFileAttributesEx(PyObject *self, PyObject *args, PyObject
 	if (bUnicode)
 		ok = PyWinObject_AsWCHAR(obfname, &wname, FALSE);
 	else
-		ok = PyWinObject_AsString(obfname, &cname, FALSE);
+		ok = PyWinObject_AsChars(obfname, &cname, FALSE);
 	if (!ok)
 		goto done;
 
@@ -4699,7 +4699,7 @@ static PyObject *py_GetFileAttributesEx(PyObject *self, PyObject *args, PyObject
 	if (buf)
 		free(buf);
 	PyWinObject_FreeWCHAR(wname);
-	PyWinObject_FreeString(cname);
+	PyWinObject_FreeChars(cname);
 	return ret;
 }
 

--- a/win32/src/win32gui.i
+++ b/win32/src/win32gui.i
@@ -6443,7 +6443,7 @@ BOOL PyParse_OPENFILENAMEW_Args(PyObject *args, PyObject *kwargs, OPENFILENAMEW 
 		PyWinObject_AsWCHAR(obInitialDir, (WCHAR **)&pofn->lpstrInitialDir, TRUE) &&
 		PyWinObject_AsWCHAR(obTitle, (WCHAR **)&pofn->lpstrTitle, TRUE) &&
 		PyWinObject_AsWCHAR(obDefExt, (WCHAR **)&pofn->lpstrDefExt, TRUE) &&
-		PyWinObject_AsResourceIdW(obTemplateName, (WCHAR **)&pofn->lpTemplateName, TRUE);
+		PyWinObject_AsResourceId(obTemplateName, (WCHAR **)&pofn->lpTemplateName, TRUE);
 		
 	done:
 	if (!ret)

--- a/win32/src/win32wnet/PyNCB.cpp
+++ b/win32/src/win32wnet/PyNCB.cpp
@@ -240,7 +240,7 @@ int PyNCB::setattro(PyObject *self, PyObject *obname, PyObject *v)
         char *value;
         DWORD valuelen;
 
-        if (!PyWinObject_AsString(v, &value, FALSE, &valuelen))
+        if (!PyWinObject_AsChars(v, &value, FALSE, &valuelen))
             return -1;
         if (valuelen > NCBNAMSZ)  // cap string length at NCBNAMSZ(16)
             valuelen = NCBNAMSZ;
@@ -249,14 +249,14 @@ int PyNCB::setattro(PyObject *self, PyObject *obname, PyObject *v)
         strncpy((char *)This->m_ncb.ncb_callname, value, valuelen);
         if (valuelen == 0)  // source was null string
             This->m_ncb.ncb_callname[0] = '\0';
-        PyWinObject_FreeString(value);
+        PyWinObject_FreeChars(value);
         return 0;
     }
 
     if (strcmp(name, "Name") == 0) {
         char *value;
         DWORD valuelen;
-        if (!PyWinObject_AsString(v, &value, FALSE, &valuelen))
+        if (!PyWinObject_AsChars(v, &value, FALSE, &valuelen))
             return -1;
         if (valuelen > NCBNAMSZ)  // cap string length at NCBNAMSZ(16)
             valuelen = NCBNAMSZ;
@@ -265,7 +265,7 @@ int PyNCB::setattro(PyObject *self, PyObject *obname, PyObject *v)
         strncpy((char *)This->m_ncb.ncb_name, value, valuelen);
         if (valuelen == 0)  // source was null string
             This->m_ncb.ncb_callname[0] = '\0';
-        PyWinObject_FreeString(value);
+        PyWinObject_FreeChars(value);
         return 0;
     }
 


### PR DESCRIPTION
* Rename and cleanup old string conversion functions now Python 2 support
  isn't required and to make "String" less ambiguous.

* Remove dead code that was only used when UNICODE was not defined, because
  it is defined everywhere.