### PR TITLE
Use bytes-string for constant bytes values

### DIFF
--- a/Pythonwin/pywin/framework/interact.py
+++ b/Pythonwin/pywin/framework/interact.py
@@ -47,7 +47,7 @@ _is_block_closer = re.compile(
     re.VERBOSE,
 ).match
 
-tracebackHeader = "Traceback (".encode("ascii")
+tracebackHeader = b"Traceback ("
 
 sectionProfile = "Interactive Window"
 valueFormatTitle = "FormatTitle"
@@ -201,7 +201,7 @@ class InteractiveFormatter(FormatterParent):
                 # It is a PythonColorizer state - seek past the end of the line
                 # and ask the Python colorizer to color that.
                 end = startSeg
-                while end < lengthDoc and cdoc[end] not in "\r\n".encode("ascii"):
+                while end < lengthDoc and cdoc[end] not in b"\r\n":
                     end = end + 1
                 self.ColorizePythonCode(cdoc[:end], startSeg, state)
                 stylePyStart = self.GetStringStyle(end - 1)

--- a/Pythonwin/pywin/framework/scriptutils.py
+++ b/Pythonwin/pywin/framework/scriptutils.py
@@ -28,9 +28,9 @@ Post-Mortem of unhandled exceptions""".split(
     "\n"
 )
 
-byte_cr = "\r".encode("ascii")
-byte_lf = "\n".encode("ascii")
-byte_crlf = "\r\n".encode("ascii")
+byte_cr = b"\r"
+byte_lf = b"\n"
+byte_crlf = b"\r\n"
 
 
 # A dialog box for the "Run Script" command.

--- a/Pythonwin/pywin/scintilla/control.py
+++ b/Pythonwin/pywin/scintilla/control.py
@@ -40,7 +40,7 @@ if dllid is None:
     dllid = win32api.LoadLibrary("Scintilla.DLL")
 
 # null_byte is str in py2k, bytes on py3k
-null_byte = "\0".encode("ascii")
+null_byte = b"\0"
 
 ## These are from Richedit.h - need to add to win32con or commctrl
 EM_GETTEXTRANGE = 1099

--- a/Pythonwin/pywin/scintilla/control.py
+++ b/Pythonwin/pywin/scintilla/control.py
@@ -39,7 +39,6 @@ if dllid is None:
     # Still not there - lets see if Windows can find it by searching?
     dllid = win32api.LoadLibrary("Scintilla.DLL")
 
-# null_byte is str in py2k, bytes on py3k
 null_byte = b"\0"
 
 ## These are from Richedit.h - need to add to win32con or commctrl

--- a/Pythonwin/pywin/scintilla/document.py
+++ b/Pythonwin/pywin/scintilla/document.py
@@ -9,11 +9,11 @@ from pywin.mfc import docview
 
 from . import scintillacon
 
-crlf_bytes = "\r\n".encode("ascii")
-lf_bytes = "\n".encode("ascii")
+crlf_bytes = b"\r\n"
+lf_bytes = b"\n"
 
 # re from pep263 - but we use it both on bytes and strings.
-re_encoding_bytes = re.compile("coding[:=]\s*([-\w.]+)".encode("ascii"))
+re_encoding_bytes = re.compile(b"coding[:=]\s*([-\w.]+)")
 re_encoding_text = re.compile("coding[:=]\s*([-\w.]+)")
 
 ParentScintillaDocument = docview.Document

--- a/adodbapi/test/adodbapitest.py
+++ b/adodbapi/test/adodbapitest.py
@@ -54,10 +54,6 @@ except ImportError:  # we are doing a shortcut import as a module -- so
         from adodbapi import ado_consts
 
 
-def str2bytes(sval):
-    return sval.encode("latin1")
-
-
 long = int
 
 
@@ -519,7 +515,7 @@ class CommonDBTests(unittest.TestCase):
             )
 
     def testDataTypeBinary(self):
-        binfld = str2bytes("\x07\x00\xE2\x40*")
+        binfld = b"\x07\x00\xE2\x40*"
         arv = [binfld, adodbapi.Binary(binfld), bytes(binfld)]
         if self.getEngine() == "PostgreSQL":
             self.helpTestDataType(

--- a/adodbapi/test/dbapi20.py
+++ b/adodbapi/test/dbapi20.py
@@ -95,10 +95,6 @@ TEST_FOR_NON_IDEMPOTENT_CLOSE = False
 #   nothing
 # - Fix bugs in test_setoutputsize_basic and test_setinputsizes
 #
-def str2bytes(sval):
-    if sys.version_info < (3, 0) and isinstance(sval, str):
-        sval = sval.decode("latin1")
-    return sval.encode("latin1")  # python 3 make unicode into bytes
 
 
 class DatabaseAPI20Test(unittest.TestCase):
@@ -910,8 +906,8 @@ class DatabaseAPI20Test(unittest.TestCase):
         # self.assertEqual(str(t1),str(t2))
 
     def test_Binary(self):
-        b = self.driver.Binary(str2bytes("Something"))
-        b = self.driver.Binary(str2bytes(""))
+        b = self.driver.Binary(b"Something")
+        b = self.driver.Binary(b"")
 
     def test_STRING(self):
         _failUnless(

--- a/com/win32com/demos/connect.py
+++ b/com/win32com/demos/connect.py
@@ -8,7 +8,6 @@
 import pythoncom
 import win32com.server.connect
 import win32com.server.util
-from pywin32_testutil import str2bytes
 from win32com.server.exception import Exception
 
 # This is the IID of the Events interface both Client and Server support.
@@ -87,7 +86,7 @@ def test(verbose=0):
     client = ConnectableClient()
     connection.Connect(server, client, IID_IConnectDemoEvents)
     CheckEvent(server, client, "Hello", verbose)
-    CheckEvent(server, client, str2bytes("Here is a null>\x00<"), verbose)
+    CheckEvent(server, client, b"Here is a null>\x00<", verbose)
     CheckEvent(server, client, "Here is a null>\x00<", verbose)
     val = "test-\xe0\xf2"  # 2 extended characters.
     CheckEvent(server, client, val, verbose)

--- a/com/win32com/test/testPersist.py
+++ b/com/win32com/test/testPersist.py
@@ -8,7 +8,6 @@ import win32com.client
 import win32com.client.dynamic
 import win32com.server.util
 import win32ui
-from pywin32_testutil import str2bytes
 from pywintypes import Unicode
 from win32com import storagecon
 from win32com.axcontrol import axcontrol
@@ -34,8 +33,8 @@ class LockBytes:
     ]
     _com_interfaces_ = [pythoncom.IID_ILockBytes]
 
-    def __init__(self, data=""):
-        self.data = str2bytes(data)
+    def __init__(self, data=b""):
+        self.data = data
         self.ctime = now
         self.mtime = now
         self.atime = now
@@ -68,7 +67,7 @@ class LockBytes:
     def SetSize(self, size):
         print("Set Size" + str(size))
         if size > len(self.data):
-            self.data = self.data + str2bytes("\000" * (size - len(self.data)))
+            self.data = self.data + b"\000" * (size - len(self.data))
         else:
             self.data = self.data[0:size]
         return S_OK

--- a/com/win32com/test/testShell.py
+++ b/com/win32com/test/testShell.py
@@ -98,13 +98,11 @@ class PIDLTester(win32com.test.util.TestCase):
     def testCIDA(self):
         self._rtCIDA([b"\0"], [[b"\0"]])
         self._rtCIDA([b"\1"], [[b"\2"]])
-        self._rtCIDA(
-            [b"\0"], [[b"\0"], [b"\1"], [b"\2"]]
-        )
+        self._rtCIDA([b"\0"], [[b"\0"], [b"\1"], [b"\2"]])
 
     def testBadShortPIDL(self):
         # A too-short child element: cb + pidl + cb
-        pidl = b"\01\00" + "\1"
+        pidl = b"\01\00" + b"\1"
         self.assertRaises(ValueError, shell.StringAsPIDL, pidl)
 
         # ack - tried to test too long PIDLs, but a len of 0xFFFF may not

--- a/com/win32com/test/testShell.py
+++ b/com/win32com/test/testShell.py
@@ -14,7 +14,6 @@ import pythoncom
 import pywintypes
 import win32com.test.util
 import win32con
-from pywin32_testutil import str2bytes
 from win32com.shell import shell
 from win32com.shell.shellcon import *
 from win32com.storagecon import *
@@ -87,25 +86,25 @@ class PIDLTester(win32com.test.util.TestCase):
         self.assertEqual(cida_str_rt, cida_str)
 
     def testPIDL(self):
-        # A PIDL of "\1" is:   cb    pidl   cb
-        expect = str2bytes("\03\00" "\1" "\0\0")
-        self.assertEqual(shell.PIDLAsString([str2bytes("\1")]), expect)
-        self._rtPIDL([str2bytes("\0")])
-        self._rtPIDL([str2bytes("\1"), str2bytes("\2"), str2bytes("\3")])
-        self._rtPIDL([str2bytes("\0") * 2048] * 2048)
+        # A PIDL of "\1" is: cb + pidl + cb
+        expect = b"\03\00" + b"\1" + b"\0\0"
+        self.assertEqual(shell.PIDLAsString([b"\1"]), expect)
+        self._rtPIDL([b"\0"])
+        self._rtPIDL([b"\1", b"\2", b"\3"])
+        self._rtPIDL([b"\0" * 2048] * 2048)
         # PIDL must be a list
         self.assertRaises(TypeError, shell.PIDLAsString, "foo")
 
     def testCIDA(self):
-        self._rtCIDA([str2bytes("\0")], [[str2bytes("\0")]])
-        self._rtCIDA([str2bytes("\1")], [[str2bytes("\2")]])
+        self._rtCIDA([b"\0"], [[b"\0"]])
+        self._rtCIDA([b"\1"], [[b"\2"]])
         self._rtCIDA(
-            [str2bytes("\0")], [[str2bytes("\0")], [str2bytes("\1")], [str2bytes("\2")]]
+            [b"\0"], [[b"\0"], [b"\1"], [b"\2"]]
         )
 
     def testBadShortPIDL(self):
-        # A too-short child element:   cb    pidl   cb
-        pidl = str2bytes("\01\00" "\1")
+        # A too-short child element: cb + pidl + cb
+        pidl = b"\01\00" + "\1"
         self.assertRaises(ValueError, shell.StringAsPIDL, pidl)
 
         # ack - tried to test too long PIDLs, but a len of 0xFFFF may not
@@ -224,7 +223,7 @@ class FileOperationTester(win32com.test.util.TestCase):
 
         self.src_name = os.path.join(tempfile.gettempdir(), "pywin32_testshell")
         self.dest_name = os.path.join(tempfile.gettempdir(), "pywin32_testshell_dest")
-        self.test_data = str2bytes("Hello from\0Python")
+        self.test_data = b"Hello from\0Python"
         f = open(self.src_name, "wb")
         f.write(self.test_data)
         f.close()

--- a/com/win32com/test/testStreams.py
+++ b/com/win32com/test/testStreams.py
@@ -3,7 +3,6 @@ import unittest
 import pythoncom
 import win32com.server.util
 import win32com.test.util
-from pywin32_testutil import str2bytes
 
 
 class Persists:
@@ -18,7 +17,7 @@ class Persists:
     _com_interfaces_ = [pythoncom.IID_IPersistStreamInit]
 
     def __init__(self):
-        self.data = str2bytes("abcdefg")
+        self.data = b"abcdefg"
         self.dirty = 1
 
     def GetClassID(self):
@@ -82,7 +81,7 @@ class BadStream(Stream):
     """
 
     def Read(self, amount):
-        return str2bytes("x") * (amount + 1)
+        return b"x" * (amount + 1)
 
 
 class StreamTest(win32com.test.util.TestCase):
@@ -98,7 +97,7 @@ class StreamTest(win32com.test.util.TestCase):
         self.assertEqual(data[1:-1], got)
 
     def testit(self):
-        mydata = str2bytes("abcdefghijklmnopqrstuvwxyz")
+        mydata = b"abcdefghijklmnopqrstuvwxyz"
 
         # First test the objects just as Python objects...
         s = Stream(mydata)
@@ -118,7 +117,7 @@ class StreamTest(win32com.test.util.TestCase):
         self._readWrite(mydata, s2, s)
         self._readWrite(mydata, s2, s2)
 
-        self._readWrite(str2bytes("string with\0a NULL"), s2, s2)
+        self._readWrite(b"string with\0a NULL", s2, s2)
         # reset the stream
         s.Write(mydata)
         p2.Load(s2)
@@ -126,7 +125,7 @@ class StreamTest(win32com.test.util.TestCase):
         self.assertEqual(s.data, mydata)
 
     def testseek(self):
-        s = Stream(str2bytes("yo"))
+        s = Stream(b"yo")
         s = win32com.server.util.wrap(s, pythoncom.IID_IStream)
         # we used to die in py3k passing a value > 32bits
         s.Seek(0x100000000, pythoncom.STREAM_SEEK_SET)

--- a/com/win32comext/mapi/mapiutil.py
+++ b/com/win32comext/mapi/mapiutil.py
@@ -147,7 +147,7 @@ def GetAllProperties(obj, make_tag_names=True):
 _MapiTypeMap = {
     type(0.0): mapitags.PT_DOUBLE,
     type(0): mapitags.PT_I4,
-    type("".encode("ascii")): mapitags.PT_STRING8,  # bytes
+    type(b""): mapitags.PT_STRING8,  # bytes
     type(""): mapitags.PT_UNICODE,  # str
     type(None): mapitags.PT_UNSPECIFIED,
     # In Python 2.2.2, bool isn't a distinct type (type(1==1) is type(0)).

--- a/win32/Demos/BackupRead_BackupWrite.py
+++ b/win32/Demos/BackupRead_BackupWrite.py
@@ -8,7 +8,7 @@ import win32api
 import win32con
 import win32file
 import win32security
-from pywin32_testutil import ob2memory, str2bytes
+from pywin32_testutil import ob2memory
 from win32com import storagecon
 
 all_sd_info = (
@@ -103,7 +103,7 @@ while 1:
     )
     print("Written:", bytes_written, "Context:", outctxt)
 win32file.BackupRead(h, 0, buf, True, True, ctxt)
-win32file.BackupWrite(outh, 0, str2bytes(""), True, True, outctxt)
+win32file.BackupWrite(outh, 0, b"", True, True, outctxt)
 win32file.CloseHandle(h)
 win32file.CloseHandle(outh)
 

--- a/win32/Demos/CreateFileTransacted_MiniVersion.py
+++ b/win32/Demos/CreateFileTransacted_MiniVersion.py
@@ -13,7 +13,6 @@ import win32file
 import win32transaction
 import winerror
 import winioctlcon
-from pywin32_testutil import str2bytes  # py3k-friendly helper
 
 
 def demo():
@@ -49,14 +48,14 @@ def demo():
         Transaction=trans,
     )
 
-    win32file.WriteFile(hfile, str2bytes("This is first miniversion.\n"))
+    win32file.WriteFile(hfile, b"This is first miniversion.\n")
     buf = win32file.DeviceIoControl(
         hfile, winioctlcon.FSCTL_TXFS_CREATE_MINIVERSION, None, buf_size, None
     )
     struct_ver, struct_len, base_ver, ver_1 = struct.unpack(buf_fmt, buf)
 
     win32file.SetFilePointer(hfile, 0, win32con.FILE_BEGIN)
-    win32file.WriteFile(hfile, str2bytes("This is second miniversion!\n"))
+    win32file.WriteFile(hfile, b"This is second miniversion!\n")
     buf = win32file.DeviceIoControl(
         hfile, winioctlcon.FSCTL_TXFS_CREATE_MINIVERSION, None, buf_size, None
     )

--- a/win32/Demos/eventLogDemo.py
+++ b/win32/Demos/eventLogDemo.py
@@ -113,7 +113,7 @@ def test():
             logType,
             2,
             strings=["The message text for event 2", "Another insert"],
-            data="Raw\0Data".encode("ascii"),
+            data=b"Raw\0Data",
             sid=my_sid,
         )
         win32evtlogutil.ReportEvent(
@@ -121,7 +121,7 @@ def test():
             1,
             eventType=win32evtlog.EVENTLOG_WARNING_TYPE,
             strings=["A warning", "An even more dire warning"],
-            data="Raw\0Data".encode("ascii"),
+            data=b"Raw\0Data",
             sid=my_sid,
         )
         win32evtlogutil.ReportEvent(
@@ -129,7 +129,7 @@ def test():
             1,
             eventType=win32evtlog.EVENTLOG_INFORMATION_TYPE,
             strings=["An info", "Too much info"],
-            data="Raw\0Data".encode("ascii"),
+            data=b"Raw\0Data",
             sid=my_sid,
         )
         print("Successfully wrote 3 records to the log")

--- a/win32/Demos/mmapfile_demo.py
+++ b/win32/Demos/mmapfile_demo.py
@@ -4,7 +4,6 @@ import tempfile
 import mmapfile
 import win32api
 import winerror
-from pywin32_testutil import str2bytes
 
 system_info = win32api.GetSystemInfo()
 page_size = system_info[1]
@@ -17,16 +16,16 @@ print(fname, fsize, mapping_name)
 
 m1 = mmapfile.mmapfile(File=fname, Name=mapping_name, MaximumSize=fsize)
 m1.seek(100)
-m1.write_byte(str2bytes("?"))
+m1.write_byte(b"?")
 m1.seek(-1, 1)
-assert m1.read_byte() == str2bytes("?")
+assert m1.read_byte() == b"?"
 
 ## A reopened named mapping should have exact same size as original mapping
 m2 = mmapfile.mmapfile(Name=mapping_name, File=None, MaximumSize=fsize * 2)
 assert m2.size() == m1.size()
 m1.seek(0, 0)
-m1.write(fsize * str2bytes("s"))
-assert m2.read(fsize) == fsize * str2bytes("s")
+m1.write(fsize * b"s")
+assert m2.read(fsize) == fsize * b"s"
 
 move_src = 100
 move_dest = 500
@@ -34,17 +33,17 @@ move_size = 150
 
 m2.seek(move_src, 0)
 assert m2.tell() == move_src
-m2.write(str2bytes("m") * move_size)
+m2.write(b"m" * move_size)
 m2.move(move_dest, move_src, move_size)
 m2.seek(move_dest, 0)
-assert m2.read(move_size) == str2bytes("m") * move_size
+assert m2.read(move_size) == b"m" * move_size
 ##    m2.write('x'* (fsize+1))
 
 m2.close()
 m1.resize(fsize * 2)
 assert m1.size() == fsize * 2
 m1.seek(fsize)
-m1.write(str2bytes("w") * fsize)
+m1.write(b"w" * fsize)
 m1.flush()
 m1.close()
 os.remove(fname)
@@ -54,7 +53,7 @@ os.remove(fname)
 ## need 10 GB free on drive where your temp folder lives
 fname_large = tempfile.mktemp()
 mapping_name = "Pywin32_large_mmap"
-offsetdata = str2bytes("This is start of offset")
+offsetdata = b"This is start of offset"
 
 ## Deliberately use odd numbers to test rounding logic
 fsize = (1024 * 1024 * 1024 * 10) + 333

--- a/win32/Demos/service/pipeTestService.py
+++ b/win32/Demos/service/pipeTestService.py
@@ -73,7 +73,7 @@ class TestPipeService(win32serviceutil.ServiceFramework):
             try:
                 # Create a loop, reading large data.  If we knew the data stream was
                 # was small, a simple ReadFile would do.
-                d = b""  # ensure bytes on py2k and py3k...
+                d = b""
                 hr = winerror.ERROR_MORE_DATA
                 while hr == winerror.ERROR_MORE_DATA:
                     hr, thisd = ReadFile(pipeHandle, 256)

--- a/win32/Demos/service/pipeTestService.py
+++ b/win32/Demos/service/pipeTestService.py
@@ -73,7 +73,7 @@ class TestPipeService(win32serviceutil.ServiceFramework):
             try:
                 # Create a loop, reading large data.  If we knew the data stream was
                 # was small, a simple ReadFile would do.
-                d = "".encode("ascii")  # ensure bytes on py2k and py3k...
+                d = b""  # ensure bytes on py2k and py3k...
                 hr = winerror.ERROR_MORE_DATA
                 while hr == winerror.ERROR_MORE_DATA:
                     hr, thisd = ReadFile(pipeHandle, 256)

--- a/win32/Demos/win32clipboardDemo.py
+++ b/win32/Demos/win32clipboardDemo.py
@@ -3,7 +3,6 @@
 # Demo/test of the win32clipboard module.
 
 import win32con
-from pywin32_testutil import str2bytes  # py3k-friendly helper
 from win32clipboard import *
 
 if not __debug__:
@@ -32,7 +31,7 @@ def TestText():
     OpenClipboard()
     try:
         text = "Hello from Python"
-        text_bytes = str2bytes(text)
+        text_bytes = text.encode("latin1")
         SetClipboardText(text)
         got = GetClipboardData(win32con.CF_TEXT)
         # CF_TEXT always gives us 'bytes' back .
@@ -54,7 +53,7 @@ def TestText():
         # Unicode tests
         EmptyClipboard()
         text = "Hello from Python unicode"
-        text_bytes = str2bytes(text)
+        text_bytes = text.encode("latin1")
         # Now set the Unicode value
         SetClipboardData(win32con.CF_UNICODETEXT, text)
         # Get it in Unicode.

--- a/win32/Demos/win32fileDemo.py
+++ b/win32/Demos/win32fileDemo.py
@@ -21,7 +21,7 @@ def SimpleFileDemo():
     handle = win32file.CreateFile(
         testName, win32file.GENERIC_WRITE, 0, None, win32con.CREATE_NEW, 0, None
     )
-    test_data = "Hello\0there".encode("ascii")
+    test_data = b"Hello\0there"
     win32file.WriteFile(handle, test_data)
     handle.Close()
     # Open it for reading.

--- a/win32/Lib/netbios.py
+++ b/win32/Lib/netbios.py
@@ -294,7 +294,7 @@ if __name__ == "__main__":
         ncb.Reset()
         ncb.Command = NCBASTAT
         ncb.Lana_num = byte_to_int(la_enum.lana[i])
-        ncb.Callname = "*               ".encode("ascii")  # ensure bytes on py2x and 3k
+        ncb.Callname = b"*               "  # ensure bytes on py2x and 3k
         adapter = ADAPTER_STATUS()
         ncb.Buffer = adapter
         Netbios(ncb)

--- a/win32/Lib/netbios.py
+++ b/win32/Lib/netbios.py
@@ -294,7 +294,7 @@ if __name__ == "__main__":
         ncb.Reset()
         ncb.Command = NCBASTAT
         ncb.Lana_num = byte_to_int(la_enum.lana[i])
-        ncb.Callname = b"*               "  # ensure bytes on py2x and 3k
+        ncb.Callname = b"*               "
         adapter = ADAPTER_STATUS()
         ncb.Buffer = adapter
         Netbios(ncb)

--- a/win32/Lib/pywin32_testutil.py
+++ b/win32/Lib/pywin32_testutil.py
@@ -12,14 +12,6 @@ import winerror
 ##
 
 
-# The test suite has lots of string constants containing binary data, but
-# the strings are used in various "bytes" contexts.
-def str2bytes(sval):
-    if sys.version_info < (3, 0) and isinstance(sval, str):
-        sval = sval.decode("latin1")
-    return sval.encode("latin1")
-
-
 # Sometimes we want to pass a string that should explicitly be treated as
 # a memory blob.
 def str2memory(sval):

--- a/win32/Lib/sspi.py
+++ b/win32/Lib/sspi.py
@@ -386,7 +386,7 @@ if __name__ == "__main__":
     print("Initiator name from the service side:", sspiserver.initiator_name)
     print("Service name from the client side:   ", sspiclient.service_name)
 
-    data = "hello".encode("ascii")  # py3k-friendly
+    data = b"hello"  # py3k-friendly
 
     # Simple signature, not compatible with GSSAPI.
     sig = sspiclient.sign(data)

--- a/win32/Lib/win32verstamp.py
+++ b/win32/Lib/win32verstamp.py
@@ -16,6 +16,7 @@ VOS_NT_WINDOWS32 = 0x00040004
 
 null_byte = b"\0"
 
+
 #
 # Set VS_FF_PRERELEASE and DEBUG if Debug
 #

--- a/win32/Lib/win32verstamp.py
+++ b/win32/Lib/win32verstamp.py
@@ -14,8 +14,7 @@ VS_FFI_STRUCVERSION = 0x00010000
 VS_FFI_FILEFLAGSMASK = 0x0000003F
 VOS_NT_WINDOWS32 = 0x00040004
 
-null_byte = b"\0"  # str in py2k, bytes in py3k
-
+null_byte = b"\0"
 
 #
 # Set VS_FF_PRERELEASE and DEBUG if Debug

--- a/win32/Lib/win32verstamp.py
+++ b/win32/Lib/win32verstamp.py
@@ -14,7 +14,7 @@ VS_FFI_STRUCVERSION = 0x00010000
 VS_FFI_FILEFLAGSMASK = 0x0000003F
 VOS_NT_WINDOWS32 = 0x00040004
 
-null_byte = "\0".encode("ascii")  # str in py2k, bytes in py3k
+null_byte = b"\0"  # str in py2k, bytes in py3k
 
 
 #

--- a/win32/test/test_clipboard.py
+++ b/win32/test/test_clipboard.py
@@ -7,7 +7,6 @@ import unittest
 import pywintypes
 import win32con
 import win32gui
-from pywin32_testutil import str2bytes
 from win32clipboard import *
 
 custom_format_name = "PythonClipboardTestFormat"
@@ -77,13 +76,13 @@ class TestStrings(unittest.TestCase):
         SetClipboardText(val)
         # GetClipboardData doesn't to auto string conversions - so on py3k,
         # CF_TEXT returns bytes.
-        expected = str2bytes(val)
+        expected = val.encode("latin1")
         self.assertEqual(GetClipboardData(win32con.CF_TEXT), expected)
         SetClipboardText(val, win32con.CF_UNICODETEXT)
         self.assertEqual(GetClipboardData(win32con.CF_UNICODETEXT), val)
 
     def test_string(self):
-        val = str2bytes("test")
+        val = b"test"
         SetClipboardData(win32con.CF_TEXT, val)
         self.assertEqual(GetClipboardData(win32con.CF_TEXT), val)
 
@@ -96,8 +95,8 @@ class TestGlobalMemory(unittest.TestCase):
         CloseClipboard()
 
     def test_mem(self):
-        val = str2bytes("test")
-        expected = str2bytes("test\0")
+        val = b"test"
+        expected = b"test\0"
         SetClipboardData(win32con.CF_TEXT, val)
         # Get the raw data - this will include the '\0'
         raw_data = GetGlobalMemory(GetClipboardDataHandle(win32con.CF_TEXT))
@@ -113,7 +112,7 @@ class TestGlobalMemory(unittest.TestCase):
             self.assertRaises(pywintypes.error, GetGlobalMemory, 1)
 
     def test_custom_mem(self):
-        test_data = str2bytes("hello\x00\xff")
+        test_data = b"hello\x00\xff"
         test_buffer = array.array("b", test_data)
         cf = RegisterClipboardFormat(custom_format_name)
         self.assertEqual(custom_format_name, GetClipboardFormatName(cf))

--- a/win32/test/test_odbc.py
+++ b/win32/test/test_odbc.py
@@ -6,7 +6,7 @@ import unittest
 
 import odbc
 import pythoncom
-from pywin32_testutil import TestSkipped, str2bytes, str2memory
+from pywin32_testutil import TestSkipped, str2memory
 from win32com.client import constants
 
 # We use the DAO ODBC driver
@@ -244,7 +244,7 @@ class TestStuff(unittest.TestCase):
         self.assertEqual(
             self.cur.execute(
                 "insert into %s (userid,username) " "values (?,?)" % self.tablename,
-                [str2bytes("Frank"), ""],
+                [b"Frank", ""],
             ),
             1,
         )

--- a/win32/test/test_pywintypes.py
+++ b/win32/test/test_pywintypes.py
@@ -87,9 +87,7 @@ class TestCase(unittest.TestCase):
         iid = pywintypes.IID(s)
         iid2 = pywintypes.IID(ob2memory(iid), True)
         self.assertEqual(iid, iid2)
-        self.assertRaises(
-            ValueError, pywintypes.IID, b"00", True
-        )  # too short
+        self.assertRaises(ValueError, pywintypes.IID, b"00", True)  # too short
         self.assertRaises(TypeError, pywintypes.IID, 0, True)  # no buffer
 
     def testGUIDRichCmp(self):

--- a/win32/test/test_pywintypes.py
+++ b/win32/test/test_pywintypes.py
@@ -5,7 +5,7 @@ import time
 import unittest
 
 import pywintypes
-from pywin32_testutil import ob2memory, str2bytes
+from pywin32_testutil import ob2memory
 
 
 class TestCase(unittest.TestCase):
@@ -88,7 +88,7 @@ class TestCase(unittest.TestCase):
         iid2 = pywintypes.IID(ob2memory(iid), True)
         self.assertEqual(iid, iid2)
         self.assertRaises(
-            ValueError, pywintypes.IID, str2bytes("00"), True
+            ValueError, pywintypes.IID, b"00", True
         )  # too short
         self.assertRaises(TypeError, pywintypes.IID, 0, True)  # no buffer
 

--- a/win32/test/test_sspi.py
+++ b/win32/test/test_sspi.py
@@ -8,7 +8,7 @@ import sspi
 import sspicon
 import win32api
 import win32security
-from pywin32_testutil import TestSkipped, str2bytes, testmain
+from pywin32_testutil import TestSkipped, testmain
 
 
 # It is quite likely that the Kerberos tests will fail due to not being
@@ -63,7 +63,7 @@ class TestSSPI(unittest.TestCase):
         pkg_size_info = sspiclient.ctxt.QueryContextAttributes(
             sspicon.SECPKG_ATTR_SIZES
         )
-        msg = str2bytes("some data to be encrypted ......")
+        msg = b"some data to be encrypted ......"
 
         trailersize = pkg_size_info["SecurityTrailer"]
         encbuf = win32security.PySecBufferDescType()
@@ -76,7 +76,7 @@ class TestSSPI(unittest.TestCase):
         sspiserver.ctxt.DecryptMessage(encbuf, 1)
         self.assertEqual(msg, encbuf[0].Buffer)
         # and test the higher-level functions
-        data_in = str2bytes("hello")
+        data_in = b"hello"
         data, sig = sspiclient.encrypt(data_in)
         self.assertEqual(sspiserver.decrypt(data, sig), data_in)
 
@@ -92,7 +92,7 @@ class TestSSPI(unittest.TestCase):
         pkg_size_info = sspiclient.ctxt.QueryContextAttributes(
             sspicon.SECPKG_ATTR_SIZES
         )
-        msg = str2bytes("some data to be encrypted ......")
+        msg = b"some data to be encrypted ......"
 
         trailersize = pkg_size_info["SecurityTrailer"]
         blocksize = pkg_size_info["BlockSize"]
@@ -136,7 +136,7 @@ class TestSSPI(unittest.TestCase):
         pkg_size_info = sspiclient.ctxt.QueryContextAttributes(
             sspicon.SECPKG_ATTR_SIZES
         )
-        msg = str2bytes("some data to be encrypted ......")
+        msg = b"some data to be encrypted ......"
 
         sigsize = pkg_size_info["MaxSignature"]
         sigbuf = win32security.PySecBufferDescType()
@@ -148,7 +148,7 @@ class TestSSPI(unittest.TestCase):
         # and test the higher-level functions
         sspiclient.next_seq_num = 1
         sspiserver.next_seq_num = 1
-        data = str2bytes("hello")
+        data = b"hello"
         key = sspiclient.sign(data)
         sspiserver.verify(data, key)
         key = sspiclient.sign(data)

--- a/win32/test/test_win32api.py
+++ b/win32/test/test_win32api.py
@@ -10,7 +10,7 @@ import win32api
 import win32con
 import win32event
 import winerror
-from pywin32_testutil import TestSkipped, str2bytes
+from pywin32_testutil import TestSkipped
 
 
 class CurrentUserTestCase(unittest.TestCase):
@@ -96,7 +96,7 @@ class Registry(unittest.TestCase):
             (
                 "REG_BINARY",
                 win32con.REG_BINARY,
-                str2bytes("\x00\x01\x02\x03\x04\x05\x06\x07\x08\x01\x00"),
+                b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x01\x00",
             ),
         )
 

--- a/win32/test/test_win32file.py
+++ b/win32/test/test_win32file.py
@@ -17,7 +17,7 @@ import win32file
 import win32pipe
 import win32timezone
 import winerror
-from pywin32_testutil import TestSkipped, str2bytes, testmain
+from pywin32_testutil import TestSkipped, testmain
 
 try:
     set
@@ -37,7 +37,7 @@ class TestReadBuffer(unittest.TestCase):
 
     def testSimpleSlice(self):
         buffer = win32file.AllocateReadBuffer(2)
-        val = str2bytes("\0\0")
+        val = b"\0\0"
         buffer[:2] = val
         self.assertEqual(buffer[0:2], val)
 
@@ -50,7 +50,7 @@ class TestSimpleOps(unittest.TestCase):
         handle = win32file.CreateFile(
             filename, win32file.GENERIC_WRITE, 0, None, win32con.CREATE_NEW, 0, None
         )
-        test_data = str2bytes("Hello\0there")
+        test_data = b"Hello\0there"
         try:
             win32file.WriteFile(handle, test_data)
             handle.Close()
@@ -91,7 +91,7 @@ class TestSimpleOps(unittest.TestCase):
         )
 
         # Write a known number of bytes to the file.
-        data = str2bytes("z") * 1025
+        data = b"z" * 1025
 
         win32file.WriteFile(h, data)
 
@@ -154,7 +154,7 @@ class TestSimpleOps(unittest.TestCase):
         )
         try:
             # Write some data
-            data = str2bytes("Some data")
+            data = b"Some data"
             (res, written) = win32file.WriteFile(f, data)
 
             self.assertFalse(res)
@@ -312,7 +312,7 @@ class TestOverlapped(unittest.TestCase):
         h = win32file.CreateFile(
             testName, desiredAccess, 0, None, win32file.CREATE_ALWAYS, 0, 0
         )
-        chunk_data = str2bytes("z") * 0x8000
+        chunk_data = b"z" * 0x8000
         num_loops = 512
         expected_size = num_loops * len(chunk_data)
         for i in range(num_loops):
@@ -440,7 +440,7 @@ class TestOverlapped(unittest.TestCase):
             time.sleep(0.1)  # let thread do its thing.
             try:
                 win32pipe.CallNamedPipe(
-                    r"\\.\pipe\pywin32_test_pipe", str2bytes("Hello there"), BUFSIZE, 0
+                    r"\\.\pipe\pywin32_test_pipe", b"Hello there", BUFSIZE, 0
                 )
             except win32pipe.error:
                 # Testing for overlapped death causes this
@@ -530,7 +530,7 @@ class TestSocketExtensions(unittest.TestCase):
             self.fail("AcceptEx Worker thread failed to start")
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.connect(("127.0.0.1", port))
-        win32file.WSASend(s, str2bytes("hello"), None)
+        win32file.WSASend(s, b"hello", None)
         overlapped = pywintypes.OVERLAPPED()
         overlapped.hEvent = win32event.CreateEvent(None, 0, 0, None)
         # Like above - WSARecv used to allow strings as the receive buffer!!
@@ -541,7 +541,7 @@ class TestSocketExtensions(unittest.TestCase):
         win32file.WSARecv(s, buffer, overlapped)
         nbytes = win32file.GetOverlappedResult(s.fileno(), overlapped, True)
         got = buffer[:nbytes]
-        self.assertEqual(got, str2bytes("hello"))
+        self.assertEqual(got, b"hello")
         # thread should have stopped
         stopped.wait(2)
         if not stopped.isSet():
@@ -720,7 +720,7 @@ class TestEncrypt(unittest.TestCase):
     def testEncrypt(self):
         fname = tempfile.mktemp("win32file_test")
         f = open(fname, "wb")
-        f.write(str2bytes("hello"))
+        f.write(b"hello")
         f.close()
         f = None
         try:
@@ -774,7 +774,7 @@ class TestConnect(unittest.TestCase):
         nbytes = win32file.GetOverlappedResult(listener.fileno(), overlapped, False)
         if expect_payload:
             self.request = buffer[:nbytes]
-        accepter.send(str2bytes("some expected response"))
+        accepter.send(b"some expected response")
 
     def test_connect_with_payload(self):
         giveup_event = win32event.CreateEvent(None, 0, 0, None)
@@ -787,7 +787,7 @@ class TestConnect(unittest.TestCase):
         ol = pywintypes.OVERLAPPED()
         s2.bind(("0.0.0.0", 0))  # connectex requires the socket be bound beforehand
         try:
-            win32file.ConnectEx(s2, self.addr, ol, str2bytes("some expected request"))
+            win32file.ConnectEx(s2, self.addr, ol, b"some expected request")
         except win32file.error as exc:
             win32event.SetEvent(giveup_event)
             if exc.winerror == 10022:  # WSAEINVAL
@@ -806,8 +806,8 @@ class TestConnect(unittest.TestCase):
         win32file.WSARecv(s2, buff, ol, 0)
         length = win32file.GetOverlappedResult(s2.fileno(), ol, 1)
         self.response = buff[:length]
-        self.assertEqual(self.response, str2bytes("some expected response"))
-        self.assertEqual(self.request, str2bytes("some expected request"))
+        self.assertEqual(self.response, b"some expected response")
+        self.assertEqual(self.request, b"some expected request")
         t.join(5)
         self.assertFalse(t.is_alive(), "worker thread didn't terminate")
 
@@ -842,7 +842,7 @@ class TestConnect(unittest.TestCase):
         win32file.WSARecv(s2, buff, ol, 0)
         length = win32file.GetOverlappedResult(s2.fileno(), ol, 1)
         self.response = buff[:length]
-        self.assertEqual(self.response, str2bytes("some expected response"))
+        self.assertEqual(self.response, b"some expected response")
         t.join(5)
         self.assertFalse(t.is_alive(), "worker thread didn't terminate")
 
@@ -889,11 +889,11 @@ class TestTransmit(unittest.TestCase):
         s2.connect(self.addr)
 
         length = 0
-        aaa = str2bytes("[AAA]")
-        bbb = str2bytes("[BBB]")
-        ccc = str2bytes("[CCC]")
-        ddd = str2bytes("[DDD]")
-        empty = str2bytes("")
+        aaa = b"[AAA]"
+        bbb = b"[BBB]"
+        ccc = b"[CCC]"
+        ddd = b"[DDD]"
+        empty = b""
         ol = pywintypes.OVERLAPPED()
         f.seek(0)
         win32file.TransmitFile(
@@ -931,7 +931,7 @@ class TestTransmit(unittest.TestCase):
 
         s2.close()
         th.join()
-        buf = str2bytes("").join(self.request)
+        buf = b"".join(self.request)
         self.assertEqual(length, len(buf))
         expected = val + aaa + val + bbb + val + val + ccc + ddd + val
         self.assertEqual(type(expected), type(buf))
@@ -1014,7 +1014,7 @@ class TestWSAEnumNetworkEvents(unittest.TestCase):
         events = win32file.WSAEnumNetworkEvents(client, client_event)
         self.assertEqual(events, {win32file.FD_CONNECT: 0, win32file.FD_WRITE: 0})
         sent = 0
-        data = str2bytes("x") * 16 * 1024
+        data = b"x" * 16 * 1024
         while sent < 16 * 1024 * 1024:
             try:
                 sent += client.send(data)

--- a/win32/test/test_win32inet.py
+++ b/win32/test/test_win32inet.py
@@ -1,7 +1,6 @@
 import unittest
 
 import winerror
-from pywin32_testutil import str2bytes  # py3k-friendly helper
 from pywin32_testutil import TestSkipped, testmain
 from win32inet import *
 from win32inetcon import *
@@ -53,8 +52,8 @@ class TestNetwork(unittest.TestCase):
             if not chunk:
                 break
             chunks.append(chunk)
-        data = str2bytes("").join(chunks)
-        assert data.find(str2bytes("Python")) > 0, repr(
+        data = b"".join(chunks)
+        assert data.find(b"Python") > 0, repr(
             data
         )  # This must appear somewhere on the main page!
 

--- a/win32/test/test_win32pipe.py
+++ b/win32/test/test_win32pipe.py
@@ -107,9 +107,7 @@ class PipeTests(unittest.TestCase):
         )
 
         buffer = win32file.AllocateReadBuffer(1024)
-        hr, got = win32pipe.TransactNamedPipe(
-            hpipe, b"foo\0bar", buffer, None
-        )
+        hr, got = win32pipe.TransactNamedPipe(hpipe, b"foo\0bar", buffer, None)
         self.assertEqual(got, b"bar\0foo")
         event.wait(5)
         self.assertTrue(event.isSet(), "Pipe server thread didn't terminate")
@@ -137,9 +135,7 @@ class PipeTests(unittest.TestCase):
         )
 
         buffer = win32file.AllocateReadBuffer(1024)
-        hr, got = win32pipe.TransactNamedPipe(
-            hpipe, b"foo\0bar", buffer, overlapped
-        )
+        hr, got = win32pipe.TransactNamedPipe(hpipe, b"foo\0bar", buffer, overlapped)
         self.assertEqual(hr, winerror.ERROR_IO_PENDING)
         nbytes = win32file.GetOverlappedResult(hpipe, overlapped, True)
         got = buffer[:nbytes]

--- a/win32/test/test_win32pipe.py
+++ b/win32/test/test_win32pipe.py
@@ -8,7 +8,6 @@ import win32event
 import win32file
 import win32pipe
 import winerror
-from pywin32_testutil import str2bytes  # py3k-friendly helper
 
 
 class PipeTests(unittest.TestCase):
@@ -21,9 +20,9 @@ class PipeTests(unittest.TestCase):
             hr in (0, winerror.ERROR_PIPE_CONNECTED), "Got error code 0x%x" % (hr,)
         )
         hr, got = win32file.ReadFile(pipe_handle, 100)
-        self.assertEqual(got, str2bytes("foo\0bar"))
+        self.assertEqual(got, b"foo\0bar")
         time.sleep(wait_time)
-        win32file.WriteFile(pipe_handle, str2bytes("bar\0foo"))
+        win32file.WriteFile(pipe_handle, b"bar\0foo")
         pipe_handle.Close()
         event.set()
 
@@ -54,9 +53,9 @@ class PipeTests(unittest.TestCase):
         self.startPipeServer(event)
 
         got = win32pipe.CallNamedPipe(
-            self.pipename, str2bytes("foo\0bar"), 1024, win32pipe.NMPWAIT_WAIT_FOREVER
+            self.pipename, b"foo\0bar", 1024, win32pipe.NMPWAIT_WAIT_FOREVER
         )
-        self.assertEqual(got, str2bytes("bar\0foo"))
+        self.assertEqual(got, b"bar\0foo")
         event.wait(5)
         self.assertTrue(event.isSet(), "Pipe server thread didn't terminate")
 
@@ -80,8 +79,8 @@ class PipeTests(unittest.TestCase):
             hpipe, win32pipe.PIPE_READMODE_MESSAGE, None, None
         )
 
-        hr, got = win32pipe.TransactNamedPipe(hpipe, str2bytes("foo\0bar"), 1024, None)
-        self.assertEqual(got, str2bytes("bar\0foo"))
+        hr, got = win32pipe.TransactNamedPipe(hpipe, b"foo\0bar", 1024, None)
+        self.assertEqual(got, b"bar\0foo")
         event.wait(5)
         self.assertTrue(event.isSet(), "Pipe server thread didn't terminate")
 
@@ -109,9 +108,9 @@ class PipeTests(unittest.TestCase):
 
         buffer = win32file.AllocateReadBuffer(1024)
         hr, got = win32pipe.TransactNamedPipe(
-            hpipe, str2bytes("foo\0bar"), buffer, None
+            hpipe, b"foo\0bar", buffer, None
         )
-        self.assertEqual(got, str2bytes("bar\0foo"))
+        self.assertEqual(got, b"bar\0foo")
         event.wait(5)
         self.assertTrue(event.isSet(), "Pipe server thread didn't terminate")
 
@@ -139,12 +138,12 @@ class PipeTests(unittest.TestCase):
 
         buffer = win32file.AllocateReadBuffer(1024)
         hr, got = win32pipe.TransactNamedPipe(
-            hpipe, str2bytes("foo\0bar"), buffer, overlapped
+            hpipe, b"foo\0bar", buffer, overlapped
         )
         self.assertEqual(hr, winerror.ERROR_IO_PENDING)
         nbytes = win32file.GetOverlappedResult(hpipe, overlapped, True)
         got = buffer[:nbytes]
-        self.assertEqual(got, str2bytes("bar\0foo"))
+        self.assertEqual(got, b"bar\0foo")
         event.wait(5)
         self.assertTrue(event.isSet(), "Pipe server thread didn't terminate")
 

--- a/win32/test/test_win32wnet.py
+++ b/win32/test/test_win32wnet.py
@@ -3,7 +3,6 @@ import unittest
 import netbios
 import win32api
 import win32wnet
-from pywin32_testutil import str2bytes
 
 RESOURCE_CONNECTED = 0x00000001
 RESOURCE_GLOBALNET = 0x00000002
@@ -114,7 +113,7 @@ class TestCase(unittest.TestCase):
             ncb.Reset()
             ncb.Command = netbios.NCBASTAT
             ncb.Lana_num = byte_to_int(la_enum.lana[i])
-            ncb.Callname = str2bytes("*               ")  # ensure bytes on py2x and 3k
+            ncb.Callname = b"*               "  # ensure bytes on py2x and 3k
             adapter = netbios.ADAPTER_STATUS()
             ncb.Buffer = adapter
             Netbios(ncb)

--- a/win32/test/test_win32wnet.py
+++ b/win32/test/test_win32wnet.py
@@ -113,7 +113,7 @@ class TestCase(unittest.TestCase):
             ncb.Reset()
             ncb.Command = netbios.NCBASTAT
             ncb.Lana_num = byte_to_int(la_enum.lana[i])
-            ncb.Callname = b"*               "  # ensure bytes on py2x and 3k
+            ncb.Callname = b"*               "
             adapter = netbios.ADAPTER_STATUS()
             ncb.Buffer = adapter
             Netbios(ncb)


### PR DESCRIPTION
Split off from https://github.com/mhammond/pywin32/pull/1990

Another PR in a series concerning code cleanup. With the final goal to make basic type-checking validation of public methods possible, easing the addition of 3.7+ type annotations.

Using bytes-strings (`b""`) for constant/known bytes values rather than needlessly calling `.encode` now that it is no longer needed for Python2 support.