### PR TITLE
Removed unused imports found by type-checkers

### DIFF
--- a/Pythonwin/pywin/Demos/app/helloapp.py
+++ b/Pythonwin/pywin/Demos/app/helloapp.py
@@ -14,7 +14,7 @@
 
 import win32con
 import win32ui
-from pywin.mfc import afxres, dialog, window
+from pywin.mfc import window
 from pywin.mfc.thread import WinApp
 
 

--- a/Pythonwin/pywin/Demos/dyndlg.py
+++ b/Pythonwin/pywin/Demos/dyndlg.py
@@ -21,7 +21,7 @@
 
 import win32con
 import win32ui
-from pywin.mfc import dialog, window
+from pywin.mfc import dialog
 
 
 def MakeDlgTemplate():

--- a/Pythonwin/pywin/Demos/ocx/msoffice.py
+++ b/Pythonwin/pywin/Demos/ocx/msoffice.py
@@ -4,11 +4,10 @@
 # It is not comlpete yet, but it _does_ show an Excel spreadsheet in a frame!
 #
 
-import regutil
 import win32con
 import win32ui
 import win32uiole
-from pywin.mfc import activex, docview, object, window
+from pywin.mfc import docview, object, window
 from win32com.client import gencache
 
 # WordModule = gencache.EnsureModule('{00020905-0000-0000-C000-000000000046}', 1033, 8, 0)

--- a/Pythonwin/pywin/Demos/threadedgui.py
+++ b/Pythonwin/pywin/Demos/threadedgui.py
@@ -6,7 +6,7 @@ import timer
 import win32api
 import win32con
 import win32ui
-from pywin.mfc import docview, thread, window
+from pywin.mfc import window
 from pywin.mfc.thread import WinThread
 
 WM_USER_PREPARE_TO_CLOSE = win32con.WM_USER + 32

--- a/Pythonwin/pywin/debugger/debugger.py
+++ b/Pythonwin/pywin/debugger/debugger.py
@@ -23,7 +23,7 @@ import win32con
 import win32ui
 from pywin.framework import app, editor, interact, scriptutils
 from pywin.framework.editor.color.coloreditor import MARKER_BREAKPOINT, MARKER_CURRENT
-from pywin.mfc import afxres, dialog, object, window
+from pywin.mfc import afxres, window
 from pywin.tools import browser, hierlist
 
 from .dbgcon import *

--- a/Pythonwin/pywin/docking/DockingBar.py
+++ b/Pythonwin/pywin/docking/DockingBar.py
@@ -658,8 +658,6 @@ def EditCreator(parent):
 
 
 def test():
-    import pywin.mfc.dialog
-
     global bar
     bar = DockingBar()
     creator = EditCreator

--- a/Pythonwin/pywin/framework/editor/color/coloreditor.py
+++ b/Pythonwin/pywin/framework/editor/color/coloreditor.py
@@ -5,13 +5,7 @@ import pywin.scintilla.keycodes
 import win32api
 import win32con
 import win32ui
-from pywin.framework.editor import (
-    GetEditorFontOption,
-    GetEditorOption,
-    SetEditorFontOption,
-    SetEditorOption,
-    defaultCharacterFormat,
-)
+from pywin.framework.editor import GetEditorOption
 from pywin.scintilla import bindings
 
 # from pywin.framework.editor import EditorPropertyPage

--- a/Pythonwin/pywin/framework/editor/configui.py
+++ b/Pythonwin/pywin/framework/editor/configui.py
@@ -2,15 +2,7 @@ import pywin.scintilla.config
 import win32api
 import win32con
 import win32ui
-from pywin.framework.editor import (
-    DeleteEditorOption,
-    GetEditorFontOption,
-    GetEditorOption,
-    SetEditorFontOption,
-    SetEditorOption,
-    defaultCharacterFormat,
-    editorTemplate,
-)
+from pywin.framework.editor import DeleteEditorOption, GetEditorOption, SetEditorOption
 from pywin.mfc import dialog
 
 from . import document
@@ -119,7 +111,6 @@ class EditorPropertyPage(dialog.PropertyPage):
             import traceback
 
             traceback.print_exc()
-            pass
 
         self.HookCommand(self.OnButSimple, win32ui.IDC_FOLD_ENABLE)
         self.HookCommand(self.OnButSimple, win32ui.IDC_RADIO1)

--- a/Pythonwin/pywin/framework/editor/editor.py
+++ b/Pythonwin/pywin/framework/editor/editor.py
@@ -26,11 +26,9 @@ import win32ui
 from pywin.framework.editor import (
     GetEditorFontOption,
     GetEditorOption,
-    SetEditorFontOption,
-    SetEditorOption,
     defaultCharacterFormat,
 )
-from pywin.mfc import afxres, dialog, docview
+from pywin.mfc import afxres, docview
 
 patImport = regex.symcomp(r"import \(<name>.*\)")
 patIndent = regex.compile(r"^\([ \t]*[~ \t]\)")

--- a/Pythonwin/pywin/framework/winout.py
+++ b/Pythonwin/pywin/framework/winout.py
@@ -23,17 +23,21 @@
 import queue
 import re
 
+import pywin.scintilla.document
 import win32api
 import win32con
 import win32ui
 from pywin.framework import app, window
 from pywin.mfc import docview
+from pywin.scintilla import scintillacon
 
 debug = lambda msg: None
-
-##debug=win32ui.OutputDebugString
-##import win32trace;win32trace.InitWrite() # for debugging - delete me!
-##debug = win32trace.write
+# debug=win32ui.OutputDebugString
+# import win32trace;win32trace.InitWrite() # for debugging - delete me!
+# debug = win32trace.write
+# WindowOutputDocumentParent=docview.RichEditDoc
+# WindowOutputDocumentParent=docview.Document
+WindowOutputDocumentParent = pywin.scintilla.document.CScintillaDocument
 
 
 class flags:
@@ -41,15 +45,6 @@ class flags:
     WQ_NONE = 0
     WQ_LINE = 1
     WQ_IDLE = 2
-
-
-# WindowOutputDocumentParent=docview.RichEditDoc
-# WindowOutputDocumentParent=docview.Document
-import pywin.scintilla.document
-from pywin import default_scintilla_encoding
-from pywin.scintilla import scintillacon
-
-WindowOutputDocumentParent = pywin.scintilla.document.CScintillaDocument
 
 
 class WindowOutputDocument(WindowOutputDocumentParent):

--- a/Pythonwin/pywin/scintilla/view.py
+++ b/Pythonwin/pywin/scintilla/view.py
@@ -1,6 +1,5 @@
 # A general purpose MFC CCtrlView view that uses Scintilla.
 
-import array
 import os
 import re
 import string
@@ -11,10 +10,10 @@ import __main__  # for attribute lookup
 import afxres
 import win32con
 import win32ui
-from pywin.mfc import dialog, docview
+from pywin.mfc import docview
 
 from . import IDLEenvironment  # IDLE emulation.
-from . import bindings, control, keycodes, scintillacon
+from . import bindings, control, scintillacon
 
 PRINTDLGORD = 1538
 IDC_PRINT_MAG_EDIT = 1010

--- a/Pythonwin/pywin/tools/hierlist.py
+++ b/Pythonwin/pywin/tools/hierlist.py
@@ -18,7 +18,7 @@ import commctrl
 import win32api
 import win32con
 import win32ui
-from pywin.mfc import dialog, docview, object, window
+from pywin.mfc import dialog, object
 from win32api import RGB
 
 

--- a/Pythonwin/pywin/tools/regedit.py
+++ b/Pythonwin/pywin/tools/regedit.py
@@ -128,8 +128,6 @@ class RegistryTreeView(docview.TreeView):
             self.hierList.Refresh(hparent)
 
     def OnAddKey(self, command, code):
-        from pywin.mfc import dialog
-
         val = dialog.GetSimpleInput("New key name", "", "Add new key")
         if val is None:
             return  # cancelled.
@@ -139,8 +137,6 @@ class RegistryTreeView(docview.TreeView):
             self.hierList.Refresh(hitem)
 
     def OnAddValue(self, command, code):
-        from pywin.mfc import dialog
-
         val = dialog.GetSimpleInput("New value", "", "Add new value")
         if val is None:
             return  # cancelled.

--- a/Pythonwin/pywin/tools/regpy.py
+++ b/Pythonwin/pywin/tools/regpy.py
@@ -1,8 +1,8 @@
 # (sort-of) Registry editor
 import commctrl
-import dialog
 import win32con
 import win32ui
+from pywin.mfc import dialog
 
 
 class RegistryControl:

--- a/Pythonwin/pywin/tools/regpy.py
+++ b/Pythonwin/pywin/tools/regpy.py
@@ -1,8 +1,8 @@
 # (sort-of) Registry editor
 import commctrl
+import dialog
 import win32con
 import win32ui
-from pywin.mfc import dialog
 
 
 class RegistryControl:

--- a/com/win32comext/axdebug/Test/host.py
+++ b/com/win32comext/axdebug/Test/host.py
@@ -5,10 +5,8 @@ import pythoncom
 import win32api
 import win32com.server.util
 import winerror
-from win32com.axdebug import adb, axdebug, codecontainer, contexts, documents, gateways
-from win32com.axdebug.util import _wrap, _wrap_remove, trace
-from win32com.axscript import axscript
-from win32com.client.util import Enumerator
+from win32com.axdebug import adb, axdebug, codecontainer, gateways
+from win32com.axdebug.util import trace
 from win32com.server.exception import Exception
 
 

--- a/com/win32comext/axdebug/contexts.py
+++ b/com/win32comext/axdebug/contexts.py
@@ -7,7 +7,7 @@ import win32com.server.util
 from . import adb, axdebug, gateways
 
 # Utility function for wrapping object created by this module.
-from .util import _wrap, _wrap_remove, trace
+from .util import _wrap
 
 
 class DebugCodeContext(gateways.DebugCodeContext, gateways.DebugDocumentContext):

--- a/com/win32comext/axdebug/debugger.py
+++ b/com/win32comext/axdebug/debugger.py
@@ -13,7 +13,7 @@ from win32com.axdebug import (
     expressions,
     gateways,
 )
-from win32com.axdebug.util import _wrap, _wrap_remove, trace
+from win32com.axdebug.util import _wrap
 from win32com.axscript import axscript
 
 currentDebugger = None

--- a/com/win32comext/axdebug/documents.py
+++ b/com/win32comext/axdebug/documents.py
@@ -7,8 +7,8 @@ import win32api
 from win32com.server.exception import Exception
 from win32com.server.util import unwrap
 
-from . import axdebug, codecontainer, contexts, gateways
-from .util import RaiseNotImpl, _wrap, _wrap_remove, trace
+from . import axdebug, gateways
+from .util import _wrap, trace
 
 # def trace(*args):
 #       pass

--- a/com/win32comext/axdebug/expressions.py
+++ b/com/win32comext/axdebug/expressions.py
@@ -8,7 +8,7 @@ import winerror
 from win32com.server.exception import COMException
 
 from . import axdebug, gateways
-from .util import RaiseNotImpl, _wrap, _wrap_remove
+from .util import RaiseNotImpl, _wrap
 
 
 # Given an object, return a nice string

--- a/com/win32comext/axscript/client/debug.py
+++ b/com/win32comext/axscript/client/debug.py
@@ -3,10 +3,9 @@ import sys
 
 import pythoncom
 import win32api
-import win32com.client.connect
 import win32com.server.util
 import winerror
-from win32com.axdebug import adb, axdebug, contexts, documents, gateways, stackframe
+from win32com.axdebug import adb, axdebug, documents, gateways
 from win32com.axdebug.codecontainer import SourceCodeContainer
 from win32com.axdebug.util import _wrap, _wrap_remove
 from win32com.client.util import Enumerator

--- a/isapi/test/extension_simple.py
+++ b/isapi/test/extension_simple.py
@@ -6,17 +6,12 @@
 # This will execute the method 'test1' below.  See below for the list of
 # test methods that are acceptable.
 
-import urllib.error
-import urllib.parse
-import urllib.request
-
 # If we have no console (eg, am running from inside IIS), redirect output
 # somewhere useful - in this case, the standard win32 trace collector.
 import win32api
 import winerror
 
-from isapi import ExtensionError, isapicon, threaded_extension
-from isapi.simple import SimpleFilter
+from isapi import ExtensionError, threaded_extension
 
 try:
     win32api.GetConsoleTitle()


### PR DESCRIPTION
Extracted from and improved over #2102 for ease of review.
Removed unused imports spotted by type-checkers. Not removing imports where it's uncertain whether they are causing side-effects. This is mostly manual changes. Then re-ran pycln.
Please validate whether some of those unused imports were meant to be re-exported symbols as part of that module's API.