### PR TITLE
Improve WinSDK search mechanism

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,8 @@ def find_platform_sdk_dir():
     preferred_ver = "10.0.16299.0"
     if preferred_ver not in installed_versions:
         print(
-            "Windows 10 SDK version", preferred_ver,
+            "Windows 10 SDK version",
+            preferred_ver,
             "is preferred, but that's not installed.")
         print("Installed versions are", installed_versions)
     else:
@@ -148,7 +149,8 @@ def find_platform_sdk_dir():
         include = [os.path.join(include_base, user_mode)]
         if not os.path.exists(os.path.join(include[0], "windows.h")):
             print(
-                "Found Windows sdk in", include,
+                "Found Windows sdk in",
+                include,
                 "but it doesn't appear to have windows.h")
             continue
         include.append(os.path.join(include_base, "shared"))

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,8 @@ def find_platform_sdk_dir():
     # that if it exists, otherwise we use the earliest installed version.
     preferred_ver = "10.0.16299.0"
     if preferred_ver not in installed_versions:
-        print("Windows 10 SDK version", preferred_ver,
+        print(
+            "Windows 10 SDK version", preferred_ver,
             "is preferred, but that's not installed.")
         print("Installed versions are", installed_versions)
     else:
@@ -146,7 +147,8 @@ def find_platform_sdk_dir():
         include_base = os.path.join(install_root, "include", ver)
         include = [os.path.join(include_base, user_mode)]
         if not os.path.exists(os.path.join(include[0], "windows.h")):
-            print("Found Windows sdk in", include,
+            print(
+                "Found Windows sdk in", include,
                 "but it doesn't appear to have windows.h")
             continue
         include.append(os.path.join(include_base, "shared"))

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,8 @@ def find_platform_sdk_dir():
         print(
             "Windows 10 SDK version",
             preferred_ver,
-            "is preferred, but that's not installed.")
+            "is preferred, but that's not installed.",
+        )
         print("Installed versions are", installed_versions)
     else:
         installed_versions = [e for e in installed_versions if e != preferred_ver]
@@ -151,7 +152,8 @@ def find_platform_sdk_dir():
             print(
                 "Found Windows sdk in",
                 include,
-                "but it doesn't appear to have windows.h")
+                "but it doesn't appear to have windows.h",
+            )
             continue
         include.append(os.path.join(include_base, "shared"))
         lib = [os.path.join(install_root, "lib", ver, user_mode)]


### PR DESCRIPTION
Found this when building for #1928. 

Not sure if anyone else ran into this. I must mention that I have 9 different *VStudio* versions installed (and each one installed its "own" *WinSDK* version). At some point I did some cleanup (as there were too many *WinSDK*s), I don't remember if I did that from *Programs and Features* or from a *VStudio* installer (in any case I didn't manually alter the paths or registry keys).

Bottom line is that I have a discrepancy between registry and disk (1<sup>st</sup> entry returned by registry does not exist on disk) and due to (what I consider) a bug in *setup.py*, I end up in the following situation:

```lang-bat
[cfati@CFATI-5510-0:e:\Work\Dev\GitHub\CristiFati\pywin32\src]> dir /b "c:\Program Files (x86)\Windows Kits\10\Include"
10.0.10150.0
10.0.10240.0
10.0.17763.0
10.0.18362.0
10.0.19041.0
10.0.22000.0

[cfati@CFATI-5510-0:e:\Work\Dev\GitHub\CristiFati\pywin32\src]> "e:\Work\Dev\VEnvs\py_pc064_03.09_test0\Scripts\python.exe" setup.py -h
Building pywin32 3.9.304.1
Windows 10 SDK version 10.0.16299.0 is preferred, but that's not installed
Installed versions are ['10.0.17134.0', '10.0.17763.0', '10.0.18362.0', '10.0.19041.0', '10.0.22000.0']
Using 10.0.17134.0
Found Windows sdk in ['C:\\Program Files (x86)\\Windows Kits\\10\\include\\10.0.17134.0\\um'] but it doesn't appear to have windows.h

It looks like you are trying to build pywin32 in an environment without
the necessary tools installed. It's much easier to grab binaries!

Please read the docstring at the top of this file, or read README.md
for more information.

Traceback (most recent call last):
  File "e:\Work\Dev\GitHub\CristiFati\pywin32\src\setup.py", line 156, in <module>
    raise RuntimeError("Can't find the Windows SDK")
RuntimeError: Can't find the Windows SDK
```

even if **I have valid *WinSDK* version**(s).

Besides the fix, I also extracted registry code in a different function (will be easier to maintain in case *MS* decides to also release *064bit* *WinSDK* versions), and renamed some variables.

This can be worked around by setting *MSSDK\_\** variables, but it should also work *OOTB*.
