### PR TITLE
Fix modeless COM browser dialog

### DIFF
--- a/Pythonwin/pywin/mfc/dialog.py
+++ b/Pythonwin/pywin/mfc/dialog.py
@@ -50,10 +50,10 @@ class Dialog(window.Wnd):
 
     # provide virtuals.
     def OnOK(self):
-        self._obj_.OnOK()
+        return self._obj_.OnOK()
 
     def OnCancel(self):
-        self._obj_.OnCancel()
+        return self._obj_.OnCancel()
 
     def OnInitDialog(self):
         self.bHaveInit = 1

--- a/Pythonwin/pywin/mfc/dialog.py
+++ b/Pythonwin/pywin/mfc/dialog.py
@@ -11,32 +11,32 @@ import win32con
 from pywin.mfc import window
 
 
-def dllFromDll(dllid):
+def dllFromDll(dll_id):
     "given a 'dll' (maybe a dll, filename, etc), return a DLL object"
-    if dllid == None:
+    if dll_id is None:
         return None
-    elif type("") == type(dllid):
-        return win32ui.LoadLibrary(dllid)
+    elif isinstance(dll_id, str):
+        return win32ui.LoadLibrary(dll_id)
     else:
         try:
-            dllid.GetFileName()
+            dll_id.GetFileName()
         except AttributeError:
             raise TypeError("DLL parameter must be None, a filename or a dll object")
-        return dllid
+        return dll_id
 
 
 class Dialog(window.Wnd):
     "Base class for a dialog"
 
-    def __init__(self, id, dllid=None):
-        """id is the resource ID, or a template
+    def __init__(self, params, dllid=None):
+        """params is the resource ID, or a template
         dllid may be None, a dll object, or a string with a dll name"""
         # must take a reference to the DLL until InitDialog.
         self.dll = dllFromDll(dllid)
-        if type(id) == type([]):  # a template
-            dlg = win32ui.CreateDialogIndirect(id)
+        if isinstance(params, list):  # a template
+            dlg = win32ui.CreateDialogIndirect(params)
         else:
-            dlg = win32ui.CreateDialog(id, self.dll)
+            dlg = win32ui.CreateDialog(params, self.dll)
         window.Wnd.__init__(self, dlg)
         self.HookCommands()
         self.bHaveInit = None

--- a/Pythonwin/pywin/tools/browser.py
+++ b/Pythonwin/pywin/tools/browser.py
@@ -8,6 +8,7 @@
 import sys
 import types
 import __main__
+import win32con
 import win32ui
 from pywin.mfc import dialog
 
@@ -398,6 +399,7 @@ class dynamic_browser(dialog.Dialog):
     ]
 
     def __init__(self, hli_root):
+        self._is_modal = True
         super().__init__(self.dt)
         self.hier_list = hierlist.HierListWithItems(hli_root, win32ui.IDB_BROWSER_HIER)
         self.HookMessage(self.on_size, win32con.WM_SIZE)
@@ -414,6 +416,8 @@ class dynamic_browser(dialog.Dialog):
     def OnCancel(self):
         self.hier_list.HierTerm()
         self.hier_list = None
+        if not self._is_modal:
+            self.EndModalLoop(win32con.IDCANCEL)
         return super().OnCancel()
 
     def on_size(self, params):
@@ -421,6 +425,10 @@ class dynamic_browser(dialog.Dialog):
         w = win32api.LOWORD(lparam)
         h = win32api.HIWORD(lparam)
         self.GetDlgItem(win32ui.IDC_LIST1).MoveWindow((0, 0, w, h))
+
+    def do_modeless(self, flags):
+        self._is_modal = False
+        return self.RunModalLoop(flags)
 
 
 def Browse(ob=__main__):

--- a/Pythonwin/pywin/tools/browser.py
+++ b/Pythonwin/pywin/tools/browser.py
@@ -398,23 +398,23 @@ class dynamic_browser(dialog.Dialog):
     ]
 
     def __init__(self, hli_root):
-        dialog.Dialog.__init__(self, self.dt)
+        super().__init__(self.dt)
         self.hier_list = hierlist.HierListWithItems(hli_root, win32ui.IDB_BROWSER_HIER)
         self.HookMessage(self.on_size, win32con.WM_SIZE)
 
     def OnInitDialog(self):
         self.hier_list.HierInit(self)
-        return dialog.Dialog.OnInitDialog(self)
+        return super().OnInitDialog()
 
     def OnOK(self):
         self.hier_list.HierTerm()
         self.hier_list = None
-        return self._obj_.OnOK()
+        return super().OnOK()
 
     def OnCancel(self):
         self.hier_list.HierTerm()
         self.hier_list = None
-        return self._obj_.OnCancel()
+        return super().OnCancel()
 
     def on_size(self, params):
         lparam = params[3]

--- a/com/win32com/client/combrowse.py
+++ b/com/win32com/client/combrowse.py
@@ -607,7 +607,7 @@ def main(modal=False):
             dlg.DoModal()
         else:
             dlg.CreateWindow()
-            dlg.ShowWindow()
+            dlg.do_modeless(0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A follow-up for #1894. <br>Fixes [\[SO\]: win32com.client combrowse.main() (Python Object Browser) is not responding Python 3.9](https://stackoverflow.com/q/72547993/4788546).

As I mentioned I am neither a *COM* expert nor an *MFC* enthusiast, and this part of *PyWin32* is new to me, although I've seen some unorthodox (to me) stuff here :).

The actual fix is the 3<sup>rd</sup> commit. It's the best compromise I found. After the crash fix, *ShowWindow* wasn't starting the dialog message loop, so calling *RunModalLoop* was required. But for some reason when dialog was closed with *IDCANCEL* (<kbd>Esc</kbd> or by clicking the *X* button), the dialog disappeared, but the loop didn't exit, so <kbd>Ctrl</kbd> + <kbd> Break</kbd> was required in the console in order to kill the process (this didn't happen for *IDOK* (<kbd>Enter</kbd>) - which worked fine). <br>That's why *EndModalLoop* is needed in *OnCancel* (even if  [\[MS.Docs\]: CDialog::OnCancel](https://docs.microsoft.com/en-us/cpp/mfc/reference/cdialog-class?view=msvc-170#oncancel) instructs to call *DestroyWindow* for modeless dialogs, that doesn't work (probably to *PyWin32* extra wrapping layer)). <br>Overriding *RunModalLoop* would have been the elegant solution, but *dialog.Dialog* doesn't have it, so the *do\_modal* wrapper was born (its naming style suggests that it doesn't come from *MFC*).

Modeless dialog works now (as seen in the image from the answer).

I don't know, maybe in the future, this functionality could be moved up to *Dialog*, but that's a task far from trivial, which would require extensive testing.
