### PR TITLE
Redundant open modes

### DIFF
--- a/AutoDuck/Dump2HHC.py
+++ b/AutoDuck/Dump2HHC.py
@@ -465,7 +465,7 @@ def main():
     cats = parseCategories()
     for cat in cats:
         file = os.path.join(gen_dir, cat.dump_file)
-        input = open(file, "r")
+        input = open(file)
         parseTopics(cat, input)
         input.close()
 

--- a/AutoDuck/InsertExternalOverviews.py
+++ b/AutoDuck/InsertExternalOverviews.py
@@ -51,7 +51,7 @@ def main():
         print("Invalid args")
         sys.exit(1)
     file = sys.argv[1]
-    input = open(file, "r")
+    input = open(file)
     out = open(file + ".2", "w")
     doc = document_object.GetDocument()
     linksHTML = genLinksHTML(doc.links)

--- a/AutoDuck/TOCToHHK.py
+++ b/AutoDuck/TOCToHHK.py
@@ -11,7 +11,7 @@ Converts an AutoDuck .IDX file into a HTML Help index file.
 def main():
     file = sys.argv[1]
     output = sys.argv[2]
-    input = open(file, "r")
+    input = open(file)
     out = open(output, "w")
     line = input.readline()
     out.write(

--- a/Pythonwin/pywin/framework/mdi_pychecker.py
+++ b/Pythonwin/pywin/framework/mdi_pychecker.py
@@ -210,7 +210,7 @@ class TheDocument(docview.RichEditDoc):
         # and starting a new grep can communicate the default parameters to the
         # new grep.
         try:
-            params = open(fnm, "r").read()
+            params = open(fnm).read()
         except:
             params = None
         self.setInitParams(params)
@@ -386,7 +386,7 @@ class TheDocument(docview.RichEditDoc):
             if self.verbose:
                 self.GetFirstView().Append("# .." + f + "\n")
             win32ui.SetStatusText("Searching " + f, 0)
-            lines = open(f, "r").readlines()
+            lines = open(f).readlines()
             for i in range(len(lines)):
                 line = lines[i]
                 if self.pat.search(line) is not None:

--- a/Pythonwin/pywin/framework/sgrepmdi.py
+++ b/Pythonwin/pywin/framework/sgrepmdi.py
@@ -191,7 +191,7 @@ class GrepDocument(docview.RichEditDoc):
         # and starting a new grep can communicate the default parameters to the
         # new grep.
         try:
-            params = open(fnm, "r").read()
+            params = open(fnm).read()
         except:
             params = None
         self.setInitParams(params)
@@ -299,7 +299,7 @@ class GrepDocument(docview.RichEditDoc):
             #  while grep is running
             if os.path.isfile(f):
                 win32ui.SetStatusText("Searching " + f, 0)
-                lines = open(f, "r").readlines()
+                lines = open(f).readlines()
                 for i in range(len(lines)):
                     line = lines[i]
                     if self.pat.search(line) is not None:

--- a/com/win32com/client/genpy.py
+++ b/com/win32com/client/genpy.py
@@ -1036,7 +1036,7 @@ class Generator:
         # don't step on each others' toes.
         # Could be a classmethod one day...
         temp_filename = self.get_temp_filename(filename)
-        return open(temp_filename, "wt", encoding=encoding)
+        return open(temp_filename, "w", encoding=encoding)
 
     def finish_writer(self, filename, f, worked):
         f.close()

--- a/com/win32com/client/makepy.py
+++ b/com/win32com/client/makepy.py
@@ -425,7 +425,7 @@ def main():
         path = os.path.dirname(outputName)
         if path != "" and not os.path.exists(path):
             os.makedirs(path)
-        f = open(outputName, "wt", encoding="mbcs")
+        f = open(outputName, "w", encoding="mbcs")
 
     else:
         f = None

--- a/com/win32com/test/util.py
+++ b/com/win32com/test/util.py
@@ -104,7 +104,7 @@ def ExecuteShellCommand(
     output_name = tempfile.mktemp("win32com_test")
     cmd = cmd + ' > "%s" 2>&1' % output_name
     rc = os.system(cmd)
-    output = open(output_name, "r").read().strip()
+    output = open(output_name).read().strip()
     os.remove(output_name)
 
     class Failed(Exception):

--- a/com/win32comext/axdebug/Test/host.py
+++ b/com/win32comext/axdebug/Test/host.py
@@ -57,7 +57,7 @@ class PySourceModuleDebugDocumentHost(gateways.DebugDocumentHost):
     def _GetCodeContainer(self):
         if self.codeContainer is None:
             try:
-                codeText = open(self.module.__file__, "rt").read()
+                codeText = open(self.module.__file__).read()
             except OSError as details:
                 codeText = "# Exception opening file\n# %s" % (details)
 

--- a/com/win32comext/axdebug/codecontainer.py
+++ b/com/win32comext/axdebug/codecontainer.py
@@ -224,7 +224,7 @@ class SourceModuleContainer(SourceCodeContainer):
             fname = self.GetFileName()
             if fname:
                 try:
-                    self.text = open(fname, "r").read()
+                    self.text = open(fname).read()
                 except OSError as details:
                     self.text = "# Exception opening file\n# %s" % (repr(details))
             else:

--- a/win32/Lib/win32rcparser.py
+++ b/win32/Lib/win32rcparser.py
@@ -584,21 +584,21 @@ def ParseStreams(rc_file, h_file):
 
 def Parse(rc_name, h_name=None):
     if h_name:
-        h_file = open(h_name, "r")
+        h_file = open(h_name)
     else:
         # See if same basename as the .rc
         h_name = rc_name[:-2] + "h"
         try:
-            h_file = open(h_name, "r")
+            h_file = open(h_name)
         except OSError:
             # See if MSVC default of 'resource.h' in the same dir.
             h_name = os.path.join(os.path.dirname(rc_name), "resource.h")
             try:
-                h_file = open(h_name, "r")
+                h_file = open(h_name)
             except OSError:
                 # .h files are optional anyway
                 h_file = None
-    rc_file = open(rc_name, "r")
+    rc_file = open(rc_name)
     try:
         return ParseStreams(rc_file, h_file)
     finally:
@@ -617,7 +617,7 @@ def GenerateFrozenResource(rc_name, output_name, h_name=None):
     rcp = Parse(rc_name, h_name)
     in_stat = os.stat(rc_name)
 
-    out = open(output_name, "wt")
+    out = open(output_name, "w")
     out.write("#%s\n" % output_name)
     out.write("#This is a generated file. Please edit %s instead.\n" % rc_name)
     out.write("__version__=%r\n" % __version__)

--- a/win32/scripts/VersionStamp/bulkstamp.py
+++ b/win32/scripts/VersionStamp/bulkstamp.py
@@ -85,7 +85,7 @@ def load_descriptions(fname, vars):
     retvars = {}
     descriptions = {}
 
-    lines = open(fname, "r").readlines()
+    lines = open(fname).readlines()
 
     for i in range(len(lines)):
         line = lines[i].strip()

--- a/win32/scripts/VersionStamp/vssutil.py
+++ b/win32/scripts/VersionStamp/vssutil.py
@@ -56,7 +56,7 @@ def SubstituteInString(inString, evalEnv):
 
 
 def SubstituteInFile(inName, outName, evalEnv):
-    inFile = open(inName, "r")
+    inFile = open(inName)
     try:
         outFile = open(outName, "w")
         try:


### PR DESCRIPTION
From https://github.com/mhammond/pywin32/pull/2100#issuecomment-1730090462
Automated changes ran using `ruff . --select=UP015 --exclude=Pythonwin/Scintilla --fix` (Ruff re-implements pyupgrade and is configurable)
https://docs.astral.sh/ruff/rules/redundant-open-modes/