### PR TITLE
More window functions in win32gui

### DIFF
--- a/win32/src/win32gui.i
+++ b/win32/src/win32gui.i
@@ -5817,6 +5817,10 @@ HWND GetWindow(
 	HWND hWnd,  // @pyparm int|hWnd||handle to original window
 	UINT uCmd   // @pyparm int|uCmd||relationship flag
 );
+// @pyswig int|GetTopWindow|Examines the Z order of the child windows associated with the specified parent window and retrieves a handle to the child window at the top of the Z order.
+HWND GetTopWindow(
+    HWND hWnd  // @pyparm int|hWnd||handle to parent window
+);
 // @pyswig int|GetWindowDC|returns the device context (DC) for the entire window, including title bar, menus, and scroll bars.
 HDC GetWindowDC(
 	HWND hWnd   // @pyparm int|hWnd||handle of window

--- a/win32/src/win32gui.i
+++ b/win32/src/win32gui.i
@@ -5817,10 +5817,18 @@ HWND GetWindow(
 	HWND hWnd,  // @pyparm int|hWnd||handle to original window
 	UINT uCmd   // @pyparm int|uCmd||relationship flag
 );
+
 // @pyswig int|GetTopWindow|Examines the Z order of the child windows associated with the specified parent window and retrieves a handle to the child window at the top of the Z order.
 HWND GetTopWindow(
     HWND hWnd  // @pyparm int|hWnd||handle to parent window
 );
+
+// @pyswig int|GetAncestor|retrieves the handle to the ancestor of the specified window.
+HWND GetAncestor(
+    HWND hWnd,  // @pyparm int|hWnd||handle to original window
+    UINT gaFlags  // @pyparm int|gaFlags||ancestor to be retrieved
+);
+
 // @pyswig int|GetWindowDC|returns the device context (DC) for the entire window, including title bar, menus, and scroll bars.
 HDC GetWindowDC(
 	HWND hWnd   // @pyparm int|hWnd||handle of window


### PR DESCRIPTION
- [\[MS.DOCS\]: GetTopWindow function (winuser.h)](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-gettopwindow)
- [\[MS.DOCS\]: GetAncestor function (winuser.h)](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getancestor)


Local test: [\[SO\]: Get Window Z-Order with Python Windows Extensions (@CristiFati's answer)](https://stackoverflow.com/a/73356781/4788546).