### PR TITLE
Improve instructions for building from source.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ be able to build most extensions and list any extensions that could not be
 built due to missing libraries - if the build actually fails with your
 configuration, please [open an issue](https://github.com/mhammond/pywin32/issues).
 
+You will need to install pywin32 (using pip) before building from source, or 
+use `python setup.py install --skip-verstamp`, because the default build process uses a win32api call..
+
 ## Release process
 
 The following steps are performed when making a new release - this is mainly

--- a/setup.py
+++ b/setup.py
@@ -1046,7 +1046,7 @@ class my_compiler(base_compiler):
                 # ignore it for now
                 if platform.machine() != "ARM64":
                     print(
-                        "** If you want to skip this step, pass '--skip-verstamp' on the command-line"
+                        "** If you want to skip this step, pass '--skip-verstamp' on the setup.py command-line"
                     )
                     raise
 


### PR DESCRIPTION
Improve user documentation for the chicken-and-egg version stamp situation when building from source.