### PR TITLE
Use modern "zero arguments" style for `super`

### DIFF
--- a/com/win32com/demos/excelRTDServer.py
+++ b/com/win32com/demos/excelRTDServer.py
@@ -132,7 +132,7 @@ class ExcelRTDServer:
 
     def __init__(self):
         """Constructor"""
-        super(ExcelRTDServer, self).__init__()
+        super().__init__()
         self.IsAlive = self.ALIVE
         self.__callback = None
         self.topics = {}
@@ -266,7 +266,7 @@ class RTDTopic:
     The others are more for convenience."""
 
     def __init__(self, TopicStrings):
-        super(RTDTopic, self).__init__()
+        super().__init__()
         self.TopicStrings = TopicStrings
         self.__currentValue = None
         self.__dirty = False
@@ -332,7 +332,7 @@ class TimeServer(ExcelRTDServer):
     INTERVAL = 0.5  # secs. Threaded timer will wake us up at this interval.
 
     def __init__(self):
-        super(TimeServer, self).__init__()
+        super().__init__()
 
         # Simply timer thread to ensure we get to update our topics, and
         # tell excel about any changes. This is a pretty basic and dirty way to
@@ -384,7 +384,7 @@ class TimeTopic(RTDTopic):
     """
 
     def __init__(self, TopicStrings):
-        super(TimeTopic, self).__init__(TopicStrings)
+        super().__init__(TopicStrings)
         try:
             self.cmd, self.delay = self.TopicStrings
         except Exception as E:

--- a/com/win32com/makegw/makegwparse.py
+++ b/com/win32com/makegw/makegwparse.py
@@ -17,12 +17,12 @@ import traceback
 
 class error_not_found(Exception):
     def __init__(self, msg="The requested item could not be found"):
-        super(error_not_found, self).__init__(msg)
+        super().__init__(msg)
 
 
 class error_not_supported(Exception):
     def __init__(self, msg="The required functionality is not supported"):
-        super(error_not_supported, self).__init__(msg)
+        super().__init__(msg)
 
 
 VERBOSE = 0

--- a/win32/Lib/pywin32_testutil.py
+++ b/win32/Lib/pywin32_testutil.py
@@ -217,7 +217,7 @@ except AttributeError:
 # handling for the TestSkipped exception.
 class TestResult(TextTestResult):
     def __init__(self, *args, **kw):
-        super(TestResult, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
         self.skips = {}  # count of skips for each reason.
 
     def addError(self, test, err):
@@ -265,10 +265,10 @@ class TestResult(TextTestResult):
                 self.stream.write("S")
                 self.stream.flush()
             return
-        super(TestResult, self).addError(test, err)
+        super().addError(test, err)
 
     def printErrors(self):
-        super(TestResult, self).printErrors()
+        super().printErrors()
         for reason, num_skipped in self.skips.items():
             self.stream.writeln("SKIPPED: %d tests - %s" % (num_skipped, reason))
 

--- a/win32/Lib/win32timezone.py
+++ b/win32/Lib/win32timezone.py
@@ -337,7 +337,7 @@ class TimeZoneDefinition(DYNAMIC_TIME_ZONE_INFORMATION):
         c) a byte structure (using _from_bytes)
         """
         try:
-            super(TimeZoneDefinition, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
             return
         except (TypeError, ValueError):
             pass
@@ -369,7 +369,7 @@ class TimeZoneDefinition(DYNAMIC_TIME_ZONE_INFORMATION):
         bias, standard_bias, daylight_bias = components[:3]
         standard_start = SYSTEMTIME(*components[3:11])
         daylight_start = SYSTEMTIME(*components[11:19])
-        super(TimeZoneDefinition, self).__init__(
+        super().__init__(
             bias,
             standard_name,
             standard_start,
@@ -393,7 +393,7 @@ class TimeZoneDefinition(DYNAMIC_TIME_ZONE_INFORMATION):
         # ctypes.memmove(ctypes.addressof(self), other, size)
 
     def __getattribute__(self, attr):
-        value = super(TimeZoneDefinition, self).__getattribute__(attr)
+        value = super().__getattribute__(attr)
         if "bias" in attr:
             value = datetime.timedelta(minutes=value)
         return value


### PR DESCRIPTION
Extracted from #2100
Documentation: https://docs.python.org/3/library/functions.html#super

This PR standardizes uses of `super` to the simplified "zero arguments" style where applicable. On Python 3 these arguments are the default and they can be omitted.