### PR TITLE
docs: Fix a few typos

### DIFF
--- a/adodbapi/test/adodbapitest.py
+++ b/adodbapi/test/adodbapitest.py
@@ -589,7 +589,7 @@ class CommonDBTests(unittest.TestCase):
         crsr = self.getCursor()
         self.helpCreateAndPopulateTableTemp(crsr)
         crsr.prepare("SELECT fldData FROM xx_%s" % config.tmp)
-        crsr.execute(crsr.command)  # remembes the one that was prepared
+        crsr.execute(crsr.command)  # remember the one that was prepared
         rs = crsr.fetchall()
         assert len(rs) == 9
         assert rs[2][0] == 2

--- a/com/win32com/demos/excelAddin.py
+++ b/com/win32com/demos/excelAddin.py
@@ -62,7 +62,7 @@ gencache.EnsureModule(
     "{2DF8D04C-5BFA-101B-BDE5-00AA0044DE52}", 0, 2, 1, bForDemand=True
 )  # Office 9
 
-# The TLB defiining the interfaces we implement
+# The TLB defining the interfaces we implement
 universal.RegisterInterfaces(
     "{AC0714F2-3D04-11D1-AE7D-00A0C90F26F4}", 0, 1, 0, ["_IDTExtensibility2"]
 )

--- a/win32/Demos/win32gui_dialog.py
+++ b/win32/Demos/win32gui_dialog.py
@@ -12,7 +12,7 @@
 # * The buttons are "old" style, rather than based on the XP theme.
 # Hence, using:
 #   import winxpgui as win32gui
-# is recommened.
+# is recommended.
 # Please report any problems.
 import sys
 

--- a/win32/Lib/win32pdhutil.py
+++ b/win32/Lib/win32pdhutil.py
@@ -81,7 +81,7 @@ def FindPerformanceAttributesByName(
     machine=None,
     bRefresh=0,
 ):
-    """Find peformance attributes by (case insensitive) instance name.
+    """Find performance attributes by (case insensitive) instance name.
 
     Given a process name, return a list with the requested attributes.
     Most useful for returning a tuple of PIDs given a process name.


### PR DESCRIPTION
There are small typos in:
- adodbapi/test/adodbapitest.py
- com/win32com/demos/excelAddin.py
- win32/Demos/win32gui_dialog.py
- win32/Lib/win32pdhutil.py

Fixes:
- Should read `remember` rather than `remembes`.
- Should read `recommended` rather than `recommened`.
- Should read `performance` rather than `peformance`.
- Should read `defining` rather than `defiining`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md