### PR TITLE
Release GIL when creating or starting a service

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,7 @@ https://mhammond.github.io/pywin32_installers.html.
 
 Coming in build 307, as yet unreleased
 --------------------------------------
+* Release GIL when calling CreateService or StartService
 
 Build 306, released 2023-03-26
 ------------------------------

--- a/Pythonwin/Scintilla/makefile_pythonwin
+++ b/Pythonwin/Scintilla/makefile_pythonwin
@@ -46,8 +46,8 @@ Scintilla:
 
 ..\pywin\scintilla\scintillacon.py: Include\Scintilla.h Include\SciLexer.h
 	@if not exist $(DIR_PYTHON)\tools\scripts\h2py.py echo ***** Can't find h2py.py in '$(DIR_PYTHON)\tools\scripts - please pass DIR_PYTHON to this script *******
-	$(DIR_PYTHON)\python.exe $(DIR_PYTHON)\tools\scripts\h2py.py Include\scintilla.h
-	$(DIR_PYTHON)\python.exe $(DIR_PYTHON)\tools\scripts\h2py.py Include\scilexer.h
+	$(DIR_PYTHON)\tools\scripts\h2py.py Include\scintilla.h
+	$(DIR_PYTHON)\tools\scripts\h2py.py Include\scilexer.h
     type scintilla.py > ..\pywin\scintilla\scintillacon.py
 	type scilexer.py >> ..\pywin\scintilla\scintillacon.py
 	del scintilla.py scilexer.py

--- a/Pythonwin/Scintilla/makefile_pythonwin
+++ b/Pythonwin/Scintilla/makefile_pythonwin
@@ -46,8 +46,8 @@ Scintilla:
 
 ..\pywin\scintilla\scintillacon.py: Include\Scintilla.h Include\SciLexer.h
 	@if not exist $(DIR_PYTHON)\tools\scripts\h2py.py echo ***** Can't find h2py.py in '$(DIR_PYTHON)\tools\scripts - please pass DIR_PYTHON to this script *******
-	$(DIR_PYTHON)\tools\scripts\h2py.py Include\scintilla.h
-	$(DIR_PYTHON)\tools\scripts\h2py.py Include\scilexer.h
+	$(DIR_PYTHON)\python.exe $(DIR_PYTHON)\tools\scripts\h2py.py Include\scintilla.h
+	$(DIR_PYTHON)\python.exe $(DIR_PYTHON)\tools\scripts\h2py.py Include\scilexer.h
     type scintilla.py > ..\pywin\scintilla\scintillacon.py
 	type scilexer.py >> ..\pywin\scintilla\scintillacon.py
 	del scintilla.py scilexer.py

--- a/win32/src/win32service.i
+++ b/win32/src/win32service.i
@@ -744,9 +744,11 @@ PyObject *MyCreateService(
 	if (!PyWinObject_AsMultipleString(obDeps, &lpDeps, TRUE))
 		goto cleanup;
 
+	Py_BEGIN_ALLOW_THREADS
 	sh = CreateService(hSCManager,lpServiceName,lpDisplayName,dwDesiredAccess,
 	                             dwServiceType, dwStartType, dwErrorControl, lpBinaryPathName,
 	                             lpLoadOrderGroup, pTagID, lpDeps, lpServiceStartName, lpPassword);
+	Py_END_ALLOW_THREADS
 	if (sh==0) {
 		PyWin_SetAPIError("CreateService");
 		rc = NULL;
@@ -809,7 +811,11 @@ PyObject *MyStartService( SC_HANDLE scHandle, PyObject *serviceArgs )
 		return NULL;
 
 	PyObject *rc;
-	if (StartService(scHandle, numStrings, (LPCWSTR *)pArgs)) {
+        BOOL ok = FALSE;
+	Py_BEGIN_ALLOW_THREADS
+	ok = StartService(scHandle, numStrings, (LPCWSTR *)pArgs);
+	Py_END_ALLOW_THREADS
+	if (ok) {
 		rc = Py_None;
 		Py_INCREF(Py_None);
 	} else


### PR DESCRIPTION
Some service take a while to start so this change releases the GIL so that the python process isn't blocked. It only applies to CreateService and StartService. I guess it could also be applied to ControlService and DeleteService but these are simple calls into the Win32 API (and we've not had a problem with services taking a long time to stop or when being deleted)

It also has a small build change: on some machines (generally developer systems) the default action for a .py file isn't to run it, but to edit it. If the default action has been changed then the build breaks so my change just runs the h2py.py script using python.exe explicitly. This seems to be the only place where .py files are run without specifying the interpreter