### PR TITLE
Replace usages of the deprecated (removed in Python 3.12) `imp` module

### DIFF
--- a/com/win32comext/axscript/client/pyscript.py
+++ b/com/win32comext/axscript/client/pyscript.py
@@ -8,6 +8,7 @@ command line.
 """
 
 import re
+import types
 
 import pythoncom
 import win32api
@@ -210,10 +211,9 @@ class PyScript(framework.COMScript):
 
     def InitNew(self):
         framework.COMScript.InitNew(self)
-        import imp
 
         self.scriptDispatch = None
-        self.globalNameSpaceModule = imp.new_module("__ax_main__")
+        self.globalNameSpaceModule = types.ModuleType("__ax_main__")
         self.globalNameSpaceModule.__dict__["ax"] = AXScriptAttribute(self)
 
         self.codeBlocks = []

--- a/isapi/install.py
+++ b/isapi/install.py
@@ -2,7 +2,7 @@
 
 # this code adapted from "Tomcat JK2 ISAPI redirector", part of Apache
 # Created July 2004, Mark Hammond.
-import imp
+import importlib.machinery
 import os
 import shutil
 import stat
@@ -39,7 +39,7 @@ _DEFAULT_CONTENT_INDEXED = False
 _DEFAULT_ENABLE_DIR_BROWSING = False
 _DEFAULT_ENABLE_DEFAULT_DOC = False
 
-_extensions = [ext for ext, _, _ in imp.get_suffixes()]
+_extensions = [ext for ext, _, _ in importlib.machinery.EXTENSION_SUFFIXES]
 is_debug_build = "_d.pyd" in _extensions
 
 this_dir = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Closes #2104
Changes based on similar changes in https://github.com/mhammond/pywin32/commit/201db642fc8dc1b2871da626f0865ee37110e262 / #1537

https://docs.python.org/3/library/imp.html
> Deprecated since version 3.4, will be removed in version 3.12: The [imp](https://docs.python.org/3/library/imp.html#module-imp) module is deprecated in favor of [importlib](https://docs.python.org/3/library/importlib.html#module-importlib).