### PR TITLE
adodbapi: Remove references to outdated `mxDateTime`

### DIFF
--- a/adodbapi/apibase.py
+++ b/adodbapi/apibase.py
@@ -192,11 +192,8 @@ class TimeConverter(object):  # this is a generic time converter skeleton
         except:  # might be a tuple
             try:
                 return self.ComDateFromTuple(obj)
-            except:  # try an mxdate
-                try:
-                    return obj.COMDate()
-                except:
-                    raise ValueError('Cannot convert "%s" to COMdate.' % repr(obj))
+            except:
+                raise ValueError('Cannot convert "%s" to COMdate.' % repr(obj))
 
     def ComDateFromTuple(self, t, microseconds=0):
         d = datetime.date(t[0], t[1], t[2])
@@ -230,46 +227,11 @@ class TimeConverter(object):  # this is a generic time converter skeleton
             if isinstance(obj, datetime.date):
                 s = obj.isoformat() + " 00:00:00"  # return exact midnight
             else:
-                try:  # maybe it has a strftime method, like mx
-                    s = obj.strftime("%Y-%m-%d %H:%M:%S")
-                except AttributeError:
-                    try:  # but may be time.struct_time
-                        s = time.strftime("%Y-%m-%d %H:%M:%S", obj)
-                    except:
-                        raise ValueError('Cannot convert "%s" to isoformat' % repr(obj))
+                try:  # but may be time.struct_time
+                    s = time.strftime("%Y-%m-%d %H:%M:%S", obj)
+                except:
+                    raise ValueError('Cannot convert "%s" to isoformat' % repr(obj))
         return s
-
-
-# -- Optional: if mx extensions are installed you may use mxDateTime ----
-try:
-    import mx.DateTime
-
-    mxDateTime = True
-except:
-    mxDateTime = False
-if mxDateTime:
-
-    class mxDateTimeConverter(TimeConverter):  # used optionally if installed
-        def __init__(self):
-            TimeConverter.__init__(self)
-            self.types.add(type(mx.DateTime))
-
-        def DateObjectFromCOMDate(self, comDate):
-            return mx.DateTime.DateTimeFromCOMDate(comDate)
-
-        def Date(self, year, month, day):
-            return mx.DateTime.Date(year, month, day)
-
-        def Time(self, hour, minute, second):
-            return mx.DateTime.Time(hour, minute, second)
-
-        def Timestamp(self, year, month, day, hour, minute, second):
-            return mx.DateTime.Timestamp(year, month, day, hour, minute, second)
-
-else:
-
-    class mxDateTimeConverter(TimeConverter):
-        pass  # if no mx is installed
 
 
 class pythonDateTimeConverter(TimeConverter):  # standard since Python 2.3

--- a/adodbapi/quick_reference.md
+++ b/adodbapi/quick_reference.md
@@ -821,8 +821,7 @@ code. It will run 2to3 when it does this, if needed.
 
 "\--postgres" run the PostgreSQL tests.
 
-"\--time" run all time tests. (If mx-DateTime is not installed it will
-be skipped.)
+"\--time" do time format test
 
 "\--verbose=n" gives lots of information.
 

--- a/adodbapi/test/adodbapitest.py
+++ b/adodbapi/test/adodbapitest.py
@@ -27,6 +27,7 @@ import decimal
 import random
 import string
 import sys
+import time
 import unittest
 
 try:
@@ -1521,40 +1522,6 @@ class TimeConverterInterfaceTest(unittest.TestCase):
         self.assertEqual(str(iso[:10]), "2003-05-02")
 
 
-if config.doMxDateTimeTest:
-    import mx.DateTime
-
-
-class TestMXDateTimeConverter(TimeConverterInterfaceTest):
-    def setUp(self):
-        self.tc = api.mxDateTimeConverter()
-
-    def testCOMDate(self):
-        t = mx.DateTime.DateTime(2002, 6, 28, 18, 15, 2)
-        cmd = self.tc.COMDate(t)
-        assert cmd == t.COMDate()
-
-    def testDateObjectFromCOMDate(self):
-        cmd = self.tc.DateObjectFromCOMDate(37435.7604282)
-        t = mx.DateTime.DateTime(2002, 6, 28, 18, 15, 0)
-        t2 = mx.DateTime.DateTime(2002, 6, 28, 18, 15, 2)
-        assert t2 > cmd > t
-
-    def testDate(self):
-        assert mx.DateTime.Date(1980, 11, 4) == self.tc.Date(1980, 11, 4)
-
-    def testTime(self):
-        assert mx.DateTime.Time(13, 11, 4) == self.tc.Time(13, 11, 4)
-
-    def testTimestamp(self):
-        t = mx.DateTime.DateTime(2002, 6, 28, 18, 15, 1)
-        obj = self.tc.Timestamp(2002, 6, 28, 18, 15, 1)
-        assert t == obj
-
-
-import time
-
-
 class TestPythonTimeConverter(TimeConverterInterfaceTest):
     def setUp(self):
         self.tc = api.pythonTimeConverter()
@@ -1637,13 +1604,9 @@ class TestPythonDateTimeConverter(TimeConverterInterfaceTest):
         assert t1 < obj < t2, obj
 
 
-suites = []
-suites.append(unittest.makeSuite(TestPythonDateTimeConverter, "test"))
-if config.doMxDateTimeTest:
-    suites.append(unittest.makeSuite(TestMXDateTimeConverter, "test"))
+suites = [unittest.makeSuite(TestPythonDateTimeConverter, "test")]
 if config.doTimeTest:
     suites.append(unittest.makeSuite(TestPythonTimeConverter, "test"))
-
 if config.doAccessTest:
     suites.append(unittest.makeSuite(TestADOwithAccessDB, "test"))
 if config.doSqlServerTest:
@@ -1670,19 +1633,13 @@ if __name__ == "__main__":
         print(__doc__)
         print("Default Date Converter is %s" % (defaultDateConverter,))
         dateconverter = defaultDateConverter
-        tag = "datetime"
         unittest.TextTestRunner().run(mysuite)
 
-        if config.iterateOverTimeTests:
-            for test, dateconverter, tag in (
-                (config.doTimeTest, api.pythonTimeConverter, "pythontime"),
-                (config.doMxDateTimeTest, api.mxDateTimeConverter, "mx"),
-            ):
-                if test:
-                    mysuite = copy.deepcopy(
-                        suite
-                    )  # work around a side effect of unittest.TextTestRunner
-                    adodbapi.adodbapi.dateconverter = dateconverter()
-                    print("Changed dateconverter to ")
-                    print(adodbapi.adodbapi.dateconverter)
-                    unittest.TextTestRunner().run(mysuite)
+        if config.doTimeTest:
+            mysuite = copy.deepcopy(
+                suite
+            )  # work around a side effect of unittest.TextTestRunner
+            adodbapi.adodbapi.dateconverter = api.pythonTimeConverter()
+            print("Changed dateconverter to ")
+            print(adodbapi.adodbapi.dateconverter)
+            unittest.TextTestRunner().run(mysuite)

--- a/adodbapi/test/adodbapitestconfig.py
+++ b/adodbapi/test/adodbapitestconfig.py
@@ -34,12 +34,12 @@ if "--help" in sys.argv:
         """Valid command-line switches are:
     --package - create a temporary test package, run 2to3 if needed.
     --all - run all possible tests
-    --time - loop over time format tests (including mxdatetime if present)
+    --time - do time format test
     --nojet - do not test against an ACCESS database file
     --mssql - test against Microsoft SQL server
     --pg - test against PostgreSQL
     --mysql - test against MariaDB
-    --remote= - test unsing remote server at= (experimental) 
+    --remote= - test using remote server at= (experimental) 
     """
     )
     exit()
@@ -106,20 +106,11 @@ doAccessTest = not ("--nojet" in sys.argv)
 doSqlServerTest = "--mssql" in sys.argv or doAllTests
 doMySqlTest = "--mysql" in sys.argv or doAllTests
 doPostgresTest = "--pg" in sys.argv or doAllTests
-iterateOverTimeTests = ("--time" in sys.argv or doAllTests) and onWindows
+doTimeTest = ("--time" in sys.argv or doAllTests) and onWindows
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # # start your environment setup here v v v
 SQL_HOST_NODE = "testsql.2txt.us,1430"
-
-try:  # If mx extensions are installed, use mxDateTime
-    import mx.DateTime
-
-    doMxDateTimeTest = True
-except:
-    doMxDateTimeTest = False  # Requires eGenixMXExtensions
-
-doTimeTest = True  # obsolete python time format
 
 if doAccessTest:
     if proxy_host:  # determine the (probably remote) database file folder


### PR DESCRIPTION
Split off from https://github.com/mhammond/pywin32/pull/1990 to make it easier to review in isolation.

Remove obsoleted code and references to `mxDateTime`, which does not support any recent enough python version. Update time tests accordingly.