### PR TITLE
Update unicode strings in comments

### DIFF
--- a/com/win32com/test/testStorage.py
+++ b/com/win32com/test/testStorage.py
@@ -14,7 +14,7 @@ class TestEnum(win32com.test.util.TestCase):
         pss = pythoncom.StgOpenStorageEx(
             fname, m, storagecon.STGFMT_FILE, 0, pythoncom.IID_IPropertySetStorage
         )
-        ###                               {"Version":2,"reserved":0,"SectorSize":512,"TemplateFile":u'somefilename'})
+        ###                               {"Version":2,"reserved":0,"SectorSize":512,"TemplateFile":'somefilename'})
 
         ## FMTID_SummaryInformation FMTID_DocSummaryInformation FMTID_UserDefinedProperties
         psuser = pss.Create(

--- a/win32/Demos/security/sspi/simple_auth.py
+++ b/win32/Demos/security/sspi/simple_auth.py
@@ -18,7 +18,7 @@ def lookup_ret_code(err):
 pkg_name='Kerberos'
 sspiclient=SSPIClient(pkg_name, win32api.GetUserName(),  ## target spn is ourself
     None, None,   ## use none for client name and authentication information for current context
-    ## u'username', (u'username',u'domain.com',u'passwd'),
+    ## 'username', ('username','domain.com','passwd'),
     sspicon.ISC_REQ_INTEGRITY|sspicon.ISC_REQ_SEQUENCE_DETECT|sspicon.ISC_REQ_REPLAY_DETECT|    \
         sspicon.ISC_REQ_DELEGATE|sspicon.ISC_REQ_CONFIDENTIALITY|sspicon.ISC_REQ_USE_SESSION_KEY)
 sspiserver=SSPIServer(pkg_name, None,

--- a/win32/Lib/win32timezone.py
+++ b/win32/Lib/win32timezone.py
@@ -144,7 +144,7 @@ True
 True
 
 This test helps ensure language support for unicode characters
->>> x = TIME_ZONE_INFORMATION(0, u'français')
+>>> x = TIME_ZONE_INFORMATION(0, 'français')
 
 
 Test conversion from one time zone to another at a DST boundary


### PR DESCRIPTION
This was missed in #1990, #2085, and #2100 because they are found in comments, not actual code.