### PR TITLE
Added support for DBT_DEVTYP_PORT in UnpackDEV_BROADCAST

### DIFF
--- a/win32/Lib/win32gui_struct.py
+++ b/win32/Lib/win32gui_struct.py
@@ -995,7 +995,7 @@ def UnpackDEV_BROADCAST(lparam):
             fmt, buf[: struct.calcsize(fmt)]
         )
     elif devtype == win32con.DBT_DEVTYP_PORT:
-        x["name"] = win32gui.PyGetString(lparam + struct.calcsize(hdr_format))   
+        x["name"] = win32gui.PyGetString(lparam + struct.calcsize(hdr_format))
     else:
         raise NotImplementedError("unknown device type %d" % (devtype,))
     return DEV_BROADCAST_INFO(devtype, **extra)

--- a/win32/Lib/win32gui_struct.py
+++ b/win32/Lib/win32gui_struct.py
@@ -994,6 +994,8 @@ def UnpackDEV_BROADCAST(lparam):
         _, _, _, x["unitmask"], x["flags"] = struct.unpack(
             fmt, buf[: struct.calcsize(fmt)]
         )
+    elif devtype == win32con.DBT_DEVTYP_PORT:
+        x["name"] = win32gui.PyGetString(lparam + struct.calcsize(hdr_format))   
     else:
         raise NotImplementedError("unknown device type %d" % (devtype,))
     return DEV_BROADCAST_INFO(devtype, **extra)


### PR DESCRIPTION
Good day!

Please, add this small commit to main code. Sample of real use (win32gui_devicenotify.py):

Device change notification: 7 None

Device change notification: 32772 DEV_BROADCAST_INFO:{'devicetype': 5, 'classguid': IID('{86E0D1E0-8089-11D0-9CE4-08003E301F73}'), 'name': '\\\\?\\USB#VID_05F9&PID_4204#5&3a5b01f9&0&2#{86e0d1e0-8089-11d0-9ce4-08003e301f73}'}

**Device change notification: 32772 DEV_BROADCAST_INFO:{'devicetype': 3, 'name': 'COM7'}**

Device change notification: 32772 DEV_BROADCAST_INFO:{'devicetype': 5, 'classguid': IID('{A5DCBF10-6530-11D2-901F-0C04FB951ED}'), 'name': '\\\\?\\USB#VID_05F9&PID_4204#5&3a5b01f9&0&2#{a5dcbf10-6530-11d2-901f-00c0
4fb951ed}'}

Device change notification: 7 None

Device change notification: 32768 DEV_BROADCAST_INFO:{'devicetype': 5, 'classguid': IID('{A5DCBF10-6530-11D2-901F-0C04FB951ED}'), 'name': '\\\\?\\USB#VID_05F9&PID_4204#5&3a5b01f9&0&2#{a5dcbf10-6530-11d2-901f-00c0
4fb951ed}'}

Device change notification: 32768 DEV_BROADCAST_INFO:{'devicetype': 5, 'classguid': IID('{86E0D1E0-8089-11D0-9CE4-8003E301F73}'), 'name': '\\\\?\\USB#VID_05F9&PID_4204#5&3a5b01f9&0&2#{86e0d1e0-8089-11d0-9ce4-0800
3e301f73}'}

**Device change notification: 32768 DEV_BROADCAST_INFO:{'devicetype': 3, 'name': 'COM7'}**