### PR TITLE
Remove references to outdated IronPython

### DIFF
--- a/adodbapi/adodbapi.py
+++ b/adodbapi/adodbapi.py
@@ -24,7 +24,6 @@ Copyright (C) 2002 Henrik Ekelund, versions 2.1 and later by Vernon Cole
 DB-API 2.0 specification: http://www.python.org/dev/peps/pep-0249/
 
 This module source should run correctly in CPython versions 2.7 and later,
-or IronPython version 2.7 and later,
 or, after running through 2to3.py, CPython 3.4 or later.
 """
 
@@ -48,45 +47,24 @@ if verbose:
 
 # --- define objects to smooth out IronPython <-> CPython differences
 onWin32 = False  # assume the worst
-if api.onIronPython:
-    from clr import Reference
-    from System import (
-        Activator,
-        Array,
-        Byte,
-        DateTime,
-        DBNull,
-        Decimal as SystemDecimal,
-        Type,
-    )
+try:
+    import pythoncom
+    import pywintypes
+    import win32com.client
+
+    onWin32 = True
 
     def Dispatch(dispatch):
-        type = Type.GetTypeFromProgID(dispatch)
-        return Activator.CreateInstance(type)
+        return win32com.client.Dispatch(dispatch)
 
-    def getIndexedValue(obj, index):
-        return obj.Item[index]
+except ImportError:
+    import warnings
 
-else:  # try pywin32
-    try:
-        import pythoncom
-        import pywintypes
-        import win32com.client
+    warnings.warn("pywin32 package required for adodbapi.", ImportWarning)
 
-        onWin32 = True
 
-        def Dispatch(dispatch):
-            return win32com.client.Dispatch(dispatch)
-
-    except ImportError:
-        import warnings
-
-        warnings.warn(
-            "pywin32 package (or IronPython) required for adodbapi.", ImportWarning
-        )
-
-    def getIndexedValue(obj, index):
-        return obj(index)
+def getIndexedValue(obj, index):
+    return obj(index)
 
 
 from collections.abc import Mapping
@@ -210,12 +188,7 @@ def _configure_parameter(p, value, adotype, settings_known):
             p.Size = L  # v2.1 Jevon
 
     elif isinstance(value, decimal.Decimal):
-        if api.onIronPython:
-            s = str(value)
-            p.Value = s
-            p.Size = len(s)
-        else:
-            p.Value = value
+        p.Value = value
         exponent = value.as_tuple()[2]
         digit_count = len(value.as_tuple()[1])
         p.Precision = digit_count
@@ -237,10 +210,6 @@ def _configure_parameter(p, value, adotype, settings_known):
             s = dateconverter.DateObjectToIsoFormatString(value)
             p.Value = s
             p.Size = len(s)
-
-    elif api.onIronPython and isinstance(value, longType):  # Iron Python Long
-        s = str(value)  # feature workaround for IPy 2.0
-        p.Value = s
 
     elif adotype == adc.adEmpty:  # ADO will not let you specify a null column
         p.Type = (
@@ -653,7 +622,7 @@ class Cursor(object):
             self.numberOfColumns = 0
             return
         self.rs = recordset  # v2.1.1 bkline
-        self.recordset_format = api.RS_ARRAY if api.onIronPython else api.RS_WIN_32
+        self.recordset_format = api.RS_WIN_32
         self.numberOfColumns = recordset.Fields.Count
         try:
             varCon = self.connection.variantConversions
@@ -790,12 +759,7 @@ class Cursor(object):
             print('Executing command="%s"' % self.commandText)
         try:
             # ----- the actual SQL is executed here ---
-            if api.onIronPython:
-                ra = Reference[int]()
-                recordset = self.cmd.Execute(ra)
-                count = ra.Value
-            else:  # pywin32
-                recordset, count = self.cmd.Execute()
+            recordset, count = self.cmd.Execute()
             # ----- ------------------------------- ---
         except Exception as e:
             _message = ""
@@ -1180,21 +1144,11 @@ class Cursor(object):
             )
             return None
 
-        if api.onIronPython:
-            try:
-                recordset = self.rs.NextRecordset()
-            except TypeError:
-                recordset = None
-            except api.Error as exc:
-                self._raiseCursorError(api.NotSupportedError, exc.args)
-        else:  # pywin32
-            try:  # [begin 2.1 ekelund]
-                rsTuple = self.rs.NextRecordset()  #
-            except pywintypes.com_error as exc:  # return appropriate error
-                self._raiseCursorError(
-                    api.NotSupportedError, exc.args
-                )  # [end 2.1 ekelund]
-            recordset = rsTuple[0]
+        try:  # [begin 2.1 ekelund]
+            rsTuple = self.rs.NextRecordset()  #
+        except pywintypes.com_error as exc:  # return appropriate error
+            self._raiseCursorError(api.NotSupportedError, exc.args)  # [end 2.1 ekelund]
+        recordset = rsTuple[0]
         if recordset is None:
             return None
         self.build_column_info(recordset)

--- a/adodbapi/is64bit.py
+++ b/adodbapi/is64bit.py
@@ -3,15 +3,10 @@ import sys
 
 
 def Python():
-    if sys.platform == "cli":  # IronPython
-        import System
-
-        return System.IntPtr.Size == 8
-    else:
-        try:
-            return sys.maxsize > 2147483647
-        except AttributeError:
-            return sys.maxint > 2147483647
+    try:
+        return sys.maxsize > 2147483647
+    except AttributeError:
+        return sys.maxint > 2147483647
 
 
 def os():

--- a/adodbapi/quick_reference.md
+++ b/adodbapi/quick_reference.md
@@ -2,10 +2,8 @@
 Adodbapi quick reference
 ========================
 
-Adodbapi is a Python DB-API 2.0 module that makes it easy to use
-Microsoft ADO
-for connecting with databases and other data sources
-using either CPython or IronPython.
+Adodbapi is a Python DB-API 2.0 module that makes it easy to use Microsoft ADO
+for connecting with databases and other data sources using CPython.
 
 Source home page:
 https://github.com/mhammond/pywin32/tree/master/adodbapi

--- a/adodbapi/readme.txt
+++ b/adodbapi/readme.txt
@@ -3,15 +3,14 @@ Project
 adodbapi
 
 A Python DB-API 2.0 (PEP-249) module that makes it easy to use Microsoft ADO 
-for connecting with databases and other data sources
-using either CPython or IronPython.
+for connecting with databases and other data sources using CPython.
 
 Home page: <http://sourceforge.net/projects/adodbapi>
 
 Features:
 * 100% DB-API 2.0 (PEP-249) compliant (including most extensions and recommendations).
 * Includes pyunit testcases that describe how to use the module.  
-* Fully implemented in Python. -- runs in Python 2.5+ Python 3.0+ and IronPython 2.6+
+* Fully implemented in Python. -- runs in Python 2.5+ and Python 3.0+
 * Licensed under the LGPL license, which means that it can be used freely even in commercial programs subject to certain restrictions. 
 * The user can choose between paramstyles: 'qmark' 'named' 'format' 'pyformat' 'dynamic'
 * Supports data retrieval by column name e.g.:
@@ -22,14 +21,9 @@ Features:
 Prerequisites:
 * C Python 2.7 or 3.5 or higher
  and pywin32 (Mark Hammond's python for windows extensions.)
-or
- Iron Python 2.7 or higher.  (works in IPy2.0 for all data types except BUFFER)
 
 Installation:
 * (C-Python on Windows): Install pywin32 ("pip install pywin32") which includes adodbapi.
-* (IronPython on Windows): Download adodbapi from http://sf.net/projects/adodbapi.  Unpack the zip.
-     Open a command window as an administrator. CD to the folder containing the unzipped files.
-     Run "setup.py install" using the IronPython of your choice.
 
 NOTE: ...........
 If you do not like the new default operation of returning Numeric columns as decimal.Decimal,
@@ -87,6 +81,6 @@ and look at the test cases in adodbapi/test directory.
 Mailing lists
 -------------
 The adodbapi mailing lists have been deactivated. Submit comments to the 
-pywin32 or IronPython mailing lists.
+pywin32 mailing lists.
   -- the bug tracker on sourceforge.net/projects/adodbapi may be checked, (infrequently).
   -- please use: https://github.com/mhammond/pywin32/issues

--- a/adodbapi/remote.py
+++ b/adodbapi/remote.py
@@ -23,7 +23,6 @@ Copyright (C) 2002 Henrik Ekelund, version 2.1 by Vernon Cole
 DB-API 2.0 specification: http://www.python.org/dev/peps/pep-0249/
 
 This module source should run correctly in CPython versions 2.5 and later,
-or IronPython version 2.7 and later,
 or, after running through 2to3.py, CPython 3.0 or later.
 """
 

--- a/adodbapi/remote/server.py
+++ b/adodbapi/remote/server.py
@@ -20,7 +20,6 @@ Copyright (C) 2013 by Vernon Cole
 DB-API 2.0 specification: http://www.python.org/dev/peps/pep-0249/
 
 This module source should run correctly in CPython versions 2.6 and later,
-or IronPython version 2.6 and later,
 or, after running through 2to3.py, CPython 3.2 or later.
 """
 

--- a/adodbapi/setup.py
+++ b/adodbapi/setup.py
@@ -1,7 +1,6 @@
 """adodbapi -- a pure Python PEP 249 DB-API package using Microsoft ADO
 
 Adodbapi can be run on CPython 3.5 and later.
-or IronPython version 2.6 and later (in theory, possibly no longer in practice!)
 """
 CLASSIFIERS = """\
 Development Status :: 5 - Production/Stable

--- a/adodbapi/test/is64bit.py
+++ b/adodbapi/test/is64bit.py
@@ -3,15 +3,10 @@ import sys
 
 
 def Python():
-    if sys.platform == "cli":  # IronPython
-        import System
-
-        return System.IntPtr.Size == 8
-    else:
-        try:
-            return sys.maxsize > 2147483647
-        except AttributeError:
-            return sys.maxint > 2147483647
+    try:
+        return sys.maxsize > 2147483647
+    except AttributeError:
+        return sys.maxint > 2147483647
 
 
 def os():

--- a/adodbapi/test/setuptestframework.py
+++ b/adodbapi/test/setuptestframework.py
@@ -85,12 +85,9 @@ def makemdb(testfolder, mdb_name):
             from win32com.client.gencache import EnsureDispatch
 
             win32 = True
-        except ImportError:  # perhaps we are running IronPython
-            win32 = False  # iron Python
-            try:
-                from System import Activator, Type
-            except:
-                pass
+        except ImportError:
+            win32 = False  # assume the worst
+            pass
 
         # Create a brand-new database - what is the story with these?
         dbe = None


### PR DESCRIPTION
Split off from https://github.com/mhammond/pywin32/pull/1990 to make it easier to review in isolation.

Remove obsoleted code and references to IronPython, which does not support any recent enough python version.