### PR TITLE
Cleanup obsolete and unsupported python code in adodbapi

### DIFF
--- a/adodbapi/__init__.py
+++ b/adodbapi/__init__.py
@@ -3,33 +3,41 @@
 Copyright (C) 2002 Henrik Ekelund, version 2.1 by Vernon Cole
 * http://sourceforge.net/projects/adodbapi
 """
-import sys
 import time
 
-from .adodbapi import Connection, Cursor, __version__, connect, dateconverter
+# Re-exports to keep backward compatibility with existing code
+from .adodbapi import (
+    Connection as Connection,
+    Cursor as Cursor,
+    __version__,
+    connect as connect,
+    dateconverter,
+)
 from .apibase import (
-    BINARY,
-    DATETIME,
-    NUMBER,
-    ROWID,
-    STRING,
-    DatabaseError,
-    DataError,
-    Error,
-    FetchFailedError,
-    IntegrityError,
-    InterfaceError,
-    InternalError,
-    NotSupportedError,
-    OperationalError,
-    ProgrammingError,
-    Warning,
-    apilevel,
-    paramstyle,
-    threadsafety,
+    BINARY as BINARY,
+    DATETIME as DATETIME,
+    NUMBER as NUMBER,
+    ROWID as ROWID,
+    STRING as STRING,
+    DatabaseError as DatabaseError,
+    DataError as DataError,
+    Error as Error,
+    FetchFailedError as FetchFailedError,
+    IntegrityError as IntegrityError,
+    InterfaceError as InterfaceError,
+    InternalError as InternalError,
+    NotSupportedError as NotSupportedError,
+    OperationalError as OperationalError,
+    ProgrammingError as ProgrammingError,
+    Warning as Warning,
+    apilevel as apilevel,
+    paramstyle as paramstyle,
+    threadsafety as threadsafety,
 )
 
 
+# -----------------------------------------------------------
+# conversion functions mandated by PEP 249
 def Binary(aString):
     """This function constructs an object capable of holding a binary (long) string value."""
     return bytes(aString)

--- a/adodbapi/adodbapi.py
+++ b/adodbapi/adodbapi.py
@@ -23,21 +23,34 @@ Copyright (C) 2002 Henrik Ekelund, versions 2.1 and later by Vernon Cole
 
 DB-API 2.0 specification: http://www.python.org/dev/peps/pep-0249/
 
-This module source should run correctly in CPython versions 2.7 and later,
-or IronPython version 2.7 and later,
-or, after running through 2to3.py, CPython 3.4 or later.
+This module source should run correctly in CPython 3.4 or later.
 """
-
-__version__ = "2.6.2.0"
-version = "adodbapi v" + __version__
-
 import copy
 import decimal
 import os
 import sys
 import weakref
 
+import pythoncom
+import pywintypes
+from win32com.client import Dispatch
+
 from . import ado_consts as adc, apibase as api, process_connect_string
+
+try:
+    import pythoncom
+    import pywintypes
+    import win32com.client
+
+    onWin32 = True
+except ImportError:
+    import warnings
+
+    warnings.warn("pywin32 package required for adodbapi.", ImportWarning)
+    onWin32 = False  # assume the worst
+
+__version__ = "3.7.0.0"
+version = "adodbapi v" + __version__
 
 try:
     verbose = int(os.environ["ADODBAPI_VERBOSE"])
@@ -46,63 +59,18 @@ except:
 if verbose:
     print(version)
 
-# --- define objects to smooth out IronPython <-> CPython differences
-onWin32 = False  # assume the worst
-if api.onIronPython:
-    from clr import Reference
-    from System import (
-        Activator,
-        Array,
-        Byte,
-        DateTime,
-        DBNull,
-        Decimal as SystemDecimal,
-        Type,
-    )
 
-    def Dispatch(dispatch):
-        type = Type.GetTypeFromProgID(dispatch)
-        return Activator.CreateInstance(type)
-
-    def getIndexedValue(obj, index):
-        return obj.Item[index]
-
-else:  # try pywin32
-    try:
-        import pythoncom
-        import pywintypes
-        import win32com.client
-
-        onWin32 = True
-
-        def Dispatch(dispatch):
-            return win32com.client.Dispatch(dispatch)
-
-    except ImportError:
-        import warnings
-
-        warnings.warn(
-            "pywin32 package (or IronPython) required for adodbapi.", ImportWarning
-        )
-
-    def getIndexedValue(obj, index):
-        return obj(index)
+def getIndexedValue(obj, index):
+    return obj(index)
 
 
 from collections.abc import Mapping
-
-# --- define objects to smooth out Python3000 <-> Python 2.x differences
-unicodeType = str
-longType = int
-StringTypes = str
-maxint = sys.maxsize
 
 
 # -----------------  The .connect method -----------------
 def make_COM_connecter():
     try:
-        if onWin32:
-            pythoncom.CoInitialize()  # v2.1 Paj
+        pythoncom.CoInitialize()  # v2.1 Paj
         c = Dispatch("ADODB.Connection")  # connect _after_ CoIninialize v2.1.1 adamvan
     except:
         raise api.InterfaceError(
@@ -198,7 +166,7 @@ def _configure_parameter(p, value, adotype, settings_known):
         p.Size = len(value)
         p.AppendChunk(value)
 
-    elif isinstance(value, StringTypes):  # v2.1 Jevon
+    elif isinstance(value, str):  # v2.1 Jevon
         L = len(value)
         if adotype in api.adoStringTypes:  # v2.2.1 Cole
             if settings_known:
@@ -210,12 +178,7 @@ def _configure_parameter(p, value, adotype, settings_known):
             p.Size = L  # v2.1 Jevon
 
     elif isinstance(value, decimal.Decimal):
-        if api.onIronPython:
-            s = str(value)
-            p.Value = s
-            p.Size = len(s)
-        else:
-            p.Value = value
+        p.Value = value
         exponent = value.as_tuple()[2]
         digit_count = len(value.as_tuple()[1])
         p.Precision = digit_count
@@ -238,10 +201,6 @@ def _configure_parameter(p, value, adotype, settings_known):
             p.Value = s
             p.Size = len(s)
 
-    elif api.onIronPython and isinstance(value, longType):  # Iron Python Long
-        s = str(value)  # feature workaround for IPy 2.0
-        p.Value = s
-
     elif adotype == adc.adEmpty:  # ADO will not let you specify a null column
         p.Type = (
             adc.adInteger
@@ -254,7 +213,7 @@ def _configure_parameter(p, value, adotype, settings_known):
 
 
 # # # # # ----- the Class that defines a connection ----- # # # # #
-class Connection(object):
+class Connection:
     # include connection attributes as class attributes required by api definition.
     Warning = api.Warning
     Error = api.Error
@@ -565,7 +524,7 @@ class Connection(object):
 
 
 # # # # # ----- the Class that defines a cursor ----- # # # # #
-class Cursor(object):
+class Cursor:
     ## ** api required attributes:
     ## description...
     ##    This read-only attribute is a sequence of 7-item sequences.
@@ -653,7 +612,7 @@ class Cursor(object):
             self.numberOfColumns = 0
             return
         self.rs = recordset  # v2.1.1 bkline
-        self.recordset_format = api.RS_ARRAY if api.onIronPython else api.RS_WIN_32
+        self.recordset_format = api.RS_WIN_32
         self.numberOfColumns = recordset.Fields.Count
         try:
             varCon = self.connection.variantConversions
@@ -790,12 +749,7 @@ class Cursor(object):
             print('Executing command="%s"' % self.commandText)
         try:
             # ----- the actual SQL is executed here ---
-            if api.onIronPython:
-                ra = Reference[int]()
-                recordset = self.cmd.Execute(ra)
-                count = ra.Value
-            else:  # pywin32
-                recordset, count = self.cmd.Execute()
+            recordset, count = self.cmd.Execute()
             # ----- ------------------------------- ---
         except Exception as e:
             _message = ""
@@ -1180,21 +1134,11 @@ class Cursor(object):
             )
             return None
 
-        if api.onIronPython:
-            try:
-                recordset = self.rs.NextRecordset()
-            except TypeError:
-                recordset = None
-            except api.Error as exc:
-                self._raiseCursorError(api.NotSupportedError, exc.args)
-        else:  # pywin32
-            try:  # [begin 2.1 ekelund]
-                rsTuple = self.rs.NextRecordset()  #
-            except pywintypes.com_error as exc:  # return appropriate error
-                self._raiseCursorError(
-                    api.NotSupportedError, exc.args
-                )  # [end 2.1 ekelund]
-            recordset = rsTuple[0]
+        try:  # [begin 2.1 ekelund]
+            rsTuple = self.rs.NextRecordset()  #
+        except pywintypes.com_error as exc:  # return appropriate error
+            self._raiseCursorError(api.NotSupportedError, exc.args)  # [end 2.1 ekelund]
+        recordset = rsTuple[0]
         if recordset is None:
             return None
         self.build_column_info(recordset)

--- a/adodbapi/apibase.py
+++ b/adodbapi/apibase.py
@@ -16,29 +16,6 @@ from . import ado_consts as adc
 
 verbose = False  # debugging flag
 
-onIronPython = sys.platform == "cli"
-if onIronPython:  # we need type definitions for odd data we may need to convert
-    # noinspection PyUnresolvedReferences
-    from System import DateTime, DBNull
-
-    NullTypes = (type(None), DBNull)
-else:
-    DateTime = type(NotImplemented)  # should never be seen on win32
-    NullTypes = type(None)
-
-# --- define objects to smooth out Python3 <-> Python 2.x differences
-unicodeType = str
-longType = int
-StringTypes = str
-makeByteBuffer = bytes
-memoryViewType = memoryview
-_BaseException = Exception
-
-try:  # jdhardy -- handle bytes under IronPython & Py3
-    bytes
-except NameError:
-    bytes = str  # define it for old Pythons
-
 
 # ------- Error handlers ------
 def standardErrorHandler(connection, cursor, errorclass, errorvalue):
@@ -55,8 +32,7 @@ def standardErrorHandler(connection, cursor, errorclass, errorvalue):
     raise errorclass(errorvalue)
 
 
-# Note: _BaseException is defined differently between Python 2.x and 3.x
-class Error(_BaseException):
+class Error(Exception):
     pass  # Exception that is the base class of all other error
     # exceptions. You can use this to catch all errors with one
     # single 'except' statement. Warnings are not considered
@@ -65,7 +41,7 @@ class Error(_BaseException):
     # module exceptions).
 
 
-class Warning(_BaseException):
+class Warning(Exception):
     pass
 
 
@@ -163,10 +139,10 @@ class FetchFailedError(OperationalError):
 #
 # def Binary(aString):
 #     """This function constructs an object capable of holding a binary (long) string value. """
-#     b = makeByteBuffer(aString)
+#     b = bytes(aString)
 #     return b
 # -----     Time converters ----------------------------------------------
-class TimeConverter(object):  # this is a generic time converter skeleton
+class TimeConverter:  # this is a generic time converter skeleton
     def __init__(self):  # the details will be filled in by instances
         self._ordinal_1899_12_31 = datetime.date(1899, 12, 31).toordinal() - 1
         # Use cls.types to compare if an input parameter is a datetime
@@ -193,11 +169,8 @@ class TimeConverter(object):  # this is a generic time converter skeleton
         except:  # might be a tuple
             try:
                 return self.ComDateFromTuple(obj)
-            except:  # try an mxdate
-                try:
-                    return obj.COMDate()
-                except:
-                    raise ValueError('Cannot convert "%s" to COMdate.' % repr(obj))
+            except:
+                raise ValueError('Cannot convert "%s" to COMdate.' % repr(obj))
 
     def ComDateFromTuple(self, t, microseconds=0):
         d = datetime.date(t[0], t[1], t[2])
@@ -231,46 +204,11 @@ class TimeConverter(object):  # this is a generic time converter skeleton
             if isinstance(obj, datetime.date):
                 s = obj.isoformat() + " 00:00:00"  # return exact midnight
             else:
-                try:  # maybe it has a strftime method, like mx
-                    s = obj.strftime("%Y-%m-%d %H:%M:%S")
-                except AttributeError:
-                    try:  # but may be time.struct_time
-                        s = time.strftime("%Y-%m-%d %H:%M:%S", obj)
-                    except:
-                        raise ValueError('Cannot convert "%s" to isoformat' % repr(obj))
+                try:  # maybe time.struct_time
+                    s = time.strftime("%Y-%m-%d %H:%M:%S", obj)
+                except:
+                    raise ValueError('Cannot convert "%s" to isoformat' % repr(obj))
         return s
-
-
-# -- Optional: if mx extensions are installed you may use mxDateTime ----
-try:
-    import mx.DateTime
-
-    mxDateTime = True
-except:
-    mxDateTime = False
-if mxDateTime:
-
-    class mxDateTimeConverter(TimeConverter):  # used optionally if installed
-        def __init__(self):
-            TimeConverter.__init__(self)
-            self.types.add(type(mx.DateTime))
-
-        def DateObjectFromCOMDate(self, comDate):
-            return mx.DateTime.DateTimeFromCOMDate(comDate)
-
-        def Date(self, year, month, day):
-            return mx.DateTime.Date(year, month, day)
-
-        def Time(self, hour, minute, second):
-            return mx.DateTime.Time(hour, minute, second)
-
-        def Timestamp(self, year, month, day, hour, minute, second):
-            return mx.DateTime.Timestamp(year, month, day, hour, minute, second)
-
-else:
-
-    class mxDateTimeConverter(TimeConverter):
-        pass  # if no mx is installed
 
 
 class pythonDateTimeConverter(TimeConverter):  # standard since Python 2.3
@@ -284,8 +222,6 @@ class pythonDateTimeConverter(TimeConverter):  # standard since Python 2.3
             new = datetime.datetime.combine(datetime.datetime.fromordinal(odn), tim)
             return new
             # return comDate.replace(tzinfo=None) # make non aware
-        elif isinstance(comDate, DateTime):
-            fComDate = comDate.ToOADate()  # ironPython clr Date/Time
         else:
             fComDate = float(comDate)  # ComDate is number of days since 1899-12-31
         integerPart = int(fComDate)
@@ -317,8 +253,6 @@ class pythonTimeConverter(TimeConverter):  # the old, ?nix type date and time
         "Returns ticks since 1970"
         if isinstance(comDate, datetime.datetime):
             return comDate.timetuple()
-        elif isinstance(comDate, DateTime):  # ironPython clr date/time
-            fcomDate = comDate.ToOADate()
         else:
             fcomDate = float(comDate)
         secondsperday = 86400  # 24*60*60
@@ -395,7 +329,7 @@ adoRemainingTypes = (
 
 
 # this class is a trick to determine whether a type is a member of a related group of types. see PEP notes
-class DBAPITypeObject(object):
+class DBAPITypeObject:
     def __init__(self, valuesTuple):
         self.values = frozenset(valuesTuple)
 
@@ -427,7 +361,7 @@ OTHER = DBAPITypeObject(adoRemainingTypes)
 
 # ------- utilities for translating python data types to ADO data types ---------------------------------
 typeMap = {
-    memoryViewType: adc.adVarBinary,
+    memoryview: adc.adVarBinary,
     float: adc.adDouble,
     type(None): adc.adEmpty,
     str: adc.adBSTR,
@@ -449,7 +383,7 @@ def pyTypeToADOType(d):
         if tp in dateconverter.types:
             return adc.adDate
         #  otherwise, attempt to discern the type by probing the data object itself -- to handle duck typing
-        if isinstance(d, StringTypes):
+        if isinstance(d, str):
             return adc.adBSTR
         if isinstance(d, numbers.Integral):
             return adc.adBigInt
@@ -463,17 +397,13 @@ def pyTypeToADOType(d):
 # ------------------------------------------------------------------------
 # variant type : function converting variant to Python value
 def variantConvertDate(v):
-    from . import dateconverter  # this function only called when adodbapi is running
+    # this function only called when adodbapi is running
+    from . import dateconverter
 
     return dateconverter.DateObjectFromCOMDate(v)
 
 
 def cvtString(variant):  # use to get old action of adodbapi v1 if desired
-    if onIronPython:
-        try:
-            return variant.ToString()
-        except:
-            pass
     return str(variant)
 
 
@@ -523,19 +453,12 @@ def identity(x):
 def cvtUnusual(variant):
     if verbose > 1:
         sys.stderr.write("Conversion called for Unusual data=%s\n" % repr(variant))
-    if isinstance(variant, DateTime):  # COMdate or System.Date
-        from .adodbapi import (  # this will only be called when adodbapi is in use, and very rarely
-            dateconverter,
-        )
-
-        return dateconverter.DateObjectFromCOMDate(variant)
     return variant  # cannot find conversion function -- just give the data to the user
 
 
 def convert_to_python(variant, func):  # convert DB value into Python value
-    if isinstance(variant, NullTypes):  # IronPython Null or None
-        return None
-    return func(variant)  # call the appropriate conversion function
+    # call the appropriate conversion function
+    return None if variant is None else func(variant)
 
 
 class MultiMap(dict):  # builds a dictionary from {(sequence,of,keys) : function}
@@ -578,7 +501,7 @@ variantConversions = MultiMap(
 RS_WIN_32, RS_ARRAY, RS_REMOTE = list(range(1, 4))
 
 
-class SQLrow(object):  # a single database row
+class SQLrow:  # a single database row
     # class to emulate a sequence, so that a column may be retrieved by either number or name
     def __init__(self, rows, index):  # "rows" is an _SQLrows object, index is which row
         self.rows = rows  # parent 'fetch' container object
@@ -654,7 +577,7 @@ class SQLrow(object):  # a single database row
     # # # #
 
 
-class SQLrows(object):
+class SQLrows:
     # class to emulate a sequence for multiple rows using a container object
     def __init__(self, ado_results, numberOfRows, cursor):
         self.ado_results = ado_results  # raw result of SQL get

--- a/adodbapi/is64bit.py
+++ b/adodbapi/is64bit.py
@@ -3,22 +3,14 @@ import sys
 
 
 def Python():
-    if sys.platform == "cli":  # IronPython
-        import System
-
-        return System.IntPtr.Size == 8
-    else:
-        try:
-            return sys.maxsize > 2147483647
-        except AttributeError:
-            return sys.maxint > 2147483647
+    return sys.maxsize > 2147483647
 
 
 def os():
     import platform
 
     pm = platform.machine()
-    if pm != ".." and pm.endswith("64"):  # recent Python (not Iron)
+    if pm != ".." and pm.endswith("64"):  # recent 64 bit Python
         return True
     else:
         import os

--- a/adodbapi/quick_reference.md
+++ b/adodbapi/quick_reference.md
@@ -2,10 +2,8 @@
 Adodbapi quick reference
 ========================
 
-Adodbapi is a Python DB-API 2.0 module that makes it easy to use
-Microsoft ADO
-for connecting with databases and other data sources
-using either CPython or IronPython.
+Adodbapi is a Python DB-API 2.0 module that makes it easy to use Microsoft ADO
+for connecting with databases and other data sources using CPython.
 
 Source home page:
 https://github.com/mhammond/pywin32/tree/master/adodbapi
@@ -107,27 +105,19 @@ access api specification is found at:
 The PEP requires several module level attributes. Older versions of
 adodbapi (which was once all one big file) defined a hundred or two. I
 hate that, but can\'t break old code, so I decided to fix the problem
-for Python 3. If using Python3 the programmer must take the time to pick
+for Python 3. The programmer must take the time to pick
 up the symbols she needs from apibase and ado\_consts.
 
 Part of the adodbapi package\'s \_\_init\_\_.py looks something like
 this:
 
 ```python
-if sys.version_info < (3,0): # in Python 2, define all symbols, just like before
-    from apibase import *  # using this is bad
-    from ado_consts import *  # using this is worse
-else:
-    # but if the user is running Python 3, then keep the dictionary clean
-    from apibase import apilevel, threadsafety, paramstyle
-    from apibase import Warning, Error, InterfaceError, DatabaseError, DataError
-    from apibase import OperationalError, IntegrityError
-    from apibase import InternalError, ProgrammingError, NotSupportedError
-    from apibase import NUMBER, STRING, BINARY, DATETIME, ROWID
+from .apibase import BINARY, DATETIME, NUMBER, ROWID, STRING, DatabaseError, DataError, Error, FetchFailedError, IntegrityError, InterfaceError, InternalError, NotSupportedError, OperationalError, ProgrammingError, Warning, apilevel, paramstyle, threadsafety
 
-from adodbapi import connect, Connection, __version__
-version = 'adodbapi v' + __version__
+from .adodbapi import Connection, Cursor, __version__, connect, dateconverter
+version = "adodbapi v" + __version__
 ```
+
 Please, use only those last four symbols from adodbapi. All others
 should be imported directly from their own sub-modules. My tests and
 examples all follow that rule.
@@ -781,7 +771,7 @@ Running the tests
 The test folder contains a set of unittest programs. Setting them up can
 be a bit complex, because you need several database servers to do a
 complete test, and each one has a different configuration. Scripts in
-this folder try to work in Python 2.7 or Python 3.5(+)
+this folder try to work in Python 3.5(+)
 
 - dbapi20.py
 

--- a/adodbapi/readme.txt
+++ b/adodbapi/readme.txt
@@ -3,15 +3,14 @@ Project
 adodbapi
 
 A Python DB-API 2.0 (PEP-249) module that makes it easy to use Microsoft ADO 
-for connecting with databases and other data sources
-using either CPython or IronPython.
+for connecting with databases and other data sources using CPython.
 
 Home page: <http://sourceforge.net/projects/adodbapi>
 
 Features:
 * 100% DB-API 2.0 (PEP-249) compliant (including most extensions and recommendations).
 * Includes pyunit testcases that describe how to use the module.  
-* Fully implemented in Python. -- runs in Python 2.5+ Python 3.0+ and IronPython 2.6+
+* Fully implemented in Python. -- runs in current versions of Python 3
 * Licensed under the LGPL license, which means that it can be used freely even in commercial programs subject to certain restrictions. 
 * The user can choose between paramstyles: 'qmark' 'named' 'format' 'pyformat' 'dynamic'
 * Supports data retrieval by column name e.g.:
@@ -20,20 +19,16 @@ Features:
 * Supports user-definable system-to-Python data conversion functions (selected by ADO data type, or by column)
 
 Prerequisites:
-* C Python 2.7 or 3.5 or higher
+* C Python 3.6 or higher
  and pywin32 (Mark Hammond's python for windows extensions.)
-or
- Iron Python 2.7 or higher.  (works in IPy2.0 for all data types except BUFFER)
 
 Installation:
 * (C-Python on Windows): Install pywin32 ("pip install pywin32") which includes adodbapi.
 * (IronPython on Windows): Download adodbapi from http://sf.net/projects/adodbapi.  Unpack the zip.
-     Open a command window as an administrator. CD to the folder containing the unzipped files.
-     Run "setup.py install" using the IronPython of your choice.
 
 NOTE: ...........
 If you do not like the new default operation of returning Numeric columns as decimal.Decimal,
-you can select other options by the user defined conversion feature. 
+you can select other options by the user defined conversion feature.
 Try:
         adodbapi.apibase.variantConversions[adodbapi.ado_consts.adNumeric] = adodbapi.apibase.cvtString
 or:
@@ -87,6 +82,6 @@ and look at the test cases in adodbapi/test directory.
 Mailing lists
 -------------
 The adodbapi mailing lists have been deactivated. Submit comments to the 
-pywin32 or IronPython mailing lists.
+pywin32 mailing lists.
   -- the bug tracker on sourceforge.net/projects/adodbapi may be checked, (infrequently).
   -- please use: https://github.com/mhammond/pywin32/issues

--- a/adodbapi/remote.py
+++ b/adodbapi/remote.py
@@ -21,13 +21,9 @@ Copyright (C) 2002 Henrik Ekelund, version 2.1 by Vernon Cole
     django adaptations and refactoring thanks to Adam Vandenberg
 
 DB-API 2.0 specification: http://www.python.org/dev/peps/pep-0249/
-
-This module source should run correctly in CPython versions 2.5 and later,
-or IronPython version 2.7 and later,
-or, after running through 2to3.py, CPython 3.0 or later.
 """
 
-__version__ = "2.6.0.4"
+__version__ = "3.7.0.0"
 version = "adodbapi.remote v" + __version__
 
 import array
@@ -40,15 +36,13 @@ import time
 try:
     import Pyro4
 except ImportError:
-    print('* * * Sorry, server operation requires Pyro4. Please "pip import" it.')
+    print('* * * Sorry, server operation requires Pyro4. Please "pip install" it.')
     exit(11)
 
 import adodbapi
 import adodbapi.apibase as api
 import adodbapi.process_connect_string
 from adodbapi.apibase import ProgrammingError
-
-_BaseException = api._BaseException
 
 sys.excepthook = Pyro4.util.excepthook
 Pyro4.config.PREFER_IP_VERSION = 0  # allow system to prefer IPv6
@@ -62,16 +56,12 @@ except:
 if verbose:
     print(version)
 
-# --- define objects to smooth out Python3 <-> Python 2.x differences
-unicodeType = str  # this line will be altered by 2to3.py to '= str'
-longType = int  # this line will be altered by 2to3.py to '= int'
-StringTypes = str
-makeByteBuffer = bytes
-memoryViewType = memoryview
 
 # -----------------------------------------------------------
 # conversion functions mandated by PEP 249
-Binary = makeByteBuffer  # override the function from apibase.py
+def Binary(aString):
+    """This function constructs an object capable of holding a binary (long) string value."""
+    return bytes(aString)
 
 
 def Date(year, month, day):
@@ -168,7 +158,7 @@ def connect(*args, **kwargs):  # --> a remote db-api connection object
                 raise api.DatabaseError(
                     "Pyro error creating connection to/thru=%s" % repr(kwargs)
                 )
-        except _BaseException as e:
+        except Exception as e:
             raise api.DatabaseError(
                 "Error creating remote connection to=%s, e=%s, %s"
                 % (repr(kwargs), repr(e), sys.exc_info()[2])
@@ -188,7 +178,7 @@ def fix_uri(uri, kwargs):
 
 
 # # # # # ----- the Class that defines a connection ----- # # # # #
-class Connection(object):
+class Connection:
     # include connection attributes required by api definition.
     Warning = api.Warning
     Error = api.Error
@@ -368,7 +358,7 @@ def fixpickle(x):
         # for 'named' paramstyle user will pass a mapping
         newargs = {}
         for arg, val in list(x.items()):
-            if isinstance(val, memoryViewType):
+            if isinstance(val, memoryview):
                 newval = array.array("B")
                 newval.fromstring(val)
                 newargs[arg] = newval
@@ -378,7 +368,7 @@ def fixpickle(x):
     # if not a mapping, then a sequence
     newargs = []
     for arg in x:
-        if isinstance(arg, memoryViewType):
+        if isinstance(arg, memoryview):
             newarg = array.array("B")
             newarg.fromstring(arg)
             newargs.append(newarg)
@@ -387,7 +377,7 @@ def fixpickle(x):
     return newargs
 
 
-class Cursor(object):
+class Cursor:
     def __init__(self, connection):
         self.command = None
         self.errorhandler = None  ## was: connection.errorhandler
@@ -569,7 +559,7 @@ class Cursor(object):
     def fetchone(self):
         try:
             f1 = self.proxy.crsr_fetchone(self.id)
-        except _BaseException as e:
+        except Exception as e:
             self._raiseCursorError(api.DatabaseError, e)
         else:
             if f1 is None:

--- a/adodbapi/remote/server.py
+++ b/adodbapi/remote/server.py
@@ -19,16 +19,14 @@ Copyright (C) 2013 by Vernon Cole
 
 DB-API 2.0 specification: http://www.python.org/dev/peps/pep-0249/
 
-This module source should run correctly in CPython versions 2.6 and later,
-or IronPython version 2.6 and later,
-or, after running through 2to3.py, CPython 3.2 or later.
+This module source should run correctly in CPython 3.2 or later.
 """
 
-__version__ = "2.6.2.0"
+__version__ = "3.7.0.0"
 version = "adodbapi.server v" + __version__
 
 PYRO_HOST = "::0"  # '::0' or '0.0.0.0' means any network
-PYRO_PORT = 9099  # may be altered below for Python 3 based servers
+PYRO_PORT = 9099  # may be altered below for Python based servers
 PYRO_COMMTIMEOUT = 40  # to be larger than the default database timeout
 SERVICE_NAME = "ado.connection"
 
@@ -42,15 +40,12 @@ import time
 try:
     import Pyro4
 except ImportError:
-    print('* * * Sorry, server operation requires Pyro4. Please "pip import" it.')
+    print('* * * Sorry, server operation requires Pyro4. Please "pip install" it.')
     exit(11)
 import adodbapi
 import adodbapi.apibase as api
 import adodbapi.process_connect_string
 
-makeByteBuffer = bytes
-_BaseException = Exception
-Binary = bytes
 try:
     pyro_host = os.environ["PYRO_HOST"]
 except:
@@ -64,25 +59,25 @@ for arg in sys.argv[1:]:
     if arg.lower().startswith("host"):
         try:
             pyro_host = arg.split("=")[1]
-        except _BaseException:
+        except Exception:
             raise TypeError('Must supply value for argument="%s"' % arg)
 
     if arg.lower().startswith("port"):
         try:
             pyro_port = int(arg.split("=")[1])
-        except _BaseException:
+        except Exception:
             raise TypeError('Must supply numeric value for argument="%s"' % arg)
 
     if arg.lower().startswith("timeout"):
         try:
             PYRO_COMMTIMEOUT = int(arg.split("=")[1])
-        except _BaseException:
+        except Exception:
             raise TypeError('Must supply numeric value for argument="%s"' % arg)
 
     if arg.lower().startswith("--verbose"):
         try:
             verbose = int(arg.split("=")[1])
-        except _BaseException:
+        except Exception:
             raise TypeError('Must supply numeric value for argument="%s"' % arg)
         adodbapi.adodbapi.verbose = verbose
     else:
@@ -97,7 +92,7 @@ Pyro4.config.SERVERTYPE = "multiplex"
 Pyro4.config.PREFER_IP_VERSION = 0  # allow system to prefer IPv6
 Pyro4.config.SERIALIZERS_ACCEPTED = set(
     ["serpent", "pickle"]
-)  # change when Py2.5 retired
+)  # TODO: change when Py2.5 retired
 
 connection_list = []
 CONNECTION_TIMEOUT = datetime.timedelta(minutes=30)
@@ -119,7 +114,7 @@ def unfixpickle(x):
         newargs = {}
         for arg, val in list(x.items()):
             if isinstance(arg, array.array):
-                newargs[arg] = Binary(val)
+                newargs[arg] = bytes(val)
             else:
                 newargs[arg] = val
         return newargs
@@ -127,13 +122,13 @@ def unfixpickle(x):
     newargs = []
     for arg in x:
         if isinstance(arg, array.array):
-            newargs.append(Binary(arg))
+            newargs.append(bytes(arg))
         else:
             newargs.append(arg)
     return newargs
 
 
-class ServerConnection(object):
+class ServerConnection:
     def __init__(self):
         self.server_connection = None
         self.cursors = {}
@@ -312,14 +307,14 @@ class ServerConnection(object):
         print("Shutdown request received")
 
 
-class ConnectionDispatcher(object):
+class ConnectionDispatcher:
     def make_connection(self):
         new_connection = ServerConnection()
         pyro_uri = self._pyroDaemon.register(new_connection)
         return pyro_uri
 
 
-class Heartbeat_Timer(object):
+class Heartbeat_Timer:
     def __init__(self, interval, work_function, tick_result_function):
         self.interval = interval
         self.last_tick = datetime.datetime.now()

--- a/adodbapi/setup.py
+++ b/adodbapi/setup.py
@@ -1,7 +1,6 @@
 """adodbapi -- a pure Python PEP 249 DB-API package using Microsoft ADO
 
 Adodbapi can be run on CPython 3.5 and later.
-or IronPython version 2.6 and later (in theory, possibly no longer in practice!)
 """
 CLASSIFIERS = """\
 Development Status :: 5 - Production/Stable

--- a/adodbapi/test/adodbapitest.py
+++ b/adodbapi/test/adodbapitest.py
@@ -26,21 +26,11 @@ import datetime
 import decimal
 import random
 import string
-import sys
 import unittest
 
-try:
-    import win32com.client
-
-    win32 = True
-except ImportError:
-    win32 = False
-
-# run the configuration module.
-import adodbapitestconfig as config  # will set sys.path to find correct version of adodbapi
-
-# in our code below, all our switches are from config.whatever
-import tryconnection
+import adodbapitestconfig as config  # run the configuration module. # will set sys.path to find correct version of adodbapi
+import tryconnection  # in our code below, all our switches are from config.whatever
+import win32com.client
 
 import adodbapi
 import adodbapi.apibase as api
@@ -52,9 +42,6 @@ except ImportError:  # we are doing a shortcut import as a module -- so
         import ado_consts
     except ImportError:
         from adodbapi import ado_consts
-
-
-long = int
 
 
 def randomstring(length):
@@ -211,49 +198,6 @@ class CommonDBTests(unittest.TestCase):
             except:
                 pass
             self.helpRollbackTblTemp()
-
-    def testUserDefinedConversionForExactNumericTypes(self):
-        # variantConversions is a dictionary of conversion functions
-        # held internally in adodbapi.apibase
-        #
-        # !!! this test intentionally alters the value of what should be constant in the module
-        # !!! no new code should use this example, to is only a test to see that the
-        # !!! deprecated way of doing this still works.  (use connection.variantConversions)
-        #
-        if not self.remote and sys.version_info < (3, 0):  ### Py3 need different test
-            oldconverter = adodbapi.variantConversions[
-                ado_consts.adNumeric
-            ]  # keep old function to restore later
-            # By default decimal and "numbers" are returned as decimals.
-            # Instead, make numbers return as  floats
-            try:
-                adodbapi.variantConversions[ado_consts.adNumeric] = adodbapi.cvtFloat
-                self.helpTestDataType(
-                    "decimal(18,2)", "NUMBER", 3.45, compareAlmostEqual=1
-                )
-                self.helpTestDataType(
-                    "numeric(18,2)", "NUMBER", 3.45, compareAlmostEqual=1
-                )
-                # now return strings
-                adodbapi.variantConversions[ado_consts.adNumeric] = adodbapi.cvtString
-                self.helpTestDataType("numeric(18,2)", "NUMBER", "3.45")
-                # now a completly weird user defined convertion
-                adodbapi.variantConversions[ado_consts.adNumeric] = (
-                    lambda x: "!!This function returns a funny unicode string %s!!" % x
-                )
-                self.helpTestDataType(
-                    "numeric(18,2)",
-                    "NUMBER",
-                    "3.45",
-                    allowedReturnValues=[
-                        "!!This function returns a funny unicode string 3.45!!"
-                    ],
-                )
-            finally:
-                # now reset the converter to its original function
-                adodbapi.variantConversions[
-                    ado_consts.adNumeric
-                ] = oldconverter  # Restore the original convertion function
 
     def helpTestDataType(
         self,
@@ -1521,37 +1465,6 @@ class TimeConverterInterfaceTest(unittest.TestCase):
         self.assertEqual(str(iso[:10]), "2003-05-02")
 
 
-if config.doMxDateTimeTest:
-    import mx.DateTime
-
-
-class TestMXDateTimeConverter(TimeConverterInterfaceTest):
-    def setUp(self):
-        self.tc = api.mxDateTimeConverter()
-
-    def testCOMDate(self):
-        t = mx.DateTime.DateTime(2002, 6, 28, 18, 15, 2)
-        cmd = self.tc.COMDate(t)
-        assert cmd == t.COMDate()
-
-    def testDateObjectFromCOMDate(self):
-        cmd = self.tc.DateObjectFromCOMDate(37435.7604282)
-        t = mx.DateTime.DateTime(2002, 6, 28, 18, 15, 0)
-        t2 = mx.DateTime.DateTime(2002, 6, 28, 18, 15, 2)
-        assert t2 > cmd > t
-
-    def testDate(self):
-        assert mx.DateTime.Date(1980, 11, 4) == self.tc.Date(1980, 11, 4)
-
-    def testTime(self):
-        assert mx.DateTime.Time(13, 11, 4) == self.tc.Time(13, 11, 4)
-
-    def testTimestamp(self):
-        t = mx.DateTime.DateTime(2002, 6, 28, 18, 15, 1)
-        obj = self.tc.Timestamp(2002, 6, 28, 18, 15, 1)
-        assert t == obj
-
-
 import time
 
 
@@ -1639,11 +1552,8 @@ class TestPythonDateTimeConverter(TimeConverterInterfaceTest):
 
 suites = []
 suites.append(unittest.makeSuite(TestPythonDateTimeConverter, "test"))
-if config.doMxDateTimeTest:
-    suites.append(unittest.makeSuite(TestMXDateTimeConverter, "test"))
 if config.doTimeTest:
     suites.append(unittest.makeSuite(TestPythonTimeConverter, "test"))
-
 if config.doAccessTest:
     suites.append(unittest.makeSuite(TestADOwithAccessDB, "test"))
 if config.doSqlServerTest:
@@ -1654,7 +1564,7 @@ if config.doPostgresTest:
     suites.append(unittest.makeSuite(TestADOwithPostgres, "test"))
 
 
-class cleanup_manager(object):
+class cleanup_manager:
     def __enter__(self):
         pass
 
@@ -1673,16 +1583,11 @@ if __name__ == "__main__":
         tag = "datetime"
         unittest.TextTestRunner().run(mysuite)
 
-        if config.iterateOverTimeTests:
-            for test, dateconverter, tag in (
-                (config.doTimeTest, api.pythonTimeConverter, "pythontime"),
-                (config.doMxDateTimeTest, api.mxDateTimeConverter, "mx"),
-            ):
-                if test:
-                    mysuite = copy.deepcopy(
-                        suite
-                    )  # work around a side effect of unittest.TextTestRunner
-                    adodbapi.adodbapi.dateconverter = dateconverter()
-                    print("Changed dateconverter to ")
-                    print(adodbapi.adodbapi.dateconverter)
-                    unittest.TextTestRunner().run(mysuite)
+        if config.doTimeTest:
+            mysuite = copy.deepcopy(
+                suite
+            )  # work around a side effect of unittest.TextTestRunner
+            adodbapi.adodbapi.dateconverter = api.pythonTimeConverter()
+            print("Changed dateconverter to ")
+            print(adodbapi.adodbapi.dateconverter)
+            unittest.TextTestRunner().run(mysuite)

--- a/adodbapi/test/adodbapitestconfig.py
+++ b/adodbapi/test/adodbapitestconfig.py
@@ -32,14 +32,14 @@ except:
 if "--help" in sys.argv:
     print(
         """Valid command-line switches are:
-    --package - create a temporary test package, run 2to3 if needed.
+    --package - create a temporary test package
     --all - run all possible tests
-    --time - loop over time format tests (including mxdatetime if present)
+    --time - do time format test
     --nojet - do not test against an ACCESS database file
     --mssql - test against Microsoft SQL server
     --pg - test against PostgreSQL
     --mysql - test against MariaDB
-    --remote= - test unsing remote server at= (experimental) 
+    --remote= - test using remote server at= (experimental)
     """
     )
     exit()
@@ -77,13 +77,8 @@ for arg in sys.argv:
 
 # function to clean up the temporary folder -- calling program must run this function before exit.
 cleanup = setuptestframework.getcleanupfunction()
-try:
-    import adodbapi  # will (hopefully) be imported using the "pth" discovered above
-except SyntaxError:
-    print(
-        '\n* * * Are you trying to run Python2 code using Python3? Re-run this test using the "--package" switch.'
-    )
-    sys.exit(11)
+import adodbapi  # will (hopefully) be imported using the "pth" discovered above
+
 try:
     print(adodbapi.version)  # show version
 except:
@@ -106,20 +101,11 @@ doAccessTest = not ("--nojet" in sys.argv)
 doSqlServerTest = "--mssql" in sys.argv or doAllTests
 doMySqlTest = "--mysql" in sys.argv or doAllTests
 doPostgresTest = "--pg" in sys.argv or doAllTests
-iterateOverTimeTests = ("--time" in sys.argv or doAllTests) and onWindows
+doTimeTest = ("--time" in sys.argv or doAllTests) and onWindows
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # # start your environment setup here v v v
 SQL_HOST_NODE = "testsql.2txt.us,1430"
-
-try:  # If mx extensions are installed, use mxDateTime
-    import mx.DateTime
-
-    doMxDateTimeTest = True
-except:
-    doMxDateTimeTest = False  # Requires eGenixMXExtensions
-
-doTimeTest = True  # obsolete python time format
 
 if doAccessTest:
     if proxy_host:  # determine the (probably remote) database file folder

--- a/adodbapi/test/dbapi20.py
+++ b/adodbapi/test/dbapi20.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-""" Python DB API 2.0 driver compliance unit test suite. 
-    
+""" Python DB API 2.0 driver compliance unit test suite.
+
     This software is Public Domain and may be used without restrictions.
 
  "Now we have booze and barflies entering the discussion, plus rumours of
@@ -11,28 +11,22 @@
     -- Ian Bicking
 """
 
-__version__ = "$Revision: 1.15.0 $"[11:-2]
+__version__ = "$Revision: 1.16.0 $"[11:-2]
 __author__ = "Stuart Bishop <stuart@stuartbishop.net>"
 
-import sys
 import time
 import unittest
 
-if sys.version[0] >= "3":  # python 3.x
-    _BaseException = Exception
 
-    def _failUnless(self, expr, msg=None):
-        self.assertTrue(expr, msg)
-
-else:  # python 2.x
-    from exceptions import Exception as _BaseException
-
-    def _failUnless(self, expr, msg=None):
-        self.failUnless(expr, msg)  ## deprecated since Python 2.6
+def _failUnless(self, expr, msg=None):
+    self.assertTrue(expr, msg)
 
 
 # set this to "True" to follow API 2.0 to the letter
 TEST_FOR_NON_IDEMPOTENT_CLOSE = False
+
+# Revision 1.16  2022/12/07 22:00:00  Avasam
+# Drop support for EOL Python 3.6 and below
 
 # Revision 1.15  2019/11/22 00:50:00  kf7xm
 # Make Turn off IDEMPOTENT_CLOSE a proper skipTest
@@ -166,7 +160,7 @@ class DatabaseAPI20Test(unittest.TestCase):
                         pass
             finally:
                 con.close()
-        except _BaseException:
+        except Exception:
             pass
 
     def _connect(self):
@@ -212,12 +206,8 @@ class DatabaseAPI20Test(unittest.TestCase):
     def test_Exceptions(self):
         # Make sure required exceptions exist, and are in the
         # defined heirarchy.
-        if sys.version[0] == "3":  # under Python 3 StardardError no longer exists
-            self.assertTrue(issubclass(self.driver.Warning, Exception))
-            self.assertTrue(issubclass(self.driver.Error, Exception))
-        else:
-            self.failUnless(issubclass(self.driver.Warning, Exception))
-            self.failUnless(issubclass(self.driver.Error, Exception))
+        self.assertTrue(issubclass(self.driver.Warning, Exception))
+        self.assertTrue(issubclass(self.driver.Error, Exception))
 
         _failUnless(self, issubclass(self.driver.InterfaceError, self.driver.Error))
         _failUnless(self, issubclass(self.driver.DatabaseError, self.driver.Error))

--- a/adodbapi/test/is64bit.py
+++ b/adodbapi/test/is64bit.py
@@ -3,22 +3,14 @@ import sys
 
 
 def Python():
-    if sys.platform == "cli":  # IronPython
-        import System
-
-        return System.IntPtr.Size == 8
-    else:
-        try:
-            return sys.maxsize > 2147483647
-        except AttributeError:
-            return sys.maxint > 2147483647
+    return sys.maxsize > 2147483647
 
 
 def os():
     import platform
 
     pm = platform.machine()
-    if pm != ".." and pm.endswith("64"):  # recent Python (not Iron)
+    if pm != ".." and pm.endswith("64"):  # recent 64 bit Python
         return True
     else:
         import os

--- a/adodbapi/test/setuptestframework.py
+++ b/adodbapi/test/setuptestframework.py
@@ -1,15 +1,9 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # Configure this in order to run the testcases.
-"setuptestframework.py v 2.6.0.8"
+"setuptestframework.py v 3.7.0.0"
 import os
 import shutil
-import sys
 import tempfile
-
-try:
-    OSErrors = (WindowsError, OSError)
-except NameError:  # not running on Windows
-    OSErrors = OSError
 
 
 def maketemp():
@@ -52,20 +46,14 @@ def makeadopackage(testfolder):
         newpackage = os.path.join(testfolder, "adodbapi")
         try:
             os.mkdir(newpackage)
-        except OSErrors:
+        except (WindowsError, OSError):
             print(
                 "*Note: temporary adodbapi package already exists: may be two versions running?"
             )
         for f in os.listdir(adoPath):
             if f.endswith(".py"):
                 shutil.copy(os.path.join(adoPath, f), newpackage)
-        if sys.version_info >= (3, 0):  # only when running Py3.n
-            save = sys.stdout
-            sys.stdout = None
-            from lib2to3.main import main  # use 2to3 to make test package
 
-            main("lib2to3.fixes", args=["-n", "-w", newpackage])
-            sys.stdout = save
         return testfolder
     else:
         raise EnvironmentError("Connot find source of adodbapi to test.")
@@ -80,41 +68,23 @@ def makemdb(testfolder, mdb_name):
     if os.path.isfile(_accessdatasource):
         print("using JET database=", _accessdatasource)
     else:
-        try:
-            from win32com.client import constants
-            from win32com.client.gencache import EnsureDispatch
-
-            win32 = True
-        except ImportError:  # perhaps we are running IronPython
-            win32 = False  # iron Python
-            try:
-                from System import Activator, Type
-            except:
-                pass
+        from win32com.client import constants
+        from win32com.client.gencache import EnsureDispatch
 
         # Create a brand-new database - what is the story with these?
         dbe = None
         for suffix in (".36", ".35", ".30"):
             try:
-                if win32:
-                    dbe = EnsureDispatch("DAO.DBEngine" + suffix)
-                else:
-                    type = Type.GetTypeFromProgID("DAO.DBEngine" + suffix)
-                    dbe = Activator.CreateInstance(type)
+                dbe = EnsureDispatch("DAO.DBEngine" + suffix)
                 break
             except:
                 pass
         if dbe:
             print("    ...Creating ACCESS db at " + _accessdatasource)
-            if win32:
-                workspace = dbe.Workspaces(0)
-                newdb = workspace.CreateDatabase(
-                    _accessdatasource, constants.dbLangGeneral, constants.dbVersion40
-                )
-            else:
-                newdb = dbe.CreateDatabase(
-                    _accessdatasource, ";LANGID=0x0409;CP=1252;COUNTRY=0"
-                )
+            workspace = dbe.Workspaces(0)
+            newdb = workspace.CreateDatabase(
+                _accessdatasource, constants.dbLangGeneral, constants.dbVersion40
+            )
             newdb.Close()
         else:
             print("    ...copying test ACCESS db to " + _accessdatasource)


### PR DESCRIPTION
Following a general understanding that adodbapi code changes will be a lot harder to test, and comments in #1990, these changes have been completely split off. With the final goal to make basic type-checking validation of public methods possible, easing the addition of 3.7+ type annotations. I am fine if that excludes adodbapi.

This cleans-up most unreachable code. Mostly due to unsupported python versions.
- Update obsolete Python1 comments
- Explicit re-exports to keep some backward compatiiblity
- Remove Python2 specific code
  - Update Python3/Python2 specific comments
  - Added a `TODO` to the comments that mentioned python 2/3 specific code. But that I didn't know how to address.
  - Replaced use of deprecated Types
  - ~~Obsolete and redundant aliases~~ #2088
  - ~~Redundant object subclassing~~ #2086
  - ~~IronPython2~~ #2049
  - ~~mxDateTime~~ #2048
- Update platform/version checks
- Removed unreachable code