### PR TITLE
Fix names with extra namespace qualification in a class

### DIFF
--- a/com/win32com/src/include/PythonCOM.h
+++ b/com/win32com/src/include/PythonCOM.h
@@ -432,9 +432,9 @@ class PYCOM_EXPORT PyOleNothing : public PyObject {
 // We need to dynamically create C++ Python objects
 // These helpers allow each type object to create it.
 #define MAKE_PYCOM_CTOR(classname) \
-    static PyIUnknown *classname::PyObConstruct(IUnknown *pInitObj) { return new classname(pInitObj); }
+    static PyIUnknown *PyObConstruct(IUnknown *pInitObj) { return new classname(pInitObj); }
 #define MAKE_PYCOM_CTOR_ERRORINFO(classname, iid)                                                       \
-    static PyIUnknown *classname::PyObConstruct(IUnknown *pInitObj) { return new classname(pInitObj); } \
+    static PyIUnknown *PyObConstruct(IUnknown *pInitObj) { return new classname(pInitObj); }            \
     static PyObject *SetPythonCOMError(PyObject *self, HRESULT hr)                                      \
     {                                                                                                   \
         return PyCom_BuildPyException(hr, GetI(self), iid);                                             \

--- a/com/win32com/src/include/PythonCOMServer.h
+++ b/com/win32com/src/include/PythonCOMServer.h
@@ -29,7 +29,7 @@ HRESULT PyCom_MakeRegisteredGatewayObject(REFIID iid, PyObject *instance, PyGate
 // other than IUnknown
 #define PYGATEWAY_MAKE_SUPPORT2(classname, IInterface, theIID, gatewaybaseclass)                                 \
    public:                                                                                                       \
-    static HRESULT classname::PyGatewayConstruct(PyObject *pPyInstance, PyGatewayBase *unkBase, void **ppResult, \
+    static HRESULT PyGatewayConstruct(PyObject *pPyInstance, PyGatewayBase *unkBase, void **ppResult,            \
                                                  REFIID iid)                                                     \
     {                                                                                                            \
         if (ppResult == NULL)                                                                                    \
@@ -134,7 +134,7 @@ class PYCOM_EXPORT PyGatewayBase :
 
     // Basically just PYGATEWAY_MAKE_SUPPORT(PyGatewayBase, IDispatch, IID_IDispatch);
     // but with special handling as its the base class.
-    static HRESULT PyGatewayBase::PyGatewayConstruct(PyObject *pPyInstance, PyGatewayBase *gatewayBase, void **ppResult,
+    static HRESULT PyGatewayConstruct(PyObject *pPyInstance, PyGatewayBase *gatewayBase, void **ppResult,
                                                      REFIID iid)
     {
         if (ppResult == NULL)

--- a/com/win32comext/adsi/src/PyADSIUtil.cpp
+++ b/com/win32comext/adsi/src/PyADSIUtil.cpp
@@ -315,7 +315,7 @@ class PyADS_OBJECT_INFO : public PyObject {
     static void deallocFunc(PyObject *ob) { delete (PyADS_OBJECT_INFO *)ob; }
 
     static struct PyMemberDef memberlist[];
-    static PyTypeObject PyADS_OBJECT_INFO::Type;
+    static PyTypeObject Type;
 
    protected:
     PyObject *obRDN, *obObjectDN, *obParentDN, *obClassName;
@@ -473,7 +473,7 @@ class PyADS_ATTR_INFO : public PyObject {
     //#pragma warning( disable : 4251 )
     static struct PyMemberDef memberlist[];
     //#pragma warning( default : 4251 )
-    static PyTypeObject PyADS_ATTR_INFO::Type;
+    static PyTypeObject Type;
 
    protected:
     DWORD dwControlCode;

--- a/com/win32comext/authorization/src/PyGSecurityInformation.h
+++ b/com/win32comext/authorization/src/PyGSecurityInformation.h
@@ -22,7 +22,7 @@ class PyGSecurityInformation : private PyGatewayBase, public ISecurityInformatio
         ObjectInfoAcquired = FALSE;
     }
     PYGATEWAY_MAKE_SUPPORT2(PyGSecurityInformation, ISecurityInformation, IID_ISecurityInformation, PyGatewayBase)
-    PyGSecurityInformation::~PyGSecurityInformation(void);
+    ~PyGSecurityInformation(void);
 
     // ISecurityInformation
     // @pymeth GetObjectInformation|Returns information identifying the object

--- a/isapi/src/PythonEng.h
+++ b/isapi/src/PythonEng.h
@@ -63,7 +63,7 @@ class CPythonHandler {
     PyObject *DoCallback(HANDLER_TYPE typ, PyObject *args);
 
     bool LoadHandler(bool reload);
-    bool CPythonHandler::CheckCallback(const char *cbname, PyObject **cb);
+    bool CheckCallback(const char *cbname, PyObject **cb);
     const char *m_namefactory;
     const char *m_nameinit;
     const char *m_namedo;

--- a/win32/src/PySecurityObjects.h
+++ b/win32/src/PySecurityObjects.h
@@ -108,7 +108,7 @@ class PYWINTYPES_EXPORT PySID : public PyObject {
     static PyObject *GetSubAuthorityCount(PyObject *self, PyObject *args);
     static PyObject *GetSubAuthority(PyObject *self, PyObject *args);
     static PyObject *GetSidIdentifierAuthority(PyObject *self, PyObject *args);
-    static struct PyMethodDef PySID::methods[];
+    static struct PyMethodDef methods[];
 
    protected:
     PSID m_psid;
@@ -145,7 +145,7 @@ class PYWINTYPES_EXPORT PyACL : public PyObject {
     /* Python support */
     int compare(PyObject *ob);
     static void deallocFunc(PyObject *ob);
-    static struct PyMethodDef PyACL::methods[];
+    static struct PyMethodDef methods[];
 
     static PyObject *Initialize(PyObject *self, PyObject *args);
     static PyObject *IsValid(PyObject *self, PyObject *args);


### PR DESCRIPTION
This fixes the following error in gcc

```
PyADSIUtil.cpp:318:25: warning: extra qualification 'PyADS_OBJECT_INFO::' on member 'Type'
PyADSIUtil.cpp:476:25: error: invalid use of qualified-name 'PyADS_OBJECT_INFO::Type'
```
