### PR TITLE
Add GitHub Action concurrency groups

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,10 @@ on:
     branches:
     - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Build and test


### PR DESCRIPTION
Configured concurrency in GitHub Action to automatically cancel obsolete runs (for example, caused by new PR commits)

Prevents things like this:
![image](https://github.com/mhammond/pywin32/assets/1350584/b412035d-f6f9-4d01-a3bc-022f18dfb71e)

This is the same configuration that a handful of official Python repositories use.
Documentation: https://docs.github.com/en/actions/using-jobs/using-concurrency