### PR TITLE
Use proper delete expression to deallocate arrays

### DIFF
--- a/com/win32com/src/PyFactory.cpp
+++ b/com/win32com/src/PyFactory.cpp
@@ -38,7 +38,7 @@ STDMETHODIMP_(ULONG) CPyFactory::Release(void)
 {
     LONG cRef = InterlockedDecrement(&m_cRef);
     if (cRef == 0)
-        delete this;
+        operator delete(this);
     return cRef;
 }
 

--- a/com/win32com/src/extensions/PyICatInformation.cpp
+++ b/com/win32com/src/extensions/PyICatInformation.cpp
@@ -68,7 +68,7 @@ PyObject *PyICatInformation::EnumClassesOfCategories(PyObject *self, PyObject *a
             if (ob == NULL || PyWinObject_AsIID(ob, pIDs + i) == FALSE) {
                 Py_XDECREF(ob);
                 PyErr_SetString(PyExc_TypeError, "One of the GUID's in the list is invalid");
-                delete pIDs;
+                delete[] pIDs;
                 return NULL;
             }
             Py_DECREF(ob);
@@ -81,7 +81,7 @@ PyObject *PyICatInformation::EnumClassesOfCategories(PyObject *self, PyObject *a
     if (listRequired != Py_None) {
         if (!PySequence_Check(listRequired)) {
             PyErr_SetString(PyExc_TypeError, "Only None or lists are supported for the params.");
-            delete pIDs;
+            delete[] pIDs;
             return NULL;
         }
         cRequired = (ULONG)PySequence_Length(listRequired);
@@ -91,8 +91,8 @@ PyObject *PyICatInformation::EnumClassesOfCategories(PyObject *self, PyObject *a
             if (ob == NULL || PyWinObject_AsIID(ob, pIDsReqd + i) == FALSE) {
                 PyErr_SetString(PyExc_TypeError, "One of the GUID's in the required list is invalid");
                 Py_XDECREF(ob);
-                delete pIDs;
-                delete pIDsReqd;
+                delete[] pIDs;
+                delete[] pIDsReqd;
                 return NULL;
             }
             Py_DECREF(ob);
@@ -103,7 +103,7 @@ PyObject *PyICatInformation::EnumClassesOfCategories(PyObject *self, PyObject *a
     PY_INTERFACE_PRECALL;
     HRESULT hr = pMy->EnumClassesOfCategories(cImplemented, pIDs, cRequired, pIDsReqd, &pEnum);
     PY_INTERFACE_POSTCALL;
-    delete pIDs;
+    delete[] pIDs;
     if (S_OK != hr)  // S_OK only acceptable
         return PyCom_BuildPyException(hr, pMy, IID_ICatInformation);
     return PyCom_PyObjectFromIUnknown(pEnum, IID_IEnumGUID, FALSE);

--- a/com/win32com/src/extensions/PyICreateTypeInfo.cpp
+++ b/com/win32com/src/extensions/PyICreateTypeInfo.cpp
@@ -366,7 +366,7 @@ PyObject *PyICreateTypeInfo::SetFuncAndParamNames(PyObject *self, PyObject *args
     }
     if (!bPythonIsHappy) {
         for (i = 0; i < cNames; i++) PyWinObject_FreeBstr(pNames[i]);
-        delete pNames;
+        delete[] pNames;
         return NULL;
     }
     HRESULT hr;
@@ -375,7 +375,7 @@ PyObject *PyICreateTypeInfo::SetFuncAndParamNames(PyObject *self, PyObject *args
     PY_INTERFACE_POSTCALL;
 
     for (i = 0; i < cNames; i++) PyWinObject_FreeBstr(pNames[i]);
-    delete pNames;
+    delete[] pNames;
 
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, pICTI, IID_ICreateTypeInfo);

--- a/com/win32com/src/extensions/PyIStream.cpp
+++ b/com/win32com/src/extensions/PyIStream.cpp
@@ -38,7 +38,7 @@ PyObject *PyIStream::Read(PyObject *self, PyObject *args)
         result = PyCom_BuildPyException(hr, pMy, IID_IStream);
     else
         result = PyBytes_FromStringAndSize(buffer, read);
-    delete buffer;
+    delete[] buffer;
     // @rdesc The result is a string containing binary data.
     return result;
 }

--- a/com/win32com/src/oleargs.cpp
+++ b/com/win32com/src/oleargs.cpp
@@ -761,7 +761,7 @@ static BOOL PyCom_SAFEARRAYFromPyObjectEx(PyObject *obj, SAFEARRAY **ppSA, bool 
         // OK - Finally can create the array...
         *ppSA = SafeArrayCreate(vt, cDims, pBounds);
         if (*ppSA == NULL) {
-            delete pBounds;
+            delete[] pBounds;
             PyErr_SetString(PyExc_MemoryError, "CreatingSafeArray");
             return FALSE;
         }

--- a/win32/src/win32apimodule.cpp
+++ b/win32/src/win32apimodule.cpp
@@ -1917,7 +1917,7 @@ static PyObject *PyGetProfileSection(PyObject *self, PyObject *args)
         DWORD retVal = 0;
         while (TRUE) {
             if (szRetBuf) {
-                delete szRetBuf;
+                delete[] szRetBuf;
                 size *= 2;
             }
             szRetBuf = new TCHAR[size]; /* cant fail - may raise exception */
@@ -1938,7 +1938,7 @@ static PyObject *PyGetProfileSection(PyObject *self, PyObject *args)
     PyWinObject_FreeTCHAR(szSection);
     PyWinObject_FreeTCHAR(iniName);
     if (szRetBuf)
-        delete szRetBuf;
+        delete[] szRetBuf;
     return ret;
     // @rdesc The return value is a list of strings.
 }

--- a/win32/src/win32service.i
+++ b/win32/src/win32service.i
@@ -864,7 +864,7 @@ static PyObject *MyEnumServicesStatus(PyObject *self, PyObject *args)
 
 	if (!result)
 	{
-		delete buffer;
+		delete[] buffer;
 		return PyWin_SetAPIError("EnumServicesStatus");
 	}
 
@@ -887,7 +887,7 @@ static PyObject *MyEnumServicesStatus(PyObject *self, PyObject *args)
 		Py_XDECREF(obDisplayName);
 	}
 
-	delete buffer;
+	delete[] buffer;
 	return retval;
 }
 %}
@@ -1029,7 +1029,7 @@ static PyObject *MyEnumDependentServices(PyObject *self, PyObject *args)
 
 	if (!result)
 	{
-		delete buffer;
+		delete[] buffer;
 		return PyWin_SetAPIError("EnumDependentServices");
 	}
 
@@ -1052,7 +1052,7 @@ static PyObject *MyEnumDependentServices(PyObject *self, PyObject *args)
 		Py_XDECREF(obDisplayName);
 	}
 
-	delete buffer;
+	delete[] buffer;
 	return retval;
 }
 %}
@@ -1093,7 +1093,7 @@ static PyObject *MyQueryServiceConfig(PyObject *self, PyObject *args)
 
 	if (!result)
 	{
-		delete buffer;
+		delete[] buffer;
 		return PyWin_SetAPIError("QueryServiceConfig");
 	}
 
@@ -1117,7 +1117,7 @@ static PyObject *MyQueryServiceConfig(PyObject *self, PyObject *args)
 			PyWinObject_FromMultipleString(config->lpDependencies),
 			PyWinObject_FromTCHAR(config->lpServiceStartName),
 			PyWinObject_FromTCHAR(config->lpDisplayName));
-	delete buffer;
+	delete[] buffer;
 	return retval;
 }
 %}


### PR DESCRIPTION
This changes use delete[] expression to deallocate arrays which
are allocated by new[] dynamically and fixes following warnings

```
PyFactory.cpp:41:9: warning: deleting object of polymorphic class type 'CPyFactory' which has non-virtual destructor might cause undefined behavior
win32service_swig.cpp:1377:24: warning: 'void operator delete(void*, long long unsigned int)' called on pointer returned from a mismatched allocation function
```
