### PR TITLE
Fix pycln undecidable cases

### DIFF
--- a/Pythonwin/pywin/framework/editor/__init__.py
+++ b/Pythonwin/pywin/framework/editor/__init__.py
@@ -5,9 +5,6 @@
 # This really isnt necessary with Scintilla, and scintilla
 # is getting so deeply embedded that it was too much work.
 
-import sys
-
-import win32con
 import win32ui
 
 defaultCharacterFormat = (-402653169, 0, 200, 0, 0, 0, 49, "Courier New")

--- a/adodbapi/__init__.py
+++ b/adodbapi/__init__.py
@@ -5,8 +5,8 @@ Copyright (C) 2002 Henrik Ekelund, version 2.1 by Vernon Cole
 """
 import time
 
+# Re-exports to keep backward compatibility with existing code
 from .adodbapi import (
-    # Re-exports to keep backward compatibility with existing code
     Connection as Connection,
     Cursor as Cursor,
     __version__,

--- a/adodbapi/__init__.py
+++ b/adodbapi/__init__.py
@@ -6,6 +6,7 @@ Copyright (C) 2002 Henrik Ekelund, version 2.1 by Vernon Cole
 import time
 
 from .adodbapi import (
+    # Re-exports to keep backward compatibility with existing code
     Connection as Connection,
     Cursor as Cursor,
     __version__,

--- a/adodbapi/__init__.py
+++ b/adodbapi/__init__.py
@@ -7,6 +7,7 @@ import time
 
 # Re-exports to keep backward compatibility with existing code
 from .adodbapi import (
+    # Re-exports to keep backward compatibility with existing code
     Connection as Connection,
     Cursor as Cursor,
     __version__,

--- a/adodbapi/__init__.py
+++ b/adodbapi/__init__.py
@@ -3,30 +3,35 @@
 Copyright (C) 2002 Henrik Ekelund, version 2.1 by Vernon Cole
 * http://sourceforge.net/projects/adodbapi
 """
-import sys
 import time
 
-from .adodbapi import Connection, Cursor, __version__, connect, dateconverter
+from .adodbapi import (
+    Connection as Connection,
+    Cursor as Cursor,
+    __version__,
+    connect as connect,
+    dateconverter,
+)
 from .apibase import (
-    BINARY,
-    DATETIME,
-    NUMBER,
-    ROWID,
-    STRING,
-    DatabaseError,
-    DataError,
-    Error,
-    FetchFailedError,
-    IntegrityError,
-    InterfaceError,
-    InternalError,
-    NotSupportedError,
-    OperationalError,
-    ProgrammingError,
-    Warning,
-    apilevel,
-    paramstyle,
-    threadsafety,
+    BINARY as BINARY,
+    DATETIME as DATETIME,
+    NUMBER as NUMBER,
+    ROWID as ROWID,
+    STRING as STRING,
+    DatabaseError as DatabaseError,
+    DataError as DataError,
+    Error as Error,
+    FetchFailedError as FetchFailedError,
+    IntegrityError as IntegrityError,
+    InterfaceError as InterfaceError,
+    InternalError as InternalError,
+    NotSupportedError as NotSupportedError,
+    OperationalError as OperationalError,
+    ProgrammingError as ProgrammingError,
+    Warning as Warning,
+    apilevel as apilevel,
+    paramstyle as paramstyle,
+    threadsafety as threadsafety,
 )
 
 

--- a/adodbapi/__init__.py
+++ b/adodbapi/__init__.py
@@ -7,7 +7,6 @@ import time
 
 # Re-exports to keep backward compatibility with existing code
 from .adodbapi import (
-    # Re-exports to keep backward compatibility with existing code
     Connection as Connection,
     Cursor as Cursor,
     __version__,

--- a/com/win32comext/adsi/__init__.py
+++ b/com/win32comext/adsi/__init__.py
@@ -25,7 +25,7 @@ else:
 # interface, as well as via IDispatch.
 import pythoncom
 
-from .adsi import *
+from .adsi import *  # nopycln: import  # win32comext/adsi/adsi.pyd
 
 LCID = 0
 


### PR DESCRIPTION
```
Pycln can not decide whether the unused imported names
are useless or imported to be used somewhere else (exported).
```