### PR TITLE
AdjustWindowRect* wrappers

### DIFF
--- a/win32/src/win32gui.i
+++ b/win32/src/win32gui.i
@@ -1833,6 +1833,18 @@ PyObject *PyFlashWindowEx(PyObject *self, PyObject *args)
 %native(FlashWindowEx) PyFlashWindowEx;
 #endif // MS_WINCE
 
+// @pyswig |AdjustWindowRect|Calculates the required size of the window rectangle, based on the desired client-rectangle size.
+BOOLAPI AdjustWindowRect(
+	RECT *BOTH,  // @pyparm <o PyRECT>|rc||A pointer to a RECT structure that contains the coordinates of the top-left and bottom-right corners of the desired client area
+	DWORD dwStyle,  // @pyparm DWORD|dwStyle||Window style
+	BOOL bMenu);  // @pyparm BOOL|bMenu||Window has a menu
+
+// @pyswig |AdjustWindowRectEx|Calculates the required size of the window rectangle, based on the desired client-rectangle size.
+BOOLAPI AdjustWindowRectEx(
+	RECT *BOTH,  // @pyparm <o PyRECT>|rc||A pointer to a RECT structure that contains the coordinates of the top-left and bottom-right corners of the desired client area
+	DWORD dwStyle,  // @pyparm DWORD|dwStyle||Window style
+	BOOL bMenu,  // @pyparm BOOL|bMenu||Window has a menu
+	DWORD dwStyle);  // @pyparm DWORD|dwExStyle||Extended window style
 
 // @pyswig int|GetWindowLong|
 // @pyparm int|hwnd||

--- a/win32/src/win32gui.i
+++ b/win32/src/win32gui.i
@@ -1844,7 +1844,7 @@ BOOLAPI AdjustWindowRectEx(
 	RECT *BOTH,  // @pyparm <o PyRECT>|rc||A pointer to a RECT structure that contains the coordinates of the top-left and bottom-right corners of the desired client area
 	DWORD dwStyle,  // @pyparm DWORD|dwStyle||Window style
 	BOOL bMenu,  // @pyparm BOOL|bMenu||Window has a menu
-	DWORD dwStyle);  // @pyparm DWORD|dwExStyle||Extended window style
+	DWORD dwExStyle);  // @pyparm DWORD|dwExStyle||Extended window style
 
 // @pyswig int|GetWindowLong|
 // @pyparm int|hwnd||


### PR DESCRIPTION
[\[MS.Learn\]: AdjustWindowRect function (winuser.h)](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-adjustwindowrect) and [\[MS.Learn\]: AdjustWindowRectEx function (winuser.h)](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-adjustwindowrectex)


**Test**:

```
[cfati@CFATI-5510-0:e:\Work\Dev\GitHub\CristiFati\pywin32\src]> "e:\Work\Dev\VEnvs\py_pc064_03.10_test1_pw32\Scripts\python.exe" -c "import win32gui as wgui;print(wgui.AdjustWindowRect((1, 2, 3, 4), 0, True))
(1, -18, 3, 4)

[cfati@CFATI-5510-0:e:\Work\Dev\GitHub\CristiFati\pywin32\src]> "e:\Work\Dev\VEnvs\py_pc064_03.10_test1_pw32\Scripts\python.exe" -c "import win32gui as wgui;print(wgui.AdjustWindowRectEx((1, 2, 3, 4), 0, 0, 0))
(1, 2, 3, 4)
```
