### PR TITLE
Various ssize_t cleanups.

### DIFF
--- a/com/win32com/src/PyIDispatch.cpp
+++ b/com/win32com/src/PyIDispatch.cpp
@@ -110,7 +110,7 @@ PyObject *PyIDispatch::GetIDsOfNames(PyObject *self, PyObject *args)
     // @pyparm string|name||A name to query for
     // @pyparmalt1 [string, ...]|[name, ...]||A sequence of string names to query
     // @comm Currently the LCID can not be specified, and  LOCALE_SYSTEM_DEFAULT is used.
-    int argc = PyTuple_GET_SIZE(args);
+    int argc = (int)PyTuple_GET_SIZE(args);
     if (argc < 1)
         return PyErr_Format(PyExc_TypeError, "At least one argument must be supplied");
 
@@ -189,7 +189,7 @@ PyObject *PyIDispatch::GetIDsOfNames(PyObject *self, PyObject *args)
 static BOOL PyCom_MakeUntypedDISPPARAMS(PyObject *args, int numArgs, WORD wFlags, DISPPARAMS *pParm,
                                         PythonOleArgHelper **ppHelpers)
 {
-    int argc = PyObject_Length(args);
+    int argc = (int)PyObject_Length(args);
     DISPID dispidNamed = DISPID_PROPERTYPUT;
     // Clean initialize
     pParm->rgvarg = NULL;
@@ -261,7 +261,7 @@ PyObject *PyIDispatch::Invoke(PyObject *self, PyObject *args)
 #else
     PyErr_Clear();
 #endif
-    int argc = PyObject_Length(args);
+    int argc = (int)PyObject_Length(args);
     if (argc == -1)
         return NULL;
     if (argc < 4)
@@ -339,7 +339,7 @@ PyObject *PyIDispatch::InvokeTypes(PyObject *self, PyObject *args)
 {
     /* InvokeType(dispid, lcid, wflags, ELEMDESC resultType, ELEMDESC[] argTypes, arg1, arg2...) */
     PyErr_Clear();
-    int argc = PyObject_Length(args);
+    int argc = (int)PyObject_Length(args);
     if (argc == -1)
         return NULL;
     if (argc < 5)
@@ -362,7 +362,7 @@ PyObject *PyIDispatch::InvokeTypes(PyObject *self, PyObject *args)
     if (PyErr_Occurred())
         return NULL;
     int numArgs;
-    int argTypesLen = PyObject_Length(argsElemDescArray);
+    int argTypesLen = (int)PyObject_Length(argsElemDescArray);
     if (!PyTuple_Check(argsElemDescArray) || argTypesLen < argc - 5)
         return PyErr_Format(PyExc_TypeError,
                             "The array of argument types must be a tuple whose size is <= to the number of arguments.");
@@ -687,7 +687,7 @@ PyObject *PyIDispatchEx::InvokeEx(PyObject *self, PyObject *args)
 
     DISPPARAMS dispparams;
     PythonOleArgHelper *helpers;
-    if (!PyCom_MakeUntypedDISPPARAMS(invokeArgs, PyObject_Length(invokeArgs), flags, &dispparams, &helpers))
+    if (!PyCom_MakeUntypedDISPPARAMS(invokeArgs, (int)PyObject_Length(invokeArgs), flags, &dispparams, &helpers))
         return NULL;
 
     VARIANT varResult;

--- a/com/win32com/src/extensions/PyGEnumVariant.cpp
+++ b/com/win32com/src/extensions/PyGEnumVariant.cpp
@@ -16,17 +16,16 @@ STDMETHODIMP PyGEnumVARIANT::Next(
 
     if (!PySequence_Check(result))
         goto error;
-    int len;
-    len = PyObject_Length(result);
-    if (len == -1)
+    Py_ssize_t len = PyObject_Length(result);
+    if (len == -1 || !PyWin_is_ssize_dword(len))
         goto error;
-    if (len > (int)celt)
+    if (len > celt)
         len = celt;
 
     if (pCeltFetched)
-        *pCeltFetched = len;
+        *pCeltFetched = (ULONG)len;
 
-    int i;
+    ULONG i;
     for (i = 0; i < len; ++i) {
         PyObject *ob = PySequence_GetItem(result, i);
         if (ob == NULL)
@@ -42,7 +41,7 @@ STDMETHODIMP PyGEnumVARIANT::Next(
 
     Py_DECREF(result);
 
-    return len < (int)celt ? S_FALSE : S_OK;
+    return len < celt ? S_FALSE : S_OK;
 
 error:
     PyErr_Clear();  // just in case

--- a/com/win32com/src/extensions/PyICatInformation.cpp
+++ b/com/win32com/src/extensions/PyICatInformation.cpp
@@ -61,7 +61,7 @@ PyObject *PyICatInformation::EnumClassesOfCategories(PyObject *self, PyObject *a
             PyErr_SetString(PyExc_TypeError, "Only None or lists are supported for the params.");
             return NULL;
         }
-        cImplemented = PySequence_Length(listImplemented);
+        cImplemented = (ULONG)PySequence_Length(listImplemented);
         pIDs = new GUID[cImplemented];
         for (ULONG i = 0; i < cImplemented; i++) {
             PyObject *ob = PySequence_GetItem(listImplemented, i);
@@ -84,7 +84,7 @@ PyObject *PyICatInformation::EnumClassesOfCategories(PyObject *self, PyObject *a
             delete pIDs;
             return NULL;
         }
-        cRequired = PySequence_Length(listRequired);
+        cRequired = (ULONG)PySequence_Length(listRequired);
         pIDsReqd = new GUID[cRequired];
         for (ULONG i = 0; i < cRequired; i++) {
             PyObject *ob = PySequence_GetItem(listRequired, i);

--- a/com/win32com/src/extensions/PyICreateTypeInfo.cpp
+++ b/com/win32com/src/extensions/PyICreateTypeInfo.cpp
@@ -350,10 +350,12 @@ PyObject *PyICreateTypeInfo::SetFuncAndParamNames(PyObject *self, PyObject *args
         PyErr_SetString(PyExc_TypeError, "The names param must be a sequence of strings/unicodes");
         return NULL;
     }
-    UINT cNames = PySequence_Length(obrgszNames);
+    Py_ssize_t cNames = PySequence_Length(obrgszNames);
+    PYWIN_CHECK_SSIZE_DWORD(cNames, NULL);
+
     OLECHAR **pNames = new OLECHAR *[cNames];
     memset(pNames, 0, sizeof(OLECHAR *) * cNames);
-    UINT i;
+    Py_ssize_t i;
     for (i = 0; bPythonIsHappy && i < cNames; i++) {
         PyObject *item = PySequence_GetItem(obrgszNames, i);
         if (item == NULL)
@@ -369,7 +371,7 @@ PyObject *PyICreateTypeInfo::SetFuncAndParamNames(PyObject *self, PyObject *args
     }
     HRESULT hr;
     PY_INTERFACE_PRECALL;
-    hr = pICTI->SetFuncAndParamNames(index, pNames, cNames);
+    hr = pICTI->SetFuncAndParamNames(index, pNames, (UINT)cNames);
     PY_INTERFACE_POSTCALL;
 
     for (i = 0; i < cNames; i++) PyWinObject_FreeBstr(pNames[i]);

--- a/com/win32com/src/extensions/PyIEnumConnectionPoints.cpp
+++ b/com/win32com/src/extensions/PyIEnumConnectionPoints.cpp
@@ -163,15 +163,14 @@ STDMETHODIMP PyGEnumConnectionPoints::Next(
 
     if (!PySequence_Check(result))
         goto error;
-    int len;
-    len = PyObject_Length(result);
-    if (len == -1)
+    Py_ssize_t len = PyObject_Length(result);
+    if (len == -1 || !PyWin_is_ssize_dword(len))
         goto error;
-    if (len > (int)celt)
+    if (len > celt)
         len = celt;
 
     if (pCeltFetched)
-        *pCeltFetched = len;
+        *pCeltFetched = (ULONG)len;
 
     int i;
     for (i = 0; i < len; ++i) {

--- a/com/win32com/src/extensions/PyIEnumConnections.cpp
+++ b/com/win32com/src/extensions/PyIEnumConnections.cpp
@@ -154,15 +154,14 @@ STDMETHODIMP PyGEnumConnections::Next(
 
     if (!PySequence_Check(result))
         goto error;
-    int len;
-    len = PyObject_Length(result);
-    if (len == -1)
+    Py_ssize_t len = PyObject_Length(result);
+    if (len == -1 || !PyWin_is_ssize_dword(len))
         goto error;
-    if (len > (int)celt)
+    if (len > celt)
         len = celt;
 
     if (pCeltFetched)
-        *pCeltFetched = len;
+        *pCeltFetched = (ULONG)len;
 
     int i;
     for (i = 0; i < len; ++i) {

--- a/com/win32com/src/extensions/PyIEnumFORMATETC.cpp
+++ b/com/win32com/src/extensions/PyIEnumFORMATETC.cpp
@@ -158,15 +158,14 @@ STDMETHODIMP PyGEnumFORMATETC::Next(
 
     if (!PySequence_Check(result))
         goto error;
-    int len;
-    len = PyObject_Length(result);
-    if (len == -1)
+    Py_ssize_t len = PyObject_Length(result);
+    if (len == -1 || !PyWin_is_ssize_dword(len))
         goto error;
-    if (len > (int)celt)
+    if (len > celt)
         len = celt;
 
     if (pCeltFetched)
-        *pCeltFetched = len;
+        *pCeltFetched = (ULONG)len;
 
     int i;
     for (i = 0; i < len; ++i) {

--- a/com/win32com/src/extensions/PyIEnumSTATPROPSETSTG.cpp
+++ b/com/win32com/src/extensions/PyIEnumSTATPROPSETSTG.cpp
@@ -165,15 +165,14 @@ STDMETHODIMP PyGEnumSTATPROPSETSTG::Next(
 
     if (!PySequence_Check(result))
         goto error;
-    int len;
-    len = PyObject_Length(result);
-    if (len == -1)
+    Py_ssize_t len = PyObject_Length(result);
+    if (len == -1 || !PyWin_is_ssize_dword(len))
         goto error;
-    if (len > (int)celt)
+    if (len > celt)
         len = celt;
 
     if (pCeltFetched)
-        *pCeltFetched = len;
+        *pCeltFetched = (ULONG)len;
 
     int i;
     for (i = 0; i < len; ++i) {

--- a/com/win32com/src/extensions/PyIEnumSTATPROPSTG.cpp
+++ b/com/win32com/src/extensions/PyIEnumSTATPROPSTG.cpp
@@ -167,15 +167,14 @@ STDMETHODIMP PyGEnumSTATPROPSTG::Next(
 
     if (!PySequence_Check(result))
         goto error;
-    int len;
-    len = PyObject_Length(result);
-    if (len == -1)
+    Py_ssize_t len = PyObject_Length(result);
+    if (len == -1 || !PyWin_is_ssize_dword(len))
         goto error;
-    if (len > (int)celt)
+    if (len > celt)
         len = celt;
 
     if (pCeltFetched)
-        *pCeltFetched = len;
+        *pCeltFetched = (ULONG)len;
 
     int i;
     PyObject *obname;

--- a/com/win32com/src/extensions/PyIEnumSTATSTG.cpp
+++ b/com/win32com/src/extensions/PyIEnumSTATSTG.cpp
@@ -161,15 +161,14 @@ STDMETHODIMP PyGEnumSTATSTG::Next(
 
     if (!PySequence_Check(result))
         goto error;
-    int len;
-    len = PyObject_Length(result);
-    if (len == -1)
+    Py_ssize_t len = PyObject_Length(result);
+    if (len == -1 || !PyWin_is_ssize_dword(len))
         goto error;
-    if (len > (int)celt)
+    if (len > celt)
         len = celt;
 
     if (pCeltFetched)
-        *pCeltFetched = len;
+        *pCeltFetched = (ULONG)len;
 
     int i;
     for (i = 0; i < len; ++i) {

--- a/com/win32com/src/extensions/PyIEnumString.cpp
+++ b/com/win32com/src/extensions/PyIEnumString.cpp
@@ -157,10 +157,10 @@ STDMETHODIMP PyGEnumString::Next(ULONG celt, LPOLESTR __RPC_FAR *rgVar, ULONG __
     // Caller is expected to allocate array of string pointers, server allocates strings themselves
     ZeroMemory(rgVar, celt * sizeof(LPOLESTR));
     result_tuple = PySequence_Tuple(result);
-    if (result_tuple == NULL)
+    if (result_tuple == NULL || PyTuple_GET_SIZE(result_tuple) > ULONG_MAX)
         return PyCom_SetCOMErrorFromPyException(IID_IEnumString);
     hr = S_OK;
-    *pCeltFetched = PyTuple_GET_SIZE(result_tuple);
+    *pCeltFetched = (ULONG)PyTuple_GET_SIZE(result_tuple);
     if (*pCeltFetched > celt) {
         PyErr_Format(PyExc_ValueError, "Received %d items , but only %d items requested", *pCeltFetched, celt);
         hr = PyCom_SetCOMErrorFromPyException(IID_IEnumString);

--- a/com/win32com/src/extensions/PyIType.cpp
+++ b/com/win32com/src/extensions/PyIType.cpp
@@ -332,7 +332,9 @@ static PyObject *typeinfo_getidsofnames(PyObject *self, PyObject *args)
     if (pti == NULL)
         return NULL;
     UINT i;
-    int argc = PyTuple_GET_SIZE(args);
+    Py_ssize_t argc = PyTuple_GET_SIZE(args);
+    PYWIN_CHECK_SSIZE_DWORD(argc, NULL);
+
     if (argc < 1) {
         PyErr_SetString(PyExc_TypeError, "At least one argument must be supplied");
         return NULL;
@@ -350,7 +352,7 @@ static PyObject *typeinfo_getidsofnames(PyObject *self, PyObject *args)
             offset = 1;
     }
 
-    UINT cNames = argc - offset;
+    UINT cNames = (UINT)argc - offset;
     OLECHAR FAR *FAR *rgszNames = new LPOLESTR[cNames];
 
     for (i = 0; i < cNames; ++i) {

--- a/com/win32com/src/extensions/PyITypeObjects.cpp
+++ b/com/win32com/src/extensions/PyITypeObjects.cpp
@@ -229,7 +229,7 @@ BOOL PyObject_AsELEMDESCArray(PyObject *ob, ELEMDESC **ppDesc, short *pNum, void
         PyErr_SetString(PyExc_TypeError, "ELEMDESCArray must be a sequence of ELEMDESCs");
         return FALSE;
     }
-    *pNum = PySequence_Length(ob);
+    *pNum = (short)PySequence_Length(ob);
     *ppDesc = (ELEMDESC *)AllocMore(pMore, sizeof(ELEMDESC) * *pNum);
     if (*ppDesc == NULL)
         return NULL;

--- a/com/win32com/src/oleargs.cpp
+++ b/com/win32com/src/oleargs.cpp
@@ -728,7 +728,7 @@ static BOOL PyCom_SAFEARRAYFromPyObjectEx(PyObject *obj, SAFEARRAY **ppSA, bool 
     for (LONG dimLook = 1; dimLook <= cDims; dimLook++) {
         pBounds[dimLook - 1].lLbound = 0;  // always!
         // Don't use PySequence_Length due to memoryview not supporting sequence protocol
-        pBounds[dimLook - 1].cElements = PyObject_Length(obItemCheck);
+        pBounds[dimLook - 1].cElements = (ULONG)PyObject_Length(obItemCheck);
         if (!bAllocNewArray) {
             LONG exist_lbound, exist_ubound;
             SafeArrayGetLBound(*ppSA, dimLook, &exist_lbound);
@@ -1683,8 +1683,8 @@ BOOL PyCom_MakeOlePythonCall(PyObject *handler, DISPPARAMS FAR *params, VARIANT 
         PyObject *simpleRet;
         if (PyTuple_Check(result) && PyTuple_Size(result)) {
             simpleRet = PyTuple_GetItem(result, 0);
-            int retNumber = 1;
-            int retTotal = PyTuple_Size(result);
+            UINT retNumber = 1;
+            UINT retTotal = (UINT)PyTuple_Size(result);
 
             // Params are reverse order - loop from the back.
             for (unsigned int param = params->cArgs; param != 0 && retNumber < retTotal; param--) {

--- a/com/win32com/src/univgw.cpp
+++ b/com/win32com/src/univgw.cpp
@@ -393,11 +393,12 @@ static PyObject *univgw_CreateVTable(PyObject *self, PyObject *args)
     if (methods == NULL)
         return NULL;
 
-    int count = PyObject_Length(methods);
+    Py_ssize_t count = PyObject_Length(methods);
     if (count == -1) {
         Py_DECREF(methods);
         return NULL;
     }
+    PYWIN_CHECK_SSIZE_DWORD(count, NULL);
     PyObject *methodsArgc = PyObject_CallMethod(obDef, "vtbl_argcounts", NULL);
     if (methodsArgc == NULL)
         return NULL;
@@ -424,7 +425,7 @@ static PyObject *univgw_CreateVTable(PyObject *self, PyObject *args)
 
     vtbl->magic = GW_VTBL_MAGIC;
     vtbl->iid = iid;
-    vtbl->cMethod = count;
+    vtbl->cMethod = (UINT)count;
     vtbl->cReservedMethods = numReservedVtables;
 
     vtbl->dispatcher = PyObject_GetAttrString(obDef, "dispatch");

--- a/win32/src/PySID.cpp
+++ b/win32/src/PySID.cpp
@@ -245,7 +245,7 @@ PYWINTYPES_EXPORT PyTypeObject PySIDType = {
     0,                                        /* tp_new */
 };
 
-PySID::PySID(int bufSize, void *buf /* = NULL */)
+PySID::PySID(Py_ssize_t bufSize, void *buf /* = NULL */)
 {
     ob_type = &PySIDType;
     _Py_NewReference(this);

--- a/win32/src/PySecurityObjects.h
+++ b/win32/src/PySecurityObjects.h
@@ -87,7 +87,7 @@ class PYWINTYPES_EXPORT PySID : public PyObject {
    public:
     PSID GetSID() { return m_psid; }
 
-    PySID(int bufSize, void *initBuf = NULL);
+    PySID(Py_ssize_t bufSize, void *initBuf = NULL);
     PySID(PSID other);
     ~PySID();
 

--- a/win32/src/PyUnicode.cpp
+++ b/win32/src/PyUnicode.cpp
@@ -183,8 +183,9 @@ BOOL PyWinObject_AsBstr(PyObject *stringObject, BSTR *pResult, BOOL bNoneOK /*= 
         // Py3.12+: only conversion yields the correct number of wide chars (incl. surrogate pairs).
         // For simplicity we use a temp buffer.
         TmpWCHAR tw = stringObject;  if (!tw) return FALSE;
+        PYWIN_CHECK_SSIZE_DWORD(tw.length, NULL);
         // SysAllocStringLen allocates length+1 wchars (and puts a \0 at end); like PyUnicode_AsWideCharString
-        *pResult = SysAllocStringLen(tw, tw.length);
+        *pResult = SysAllocStringLen(tw, (UINT)tw.length);
     }
     else if (stringObject == Py_None) {
         if (bNoneOK) {

--- a/win32/src/PyWinTypes.h
+++ b/win32/src/PyWinTypes.h
@@ -121,6 +121,7 @@ PYWINTYPES_EXPORT PyObject *PyWin_SetBasicCOMError(HRESULT hr);
 //
 // A sizes/lengths are reported as a `DWORD` rather than a `Py_ssize_t`, that's what the callers
 // need. `Py_ssize_t` used as the "in" type.
+// (We also use this for UINT and ULONG, all of which are 32bit unsigned ints.)
 
 // Sometimes we need to downcast from a ssize_t to a DWORD
 inline bool PyWin_is_ssize_dword(Py_ssize_t val) {

--- a/win32/src/win32file.i
+++ b/win32/src/win32file.i
@@ -1879,7 +1879,7 @@ static PyObject *py_ConnectEx( PyObject *self, PyObject *args, PyObject *kwargs 
 
 	rc=0;
 	Py_BEGIN_ALLOW_THREADS;
-	if (!lpfnConnectEx(sConnecting, res->ai_addr, res->ai_addrlen, pybuf.ptr(), pybuf.len(), &sent, pOverlapped))
+	if (!lpfnConnectEx(sConnecting, res->ai_addr, (int)res->ai_addrlen, pybuf.ptr(), pybuf.len(), &sent, pOverlapped))
 		rc=WSAGetLastError();
 	Py_END_ALLOW_THREADS;
 	WspiapiFreeAddrInfo(res);
@@ -3493,10 +3493,10 @@ PyObject *PyWinObject_FromPENCRYPTION_CERTIFICATE_HASH_LIST(PENCRYPTION_CERTIFIC
 }
 
 BOOL PyWinObject_AsPENCRYPTION_CERTIFICATE_LIST(PyObject *obcert_list, PENCRYPTION_CERTIFICATE_LIST pecl)
-{	
+{
 	char *format_msg="ENCRYPTION_CERTIFICATE_LIST must be represented as a sequence of sequences of (PySID, str, int dwCertEncodingType )";
 	BOOL bSuccess=TRUE;
-	DWORD cert_cnt=0, cert_ind=0;
+	DWORD cert_ind=0;
 	PENCRYPTION_CERTIFICATE *ppec=NULL;
 	PyObject *obcert=NULL;
 	PyObject *obsid=NULL, *obcert_member=NULL;
@@ -3505,7 +3505,9 @@ BOOL PyWinObject_AsPENCRYPTION_CERTIFICATE_LIST(PyObject *obcert_list, PENCRYPTI
 		PyErr_SetString(PyExc_TypeError,format_msg);
 		return FALSE;
 		}
-	cert_cnt=PySequence_Length(obcert_list);
+	Py_ssize_t ssize_cert_cnt=PySequence_Length(obcert_list);
+	PYWIN_CHECK_SSIZE_DWORD(ssize_cert_cnt, FALSE);
+	DWORD cert_cnt=(DWORD)ssize_cert_cnt;
 	pecl->nUsers=cert_cnt;
 	ppec=(PENCRYPTION_CERTIFICATE *)malloc(cert_cnt*sizeof(PENCRYPTION_CERTIFICATE));
 	if (ppec==NULL){
@@ -3585,7 +3587,7 @@ BOOL PyWinObject_AsPENCRYPTION_CERTIFICATE_HASH_LIST(PyObject *obhash_list, PENC
 {
 	char *err_msg="ENCRYPTION_CERTIFICATE_HASH_LIST must be represented as a sequence of sequences of (PySID, bytes, string)";
 	BOOL bSuccess=TRUE;
-	DWORD hash_cnt=0, hash_ind=0;
+	DWORD hash_ind=0;
 	PENCRYPTION_CERTIFICATE_HASH *ppech=NULL;
 	PyObject *obsid=NULL, *obDisplayInformation=NULL, *obhash=NULL;
 	PyObject *obhash_item=NULL;
@@ -3594,7 +3596,10 @@ BOOL PyWinObject_AsPENCRYPTION_CERTIFICATE_HASH_LIST(PyObject *obhash_list, PENC
 		PyErr_SetString(PyExc_TypeError,err_msg);
 		return FALSE;
 		}
-	hash_cnt=PySequence_Length(obhash_list);
+	Py_ssize_t ssize_hash_cnt=PySequence_Length(obhash_list);
+	PYWIN_CHECK_SSIZE_DWORD(ssize_hash_cnt, FALSE);
+	DWORD hash_cnt=(DWORD)ssize_hash_cnt;
+
 	pechl->nCert_Hash=hash_cnt;
 	ppech=(PENCRYPTION_CERTIFICATE_HASH *)malloc(hash_cnt*sizeof(PENCRYPTION_CERTIFICATE_HASH));
 	if (ppech==NULL){

--- a/win32/src/win32gui.i
+++ b/win32/src/win32gui.i
@@ -6290,7 +6290,7 @@ BOOL PyParse_OPENFILENAMEW_Args(PyObject *args, PyObject *kwargs, OPENFILENAMEW 
 
 PyObject *PyReturn_OPENFILENAMEW_Output(OPENFILENAMEW *pofn)
 {
-	DWORD filechars, filterchars;
+	Py_ssize_t filechars, filterchars;
 	// If OFN_ALLOWMULTISELECT is set, the terminator is 2 NULLs,
 	// otherwise a single NULL.
 	if (pofn->Flags & OFN_ALLOWMULTISELECT) {


### PR DESCRIPTION
Primarily just avoids warning when converting between Py_ssize_t and ints. Many cases the sizes are checked, but other cases just blindly cast - the latter is done when it seems almost impossible the int will be large enough to overflow, but that choice might seem arbitrary in some cases.

@kxrob, if you have a chance, can you check I didn't do anything too crazy?