### PR TITLE
Fix uninitialized member failure

### DIFF
--- a/com/win32com/client/combrowse.py
+++ b/com/win32com/client/combrowse.py
@@ -32,7 +32,7 @@ from pywin.tools import browser
 
 class HLIRoot(browser.HLIPythonObject):
     def __init__(self, title):
-        self.name = title
+        super().__init__(name=title)
 
     def GetSubList(self):
         return [


### PR DESCRIPTION
First of all I want to mention that I don't have very much experience with *COM*, while its *PyWin32*  wrappers are some kind of a nebula.

I discovered this while investigating [\[SO\]: win32com.client combrowse.main() (Python Object Browser) is not responding Python 3.9](https://stackoverflow.com/questions/72547993).

Very easy to reproduce:

>    ```
>    [cfati@CFATI-5510-0:C:\Windows\System32]> "e:\Work\Dev\VEnvs\py_pc064_03.09_test0\Scripts\python.exe" -c "from win32com.client.combrowse import HLIRoot as HO;print(HO(''))"
>    Traceback (most recent call last):
>      File "<string>", line 1, in <module>
>      File "e:\Work\Dev\VEnvs\py_pc064_03.09_test0\lib\site-packages\Pythonwin\pywin\tools\browser.py", line 56, in __repr__
>        + repr(self.myobject)
>    AttributeError: 'HLIRoot' object has no attribute 'myobject'
>    ```

At the beginning I wanted to modify *browser.HLIPythonObject.\_\_repr\_\_*, but I realized that would only be a lame workaround (*gainarie*), so after a bit of code browsing I came up with this.

After patching the file:

>    ```
>    [cfati@CFATI-5510-0:C:\Windows\System32]> "e:\Work\Dev\VEnvs\py_pc064_03.09_test0\Scripts\python.exe" -c "from win32com.client.combrowse import HLIRoot as HO;print(HO(''))"
>    HLIPythonObject(Generic) - name: None object: None
>    ```


As a note, the crash is no longer visible (the dialog only flashes, because the program terminates), but if adding a *time.sleep* after the dialog is displayed, it is mostly frozen, not sure should I call some of its methods (like *Wndproc*)? Not an *MFC* fan.
