### PR TITLE
Removed redundant and obsolete references to older python unicode compatibility

### DIFF
--- a/Pythonwin/pywin/debugger/debugger.py
+++ b/Pythonwin/pywin/debugger/debugger.py
@@ -26,14 +26,9 @@ from pywin.framework.editor.color.coloreditor import MARKER_BREAKPOINT, MARKER_C
 from pywin.mfc import afxres, dialog, object, window
 from pywin.tools import browser, hierlist
 
-# import win32traceutil
-if win32ui.UNICODE:
-    LVN_ENDLABELEDIT = commctrl.LVN_ENDLABELEDITW
-else:
-    LVN_ENDLABELEDIT = commctrl.LVN_ENDLABELEDITA
-
 from .dbgcon import *
 
+LVN_ENDLABELEDIT = commctrl.LVN_ENDLABELEDITW
 error = "pywin.debugger.error"
 
 

--- a/Pythonwin/pywin/framework/interact.py
+++ b/Pythonwin/pywin/framework/interact.py
@@ -138,7 +138,7 @@ class InteractiveFormatter(FormatterParent):
             return
         state = styleStart
         # As per comments in Colorize(), we work with the raw utf8
-        # bytes. To avoid too muych py3k pain, we treat each utf8 byte
+        # bytes. To avoid too much pain, we treat each utf8 byte
         # as a latin-1 unicode character - we only use it to compare
         # against ascii chars anyway...
         chNext = cdoc[0:1].decode("latin-1")

--- a/Pythonwin/pywin/framework/toolmenu.py
+++ b/Pythonwin/pywin/framework/toolmenu.py
@@ -149,10 +149,7 @@ def HandleToolCommand(cmd, code):
 import commctrl
 from pywin.mfc import dialog
 
-if win32ui.UNICODE:
-    LVN_ENDLABELEDIT = commctrl.LVN_ENDLABELEDITW
-else:
-    LVN_ENDLABELEDIT = commctrl.LVN_ENDLABELEDITA
+LVN_ENDLABELEDIT = commctrl.LVN_ENDLABELEDITW
 
 
 class ToolMenuPropPage(dialog.PropertyPage):

--- a/Pythonwin/pywin/idle/PyParse.py
+++ b/Pythonwin/pywin/idle/PyParse.py
@@ -122,10 +122,6 @@ for ch in ")}]":
     _tran[ord(ch)] = ")"
 for ch in "\"'\\\n#":
     _tran[ord(ch)] = ch
-# We are called with unicode strings, and str.translate is one of the few
-# py2k functions which can't 'do the right thing' - so take care to ensure
-# _tran is full of unicode...
-_tran = "".join(_tran)
 del ch
 
 

--- a/Pythonwin/pywin/tools/browser.py
+++ b/Pythonwin/pywin/tools/browser.py
@@ -309,7 +309,7 @@ class HLIDict(HLIPythonObject):
         return ret
 
 
-# In Python 1.6, strings and Unicode have builtin methods, but we dont really want to see these
+# strings and Unicode have builtin methods, but we dont really want to see these
 class HLIString(HLIPythonObject):
     def IsExpandable(self):
         return 0

--- a/Pythonwin/pywin/tools/hierlist.py
+++ b/Pythonwin/pywin/tools/hierlist.py
@@ -106,14 +106,8 @@ class HierList(object.Object):
         self.listControl.SetImageList(self.imageList, commctrl.LVSIL_NORMAL)
         # 		self.list.AttachObject(self)
 
-        ## ??? Need a better way to do this - either some way to detect if it's compiled with UNICODE
-        ##  defined, and/or a way to switch the constants based on UNICODE ???
-        if sys.version_info[0] < 3:
-            parent.HookNotify(self.OnTreeItemExpanding, commctrl.TVN_ITEMEXPANDINGA)
-            parent.HookNotify(self.OnTreeItemSelChanged, commctrl.TVN_SELCHANGEDA)
-        else:
-            parent.HookNotify(self.OnTreeItemExpanding, commctrl.TVN_ITEMEXPANDINGW)
-            parent.HookNotify(self.OnTreeItemSelChanged, commctrl.TVN_SELCHANGEDW)
+        parent.HookNotify(self.OnTreeItemExpanding, commctrl.TVN_ITEMEXPANDINGW)
+        parent.HookNotify(self.OnTreeItemSelChanged, commctrl.TVN_SELCHANGEDW)
         parent.HookNotify(self.OnTreeItemDoubleClick, commctrl.NM_DBLCLK)
         self.notify_parent = parent
 

--- a/com/win32com/client/makepy.py
+++ b/com/win32com/client/makepy.py
@@ -34,10 +34,7 @@ Usage:
 
   -h    -- Do not generate hidden methods.
 
-  -u    -- Python 1.5 and earlier: Do NOT convert all Unicode objects to
-           strings.
-
-           Python 1.6 and later: Convert all Unicode objects to strings.
+  -u    -- Convert all Unicode objects to strings.
 
   -o    -- Create output in a specified output file.  If the path leading
            to the file does not exist, any missing directories will be

--- a/com/win32com/server/policy.py
+++ b/com/win32com/server/policy.py
@@ -680,9 +680,7 @@ class EventHandlerPolicy(DesignatedWrapPolicy):
     """The default policy used by event handlers in the win32com.client package.
 
     In addition to the base policy, this provides argument conversion semantics for
-    params
-      * dispatch params are converted to dispatch objects.
-      * Unicode objects are converted to strings (1.5.2 and earlier)
+    params: dispatch params are converted to dispatch objects
 
     NOTE: Later, we may allow the object to override this process??
     """

--- a/com/win32com/test/testCollections.py
+++ b/com/win32com/test/testCollections.py
@@ -5,17 +5,13 @@
 #
 # Also has the side effect of testing some of the PythonCOM error semantics.
 import sys
+import unittest
 
 import pythoncom
-import pywintypes
 import win32com.client
 import win32com.server.util
 import win32com.test.util
 import winerror
-
-L = pywintypes.Unicode
-
-import unittest
 
 error = "collection test error"
 

--- a/com/win32com/test/testPersist.py
+++ b/com/win32com/test/testPersist.py
@@ -8,7 +8,6 @@ import win32com.client
 import win32com.client.dynamic
 import win32com.server.util
 import win32ui
-from pywintypes import Unicode
 from win32com import storagecon
 from win32com.axcontrol import axcontrol
 from win32com.test.util import CheckClean

--- a/com/win32com/test/testvb.py
+++ b/com/win32com/test/testvb.py
@@ -365,8 +365,7 @@ def TestArrays(vbtest, bUseGenerated):
             testData,
             list(resultData),
         )
-        # This time, instead of an explicit str() for 1.5, we just
-        # pass Unicode, so the result should compare equal
+        # This time, we just pass Unicode, so the result should compare equal
         testData = [1, 2.0, "3"]
         resultData, byRefParam = vbtest.PassSAFEARRAYVariant(testData)
         assert testData == list(byRefParam)

--- a/com/win32comext/axscript/client/error.py
+++ b/com/win32comext/axscript/client/error.py
@@ -2,11 +2,9 @@
 
  This contains the core exceptions that the implementations should raise
  as well as the IActiveScriptError interface code.
- 
 """
 
 import re
-import sys
 import traceback
 
 import pythoncom
@@ -190,21 +188,6 @@ class AXScriptException(win32com.server.exception.COMException):
             bits.append("COM Error: " + desc)
         else:
             bits.extend(traceback.format_exception_only(exc_type, value))
-
-        # XXX - this utf8 encoding seems bogus.  From well before py3k,
-        # we had the comment:
-        # > all items in the list are utf8 courtesy of Python magically
-        # > converting unicode to utf8 before compilation.
-        # but that is likely just confusion from early unicode days;
-        # Python isn't doing it, pywin32 probably was, so 'mbcs' would
-        # be the default encoding.  We should never hit this these days
-        # anyway, but on py3k, we *never* will, and str objects there
-        # don't have a decode method...
-        if sys.version_info < (3,):
-            for i in range(len(bits)):
-                if isinstance(bits[i], str):
-                    # assert isinstance(bits[i], str), type(bits[i])
-                    bits[i] = bits[i].decode("utf8")
 
         self.description = ExpandTabs("".join(bits))
         # Clear tracebacks etc.

--- a/win32/Lib/win32gui_struct.py
+++ b/win32/Lib/win32gui_struct.py
@@ -60,26 +60,13 @@ if is64bit:
 else:
     _nmhdr_align_padding = ""
 
+
 # Encode a string suitable for passing in a win32gui related structure
-# If win32gui is built with UNICODE defined (ie, py3k), then functions
-# like InsertMenuItem are actually calling InsertMenuItemW etc, so all
-# strings will need to be unicode.
-if win32gui.UNICODE:
-
-    def _make_text_buffer(text):
-        # XXX - at this stage win32gui.UNICODE is only True in py3k,
-        # and in py3k is makes sense to reject bytes.
-        if not isinstance(text, str):
-            raise TypeError("MENUITEMINFO text must be unicode")
-        data = (text + "\0").encode("utf-16le")
-        return array.array("b", data)
-
-else:
-
-    def _make_text_buffer(text):
-        if isinstance(text, str):
-            text = text.encode("mbcs")
-        return array.array("b", text + "\0")
+def _make_text_buffer(text):
+    if not isinstance(text, str):
+        raise TypeError("MENUITEMINFO text must be unicode")
+    data = (text + "\0").encode("utf-16le")
+    return array.array("b", data)
 
 
 # make an 'empty' buffer, ready for filling with cch characters.
@@ -929,15 +916,9 @@ def PackDEV_BROADCAST_VOLUME(unitmask, flags):
 
 
 def PackDEV_BROADCAST_DEVICEINTERFACE(classguid, name=""):
-    if win32gui.UNICODE:
-        # This really means "is py3k?" - so not accepting bytes is OK
-        if not isinstance(name, str):
-            raise TypeError("Must provide unicode for the name")
-        name = name.encode("utf-16le")
-    else:
-        # py2k was passed a unicode object - encode as mbcs.
-        if isinstance(name, str):
-            name = name.encode("mbcs")
+    if not isinstance(name, str):
+        raise TypeError("Must provide unicode for the name")
+    name = name.encode("utf-16le")
 
     # 16 bytes for the IID followed by \0 term'd string.
     rest_fmt = "16s%ds" % len(name)

--- a/win32/Lib/win32timezone.py
+++ b/win32/Lib/win32timezone.py
@@ -888,15 +888,6 @@ DLLCache = DLLHandleCache()
 
 def resolveMUITimeZone(spec):
     """Resolve a multilingual user interface resource for the time zone name
-    >>> #some pre-amble for the doc-tests to be py2k and py3k aware)
-    >>> try: unicode and None
-    ... except NameError: unicode=str
-    ...
-    >>> import sys
-    >>> result = resolveMUITimeZone('@tzres.dll,-110')
-    >>> expectedResultType = [type(None),unicode][sys.getwindowsversion() >= (6,)]
-    >>> type(result) is expectedResultType
-    True
 
     spec should be of the format @path,-stringID[;comment]
     see http://msdn2.microsoft.com/en-us/library/ms725481.aspx for details

--- a/win32/Lib/win32verstamp.py
+++ b/win32/Lib/win32verstamp.py
@@ -5,7 +5,6 @@ import glob
 import optparse
 import os
 import struct
-import sys
 
 from win32api import BeginUpdateResource, EndUpdateResource, UpdateResource
 
@@ -53,10 +52,7 @@ def VS_FIXEDFILEINFO(maj, min, sub, build, debug=0, is_dll=1):
 
 def nullterm(s):
     # get raw bytes for a NULL terminated unicode string.
-    if sys.version_info[:2] < (3, 7):
-        return (str(s) + "\0").encode("unicode-internal")
-    else:
-        return (str(s) + "\0").encode("utf-16le")
+    return (str(s) + "\0").encode("utf-16le")
 
 
 def pad32(s, extra=2):

--- a/win32/test/test_clipboard.py
+++ b/win32/test/test_clipboard.py
@@ -74,8 +74,8 @@ class TestStrings(unittest.TestCase):
     def test_unicode_text(self):
         val = "test-val"
         SetClipboardText(val)
-        # GetClipboardData doesn't to auto string conversions - so on py3k,
-        # CF_TEXT returns bytes.
+        # GetClipboardData doesn't do auto string conversions -
+        # so CF_TEXT returns bytes.
         expected = val.encode("latin1")
         self.assertEqual(GetClipboardData(win32con.CF_TEXT), expected)
         SetClipboardText(val, win32con.CF_UNICODETEXT)

--- a/win32/test/test_win32trace.py
+++ b/win32/test/test_win32trace.py
@@ -120,8 +120,6 @@ class TestModuleOps(BasicSetupTearDown):
     def testRoundTripUnicode(self):
         win32trace.write("\xa9opyright Syver Enstad")
         syverEnstad = win32trace.read()
-        # str objects are always returned in py2k (latin-1 encoding was used
-        # on unicode objects)
         self.assertEqual("\xa9opyright Syver Enstad", syverEnstad)
 
     def testBlockingRead(self):
@@ -130,8 +128,6 @@ class TestModuleOps(BasicSetupTearDown):
 
     def testBlockingReadUnicode(self):
         win32trace.write("\xa9opyright Syver Enstad")
-        # str objects are always returned in py2k (latin-1 encoding was used
-        # on unicode objects)
         self.assertEqual("\xa9opyright Syver Enstad", win32trace.blockingread())
 
     def testFlush(self):

--- a/win32/test/test_win32wnet.py
+++ b/win32/test/test_win32wnet.py
@@ -64,7 +64,7 @@ class TestCase(unittest.TestCase):
                 new_val = val + 1
             elif typ is str:
                 if val is not None:
-                    # on py2k, must be string or unicode.  py3k must be string or bytes.
+                    # must be string
                     self.assertTrue(
                         isinstance(val, str), "Attr %r has value %r" % (attr, val)
                     )


### PR DESCRIPTION
Extracted from #1990 to make it easier to review and test in isolation.
Left adodbapi/ironpython changes to #2049 

Removed redundant and obsolete references to older python unicode compatibility.
Kept the following for backward compatibility:
- `win32ui.UNICODE`
- deprecated `UnicodeToString`/`bUnicodeToString`/`_unicode_to_string_` params
- unused `pywin.is_platform_unicode`