### PR TITLE
better error handling for setup.py install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -630,6 +630,10 @@ class my_build_ext(build_ext):
         canary_dll = find_visual_studio_file(
             r"VC\Redist\MSVC\*\{}\*\mfc140u.dll".format(self.plat_dir)
         )
+        
+        if not canary_dll:
+            raise RuntimeError("MFC dll not found!")
+            
         mfc_dir = os.path.dirname(canary_dll)
         mfc_contents = [os.path.join(mfc_dir, p) for p in os.listdir(mfc_dir)]
 


### PR DESCRIPTION
An error handling for a case where MFC was not installed locally when trying to run 'setup.py install'.
Happened to me, and the unedited version does not throw an indicative error.