### PR TITLE
Fix: inspect.formatargspec removed in Py3.11

### DIFF
--- a/Pythonwin/pywin/idle/CallTips.py
+++ b/Pythonwin/pywin/idle/CallTips.py
@@ -130,7 +130,7 @@ def get_arg_text(ob):
             fob = ob
         if inspect.isfunction(fob) or inspect.ismethod(fob):
             try:
-                argText = inspect.formatargspec(*inspect.getfullargspec(fob))
+                argText = str(inspect.signature(fob))
             except:
                 print("Failed to format the args")
                 traceback.print_exc()


### PR DESCRIPTION
fixes #1974