### PR TITLE
Fix some importlib usages

### DIFF
--- a/isapi/install.py
+++ b/isapi/install.py
@@ -39,9 +39,6 @@ _DEFAULT_CONTENT_INDEXED = False
 _DEFAULT_ENABLE_DIR_BROWSING = False
 _DEFAULT_ENABLE_DEFAULT_DOC = False
 
-_extensions = [ext for ext, _, _ in importlib.machinery.EXTENSION_SUFFIXES]
-is_debug_build = "_d.pyd" in _extensions
-
 this_dir = os.path.abspath(os.path.dirname(__file__))
 
 
@@ -504,9 +501,7 @@ def DeleteExtensionFileRecords(params, options):
 
 
 def CheckLoaderModule(dll_name):
-    suffix = ""
-    if is_debug_build:
-        suffix = "_d"
+    suffix = "_d" if "_d.pyd" in importlib.machinery.EXTENSION_SUFFIXES else ""
     template = os.path.join(this_dir, "PyISAPI_loader" + suffix + ".dll")
     if not os.path.isfile(template):
         raise ConfigurationError("Template loader '%s' does not exist" % (template,))

--- a/win32/Lib/win32serviceutil.py
+++ b/win32/Lib/win32serviceutil.py
@@ -6,7 +6,7 @@
 # when things go wrong - eg, not enough permissions to hit the
 # registry etc.
 
-import importlib
+import importlib.machinery
 import os
 import sys
 import warnings


### PR DESCRIPTION
See https://github.com/python/typeshed/pull/10746#issuecomment-1730371768 as to why importing directly from `importlib` shouldn't be relied on for `importlib.machinery`, `importlib.util` and `importlib.abc`.
Mypy & Pyright (see #2102) will also catch the two issues fixed here.