### PR TITLE
Re-implement `newer` and `newer_group` to avoid deprecated `distutils.util`

### DIFF
--- a/com/win32com/test/pippo_server.py
+++ b/com/win32com/test/pippo_server.py
@@ -6,9 +6,10 @@ import os
 import sys
 
 import pythoncom
-import win32com
 import winerror
 from win32com.server.util import wrap
+
+from .util import newer
 
 
 class CPippo:
@@ -41,8 +42,6 @@ class CPippo:
 
 
 def BuildTypelib():
-    from distutils.dep_util import newer
-
     this_dir = os.path.dirname(__file__)
     idl = os.path.abspath(os.path.join(this_dir, "pippo.idl"))
     tlb = os.path.splitext(idl)[0] + ".tlb"

--- a/com/win32com/test/util.py
+++ b/com/win32com/test/util.py
@@ -12,7 +12,11 @@ import win32api
 import win32com
 import winerror
 from pythoncom import _GetGatewayCount, _GetInterfaceCount
-from pywin32_testutil import LeakTestCase
+from pywin32_testutil import (
+    LeakTestCase,
+    TestLoader as TestLoader,
+    TestRunner as TestRunner,
+)
 
 
 def newer(source, target):

--- a/com/win32com/test/util.py
+++ b/com/win32com/test/util.py
@@ -1,4 +1,3 @@
-import gc
 import logging
 import os
 import sys
@@ -13,7 +12,16 @@ import win32api
 import win32com
 import winerror
 from pythoncom import _GetGatewayCount, _GetInterfaceCount
-from pywin32_testutil import LeakTestCase, TestLoader, TestResult, TestRunner
+from pywin32_testutil import LeakTestCase
+
+
+def newer(source, target):
+    """Re-implemented from deprecated `distutils.dep_util.newer`"""
+    if not os.path.exists(target):
+        return True
+    mtime1 = os.path.getmtime(source)
+    mtime2 = os.path.getmtime(target)
+    return mtime1 > mtime2
 
 
 def CheckClean():


### PR DESCRIPTION
Work towards #2119

`setuptools.util` does not currently re-expose methods from `distutils.util`. And may not want to do so (see discussion in https://github.com/pypa/setuptools/pull/4069 ). This PR explores re-implementing `newer` and `newer_group` methods to avoid depending on deprecated `distutils.util`.
There might be a better location to move these methods.

The two usages of `newer_group` in `setup.py` also come with a comment suggesting that this method may not be necessary and possibly improved/removed in the future. To me it looks like a build optimization to not regenerate certain files. I would like your thoughts on this @mhammond 