### PR TITLE
Remove deprecated `UnicodeToString` param

### DIFF
--- a/com/win32com/client/__init__.py
+++ b/com/win32com/client/__init__.py
@@ -21,7 +21,6 @@ def __WrapDispatch(
     userName=None,
     resultCLSID=None,
     typeinfo=None,
-    UnicodeToString=None,
     clsctx=pythoncom.CLSCTX_SERVER,
     WrapperClass=None,
 ):
@@ -29,7 +28,6 @@ def __WrapDispatch(
     Helper function to return a makepy generated class for a CLSID if it exists,
     otherwise cope by using CDispatch.
     """
-    assert UnicodeToString is None, "this is deprecated and will go away"
     if resultCLSID is None:
         try:
             typeinfo = dispatch.GetTypeInfo()
@@ -110,11 +108,9 @@ def Dispatch(
     userName=None,
     resultCLSID=None,
     typeinfo=None,
-    UnicodeToString=None,
     clsctx=pythoncom.CLSCTX_SERVER,
 ):
     """Creates a Dispatch based COM object."""
-    assert UnicodeToString is None, "this is deprecated and will go away"
     dispatch, userName = dynamic._GetGoodDispatchAndUserName(dispatch, userName, clsctx)
     return __WrapDispatch(dispatch, userName, resultCLSID, typeinfo, clsctx=clsctx)
 
@@ -125,11 +121,9 @@ def DispatchEx(
     userName=None,
     resultCLSID=None,
     typeinfo=None,
-    UnicodeToString=None,
     clsctx=None,
 ):
     """Creates a Dispatch based COM object on a specific machine."""
-    assert UnicodeToString is None, "this is deprecated and will go away"
     # If InProc is registered, DCOM will use it regardless of the machine name
     # (and regardless of the DCOM config for the object.)  So unless the user
     # specifies otherwise, we exclude inproc apps when a remote machine is used.
@@ -157,11 +151,8 @@ class CDispatch(dynamic.CDispatch):
     if/when possible.
     """
 
-    def _wrap_dispatch_(
-        self, ob, userName=None, returnCLSID=None, UnicodeToString=None
-    ):
-        assert UnicodeToString is None, "this is deprecated and will go away"
-        return Dispatch(ob, userName, returnCLSID, None)
+    def _wrap_dispatch_(self, ob, userName=None, returnCLSID=None):
+        return Dispatch(ob, userName, returnCLSID)
 
     def __dir__(self):
         return dynamic.CDispatch.__dir__(self)

--- a/com/win32com/client/dynamic.py
+++ b/com/win32com/client/dynamic.py
@@ -125,10 +125,8 @@ def Dispatch(
     userName=None,
     createClass=None,
     typeinfo=None,
-    UnicodeToString=None,
     clsctx=pythoncom.CLSCTX_SERVER,
 ):
-    assert UnicodeToString is None, "this is deprecated and will go away"
     IDispatch, userName = _GetGoodDispatchAndUserName(IDispatch, userName, clsctx)
     if createClass is None:
         createClass = CDispatch
@@ -180,11 +178,9 @@ def DumbDispatch(
     IDispatch,
     userName=None,
     createClass=None,
-    UnicodeToString=None,
     clsctx=pythoncom.CLSCTX_SERVER,
 ):
     "Dispatch with no type info"
-    assert UnicodeToString is None, "this is deprecated and will go away"
     IDispatch, userName = _GetGoodDispatchAndUserName(IDispatch, userName, clsctx)
     if createClass is None:
         createClass = CDispatch
@@ -192,10 +188,7 @@ def DumbDispatch(
 
 
 class CDispatch:
-    def __init__(
-        self, IDispatch, olerepr, userName=None, UnicodeToString=None, lazydata=None
-    ):
-        assert UnicodeToString is None, "this is deprecated and will go away"
+    def __init__(self, IDispatch, olerepr, userName=None, lazydata=None):
         if userName is None:
             userName = "<unknown>"
         self.__dict__["_oleobj_"] = IDispatch
@@ -369,10 +362,12 @@ class CDispatch:
         return self._get_good_object_(result, user, resultCLSID)
 
     def _wrap_dispatch_(
-        self, ob, userName=None, returnCLSID=None, UnicodeToString=None
+        self,
+        ob,
+        userName=None,
+        returnCLSID=None,
     ):
         # Given a dispatch object, wrap it in a class
-        assert UnicodeToString is None, "this is deprecated and will go away"
         return Dispatch(ob, userName)
 
     def _get_good_single_object_(self, ob, userName=None, ReturnCLSID=None):

--- a/com/win32com/client/genpy.py
+++ b/com/win32com/client/genpy.py
@@ -877,9 +877,7 @@ class Generator:
         sourceFilename,
         progressObject,
         bBuildHidden=1,
-        bUnicodeToString=None,
     ):
-        assert bUnicodeToString is None, "this is deprecated and will go away"
         self.bHaveWrittenDispatchBaseClass = 0
         self.bHaveWrittenCoClassBaseClass = 0
         self.bHaveWrittenEventBaseClass = 0

--- a/com/win32com/client/makepy.py
+++ b/com/win32com/client/makepy.py
@@ -240,11 +240,9 @@ def GenerateFromTypeLibSpec(
     file=None,
     verboseLevel=None,
     progressInstance=None,
-    bUnicodeToString=None,
     bForDemand=bForDemandDefault,
     bBuildHidden=1,
 ):
-    assert bUnicodeToString is None, "this is deprecated and will go away"
     if verboseLevel is None:
         verboseLevel = 0  # By default, we use no gui and no verbose level!
 
@@ -338,9 +336,8 @@ def GenerateFromTypeLibSpec(
 
 
 def GenerateChildFromTypeLibSpec(
-    child, typelibInfo, verboseLevel=None, progressInstance=None, bUnicodeToString=None
+    child, typelibInfo, verboseLevel=None, progressInstance=None
 ):
-    assert bUnicodeToString is None, "this is deprecated and will go away"
     if verboseLevel is None:
         verboseLevel = (
             0  # By default, we use no gui, and no verbose level for the children.

--- a/com/win32comext/adsi/__init__.py
+++ b/com/win32comext/adsi/__init__.py
@@ -78,10 +78,7 @@ class ADSIEnumerator:
 
 
 class ADSIDispatch(win32com.client.CDispatch):
-    def _wrap_dispatch_(
-        self, ob, userName=None, returnCLSID=None, UnicodeToString=None
-    ):
-        assert UnicodeToString is None, "this is deprectated and will be removed"
+    def _wrap_dispatch_(self, ob, userName=None, returnCLSID=None):
         if not userName:
             userName = "ADSI-object"
         olerepr = win32com.client.dynamic.MakeOleRepr(ob, None, None)


### PR DESCRIPTION
Follow-up to #2085 but includes changes that could be breaking for some users if they still explicitly passed `None`.
Removes a very old deprecation message.