### PR TITLE
win32com: Initialize variable before jumping to a label

### DIFF
--- a/com/win32com/src/extensions/PyGEnumVariant.cpp
+++ b/com/win32com/src/extensions/PyGEnumVariant.cpp
@@ -10,13 +10,14 @@ STDMETHODIMP PyGEnumVARIANT::Next(
 {
     PY_GATEWAY_METHOD;
     PyObject *result;
+    Py_ssize_t len;
     HRESULT hr = InvokeViaPolicy("Next", &result, "i", celt);
     if (FAILED(hr))
         return hr;
 
     if (!PySequence_Check(result))
         goto error;
-    Py_ssize_t len = PyObject_Length(result);
+    len = PyObject_Length(result);
     if (len == -1 || !PyWin_is_ssize_dword(len))
         goto error;
     if (len > celt)
@@ -25,8 +26,7 @@ STDMETHODIMP PyGEnumVARIANT::Next(
     if (pCeltFetched)
         *pCeltFetched = (ULONG)len;
 
-    ULONG i;
-    for (i = 0; i < len; ++i) {
+    for (ULONG i = 0; i < len; ++i) {
         PyObject *ob = PySequence_GetItem(result, i);
         if (ob == NULL)
             goto error;

--- a/com/win32com/src/extensions/PyIEnumConnectionPoints.cpp
+++ b/com/win32com/src/extensions/PyIEnumConnectionPoints.cpp
@@ -157,13 +157,14 @@ STDMETHODIMP PyGEnumConnectionPoints::Next(
 {
     PY_GATEWAY_METHOD;
     PyObject *result;
+    Py_ssize_t len;
     HRESULT hr = InvokeViaPolicy("Next", &result, "i", celt);
     if (FAILED(hr))
         return hr;
 
     if (!PySequence_Check(result))
         goto error;
-    Py_ssize_t len = PyObject_Length(result);
+    len = PyObject_Length(result);
     if (len == -1 || !PyWin_is_ssize_dword(len))
         goto error;
     if (len > celt)
@@ -172,8 +173,7 @@ STDMETHODIMP PyGEnumConnectionPoints::Next(
     if (pCeltFetched)
         *pCeltFetched = (ULONG)len;
 
-    int i;
-    for (i = 0; i < len; ++i) {
+    for (int i = 0; i < len; ++i) {
         PyObject *ob = PySequence_GetItem(result, i);
         if (ob == NULL)
             goto error;

--- a/com/win32com/src/extensions/PyIEnumConnections.cpp
+++ b/com/win32com/src/extensions/PyIEnumConnections.cpp
@@ -148,13 +148,14 @@ STDMETHODIMP PyGEnumConnections::Next(
 {
     PY_GATEWAY_METHOD;
     PyObject *result;
+    Py_ssize_t len;
     HRESULT hr = InvokeViaPolicy("Next", &result, "i", celt);
     if (FAILED(hr))
         return hr;
 
     if (!PySequence_Check(result))
         goto error;
-    Py_ssize_t len = PyObject_Length(result);
+    len = PyObject_Length(result);
     if (len == -1 || !PyWin_is_ssize_dword(len))
         goto error;
     if (len > celt)
@@ -163,8 +164,7 @@ STDMETHODIMP PyGEnumConnections::Next(
     if (pCeltFetched)
         *pCeltFetched = (ULONG)len;
 
-    int i;
-    for (i = 0; i < len; ++i) {
+    for (int i = 0; i < len; ++i) {
         PyObject *ob = PySequence_GetItem(result, i);
         if (ob == NULL)
             goto error;

--- a/com/win32com/src/extensions/PyIEnumFORMATETC.cpp
+++ b/com/win32com/src/extensions/PyIEnumFORMATETC.cpp
@@ -152,13 +152,14 @@ STDMETHODIMP PyGEnumFORMATETC::Next(
 {
     PY_GATEWAY_METHOD;
     PyObject *result;
+    Py_ssize_t len;
     HRESULT hr = InvokeViaPolicy("Next", &result, "i", celt);
     if (FAILED(hr))
         return hr;
 
     if (!PySequence_Check(result))
         goto error;
-    Py_ssize_t len = PyObject_Length(result);
+    len = PyObject_Length(result);
     if (len == -1 || !PyWin_is_ssize_dword(len))
         goto error;
     if (len > celt)
@@ -167,8 +168,7 @@ STDMETHODIMP PyGEnumFORMATETC::Next(
     if (pCeltFetched)
         *pCeltFetched = (ULONG)len;
 
-    int i;
-    for (i = 0; i < len; ++i) {
+    for (int i = 0; i < len; ++i) {
         PyObject *ob = PySequence_GetItem(result, i);
         if (ob == NULL)
             goto error;

--- a/com/win32com/src/extensions/PyIEnumSTATPROPSETSTG.cpp
+++ b/com/win32com/src/extensions/PyIEnumSTATPROPSETSTG.cpp
@@ -159,13 +159,14 @@ STDMETHODIMP PyGEnumSTATPROPSETSTG::Next(
 {
     PY_GATEWAY_METHOD;
     PyObject *result;
+    Py_ssize_t len;
     HRESULT hr = InvokeViaPolicy("Next", &result, "i", celt);
     if (FAILED(hr))
         return hr;
 
     if (!PySequence_Check(result))
         goto error;
-    Py_ssize_t len = PyObject_Length(result);
+    len = PyObject_Length(result);
     if (len == -1 || !PyWin_is_ssize_dword(len))
         goto error;
     if (len > celt)
@@ -174,8 +175,7 @@ STDMETHODIMP PyGEnumSTATPROPSETSTG::Next(
     if (pCeltFetched)
         *pCeltFetched = (ULONG)len;
 
-    int i;
-    for (i = 0; i < len; ++i) {
+    for (int i = 0; i < len; ++i) {
         TmpPyObject ob = PySequence_GetItem(result, i);
         if (ob == NULL)
             goto error;

--- a/com/win32com/src/extensions/PyIEnumSTATPROPSTG.cpp
+++ b/com/win32com/src/extensions/PyIEnumSTATPROPSTG.cpp
@@ -161,13 +161,15 @@ STDMETHODIMP PyGEnumSTATPROPSTG::Next(
 {
     PY_GATEWAY_METHOD;
     PyObject *result;
+    PyObject *obname;
+    Py_ssize_t len;
     HRESULT hr = InvokeViaPolicy("Next", &result, "i", celt);
     if (FAILED(hr))
         return hr;
 
     if (!PySequence_Check(result))
         goto error;
-    Py_ssize_t len = PyObject_Length(result);
+    len = PyObject_Length(result);
     if (len == -1 || !PyWin_is_ssize_dword(len))
         goto error;
     if (len > celt)
@@ -176,9 +178,7 @@ STDMETHODIMP PyGEnumSTATPROPSTG::Next(
     if (pCeltFetched)
         *pCeltFetched = (ULONG)len;
 
-    int i;
-    PyObject *obname;
-    for (i = 0; i < len; ++i) {
+    for (int i = 0; i < len; ++i) {
         TmpPyObject ob = PySequence_GetItem(result, i);
         if (ob == NULL)
             goto error;

--- a/com/win32com/src/extensions/PyIEnumSTATSTG.cpp
+++ b/com/win32com/src/extensions/PyIEnumSTATSTG.cpp
@@ -155,13 +155,14 @@ STDMETHODIMP PyGEnumSTATSTG::Next(
 {
     PY_GATEWAY_METHOD;
     PyObject *result;
+    Py_ssize_t len;
     HRESULT hr = InvokeViaPolicy("Next", &result, "i", celt);
     if (FAILED(hr))
         return hr;
 
     if (!PySequence_Check(result))
         goto error;
-    Py_ssize_t len = PyObject_Length(result);
+    len = PyObject_Length(result);
     if (len == -1 || !PyWin_is_ssize_dword(len))
         goto error;
     if (len > celt)
@@ -170,8 +171,7 @@ STDMETHODIMP PyGEnumSTATSTG::Next(
     if (pCeltFetched)
         *pCeltFetched = (ULONG)len;
 
-    int i;
-    for (i = 0; i < len; ++i) {
+    for (int i = 0; i < len; ++i) {
         PyObject *ob = PySequence_GetItem(result, i);
         if (ob == NULL)
             goto error;


### PR DESCRIPTION
This fixes the following error with gcc

```
PyGEnumVariant.cpp: In member function 'virtual HRESULT PyGEnumVARIANT::Next(ULONG, VARIANT*, ULONG*)':
PyGEnumVariant.cpp:46:1: error: jump to label 'error'
PyGEnumVariant.cpp:18:14: note: from here
PyGEnumVariant.cpp:19:16: note: crosses initialization of 'Py_ssize_t len'
```
