### PR TITLE
Simplify and improve pywintypes search for dll in site-packages.

### DIFF
--- a/win32/Lib/pywintypes.py
+++ b/win32/Lib/pywintypes.py
@@ -87,23 +87,17 @@ def __import_pywin32_system_module__(modname, globs):
         # In a worst-case, it means, say 'python -c "import win32api"'
         # will not work but 'python -c "import pywintypes, win32api"' will,
         # but it's better than nothing.
-        # We prefer the "user" site-packages if it exists...
+
+        # We use the same logic as pywin32_bootstrap to find potential location for the dll
+        # Simply import pywin32_system32 and look in the paths in pywin32_system32.__path__
+
         if found is None:
-            import site
-
-            maybe = os.path.join(site.USER_SITE, "pywin32_system32", filename)
-            if os.path.isfile(maybe):
-                found = maybe
-
-        # Or the "global" site-packages.
-        if found is None:
-            import sysconfig
-
-            maybe = os.path.join(
-                sysconfig.get_paths()["platlib"], "pywin32_system32", filename
-            )
-            if os.path.isfile(maybe):
-                found = maybe
+            import pywin32_system32
+            for path in pywin32_system32.__path__:
+                maybe = os.path.join(path, filename)
+                if os.path.isfile(maybe):
+                    found = maybe
+                    break
 
         if found is None:
             # give up in disgust.

--- a/win32/Lib/pywintypes.py
+++ b/win32/Lib/pywintypes.py
@@ -93,6 +93,7 @@ def __import_pywin32_system_module__(modname, globs):
 
         if found is None:
             import pywin32_system32
+
             for path in pywin32_system32.__path__:
                 maybe = os.path.join(path, filename)
                 if os.path.isfile(maybe):


### PR DESCRIPTION
Fixes #1932 

The current method only looks at "global" and "user" site,
which is not enough if pywin32 is installed in "system" site packages
and imported from a venv created with --system-site-packages.

With this updated approach, we avoid looking at each site separately
and let the import statement find the location of pywin32_system32.