### PR TITLE
Fix ModuleNotFoundError in axdebug

### DIFF
--- a/com/win32comext/axdebug/adb.py
+++ b/com/win32comext/axdebug/adb.py
@@ -3,9 +3,8 @@
 from win32com.axdebug.util import trace, _wrap, _wrap_remove
 from win32com.server.util import unwrap
 import win32com.client.connect
-from . import gateways
+from . import gateways, axdebug, stackframe
 import sys, bdb, traceback
-import axdebug, stackframe
 import win32api, pythoncom
 import _thread, os
 

--- a/com/win32comext/axdebug/contexts.py
+++ b/com/win32comext/axdebug/contexts.py
@@ -1,12 +1,11 @@
 """ A module for managing the AXDebug I*Contexts
 
 """
-import gateways, axdebug
 import pythoncom, win32com.server.util
 
 # Utility function for wrapping object created by this module.
 from .util import _wrap, _wrap_remove, trace
-from . import adb
+from . import adb, gateways, axdebug
 
 
 class DebugCodeContext(gateways.DebugCodeContext, gateways.DebugDocumentContext):

--- a/com/win32comext/axdebug/documents.py
+++ b/com/win32comext/axdebug/documents.py
@@ -1,12 +1,10 @@
 """ Management of documents for AXDebugging.
 """
 
-import axdebug, gateways
 import pythoncom
 from .util import _wrap, _wrap_remove, RaiseNotImpl, trace
 from win32com.server.util import unwrap
-from . import codecontainer
-from . import contexts
+from . import codecontainer, contexts, axdebug, gateways
 from win32com.server.exception import Exception
 import win32api, winerror, os, string, sys
 

--- a/com/win32comext/axdebug/expressions.py
+++ b/com/win32comext/axdebug/expressions.py
@@ -1,4 +1,4 @@
-import axdebug, gateways
+from . import axdebug, gateways
 from .util import _wrap, _wrap_remove, RaiseNotImpl
 import io, traceback
 from pprint import pprint

--- a/com/win32comext/axdebug/stackframe.py
+++ b/com/win32comext/axdebug/stackframe.py
@@ -4,7 +4,8 @@ Provides Implements a nearly complete wrapper for a stack frame.
 """
 import sys
 from .util import _wrap, RaiseNotImpl
-import expressions, gateways, axdebug, winerror
+from . import expressions, gateways, axdebug
+import winerror
 import pythoncom
 from win32com.server.exception import COMException
 


### PR DESCRIPTION
Hopefully fixes #1982 . I was not able to run `pip install -e .` so I couldn't test to confirm.