### PR TITLE
Update collection literals and comprehensions

### DIFF
--- a/com/win32com/test/testShell.py
+++ b/com/win32com/test/testShell.py
@@ -137,8 +137,8 @@ class FILEGROUPDESCRIPTORTester(win32com.test.util.TestCase):
         fgd = shell.FILEGROUPDESCRIPTORAsString([], make_unicode)
         header = struct.pack("i", 0)
         self.assertEqual(header, fgd[: len(header)])
-        self._testRT(dict())
-        d = dict()
+        self._testRT({})
+        d = {}
         fgd = shell.FILEGROUPDESCRIPTORAsString([d], make_unicode)
         header = struct.pack("i", 1)
         self.assertEqual(header, fgd[: len(header)])
@@ -153,53 +153,53 @@ class FILEGROUPDESCRIPTORTester(win32com.test.util.TestCase):
     def testComplex(self):
         clsid = pythoncom.MakeIID("{CD637886-DB8B-4b04-98B5-25731E1495BE}")
         ctime, atime, wtime = self._getTestTimes()
-        d = dict(
-            cFileName="foo.txt",
-            clsid=clsid,
-            sizel=(1, 2),
-            pointl=(3, 4),
-            dwFileAttributes=win32con.FILE_ATTRIBUTE_NORMAL,
-            ftCreationTime=ctime,
-            ftLastAccessTime=atime,
-            ftLastWriteTime=wtime,
-            nFileSize=sys.maxsize + 1,
-        )
+        d = {
+            "cFileName": "foo.txt",
+            "clsid": clsid,
+            "sizel": (1, 2),
+            "pointl": (3, 4),
+            "dwFileAttributes": win32con.FILE_ATTRIBUTE_NORMAL,
+            "ftCreationTime": ctime,
+            "ftLastAccessTime": atime,
+            "ftLastWriteTime": wtime,
+            "nFileSize": sys.maxsize + 1,
+        }
         self._testRT(d)
 
     def testUnicode(self):
         # exercise a bug fixed in build 210 - multiple unicode objects failed.
         ctime, atime, wtime = self._getTestTimes()
         d = [
-            dict(
-                cFileName="foo.txt",
-                sizel=(1, 2),
-                pointl=(3, 4),
-                dwFileAttributes=win32con.FILE_ATTRIBUTE_NORMAL,
-                ftCreationTime=ctime,
-                ftLastAccessTime=atime,
-                ftLastWriteTime=wtime,
-                nFileSize=sys.maxsize + 1,
-            ),
-            dict(
-                cFileName="foo2.txt",
-                sizel=(1, 2),
-                pointl=(3, 4),
-                dwFileAttributes=win32con.FILE_ATTRIBUTE_NORMAL,
-                ftCreationTime=ctime,
-                ftLastAccessTime=atime,
-                ftLastWriteTime=wtime,
-                nFileSize=sys.maxsize + 1,
-            ),
-            dict(
-                cFileName="foo\xa9.txt",
-                sizel=(1, 2),
-                pointl=(3, 4),
-                dwFileAttributes=win32con.FILE_ATTRIBUTE_NORMAL,
-                ftCreationTime=ctime,
-                ftLastAccessTime=atime,
-                ftLastWriteTime=wtime,
-                nFileSize=sys.maxsize + 1,
-            ),
+            {
+                "cFileName": "foo.txt",
+                "sizel": (1, 2),
+                "pointl": (3, 4),
+                "dwFileAttributes": win32con.FILE_ATTRIBUTE_NORMAL,
+                "ftCreationTime": ctime,
+                "ftLastAccessTime": atime,
+                "ftLastWriteTime": wtime,
+                "nFileSize": sys.maxsize + 1,
+            },
+            {
+                "cFileName": "foo2.txt",
+                "sizel": (1, 2),
+                "pointl": (3, 4),
+                "dwFileAttributes": win32con.FILE_ATTRIBUTE_NORMAL,
+                "ftCreationTime": ctime,
+                "ftLastAccessTime": atime,
+                "ftLastWriteTime": wtime,
+                "nFileSize": sys.maxsize + 1,
+            },
+            {
+                "cFileName": "foo\xa9.txt",
+                "sizel": (1, 2),
+                "pointl": (3, 4),
+                "dwFileAttributes": win32con.FILE_ATTRIBUTE_NORMAL,
+                "ftCreationTime": ctime,
+                "ftLastAccessTime": atime,
+                "ftLastWriteTime": wtime,
+                "nFileSize": sys.maxsize + 1,
+            },
         ]
         s = shell.FILEGROUPDESCRIPTORAsString(d, 1)
         d2 = shell.StringAsFILEGROUPDESCRIPTOR(s)

--- a/com/win32comext/axdebug/expressions.py
+++ b/com/win32comext/axdebug/expressions.py
@@ -65,7 +65,7 @@ class Expression(gateways.DebugExpression):
                     sys.exc_info()[0], sys.exc_info()[1]
                 )
                 # l is a list of strings with trailing "\n"
-                self.result = string.join(map(lambda s: s[:-1], l), "\n")
+                self.result = string.join((s[:-1] for s in l), "\n")
                 self.hresult = winerror.E_FAIL
         finally:
             self.isComplete = 1

--- a/com/win32comext/bits/test/show_all_jobs.py
+++ b/com/win32comext/bits/test/show_all_jobs.py
@@ -2,21 +2,17 @@
 import pythoncom
 from win32com.bits import bits
 
-states = dict(
-    [
-        (val, (name[13:]))
-        for name, val in vars(bits).items()
-        if name.startswith("BG_JOB_STATE_")
-    ]
-)
+states = {
+    val: name[13:]
+    for name, val in vars(bits).items()
+    if name.startswith("BG_JOB_STATE_")
+}
 
-job_types = dict(
-    [
-        (val, (name[12:]))
-        for name, val in vars(bits).items()
-        if name.startswith("BG_JOB_TYPE_")
-    ]
-)
+job_types = {
+    val: name[12:]
+    for name, val in vars(bits).items()
+    if name.startswith("BG_JOB_TYPE_")
+}
 
 bcm = pythoncom.CoCreateInstance(
     bits.CLSID_BackgroundCopyManager,

--- a/com/win32comext/bits/test/test_bits.py
+++ b/com/win32comext/bits/test/test_bits.py
@@ -11,13 +11,11 @@ TIMEOUT = 200  # ms
 StopEvent = win32event.CreateEvent(None, 0, 0, None)
 
 job_name = "bits-pywin32-test"
-states = dict(
-    [
-        (val, (name[13:]))
-        for name, val in vars(bits).items()
-        if name.startswith("BG_JOB_STATE_")
-    ]
-)
+states = {
+    val: (name[13:])
+    for name, val in vars(bits).items()
+    if name.startswith("BG_JOB_STATE_")
+}
 
 bcm = pythoncom.CoCreateInstance(
     bits.CLSID_BackgroundCopyManager,

--- a/com/win32comext/shell/demos/IFileOperationProgressSink.py
+++ b/com/win32comext/shell/demos/IFileOperationProgressSink.py
@@ -5,9 +5,7 @@ import pythoncom
 from win32com.server.policy import DesignatedWrapPolicy
 from win32com.shell import shell, shellcon
 
-tsf_flags = list(
-    (k, v) for k, v in list(shellcon.__dict__.items()) if k.startswith("TSF_")
-)
+tsf_flags = [(k, v) for k, v in list(shellcon.__dict__.items()) if k.startswith("TSF_")]
 
 
 def decode_flags(flags):

--- a/com/win32comext/shell/demos/ITransferAdviseSink.py
+++ b/com/win32comext/shell/demos/ITransferAdviseSink.py
@@ -4,9 +4,7 @@ import pythoncom
 from win32com.server.policy import DesignatedWrapPolicy
 from win32com.shell import shell, shellcon
 
-tsf_flags = list(
-    (k, v) for k, v in list(shellcon.__dict__.items()) if k.startswith("TSF_")
-)
+tsf_flags = [(k, v) for k, v in list(shellcon.__dict__.items()) if k.startswith("TSF_")]
 
 TRANSFER_ADVISE_STATES = {}
 for k, v in list(shellcon.__dict__.items()):

--- a/com/win32comext/shell/demos/servers/folder_view.py
+++ b/com/win32comext/shell/demos/servers/folder_view.py
@@ -150,9 +150,13 @@ def make_item_enum(level, flags):
             else:
                 skip = not (flags & shellcon.SHCONTF_NONFOLDERS)
         if not skip:
-            data = dict(
-                name=name, size=size, sides=sides, level=level, is_folder=is_folder
-            )
+            data = {
+                "name": name,
+                "size": size,
+                "sides": sides,
+                "level": level,
+                "is_folder": is_folder,
+            }
             pidls.append([pickle.dumps(data)])
     return NewEnum(pidls, shell.IID_IEnumIDList)
 

--- a/win32/Lib/win32timezone.py
+++ b/win32/Lib/win32timezone.py
@@ -578,7 +578,7 @@ class TimeZoneInfo(datetime.tzinfo):
         # if the target year is greater or equal.
         self.dynamicInfo = RangeMap(
             zip(years, values),
-            sort_params=dict(reverse=True),
+            sort_params={"reverse": True},
             key_match_comparator=operator.ge,
         )
 
@@ -967,7 +967,7 @@ class RangeMap(dict):
         self.match = key_match_comparator
 
     def __getitem__(self, item):
-        sorted_keys = sorted(list(self.keys()), **self.sort_params)
+        sorted_keys = sorted(self.keys(), **self.sort_params)
         if isinstance(item, RangeMap.Item):
             result = self.__getitem__(sorted_keys[item])
         else:
@@ -998,7 +998,7 @@ class RangeMap(dict):
         raise KeyError(item)
 
     def bounds(self):
-        sorted_keys = sorted(list(self.keys()), **self.sort_params)
+        sorted_keys = sorted(self.keys(), **self.sort_params)
         return (
             sorted_keys[RangeMap.first_item],
             sorted_keys[RangeMap.last_item],

--- a/win32/test/handles.py
+++ b/win32/test/handles.py
@@ -100,12 +100,12 @@ class PyHandleTestCase(unittest.TestCase):
 
     def testHandleInDict(self):
         h = pywintypes.HANDLE(1)
-        d = dict(foo=h)
+        d = {"foo": h}
         self.assertEqual(d["foo"], h)
 
     def testHandleInDictThenInt(self):
         h = pywintypes.HANDLE(1)
-        d = dict(foo=h)
+        d = {"foo": h}
         self.assertEqual(d["foo"], 1)
 
     def testHandleCompareNone(self):

--- a/win32/test/test_pywintypes.py
+++ b/win32/test/test_pywintypes.py
@@ -103,7 +103,7 @@ class TestCase(unittest.TestCase):
     def testGUIDInDict(self):
         s = "{00020400-0000-0000-C000-000000000046}"
         iid = pywintypes.IID(s)
-        d = dict(item=iid)
+        d = {"item": iid}
         self.assertEqual(d["item"], iid)
 
 

--- a/win32/test/test_security.py
+++ b/win32/test/test_security.py
@@ -46,7 +46,7 @@ class SecurityTests(unittest.TestCase):
         self.assertNotEqual(None, self.pwr_sid)
 
     def testSIDInDict(self):
-        d = dict(foo=self.pwr_sid)
+        d = {"foo": self.pwr_sid}
         self.assertEqual(d["foo"], self.pwr_sid)
 
     def testBuffer(self):

--- a/win32/test/test_win32guistruct.py
+++ b/win32/test/test_win32guistruct.py
@@ -9,7 +9,7 @@ import win32gui_struct
 
 class TestBase(unittest.TestCase):
     def assertDictEquals(self, d, **kw):
-        checked = dict()
+        checked = {}
         for n, v in kw.items():
             self.assertEqual(v, d[n], "'%s' doesn't match: %r != %r" % (n, v, d[n]))
             checked[n] = True
@@ -22,17 +22,17 @@ class TestBase(unittest.TestCase):
 
 class TestMenuItemInfo(TestBase):
     def _testPackUnpack(self, text):
-        vals = dict(
-            fType=win32con.MFT_MENUBARBREAK,
-            fState=win32con.MFS_CHECKED,
-            wID=123,
-            hSubMenu=1234,
-            hbmpChecked=12345,
-            hbmpUnchecked=123456,
-            dwItemData=1234567,
-            text=text,
-            hbmpItem=321,
-        )
+        vals = {
+            "fType": win32con.MFT_MENUBARBREAK,
+            "fState": win32con.MFS_CHECKED,
+            "wID": 123,
+            "hSubMenu": 1234,
+            "hbmpChecked": 12345,
+            "hbmpUnchecked": 123456,
+            "dwItemData": 1234567,
+            "text": text,
+            "hbmpItem": 321,
+        }
         mii, extras = win32gui_struct.PackMENUITEMINFO(**vals)
         (
             fType,
@@ -94,7 +94,13 @@ class TestMenuItemInfo(TestBase):
 
 class TestMenuInfo(TestBase):
     def testPackUnpack(self):
-        vals = dict(dwStyle=1, cyMax=2, hbrBack=3, dwContextHelpID=4, dwMenuData=5)
+        vals = {
+            "dwStyle": 1,
+            "cyMax": 2,
+            "hbrBack": 3,
+            "dwContextHelpID": 4,
+            "dwMenuData": 5,
+        }
 
         mi = win32gui_struct.PackMENUINFO(**vals)
         (
@@ -132,16 +138,16 @@ class TestMenuInfo(TestBase):
 
 class TestTreeViewItem(TestBase):
     def _testPackUnpack(self, text):
-        vals = dict(
-            hitem=1,
-            state=2,
-            stateMask=3,
-            text=text,
-            image=4,
-            selimage=5,
-            citems=6,
-            param=7,
-        )
+        vals = {
+            "hitem": 1,
+            "state": 2,
+            "stateMask": 3,
+            "text": text,
+            "image": 4,
+            "selimage": 5,
+            "citems": 6,
+            "param": 7,
+        }
 
         ti, extra = win32gui_struct.PackTVITEM(**vals)
         (
@@ -197,16 +203,16 @@ class TestTreeViewItem(TestBase):
 
 class TestListViewItem(TestBase):
     def _testPackUnpack(self, text):
-        vals = dict(
-            item=None,
-            subItem=None,
-            state=1,
-            stateMask=2,
-            text=text,
-            image=3,
-            param=4,
-            indent=5,
-        )
+        vals = {
+            "item": None,
+            "subItem": None,
+            "state": 1,
+            "stateMask": 2,
+            "text": text,
+            "image": 3,
+            "param": 4,
+            "indent": 5,
+        }
 
         ti, extra = win32gui_struct.PackLVITEM(**vals)
         (
@@ -265,7 +271,7 @@ class TestListViewItem(TestBase):
 
 class TestLVColumn(TestBase):
     def _testPackUnpack(self, text):
-        vals = dict(fmt=1, cx=2, text=text, subItem=3, image=4, order=5)
+        vals = {"fmt": 1, "cx": 2, "text": text, "subItem": 3, "image": 4, "order": 5}
 
         ti, extra = win32gui_struct.PackLVCOLUMN(**vals)
         fmt, cx, text, subItem, image, order = win32gui_struct.UnpackLVCOLUMN(ti)

--- a/win32/test/test_win32inet.py
+++ b/win32/test/test_win32inet.py
@@ -12,7 +12,7 @@ class CookieTests(unittest.TestCase):
         InternetSetCookie("http://www.python.org", None, data)
         got = InternetGetCookie("http://www.python.org", None)
         # handle that there might already be cookies for the domain.
-        bits = map(lambda x: x.strip(), got.split(";"))
+        bits = (x.strip() for x in got.split(";"))
         self.assertTrue(data in bits)
 
     def testCookiesEmpty(self):


### PR DESCRIPTION
Extracted from, and improved over #2100
These were found by running `ruff . --select=C4 --exclude=build --exclude=Pythonwin/Scintilla --exclude=adodbapi`
Documentation: https://beta.ruff.rs/docs/rules/#flake8-comprehensions-c4

This PR uses more modern collection literals and comprehensions where applicable. There's some expected performance gains here from the use of comprehensions and less function call overhead. On top of often more concise syntax