### PR TITLE
Handle `varchar(max)`/`nvarchar(max)` column sizes

### DIFF
--- a/win32/src/odbc.cpp
+++ b/win32/src/odbc.cpp
@@ -1010,13 +1010,13 @@ static BOOL bindOutput(cursorObject *cur)
                 break;
             case SQL_BINARY:
             case SQL_VARBINARY:
-                if (!bindOutputVar(cur, rawCopy, SQL_C_BINARY, cur->max_width, pos, false))
+                if (!bindOutputVar(cur, rawCopy, SQL_C_BINARY, (vsize == 0) ? cur->max_width : vsize, pos, false))
                     return FALSE;
                 typeOf = DbiRaw;
                 break;
             case SQL_VARCHAR:
             case SQL_WVARCHAR:
-                if (!bindOutputVar(cur, wcharCopy, SQL_C_WCHAR, (vsize + 1) * sizeof(WCHAR), pos, false))
+                if (!bindOutputVar(cur, wcharCopy, SQL_C_WCHAR, (((vsize == 0) ? cur->max_width : vsize) + 1) * sizeof(WCHAR), pos, false))
                     return FALSE;
                 typeOf = DbiString;
                 break;


### PR DESCRIPTION
`SQLDescribeCol()` returns 0 ("unlimited") as column sizes for `varchar(max)`/`nvarchar(max)`/`varbinary(max)` types. We use the cursor's maximum output size instead in this case.

The change for `SQL_BINARY`/`SQL_VARBINARY` cases is not a must but fits the idea of the original commit (c91a0f1).

Fixes mhammond#1953.