### PR TITLE
Update and standardise obsolete `OSError` aliases:

### DIFF
--- a/AutoDuck/fixHelpCompression.py
+++ b/AutoDuck/fixHelpCompression.py
@@ -9,7 +9,7 @@ fname = sys.argv[1]
 
 try:
     os.stat(fname)
-except os.error:
+except OSError:
     sys.stderr.write("The project file '%s' was not found\n" % (fname))
     sys.exit(1)
 

--- a/Pythonwin/Scintilla/src/LexGen.py
+++ b/Pythonwin/Scintilla/src/LexGen.py
@@ -107,7 +107,7 @@ def UpdateFile(filename, updated):
     it as modified."""
     try:
         infile = open(filename, "rb")
-    except IOError:  # File is not there yet
+    except OSError:  # File is not there yet
         out = open(filename, "wb")
         out.write(updated)
         out.close()
@@ -136,7 +136,7 @@ def Generate(inpath, outpath, commentPrefix, eolType, *lists):
     #      % (inpath, outpath, commentPrefix, eolType)
     try:
         infile = open(inpath, "r")
-    except IOError:
+    except OSError:
         print("Can not open", inpath)
         return
     original = infile.read()

--- a/Pythonwin/pywin/Demos/hiertest.py
+++ b/Pythonwin/pywin/Demos/hiertest.py
@@ -105,7 +105,7 @@ class HLIFileDir(hierlist.HierListItem):
                 os.path.basename(self.filename),
                 os.stat(self.filename)[6],
             )
-        except os.error as details:
+        except OSError as details:
             return "%-20s - %s" % (self.filename, details[1])
 
     def IsExpandable(self):

--- a/Pythonwin/pywin/framework/app.py
+++ b/Pythonwin/pywin/framework/app.py
@@ -379,7 +379,7 @@ class AboutBox(dialog.Dialog):
                 open(os.path.join(site_packages, "pywin32.version.txt")).read().strip()
             )
             ver = "pywin32 build %s" % build_no
-        except EnvironmentError:
+        except OSError:
             ver = None
         if ver is None:
             # See if we are Part of Active Python

--- a/Pythonwin/pywin/framework/bitmap.py
+++ b/Pythonwin/pywin/framework/bitmap.py
@@ -28,7 +28,7 @@ class BitmapDocument(docview.Document):
         try:
             try:
                 self.bitmap.LoadBitmapFile(f)
-            except IOError:
+            except OSError:
                 win32ui.MessageBox("Could not load the bitmap from %s" % filename)
                 return 0
         finally:

--- a/Pythonwin/pywin/framework/editor/document.py
+++ b/Pythonwin/pywin/framework/editor/document.py
@@ -66,23 +66,23 @@ class EditorDocumentBase(ParentEditorDocument):
             tempPath = os.path.join(win32api.GetTempPath(), "bak")
             try:
                 os.mkdir(tempPath, 0)
-            except os.error:
+            except OSError:
                 pass
             bakFileName = os.path.join(tempPath, basename)
         try:
             os.unlink(bakFileName)  # raise NameError if no bakups wanted.
-        except (os.error, NameError):
+        except (OSError, NameError):
             pass
         try:
             # Do a copy as it might be on different volumes,
             # and the file may be a hard-link, causing the link
             # to follow the backup.
             shutil.copy2(fileName, bakFileName)
-        except (os.error, NameError, IOError):
+        except (OSError, NameError):
             pass
         try:
             self.SaveFile(fileName)
-        except IOError as details:
+        except OSError as details:
             win32ui.MessageBox("Error - could not save file\r\n\r\n%s" % details)
             return 0
         except (UnicodeEncodeError, LookupError) as details:
@@ -99,7 +99,7 @@ class EditorDocumentBase(ParentEditorDocument):
             if rc == win32con.IDYES:
                 try:
                     self.SaveFile(fileName, encoding="latin-1")
-                except IOError as details:
+                except OSError as details:
                     win32ui.MessageBox(
                         "Error - could not save file\r\n\r\n%s" % details
                     )
@@ -155,7 +155,7 @@ class EditorDocumentBase(ParentEditorDocument):
             return
         try:
             newstat = os.stat(self.GetPathName())
-        except os.error as exc:
+        except OSError as exc:
             if not self.bReportedFileNotFound:
                 print(
                     "The file '%s' is open for editing, but\nchecking it for changes caused the error: %s"
@@ -207,7 +207,7 @@ class EditorDocumentBase(ParentEditorDocument):
         if self.GetPathName():
             try:
                 self.fileStat = os.stat(self.GetPathName())
-            except os.error:
+            except OSError:
                 self.fileStat = None
         else:
             self.fileStat = None

--- a/Pythonwin/pywin/framework/editor/editor.py
+++ b/Pythonwin/pywin/framework/editor/editor.py
@@ -101,7 +101,7 @@ class EditorDocument(ParentEditorDocument):
         win32ui.SetStatusText("Loading file...", 1)
         try:
             f = open(filename, "rb")
-        except IOError:
+        except OSError:
             win32ui.MessageBox(
                 filename
                 + "\nCan not find this file\nPlease verify that the correct path and file name are given"

--- a/Pythonwin/pywin/framework/scriptutils.py
+++ b/Pythonwin/pywin/framework/scriptutils.py
@@ -288,7 +288,7 @@ def RunScript(defName=None, defArgs=None, bShowDialog=1, debuggingType=None):
         try:
             os.stat(fnameonly)  # See if it is OK as is...
             script = fnameonly
-        except os.error:
+        except OSError:
             fullScript = LocatePythonFile(script)
             if fullScript is None:
                 win32ui.MessageBox("The file '%s' can not be located" % script)
@@ -308,7 +308,7 @@ def RunScript(defName=None, defArgs=None, bShowDialog=1, debuggingType=None):
     # So: do the binary thing and manually normalize \r\n.
     try:
         f = open(script, "rb")
-    except IOError as exc:
+    except OSError as exc:
         win32ui.MessageBox(
             "The file could not be opened - %s (%d)" % (exc.strerror, exc.errno)
         )
@@ -505,7 +505,7 @@ def CheckFile():
     win32ui.DoWaitCursor(1)
     try:
         f = open(pathName)
-    except IOError as details:
+    except OSError as details:
         print("Cant open file '%s' - %s" % (pathName, details))
         return
     try:
@@ -640,7 +640,7 @@ def FindTabNanny():
     fname = os.path.join(path, "Tools\\Scripts\\%s" % filename)
     try:
         os.stat(fname)
-    except os.error:
+    except OSError:
         print(
             "WARNING - The file '%s' can not be located in path '%s'" % (filename, path)
         )

--- a/Pythonwin/pywin/framework/winout.py
+++ b/Pythonwin/pywin/framework/winout.py
@@ -60,7 +60,7 @@ class WindowOutputDocument(WindowOutputDocumentParent):
         win32ui.SetStatusText("Saving file...", 1)
         try:
             self.SaveFile(fileName)
-        except IOError as details:
+        except OSError as details:
             win32ui.MessageBox("Error - could not save file\r\n\r\n%s" % details)
             return 0
         win32ui.SetStatusText("Ready")

--- a/Pythonwin/pywin/scintilla/config.py
+++ b/Pythonwin/pywin/scintilla/config.py
@@ -91,7 +91,7 @@ class ConfigManager:
             try:
                 f = find_config_file(f)
                 src_stat = os.stat(f)
-            except os.error:
+            except OSError:
                 self.report_error("Config file '%s' not found" % f)
                 return
             self.filename = f
@@ -119,7 +119,7 @@ class ConfigManager:
                             return  # We are ready to roll!
                 finally:
                     cf.close()
-            except (os.error, IOError, EOFError):
+            except (OSError, EOFError):
                 pass
             fp = open(f)
             b_close = True
@@ -167,7 +167,7 @@ class ConfigManager:
                 marshal.dump(src_stat[stat.ST_MTIME], cf)
                 marshal.dump(self.cache, cf)
                 cf.close()
-            except (IOError, EOFError):
+            except (OSError, EOFError):
                 pass  # Ignore errors - may be read only.
 
     def configure(self, editor, subsections=None):

--- a/Pythonwin/pywin/scintilla/document.py
+++ b/Pythonwin/pywin/scintilla/document.py
@@ -47,7 +47,7 @@ class CScintillaDocument(ParentScintillaDocument):
                 self._LoadTextFromFile(f)
             finally:
                 f.close()
-        except IOError:
+        except OSError:
             rc = win32ui.MessageBox(
                 "Could not load the file from %s\n\nDo you want to create a new file?"
                 % filename,
@@ -63,7 +63,7 @@ class CScintillaDocument(ParentScintillaDocument):
                     self._LoadTextFromFile(f)
                 finally:
                     f.close()
-            except IOError as e:
+            except OSError as e:
                 rc = win32ui.MessageBox("Cannot create the file %s" % filename)
         return 1
 

--- a/com/win32com/client/gencache.py
+++ b/com/win32com/client/gencache.py
@@ -61,7 +61,7 @@ def __init__():
     # Initialize the module.  Called once explicitly at module import below.
     try:
         _LoadDicts()
-    except IOError:
+    except OSError:
         Rebuild()
 
 
@@ -100,7 +100,7 @@ def _LoadDicts():
         except AttributeError:
             # The __loader__ has no get_data method.  See below.
             return
-        except IOError:
+        except OSError:
             # Our gencache is in a .zip file (and almost certainly readonly)
             # but no dicts file.  That actually needn't be fatal for a frozen
             # application.  Assuming they call "EnsureModule" with the same
@@ -115,7 +115,7 @@ def _LoadDicts():
             return
         f = io.BytesIO(data)
     else:
-        # NOTE: IOError on file open must be caught by caller.
+        # NOTE: OSError on file open must be caught by caller.
         f = open(os.path.join(win32com.__gen_path__, "dicts.dat"), "rb")
     try:
         p = pickle.Unpickler(f)
@@ -147,12 +147,12 @@ def GetGeneratePath():
     try:
         os.makedirs(win32com.__gen_path__)
         # os.mkdir(win32com.__gen_path__)
-    except os.error:
+    except OSError:
         pass
     try:
         fname = os.path.join(win32com.__gen_path__, "__init__.py")
         os.stat(fname)
-    except os.error:
+    except OSError:
         f = open(fname, "w")
         f.write(
             "# Generated file - this directory may be deleted to reset the COM cache...\n"
@@ -528,11 +528,11 @@ def EnsureModule(
                 # try to erase the bad file from the cache
                 try:
                     os.unlink(filePath)
-                except os.error:
+                except OSError:
                     pass
                 try:
                     os.unlink(filePathPyc)
-                except os.error:
+                except OSError:
                     pass
                 if os.path.isdir(filePathPrefix):
                     import shutil
@@ -554,13 +554,13 @@ def EnsureModule(
                 try:
                     pyModTime = os.stat(filePath)[8]
                     fModTimeSet = 1
-                except os.error as e:
+                except OSError as e:
                     # If .py file fails, try .pyc file
                     # print "Trying pyc stat", filePathPyc
                     try:
                         pyModTime = os.stat(filePathPyc)[8]
                         fModTimeSet = 1
-                    except os.error as e:
+                    except OSError as e:
                         pass
                 # print "Trying stat typelib", pyModTime
                 # print str(typLibPath)
@@ -568,7 +568,7 @@ def EnsureModule(
                 if fModTimeSet and (typLibModTime > pyModTime):
                     bReloadNeeded = 1
                     module = None
-    except (ImportError, os.error):
+    except (ImportError, OSError):
         module = None
     if module is None:
         # We need to build an item.  If we are in a read-only cache, we

--- a/com/win32com/client/genpy.py
+++ b/com/win32com/client/genpy.py
@@ -1042,13 +1042,13 @@ class Generator:
         f.close()
         try:
             os.unlink(filename)
-        except os.error:
+        except OSError:
             pass
         temp_filename = self.get_temp_filename(filename)
         if worked:
             try:
                 os.rename(temp_filename, filename)
-            except os.error:
+            except OSError:
                 # If we are really unlucky, another process may have written the
                 # file in between our calls to os.unlink and os.rename. So try
                 # again, but only once.
@@ -1064,7 +1064,7 @@ class Generator:
                 #   as well.
                 try:
                     os.unlink(filename)
-                except os.error:
+                except OSError:
                     pass
                 os.rename(temp_filename, filename)
         else:

--- a/com/win32com/client/makepy.py
+++ b/com/win32com/client/makepy.py
@@ -300,15 +300,15 @@ def GenerateFromTypeLibSpec(
             if bForDemand:
                 try:
                     os.unlink(full_name + ".py")
-                except os.error:
+                except OSError:
                     pass
                 try:
                     os.unlink(full_name + ".pyc")
-                except os.error:
+                except OSError:
                     pass
                 try:
                     os.unlink(full_name + ".pyo")
-                except os.error:
+                except OSError:
                     pass
                 if not os.path.isdir(full_name):
                     os.mkdir(full_name)

--- a/com/win32com/demos/excelAddin.py
+++ b/com/win32com/demos/excelAddin.py
@@ -156,7 +156,7 @@ def UnregisterAddin(klass):
             winreg.HKEY_CURRENT_USER,
             "Software\\Microsoft\\Office\\Excel\\Addins\\" + klass._reg_progid_,
         )
-    except WindowsError:
+    except OSError:
         pass
 
 

--- a/com/win32com/demos/iebutton.py
+++ b/com/win32com/demos/iebutton.py
@@ -157,7 +157,7 @@ def register(classobj):
         winreg.SetValueEx(hKey, "ToolTip", 0, winreg.REG_SZ, classobj._tool_tip_)
         winreg.SetValueEx(hKey, "Icon", 0, winreg.REG_SZ, classobj._icon_)
         winreg.SetValueEx(hKey, "HotIcon", 0, winreg.REG_SZ, classobj._hot_icon_)
-    except WindowsError:
+    except OSError:
         print("Couldn't set standard toolbar reg keys.")
     else:
         print("Set standard toolbar reg keys.")
@@ -180,7 +180,7 @@ def unregister(classobj):
         winreg.DeleteValue(hKey, "Icon")
         winreg.DeleteValue(hKey, "HotIcon")
         winreg.DeleteKey(winreg.HKEY_LOCAL_MACHINE, subKeyCLSID)
-    except WindowsError:
+    except OSError:
         print("Couldn't delete Standard toolbar regkey.")
     else:
         print("Deleted Standard toolbar regkey.")

--- a/com/win32com/demos/ietoolbar.py
+++ b/com/win32com/demos/ietoolbar.py
@@ -328,7 +328,7 @@ def DllRegisterServer():
         subKey = winreg.SetValueEx(
             hkey, comclass._reg_clsid_, 0, winreg.REG_BINARY, "\0"
         )
-    except WindowsError:
+    except OSError:
         print(
             "Couldn't set registry value.\nhkey: %d\tCLSID: %s\n"
             % (hkey, comclass._reg_clsid_)
@@ -351,7 +351,7 @@ def DllUnregisterServer():
             winreg.HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Internet Explorer\\Toolbar"
         )
         winreg.DeleteValue(hkey, comclass._reg_clsid_)
-    except WindowsError:
+    except OSError:
         print(
             "Couldn't delete registry value.\nhkey: %d\tCLSID: %s\n"
             % (hkey, comclass._reg_clsid_)

--- a/com/win32com/demos/outlookAddin.py
+++ b/com/win32com/demos/outlookAddin.py
@@ -124,7 +124,7 @@ def UnregisterAddin(klass):
             winreg.HKEY_CURRENT_USER,
             "Software\\Microsoft\\Office\\Outlook\\Addins\\" + klass._reg_progid_,
         )
-    except WindowsError:
+    except OSError:
         pass
 
 

--- a/com/win32com/server/register.py
+++ b/com/win32com/server/register.py
@@ -134,7 +134,7 @@ def _find_localserver_module():
     pyfile = os.path.join(path, baseName + ".py")
     try:
         os.stat(pyfile)
-    except os.error:
+    except OSError:
         # See if we have a compiled extension
         if __debug__:
             ext = ".pyc"
@@ -143,7 +143,7 @@ def _find_localserver_module():
         pyfile = os.path.join(path, baseName + ext)
         try:
             os.stat(pyfile)
-        except os.error:
+        except OSError:
             raise RuntimeError(
                 "Can not locate the Python module 'win32com.server.%s'" % baseName
             )
@@ -623,7 +623,7 @@ def ReExecuteElevated(flags):
         for f in (outfile, batfile):
             try:
                 os.unlink(f)
-            except os.error as exc:
+            except OSError as exc:
                 print("Failed to remove tempfile '%s': %s" % (f, exc))
 
 

--- a/com/win32com/test/GenTestScripts.py
+++ b/com/win32com/test/GenTestScripts.py
@@ -27,7 +27,7 @@ def GenerateFromRegistered(fname, *loadArgs):
     genPath = GetGenPath()
     try:
         os.stat(genPath)
-    except os.error:
+    except OSError:
         os.mkdir(genPath)
     # Ensure an __init__ exists.
     open(os.path.join(genPath, "__init__.py"), "w").close()
@@ -67,13 +67,13 @@ def CleanAll():
         try:
             name = args[0] + ".py"
             os.unlink(os.path.join(genPath, name))
-        except os.error as details:
+        except OSError as details:
             if isinstance(details, tuple) and details[0] != 2:
                 print("Could not deleted generated", name, details)
         try:
             name = args[0] + ".pyc"
             os.unlink(os.path.join(genPath, name))
-        except os.error as details:
+        except OSError as details:
             if isinstance(details, tuple) and details[0] != 2:
                 print("Could not deleted generated", name, details)
         try:
@@ -86,7 +86,7 @@ def CleanAll():
             pass
     try:
         os.rmdir(genPath)
-    except os.error as details:
+    except OSError as details:
         print("Could not delete test directory -", details)
 
 

--- a/com/win32com/test/testAccess.py
+++ b/com/win32com/test/testAccess.py
@@ -26,7 +26,7 @@ def CreateTestAccessDatabase(dbname=None):
 
     try:
         os.unlink(dbname)
-    except os.error:
+    except OSError:
         print(
             "WARNING - Unable to delete old test database - expect a COM exception RSN!"
         )

--- a/com/win32com/test/testShell.py
+++ b/com/win32com/test/testShell.py
@@ -221,7 +221,7 @@ class FileOperationTester(win32com.test.util.TestCase):
         f.close()
         try:
             os.unlink(self.dest_name)
-        except os.error:
+        except OSError:
             pass
 
     def tearDown(self):

--- a/com/win32com/test/testxslt.py
+++ b/com/win32com/test/testxslt.py
@@ -26,7 +26,7 @@ class XSLT(win32com.test.util.TestCase):
         finally:
             try:
                 os.unlink(output_name)
-            except os.error:
+            except OSError:
                 pass
 
 

--- a/com/win32com/test/util.py
+++ b/com/win32com/test/util.py
@@ -45,7 +45,7 @@ def RegisterPythonServer(filename, progids=None, verbose=0):
                 HKCR = winreg.HKEY_CLASSES_ROOT
                 hk = winreg.OpenKey(HKCR, "CLSID\\%s" % clsid)
                 dll = winreg.QueryValue(hk, "InprocServer32")
-            except WindowsError:
+            except OSError:
                 # no CLSID or InProcServer32 - not registered
                 break
             ok_files = [

--- a/com/win32comext/axdebug/Test/host.py
+++ b/com/win32comext/axdebug/Test/host.py
@@ -58,7 +58,7 @@ class PySourceModuleDebugDocumentHost(gateways.DebugDocumentHost):
         if self.codeContainer is None:
             try:
                 codeText = open(self.module.__file__, "rt").read()
-            except IOError as details:
+            except OSError as details:
                 codeText = "# Exception opening file\n# %s" % (details)
 
             self.codeContainer = codecontainer.SourceCodeContainer(

--- a/com/win32comext/axdebug/codecontainer.py
+++ b/com/win32comext/axdebug/codecontainer.py
@@ -225,7 +225,7 @@ class SourceModuleContainer(SourceCodeContainer):
             if fname:
                 try:
                     self.text = open(fname, "r").read()
-                except IOError as details:
+                except OSError as details:
                     self.text = "# Exception opening file\n# %s" % (repr(details))
             else:
                 self.text = "# No file available for module '%s'" % (self.module)

--- a/com/win32comext/ifilter/demo/filterDemo.py
+++ b/com/win32comext/ifilter/demo/filterDemo.py
@@ -220,7 +220,7 @@ class FileParser:
             ret = " ".join([str(arg) for arg in args])
             try:
                 print(ret)
-            except IOError:
+            except OSError:
                 pass
 
 

--- a/com/win32comext/shell/demos/servers/column_provider.py
+++ b/com/win32comext/shell/demos/servers/column_provider.py
@@ -108,7 +108,7 @@ def DllUnregisterServer():
             winreg.HKEY_CLASSES_ROOT,
             "Folder\\ShellEx\\ColumnHandlers\\" + str(ColumnProvider._reg_clsid_),
         )
-    except WindowsError as details:
+    except OSError as details:
         import errno
 
         if details.errno != errno.ENOENT:

--- a/com/win32comext/shell/demos/servers/context_menu.py
+++ b/com/win32comext/shell/demos/servers/context_menu.py
@@ -104,7 +104,7 @@ def DllUnregisterServer():
             winreg.HKEY_CLASSES_ROOT,
             "Python.File\\shellex\\ContextMenuHandlers\\PythonSample",
         )
-    except WindowsError as details:
+    except OSError as details:
         import errno
 
         if details.errno != errno.ENOENT:

--- a/com/win32comext/shell/demos/servers/copy_hook.py
+++ b/com/win32comext/shell/demos/servers/copy_hook.py
@@ -55,7 +55,7 @@ def DllUnregisterServer():
             winreg.HKEY_CLASSES_ROOT,
             "directory\\shellex\\CopyHookHandlers\\" + ShellExtension._reg_desc_,
         )
-    except WindowsError as details:
+    except OSError as details:
         import errno
 
         if details.errno != errno.ENOENT:
@@ -65,7 +65,7 @@ def DllUnregisterServer():
             winreg.HKEY_CLASSES_ROOT,
             "*\\shellex\\CopyHookHandlers\\" + ShellExtension._reg_desc_,
         )
-    except WindowsError as details:
+    except OSError as details:
         import errno
 
         if details.errno != errno.ENOENT:

--- a/com/win32comext/shell/demos/servers/empty_volume_cache.py
+++ b/com/win32comext/shell/demos/servers/empty_volume_cache.py
@@ -170,7 +170,7 @@ def DllUnregisterServer():
     )
     try:
         key = winreg.DeleteKey(winreg.HKEY_LOCAL_MACHINE, kn)
-    except WindowsError as details:
+    except OSError as details:
         import errno
 
         if details.errno != errno.ENOENT:

--- a/com/win32comext/shell/demos/servers/folder_view.py
+++ b/com/win32comext/shell/demos/servers/folder_view.py
@@ -840,7 +840,7 @@ def DllUnregisterServer():
     for path in paths:
         try:
             winreg.DeleteKey(winreg.HKEY_LOCAL_MACHINE, path)
-        except WindowsError as details:
+        except OSError as details:
             import errno
 
             if details.errno != errno.ENOENT:

--- a/com/win32comext/shell/demos/servers/icon_handler.py
+++ b/com/win32comext/shell/demos/servers/icon_handler.py
@@ -64,7 +64,7 @@ def DllUnregisterServer():
         key = winreg.DeleteKey(
             winreg.HKEY_CLASSES_ROOT, "Python.File\\shellex\\IconHandler"
         )
-    except WindowsError as details:
+    except OSError as details:
         import errno
 
         if details.errno != errno.ENOENT:

--- a/com/win32comext/shell/demos/servers/shell_view.py
+++ b/com/win32comext/shell/demos/servers/shell_view.py
@@ -953,7 +953,7 @@ def DllUnregisterServer():
             "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\"
             "Explorer\\Desktop\\Namespace\\" + ShellFolderRoot._reg_clsid_,
         )
-    except WindowsError as details:
+    except OSError as details:
         import errno
 
         if details.errno != errno.ENOENT:

--- a/isapi/__init__.py
+++ b/isapi/__init__.py
@@ -4,7 +4,7 @@
 # Exceptions thrown by the DLL framework.
 class ISAPIError(Exception):
     def __init__(self, errno, strerror=None, funcname=None):
-        # named attributes match IOError etc.
+        # named attributes match OSError etc.
         self.errno = errno
         self.strerror = strerror
         self.funcname = funcname

--- a/isapi/install.py
+++ b/isapi/install.py
@@ -516,7 +516,7 @@ def CheckLoaderModule(dll_name):
     src_stat = os.stat(template)
     try:
         dest_stat = os.stat(dll_name)
-    except os.error:
+    except OSError:
         same = 0
     else:
         same = (

--- a/pywin32_postinstall.py
+++ b/pywin32_postinstall.py
@@ -27,7 +27,7 @@ class Tee:
         if self.f is not None:
             try:
                 self.f.write(what.replace("\n", "\r\n"))
-            except IOError:
+            except OSError:
                 pass
         tee_f.write(what)
 
@@ -35,7 +35,7 @@ class Tee:
         if self.f is not None:
             try:
                 self.f.flush()
-            except IOError:
+            except OSError:
                 pass
         tee_f.flush()
 
@@ -399,7 +399,7 @@ def fixup_dbi():
                     os.rename(this_pyd, this_dest)
                     print("renamed '%s'->'%s.old'" % (this_pyd, this_pyd))
                     file_created(this_pyd + ".old")
-            except os.error as exc:
+            except OSError as exc:
                 print("FAILED to rename '%s': %s" % (this_pyd, exc))
 
 
@@ -423,11 +423,11 @@ def install(lib_dir):
         for root in winreg.HKEY_LOCAL_MACHINE, winreg.HKEY_CURRENT_USER:
             try:
                 winreg.DeleteKey(root, keyname + "\\Debug")
-            except WindowsError:
+            except OSError:
                 pass
             try:
                 winreg.DeleteKey(root, keyname)
-            except WindowsError:
+            except OSError:
                 pass
     LoadSystemModule(lib_dir, "pywintypes")
     LoadSystemModule(lib_dir, "pythoncom")
@@ -635,11 +635,11 @@ def uninstall(lib_dir):
         # The dbi.pyd.old files we may have created.
         try:
             os.remove(os.path.join(lib_dir, "win32", "dbi.pyd.old"))
-        except os.error:
+        except OSError:
             pass
         try:
             os.remove(os.path.join(lib_dir, "win32", "dbi_d.pyd.old"))
-        except os.error:
+        except OSError:
             pass
 
     except Exception as why:
@@ -764,7 +764,7 @@ def main():
     if args.wait is not None:
         try:
             os.waitpid(args.wait, 0)
-        except os.error:
+        except OSError:
             # child already dead
             pass
 

--- a/setup.py
+++ b/setup.py
@@ -306,7 +306,7 @@ class WinExt_win32com_mapi(WinExt_win32com):
                 if type_id == winreg.REG_SZ:
                     sdk_install_dir = value
                     break
-            except WindowsError:
+            except OSError:
                 pass
         if sdk_install_dir is not None:
             d = os.path.join(sdk_install_dir, "SDK", "Include")
@@ -368,7 +368,7 @@ class my_build(build):
             f = open(ver_fname, "w")
             f.write("%s\n" % build_id)
             f.close()
-        except EnvironmentError as why:
+        except OSError as why:
             print("Failed to open '%s': %s" % (ver_fname, why))
 
 

--- a/win32/Demos/winprocess.py
+++ b/win32/Demos/winprocess.py
@@ -179,7 +179,7 @@ def run(cmd, mSec=None, stdin=None, stdout=None, stderr=None, **kw):
     child = Process(cmd, **kw)
     if child.wait(mSec) != win32event.WAIT_OBJECT_0:
         child.kill()
-        raise WindowsError("process timeout exceeded")
+        raise OSError("process timeout exceeded")
     return child.exitCode()
 
 
@@ -226,5 +226,5 @@ _this_is_a_test_of_stderr_\r
         for n in (cmd_name, out_name):
             try:
                 os.unlink(cmd_name)
-            except os.error:
+            except OSError:
                 pass

--- a/win32/Lib/regcheck.py
+++ b/win32/Lib/regcheck.py
@@ -23,8 +23,7 @@ def CheckRegisteredExe(exename):
                 regutil.GetRootKey(), regutil.GetAppPathsKey() + "\\" + exename
             )
         )
-    # 	except SystemError:
-    except (os.error, win32api.error):
+    except (OSError, win32api.error):
         print("Registration of %s - Not registered correctly" % exename)
 
 
@@ -115,7 +114,7 @@ def CheckHelpFiles(verbose):
                     os.stat(helpFile)
                     if verbose:
                         print(helpFile)
-                except os.error:
+                except OSError:
                     print("** Help file %s does not exist" % helpFile)
                 keyNo = keyNo + 1
             except win32api.error as exc:

--- a/win32/Lib/regutil.py
+++ b/win32/Lib/regutil.py
@@ -151,7 +151,7 @@ def RegisterModule(modName, modPath):
         import os
 
         os.stat(modPath)
-    except os.error:
+    except OSError:
         print("Warning: Registering non-existant module %s" % modPath)
     win32api.RegSetValue(
         GetRootKey(),
@@ -209,7 +209,7 @@ def RegisterHelpFile(helpFile, helpPath, helpDesc=None, bCheckFile=1):
     try:
         if bCheckFile:
             os.stat(fullHelpFile)
-    except os.error:
+    except OSError:
         raise ValueError("Help file does not exist")
     # Now register with Python itself.
     win32api.RegSetValue(
@@ -269,7 +269,7 @@ def RegisterCoreDLL(coredllName=None):
     else:
         try:
             os.stat(coredllName)
-        except os.error:
+        except OSError:
             print("Warning: Registering non-existant core DLL %s" % coredllName)
 
     hKey = win32api.RegCreateKey(GetRootKey(), BuildDefaultPythonKey())

--- a/win32/Lib/win32rcparser.py
+++ b/win32/Lib/win32rcparser.py
@@ -590,12 +590,12 @@ def Parse(rc_name, h_name=None):
         h_name = rc_name[:-2] + "h"
         try:
             h_file = open(h_name, "r")
-        except IOError:
+        except OSError:
             # See if MSVC default of 'resource.h' in the same dir.
             h_name = os.path.join(os.path.dirname(rc_name), "resource.h")
             try:
                 h_file = open(h_name, "r")
-            except IOError:
+            except OSError:
                 # .h files are optional anyway
                 h_file = None
     rc_file = open(rc_name, "r")

--- a/win32/Lib/win32serviceutil.py
+++ b/win32/Lib/win32serviceutil.py
@@ -1027,7 +1027,7 @@ class ServiceFramework:
     def SvcOther(self, control):
         try:
             print("Unknown control status - %d" % control)
-        except IOError:
+        except OSError:
             # services may not have a valid stdout!
             pass
 

--- a/win32/Lib/win32timezone.py
+++ b/win32/Lib/win32timezone.py
@@ -568,7 +568,7 @@ class TimeZoneInfo(datetime.tzinfo):
         """
         try:
             info = key.subkey("Dynamic DST")
-        except WindowsError:
+        except OSError:
             return
         del info["FirstEntry"]
         del info["LastEntry"]
@@ -824,7 +824,7 @@ class _RegKeyDict(dict):
         try:
             for index in count():
                 yield func(key, index)
-        except WindowsError:
+        except OSError:
             pass
 
 

--- a/win32/Lib/win32verstamp.py
+++ b/win32/Lib/win32verstamp.py
@@ -126,7 +126,7 @@ def stamp(pathname, options):
     try:
         f = open(pathname, "a+b")
         f.close()
-    except IOError as why:
+    except OSError as why:
         print("WARNING: File %s could not be opened - %s" % (pathname, why))
 
     ver = options.version

--- a/win32/scripts/VersionStamp/BrandProject.py
+++ b/win32/scripts/VersionStamp/BrandProject.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
     path = args[2]
     try:
         os.stat(descFile)
-    except IOError:
+    except OSError:
         usage("The description file '%s' can not be found" % (descFile))
     if not os.path.isdir(path):
         usage("The path to the files to stamp '%s' does not exist" % (path))

--- a/win32/scripts/backupEventLog.py
+++ b/win32/scripts/backupEventLog.py
@@ -21,7 +21,7 @@ def BackupClearLog(logType):
                 "%s%s-%s" % (datePrefix, index, logType) + ".evt",
             )
             os.stat(fname)
-        except os.error:
+        except OSError:
             fileExists = 0
         retry = retry + 1
     # OK - have unique file name.

--- a/win32/scripts/regsetup.py
+++ b/win32/scripts/regsetup.py
@@ -15,7 +15,7 @@ def FileExists(fname):
     try:
         os.stat(fname)
         return 1
-    except os.error as details:
+    except OSError as details:
         return 0
 
 
@@ -192,7 +192,7 @@ def LocateFileName(fileNamesString, searchPaths):
                 retPath = os.path.join(path, fileName)
                 os.stat(retPath)
                 break
-            except os.error:
+            except OSError:
                 retPath = None
         if retPath:
             break

--- a/win32/test/handles.py
+++ b/win32/test/handles.py
@@ -27,16 +27,16 @@ class PyHandleTestCase(unittest.TestCase):
             # this case
 
         def f2(invalidate):
-            """This function should throw an IOError."""
+            """This function should throw an OSError."""
             try:
                 f1(invalidate)
             except ZeroDivisionError as exc:
-                raise IOError("raise 2")
+                raise OSError("raise 2")
 
-        self.assertRaises(IOError, f2, False)
+        self.assertRaises(OSError, f2, False)
         # Now do it again, but so the auto object destruction
         # actually fails.
-        self.assertRaises(IOError, f2, True)
+        self.assertRaises(OSError, f2, True)
 
     def testCleanup2(self):
         # Cause an exception during object destruction.

--- a/win32/test/test_win32file.py
+++ b/win32/test/test_win32file.py
@@ -65,7 +65,7 @@ class TestSimpleOps(unittest.TestCase):
             handle.Close()
             try:
                 os.unlink(filename)
-            except os.error:
+            except OSError:
                 pass
 
     # A simple test using normal read/write operations.
@@ -573,7 +573,7 @@ class TestFindFiles(unittest.TestCase):
             # reference count leaks, that function showed leaks!  os.rmdir
             # doesn't have that problem.
             os.rmdir(test_path)
-        except os.error:
+        except OSError:
             pass
         os.mkdir(test_path)
         try:
@@ -863,7 +863,7 @@ class TestTransmit(unittest.TestCase):
                 try:
                     s1.bind(self.addr)
                     break
-                except os.error as exc:
+                except OSError as exc:
                     if exc.winerror != 10013:
                         raise
                     print("Failed to use port", self.addr, "trying another random one")
@@ -1013,7 +1013,7 @@ class TestWSAEnumNetworkEvents(unittest.TestCase):
         while sent < 16 * 1024 * 1024:
             try:
                 sent += client.send(data)
-            except socket.error as e:
+            except OSError as e:
                 if e.args[0] == win32file.WSAEINTR:
                     continue
                 elif e.args[0] in (win32file.WSAEWOULDBLOCK, win32file.WSAENOBUFS):
@@ -1035,7 +1035,7 @@ class TestWSAEnumNetworkEvents(unittest.TestCase):
         while received < sent:
             try:
                 received += len(server.recv(16 * 1024))
-            except socket.error as e:
+            except OSError as e:
                 if e.args[0] in [win32file.WSAEINTR, win32file.WSAEWOULDBLOCK]:
                     continue
                 else:


### PR DESCRIPTION
Missed in #2087 , Extracted from #2100
Documentation: https://docs.python.org/3/library/exceptions.html#OSError

This PR updates all of the following to `OSError`:
- `IOError`
- `WindowsError`
- `mmap.error`
- `select.error`
- `socket.error`
- `os.error`

Except for adodbapi code, that's done in #2088