### PR TITLE
Specify system import library in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1205,7 +1205,7 @@ for info in (
     ),
     (
         "win32file",
-        "",
+        "ws2_32 mswsock",
         0x0500,
         """
               win32/src/win32file.i

--- a/win32/src/win32file.i
+++ b/win32/src/win32file.i
@@ -1674,14 +1674,6 @@ int _setmaxstdio(
 // @pyswig int| _getmaxstdio|Returns the maximum number of CRT io streams.
 int _getmaxstdio( void );
 
-
-// Overlapped Socket stuff
-%{
-#pragma comment(lib,"mswsock.lib") // too lazy to change the project file :-)
-#pragma comment(lib,"ws2_32.lib")
-%}
-
-
 %{
 // @pyswig |TransmitFile|Transmits a file over a socket
 // TransmitFile(sock, filehandle, bytes_to_write, bytes_per_send, overlap, flags [, (prepend_buf, postpend_buf)])


### PR DESCRIPTION
The 'pragma comment' specifier is MSVC and Visual Studio specific.
It does not work in mingw environment with gcc or clang. So, this
fixes linking with those system libraries in mingw and resolves
unknown pragma warnings also.