### PR TITLE
Remove legacy/deprecated App code from `pywin.framework.app`

### DIFF
--- a/Pythonwin/pywin/Demos/app/basictimerapp.py
+++ b/Pythonwin/pywin/Demos/app/basictimerapp.py
@@ -8,7 +8,7 @@ import timer
 import win32api
 import win32con
 import win32ui
-from pywin.framework import cmdline, dlgappcore
+from pywin.framework import dlgappcore
 
 
 class TimerAppDialog(dlgappcore.AppDialog):

--- a/Pythonwin/pywin/Demos/app/customprint.py
+++ b/Pythonwin/pywin/Demos/app/customprint.py
@@ -5,7 +5,6 @@
 
 # This sample was contributed by Roger Burnham.
 
-import win32api
 import win32con
 import win32ui
 from pywin.framework import app

--- a/Pythonwin/pywin/Demos/app/dlgappdemo.py
+++ b/Pythonwin/pywin/Demos/app/dlgappdemo.py
@@ -9,7 +9,7 @@
 import sys
 
 import win32ui
-from pywin.framework import app, dlgappcore
+from pywin.framework import dlgappcore
 
 
 class TestDialogApp(dlgappcore.DialogApp):
@@ -43,7 +43,7 @@ class TestAppDialog(dlgappcore.AppDialog):
             win32ui.OutputDebug("dlgapp - no edit control! >>\n%s\n<<\n" % str)
 
 
-app.AppBuilder = TestDialogApp
+app = TestDialogApp()
 
 if __name__ == "__main__":
     import demoutils

--- a/Pythonwin/pywin/Demos/app/dojobapp.py
+++ b/Pythonwin/pywin/Demos/app/dojobapp.py
@@ -6,10 +6,9 @@
 # pythonwin /app demos\dojobapp.py
 
 
-import win32api
 import win32con
 import win32ui
-from pywin.framework import app, dlgappcore
+from pywin.framework import dlgappcore
 
 
 class DoJobAppDialog(dlgappcore.AppDialog):
@@ -57,7 +56,7 @@ class CopyToDialogApp(DoJobDialogApp):
         DoJobDialogApp.__init__(self)
 
 
-app.AppBuilder = DoJobDialogApp
+app = DoJobDialogApp()
 
 
 def t():

--- a/Pythonwin/pywin/framework/app.py
+++ b/Pythonwin/pywin/framework/app.py
@@ -1,4 +1,3 @@
-# App.py
 # Application stuff.
 # The application is responsible for managing the main frame window.
 #
@@ -16,29 +15,6 @@ from pywin.mfc import afxres, dialog, window
 from pywin.mfc.thread import WinApp
 
 from . import scriptutils
-
-## NOTE: App and AppBuild should NOT be used - instead, you should contruct your
-## APP class manually whenever you like (just ensure you leave these 2 params None!)
-## Whoever wants the generic "Application" should get it via win32iu.GetApp()
-
-# These are "legacy"
-AppBuilder = None
-App = None  # default - if used, must end up a CApp derived class.
-
-
-# Helpers that should one day be removed!
-def AddIdleHandler(handler):
-    print(
-        "app.AddIdleHandler is deprecated - please use win32ui.GetApp().AddIdleHandler() instead."
-    )
-    return win32ui.GetApp().AddIdleHandler(handler)
-
-
-def DeleteIdleHandler(handler):
-    print(
-        "app.DeleteIdleHandler is deprecated - please use win32ui.GetApp().DeleteIdleHandler() instead."
-    )
-    return win32ui.GetApp().DeleteIdleHandler(handler)
 
 
 # Helper for writing a Window position by name, and later loading it.
@@ -169,10 +145,6 @@ class CApp(WinApp):
         if self._obj_:
             self._obj_.AttachObject(None)
         self._obj_ = None
-        global App
-        global AppBuilder
-        App = None
-        AppBuilder = None
         return 0
 
     def HaveIdleHandler(self, handler):

--- a/Pythonwin/pywin/framework/intpyapp.py
+++ b/Pythonwin/pywin/framework/intpyapp.py
@@ -551,8 +551,4 @@ class InteractivePythonApp(app.CApp):
         help.SelectAndRunHelpFile()
 
 
-# As per the comments in app.py, this use is depreciated.
-# app.AppBuilder = InteractivePythonApp
-
-# Now all we do is create the application
 thisApp = InteractivePythonApp()

--- a/Pythonwin/pywin/framework/startup.py
+++ b/Pythonwin/pywin/framework/startup.py
@@ -64,17 +64,3 @@ if len(sys.argv) >= 2 and sys.argv[0].lower() in ("/app", "-app"):
 
 # Import the application module.
 __import__(moduleName)
-
-try:
-    win32ui.GetApp()._obj_
-    # This worked - an app already exists - do nothing more
-except (AttributeError, win32ui.error):
-    # This means either no app object exists at all, or the one
-    # that does exist does not have a Python class (ie, was created
-    # by the host .EXE).  In this case, we do the "old style" init...
-    from . import app
-
-    if app.AppBuilder is None:
-        raise TypeError("No application object has been registered")
-
-    app.App = app.AppBuilder()


### PR DESCRIPTION
Looking at very old deprecated code, this seemed like another easy one with decent cleanup.
Removes deprecated code and obsolete/legacy way of registering an app and its Idle handlers from `pywin.framework.app`.
I validated that affected demos still work when run with `Pythonwin.exe /app`