### PR TITLE
perfmon: Fix illegal byte sequence error in a wide string

### DIFF
--- a/win32/src/PerfMon/perfmondata.cpp
+++ b/win32/src/PerfMon/perfmondata.cpp
@@ -414,7 +414,7 @@ HANDLE MonOpenEventLog(const TCHAR *szSourceName)
 --*/
 {
     HKEY hAppKey;
-    TCHAR LogLevelKeyName[] = _T("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Perflib");
+    TCHAR LogLevelKeyName[] = _T("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Perflib");
 
     TCHAR LogLevelValueName[] = _T("EventLogLevel");
     LONG lStatus;


### PR DESCRIPTION
This replaces non-breaking space (U+00a0) with space (U+0020) character. Also fixes the following error:

```
win32/src/PerfMon/perfmondata.cpp:417:31: error: converting to execution character set: Illegal byte sequence
  417 |     TCHAR LogLevelKeyName[] = _T("SOFTWARE\\Microsoft\\WindowsáNT\\CurrentVersion\\Perflib");
      |                               ^~
```
