### PR TITLE
Add missing braces to avoid ambiguous if-else statement

### DIFF
--- a/com/win32comext/taskscheduler/src/PyIScheduledWorkItem.cpp
+++ b/com/win32comext/taskscheduler/src/PyIScheduledWorkItem.cpp
@@ -482,13 +482,14 @@ PyObject *PyIScheduledWorkItem::SetWorkItemData(PyObject *self, PyObject *args)
     PyObject *obworkitem_data = NULL;
     if (!PyArg_ParseTuple(args, "O:PyIScheduledWorkItem::SetWorkItemData", &obworkitem_data))
         return NULL;
-    if (obworkitem_data != Py_None)
+    if (obworkitem_data != Py_None) {
         if (PyBytes_AsStringAndSize(obworkitem_data, (CHAR **)&workitem_data, &data_len) == -1)
             return NULL;
         else
             // Task Scheduler won't take an empty string for data anymore ??????
             if (data_len == 0)
             workitem_data = NULL;
+    }
 
     HRESULT hr;
     PY_INTERFACE_PRECALL;

--- a/win32/src/PyDEVMODE.cpp
+++ b/win32/src/PyDEVMODE.cpp
@@ -349,7 +349,7 @@ PyObject *PyDEVMODEW::tp_new(PyTypeObject *typ, PyObject *args, PyObject *kwargs
 
 BOOL PyWinObject_AsDEVMODE(PyObject *ob, PDEVMODEW *ppDEVMODE, BOOL bNoneOk)
 {
-    if (ob == Py_None)
+    if (ob == Py_None) {
         if (bNoneOk) {
             *ppDEVMODE = NULL;
             return TRUE;
@@ -358,6 +358,7 @@ BOOL PyWinObject_AsDEVMODE(PyObject *ob, PDEVMODEW *ppDEVMODE, BOOL bNoneOk)
             PyErr_SetString(PyExc_ValueError, "PyDEVMODE cannot be None in this context");
             return FALSE;
         }
+    }
     if (!PyDEVMODEW_Check(ob))
         return FALSE;
     *ppDEVMODE = ((PyDEVMODEW *)ob)->GetDEVMODE();

--- a/win32/src/PythonService.cpp
+++ b/win32/src/PythonService.cpp
@@ -860,7 +860,7 @@ void WINAPI service_main(DWORD dwArgc, LPTSTR *lpszArgv)
         if (instance)
             ReportPythonError(E_PYS_NOT_CONTROL_HANDLER);
         // else no instance - an error has already been reported.
-        if (!bServiceDebug)
+        if (!bServiceDebug) {
             if (g_RegisterServiceCtrlHandlerEx) {
                 // Use 2K/XP extended registration if available
                 pe->sshStatusHandle = g_RegisterServiceCtrlHandlerEx(lpszArgv[0], service_ctrl_ex, pe);
@@ -869,6 +869,7 @@ void WINAPI service_main(DWORD dwArgc, LPTSTR *lpszArgv)
                 // Otherwise fall back to NT
                 pe->sshStatusHandle = RegisterServiceCtrlHandler(lpszArgv[0], service_ctrl);
             }
+        }
     }
     // No instance - we can't start.
     if (!instance) {

--- a/win32/src/win32api_display.cpp
+++ b/win32/src/win32api_display.cpp
@@ -133,29 +133,33 @@ PyObject *PyDISPLAY_DEVICE::getattro(PyObject *self, PyObject *obname)
     if (name == NULL)
         return NULL;
 
-    if (strcmp(name, "DeviceName") == 0)
+    if (strcmp(name, "DeviceName") == 0) {
         if (pdisplay_device->DeviceName[31] == 0)  // in case DeviceName fills space and has no trailing NULL
             return PyWinObject_FromTCHAR(pdisplay_device->DeviceName);
         else
             return PyWinObject_FromTCHAR(pdisplay_device->DeviceName, 32);
+    }
 
-    if (strcmp(name, "DeviceString") == 0)
+    if (strcmp(name, "DeviceString") == 0) {
         if (pdisplay_device->DeviceString[127] == 0)  // in case DeviceString fills space and has no trailing NULL
             return PyWinObject_FromTCHAR(pdisplay_device->DeviceString);
         else
             return PyWinObject_FromTCHAR(pdisplay_device->DeviceString, 128);
+    }
 
-    if (strcmp(name, "DeviceID") == 0)
+    if (strcmp(name, "DeviceID") == 0) {
         if (pdisplay_device->DeviceID[127] == 0)  // in case DeviceID fills space and has no trailing NULL
             return PyWinObject_FromTCHAR(pdisplay_device->DeviceID);
         else
             return PyWinObject_FromTCHAR(pdisplay_device->DeviceID, 128);
+    }
 
-    if (strcmp(name, "DeviceKey") == 0)
+    if (strcmp(name, "DeviceKey") == 0) {
         if (pdisplay_device->DeviceKey[127] == 0)  // in case DeviceKey fills space and has no trailing NULL
             return PyWinObject_FromTCHAR(pdisplay_device->DeviceKey);
         else
             return PyWinObject_FromTCHAR(pdisplay_device->DeviceKey, 128);
+    }
 
     return PyObject_GenericGetAttr(self, obname);
 }
@@ -242,7 +246,7 @@ PyObject *PyDISPLAY_DEVICE::tp_new(PyTypeObject *typ, PyObject *args, PyObject *
 
 BOOL PyWinObject_AsDISPLAY_DEVICE(PyObject *ob, PDISPLAY_DEVICE *ppDISPLAY_DEVICE, BOOL bNoneOk)
 {
-    if (ob == Py_None)
+    if (ob == Py_None) {
         if (bNoneOk) {
             *ppDISPLAY_DEVICE = NULL;
             return TRUE;
@@ -251,6 +255,7 @@ BOOL PyWinObject_AsDISPLAY_DEVICE(PyObject *ob, PDISPLAY_DEVICE *ppDISPLAY_DEVIC
             PyErr_SetString(PyExc_ValueError, "PyDISPLAY_DEVICE cannot be None in this context");
             return FALSE;
         }
+    }
     if (!PyDISPLAY_DEVICE_Check(ob))
         return FALSE;
     *ppDISPLAY_DEVICE = ((PyDISPLAY_DEVICE *)ob)->GetDISPLAY_DEVICE();

--- a/win32/src/win32consolemodule.cpp
+++ b/win32/src/win32consolemodule.cpp
@@ -1295,14 +1295,15 @@ PyObject *PyConsoleScreenBuffer::PyScrollConsoleScreenBuffer(PyObject *self, PyO
     if (PyWinObject_AsSMALL_RECT(obscrollrect, &pscrollrect, FALSE) &&
         PyWinObject_AsSMALL_RECT(obcliprect, &pcliprect, TRUE) &&
         PyWinObject_AsCOORD(obdestcoord, &pdestcoord, FALSE) &&
-        PyWinObject_AsSingleWCHAR(obfillchar, &char_info.Char.UnicodeChar))
+        PyWinObject_AsSingleWCHAR(obfillchar, &char_info.Char.UnicodeChar)) {
         if (!ScrollConsoleScreenBuffer(((PyConsoleScreenBuffer *)self)->m_handle, pscrollrect, pcliprect, *pdestcoord,
-                                       &char_info))
+                                       &char_info)) {
             PyWin_SetAPIError("ScrollConsoleScreenBuffer");
-        else {
+        } else {
             Py_INCREF(Py_None);
             return Py_None;
         }
+    }
     return NULL;
 }
 
@@ -1813,13 +1814,14 @@ static PyObject *PyAddConsoleAlias(PyObject *self, PyObject *args, PyObject *kwa
         return NULL;
     CHECK_PFN(AddConsoleAlias);
     if (PyWinObject_AsWCHAR(obsource, &source, FALSE) && PyWinObject_AsWCHAR(obtarget, &target, TRUE) &&
-        PyWinObject_AsWCHAR(obexename, &exename, FALSE))
-        if (!(*pfnAddConsoleAlias)(source, target, exename))
+        PyWinObject_AsWCHAR(obexename, &exename, FALSE)) {
+        if (!(*pfnAddConsoleAlias)(source, target, exename)) {
             PyWin_SetAPIError("AddConsoleAlias");
-        else {
+        } else {
             Py_INCREF(Py_None);
             ret = Py_None;
         }
+    }
     PyWinObject_FreeWCHAR(source);
     PyWinObject_FreeWCHAR(target);
     PyWinObject_FreeWCHAR(exename);

--- a/win32/src/win32crypt/win32cryptmodule.cpp
+++ b/win32/src/win32crypt/win32cryptmodule.cpp
@@ -486,7 +486,7 @@ static PyObject *PyCertEnumSystemStore(PyObject *self, PyObject *args, PyObject 
         CertEnumSystemStore(dwFlags, pvSystemStoreLocationPara, ret, CertEnumSystemStoreCallback);
     Py_END_ALLOW_THREADS
 
-        if (!bsuccess)
+    if (!bsuccess)
     {
         Py_DECREF(ret);
         ret = NULL;
@@ -495,10 +495,12 @@ static PyObject *PyCertEnumSystemStore(PyObject *self, PyObject *args, PyObject 
     }
 
     if (pvSystemStoreLocationPara != NULL)
+    {
         if (dwFlags & CERT_SYSTEM_STORE_RELOCATE_FLAG)
             PyWinObject_FreeWCHAR((WCHAR *)cssrp.pwszSystemStore);
         else
             PyWinObject_FreeWCHAR((WCHAR *)pvSystemStoreLocationPara);
+    }
     return ret;
 }
 

--- a/win32/src/win32print/win32print.cpp
+++ b/win32/src/win32print/win32print.cpp
@@ -352,7 +352,7 @@ BOOL PyWinObject_AsPRINTER_INFO(DWORD level, PyObject *obinfo, LPBYTE *pbuf)
     size_t bufsize;
 
     *pbuf = NULL;
-    if (level == 0)
+    if (level == 0) {
         if (obinfo == Py_None)
             return TRUE;
         else {
@@ -364,6 +364,7 @@ BOOL PyWinObject_AsPRINTER_INFO(DWORD level, PyObject *obinfo, LPBYTE *pbuf)
             }
             return TRUE;
         }
+    }
 
     if (!PyDict_Check(obinfo)) {
         PyErr_Format(PyExc_TypeError, "PRINTER_INFO_%d must be a dictionary", level);
@@ -2458,13 +2459,14 @@ static PyObject *PyDeletePrinterDriver(PyObject *self, PyObject *args)
     // @comm Does not delete associated driver files - use <om win32print.DeletePrinterDriverEx> if this is required
     if (PyArg_ParseTuple(args, "OOO:DeletePrinterDriver", &observername, &obenvironment, &obdrivername) &&
         PyWinObject_AsWCHAR(observername, &servername, TRUE) &&
-        PyWinObject_AsWCHAR(obenvironment, &environment, TRUE) && PyWinObject_AsWCHAR(obdrivername, &drivername, FALSE))
+        PyWinObject_AsWCHAR(obenvironment, &environment, TRUE) && PyWinObject_AsWCHAR(obdrivername, &drivername, FALSE)) {
         if (DeletePrinterDriverW(servername, environment, drivername)) {
             Py_INCREF(Py_None);
             ret = Py_None;
         }
         else
             PyWin_SetAPIError("DeletePrinterDriver");
+    }
 
     if (servername != NULL)
         PyWinObject_FreeWCHAR(servername);
@@ -2493,13 +2495,14 @@ static PyObject *PyDeletePrinterDriverEx(PyObject *self, PyObject *args)
     if (PyArg_ParseTuple(args, "OOOll:DeletePrinterDriverEx", &observername, &obenvironment, &obdrivername, &deleteflag,
                          &versionflag) &&
         PyWinObject_AsWCHAR(observername, &servername, TRUE) &&
-        PyWinObject_AsWCHAR(obenvironment, &environment, TRUE) && PyWinObject_AsWCHAR(obdrivername, &drivername, FALSE))
+        PyWinObject_AsWCHAR(obenvironment, &environment, TRUE) && PyWinObject_AsWCHAR(obdrivername, &drivername, FALSE)) {
         if ((*pfnDeletePrinterDriverEx)(servername, environment, drivername, deleteflag, versionflag)) {
             Py_INCREF(Py_None);
             ret = Py_None;
         }
         else
             PyWin_SetAPIError("DeletePrinterDriverEx");
+    }
 
     if (servername != NULL)
         PyWinObject_FreeWCHAR(servername);

--- a/win32/src/win32tsmodule.cpp
+++ b/win32/src/win32tsmodule.cpp
@@ -95,10 +95,10 @@ static PyObject *PyWTSQueryUserConfig(PyObject *self, PyObject *args, PyObject *
             &obUserName,       // @pyparm <o PyUnicode>|UserName||Name of user
             &WTSConfigClass))  // @pyparm int|ConfigClass||Type of information to be returned, win32ts.WTSUserConfig*
         return NULL;
-    if (PyWinObject_AsWCHAR(obServerName, &ServerName, TRUE) && PyWinObject_AsWCHAR(obUserName, &UserName, FALSE))
+    if (PyWinObject_AsWCHAR(obServerName, &ServerName, TRUE) && PyWinObject_AsWCHAR(obUserName, &UserName, FALSE)) {
         if (!WTSQueryUserConfig(ServerName, UserName, WTSConfigClass, &buf, &bufsize))
             PyWin_SetAPIError("WTSQueryUserConfig");
-        else
+        else {
             switch (WTSConfigClass) {
                 // @flagh ConfigClass|Returned value
                 case WTSUserConfigInitialProgram:    // @flag WTSUserConfigInitialProgram|Unicode string, program to be
@@ -137,6 +137,8 @@ static PyObject *PyWTSQueryUserConfig(PyObject *self, PyObject *args, PyObject *
                 default:
                     PyErr_SetString(PyExc_NotImplementedError, "Config class not supported yet");
             }
+        }
+    }
 
     PyWinObject_FreeWCHAR(ServerName);
     PyWinObject_FreeWCHAR(UserName);


### PR DESCRIPTION
    This fixes the following warnings with gcc
    win32/src/win32tsmodule.cpp:98:8: warning: suggest explicit braces to avoid ambiguous 'else' [-Wdangling-else]