### PR TITLE
Fix import error when using a custom cache location

### DIFF
--- a/com/win32com/client/gencache.py
+++ b/com/win32com/client/gencache.py
@@ -729,9 +729,9 @@ def _GetModule(fname):
         # Are we using a custom cache location?
         sys.path.append(win32com.__gen_path__)
         mod = __import__(fname)
-        sys.modules[mod_name] = mod # Save the module with the expected name
-        del sys.path[-1] # Restore syspath
-        del sys.modules[fname] # Clean up sys.modules
+        sys.modules[mod_name] = mod  # Save the module with the expected name
+        del sys.path[-1]  # Restore syspath
+        del sys.modules[fname]  # Clean up sys.modules
     return sys.modules[mod_name]
 
 

--- a/com/win32com/client/gencache.py
+++ b/com/win32com/client/gencache.py
@@ -722,8 +722,16 @@ def GetGeneratedInfos():
 
 def _GetModule(fname):
     """Given the name of a module in the gen_py directory, import and return it."""
-    mod_name = "win32com.gen_py.%s" % fname
-    mod = __import__(mod_name)
+    try:
+        mod_name = "win32com.gen_py.%s" % fname
+        mod = __import__(mod_name)
+    except ImportError:
+        # Are we using a custom cache location?
+        sys.path.append(win32com.__gen_path__)
+        mod = __import__(fname)
+        sys.modules[mod_name] = mod # Save the module with the expected name
+        del sys.path[-1] # Restore syspath
+        del sys.modules[fname] # Clean up sys.modules
     return sys.modules[mod_name]
 
 


### PR DESCRIPTION
### Background ###

One of the work arounds when users don't have admin privileges is to create a custom cache location as described in https://github.com/mhammond/pywin32/issues/1143#issuecomment-746261942

### Problem ###

Unfortunately that work around does not work when trying to import a module that has not already been generated:

```
  File "C:\Users\jorge\test\msword.py", line 90, in __init__
    self.comWordApp = win32.DispatchWithEvents('Word.Application', _COMWordApp)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\WPy64-31120b3\python-3.11.2.amd64\Lib\site-packages\win32com\client\__init__.py", line 323, in DispatchWithEvents
    gencache.EnsureModule(tla[0], tla[1], tla[3], tla[4], bValidateFile=0)
  File "C:\Program Files\WPy64-31120b3\python-3.11.2.amd64\Lib\site-packages\win32com\client\gencache.py", line 601, in EnsureModule
    module = MakeModuleForTypelib(
             ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\WPy64-31120b3\python-3.11.2.amd64\Lib\site-packages\win32com\client\gencache.py", line 318, in MakeModuleForTypelib
    makepy.GenerateFromTypeLibSpec(
  File "C:\Program Files\WPy64-31120b3\python-3.11.2.amd64\Lib\site-packages\win32com\client\makepy.py", line 338, in GenerateFromTypeLibSpec
    gencache.AddModuleToCache(info.clsid, info.lcid, info.major, info.minor)
  File "C:\Program Files\WPy64-31120b3\python-3.11.2.amd64\Lib\site-packages\win32com\client\gencache.py", line 647, in AddModuleToCache
    mod = _GetModule(fname)
          ^^^^^^^^^^^^^^^^^
  File "C:\Program Files\WPy64-31120b3\python-3.11.2.amd64\Lib\site-packages\win32com\client\gencache.py", line 726, in _GetModule
    mod = __import__(mod_name)
          ^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'win32com.gen_py.00020905-0000-0000-C000-000000000046x0x8x5'
```

### Solution ###

This PR fixes the above bug by attempting to import the module from the custom location if the import from the default location fails.