### PR TITLE
Replace tabs with spaces in strings

### DIFF
--- a/Pythonwin/pywin/Demos/guidemo.py
+++ b/Pythonwin/pywin/Demos/guidemo.py
@@ -17,7 +17,7 @@ demos = [  # 	('Font', 'import fontdemo;fontdemo.FontDemo()'),
     ("Dynamic window creation", "import createwin;createwin.demo()"),
     ("Various Dialog demos", "import dlgtest;dlgtest.demo()"),
     ("OCX Control Demo", "from ocx import ocxtest;ocxtest.demo()"),
-    ("OCX Serial Port Demo", "from ocx import ocxserialtest;	ocxserialtest.test()"),
+    ("OCX Serial Port Demo", "from ocx import ocxserialtest; ocxserialtest.test()"),
     (
         "IE4 Control Demo",
         'from ocx import webbrowser; webbrowser.Demo("http://www.python.org")',

--- a/Pythonwin/pywin/docking/DockingBar.py
+++ b/Pythonwin/pywin/docking/DockingBar.py
@@ -234,15 +234,15 @@ class DockingBar(window.Wnd):
             return 0
         lparam = msg[3]
         """ LPARAM used with WM_WINDOWPOSCHANGED:
-			typedef struct {
-				HWND hwnd;
-				HWND hwndInsertAfter;
-				int x;
-				int y;
-				int cx;
-				int cy;
-				UINT flags;} WINDOWPOS;
-		"""
+            typedef struct {
+                HWND hwnd;
+                HWND hwndInsertAfter;
+                int x;
+                int y;
+                int cx;
+                int cy;
+                UINT flags;} WINDOWPOS;
+        """
         format = "PPiiiii"
         bytes = win32ui.GetBytes(lparam, struct.calcsize(format))
         hwnd, hwndAfter, x, y, cx, cy, flags = struct.unpack(format, bytes)

--- a/Pythonwin/pywin/scintilla/IDLEenvironment.py
+++ b/Pythonwin/pywin/scintilla/IDLEenvironment.py
@@ -533,30 +533,30 @@ def test():
     e.SetSel((4, 4))
 
     skip = """
-	TestCheck("insert", e, 4)
-	TestCheck("insert wordstart", e, 3)
-	TestCheck("insert wordend", e, 8)
-	TestCheck("insert linestart", e, 0)
-	TestCheck("insert lineend", e, 12)
-	TestCheck("insert + 4 chars", e, 8)
-	TestCheck("insert +4c", e, 8)
-	TestCheck("insert - 2 chars", e, 2)
-	TestCheck("insert -2c", e, 2)
-	TestCheck("insert-2c", e, 2)
-	TestCheck("insert-2 c", e, 2)
-	TestCheck("insert- 2c", e, 2)
-	TestCheck("1.1", e, 1)
-	TestCheck("1.0", e, 0)
-	TestCheck("2.0", e, 13)
-	try:
-		TestCheck("sel.first", e, 0)
-		print("*** sel.first worked with an empty selection")
-	except TextError:
-		pass
-	e.SetSel((4,5))
-	TestCheck("sel.first- 2c", e, 2)
-	TestCheck("sel.last- 2c", e, 3)
-	"""
+    TestCheck("insert", e, 4)
+    TestCheck("insert wordstart", e, 3)
+    TestCheck("insert wordend", e, 8)
+    TestCheck("insert linestart", e, 0)
+    TestCheck("insert lineend", e, 12)
+    TestCheck("insert + 4 chars", e, 8)
+    TestCheck("insert +4c", e, 8)
+    TestCheck("insert - 2 chars", e, 2)
+    TestCheck("insert -2c", e, 2)
+    TestCheck("insert-2c", e, 2)
+    TestCheck("insert-2 c", e, 2)
+    TestCheck("insert- 2c", e, 2)
+    TestCheck("1.1", e, 1)
+    TestCheck("1.0", e, 0)
+    TestCheck("2.0", e, 13)
+    try:
+        TestCheck("sel.first", e, 0)
+        print("*** sel.first worked with an empty selection")
+    except TextError:
+        pass
+    e.SetSel((4,5))
+    TestCheck("sel.first- 2c", e, 2)
+    TestCheck("sel.last- 2c", e, 3)
+    """
     # Check EOL semantics
     e.SetSel((4, 4))
     TestGet("insert lineend", "insert lineend +1c", t, "\n")

--- a/com/win32com/client/gencache.py
+++ b/com/win32com/client/gencache.py
@@ -768,12 +768,12 @@ __init__()
 
 def usage():
     usageString = """\
-	  Usage: gencache [-q] [-d] [-r]
+      Usage: gencache [-q] [-d] [-r]
 
-			 -q         - Quiet
-			 -d         - Dump the cache (typelibrary description and filename).
-			 -r         - Rebuild the cache dictionary from the existing .py files
-	"""
+             -q         - Quiet
+             -d         - Dump the cache (typelibrary description and filename).
+             -r         - Rebuild the cache dictionary from the existing .py files
+    """
     print(usageString)
     sys.exit(1)
 

--- a/com/win32com/makegw/makegw.py
+++ b/com/win32com/makegw/makegw.py
@@ -144,11 +144,11 @@ def _write_ifc_h(f, interface):
 class Py{interface.name} : public Py{interface.base}
 {{
 public:
-	MAKE_PYCOM_CTOR(Py{interface.name});
-	static {interface.name} *GetI(PyObject *self);
-	static PyComTypeObject type;
+    MAKE_PYCOM_CTOR(Py{interface.name});
+    static {interface.name} *GetI(PyObject *self);
+    static PyComTypeObject type;
 
-	// The Python methods
+    // The Python methods
 """
     )
     for method in interface.methods:
@@ -159,8 +159,8 @@ public:
         f"""\
 
 protected:
-	Py{interface.name}(IUnknown *pdisp);
-	~Py{interface.name}();
+    Py{interface.name}(IUnknown *pdisp);
+    ~Py{interface.name}();
 }};
 """
     )
@@ -175,9 +175,9 @@ def _write_ifc_cpp(f, interface):
 // Interface Implementation
 
 Py{name}::Py{name}(IUnknown *pdisp):
-	Py{base}(pdisp)
+    Py{base}(pdisp)
 {{
-	ob_type = &type;
+    ob_type = &type;
 }}
 
 Py{name}::~Py{name}()
@@ -186,7 +186,7 @@ Py{name}::~Py{name}()
 
 /* static */ {name} *Py{name}::GetI(PyObject *self)
 {{
-	return ({name} *)Py{base}::GetI(self);
+    return ({name} *)Py{base}::GetI(self);
 }}
 
 """.format(
@@ -203,9 +203,9 @@ Py{name}::~Py{name}()
 // @pymethod |Py{interfacename}|{method}|Description of {method}.
 PyObject *Py{interfacename}::{method}(PyObject *self, PyObject *args)
 {{
-	{interfacename} *p{ptr} = GetI(self);
-	if ( p{ptr} == NULL )
-		return NULL;
+    {interfacename} *p{ptr} = GetI(self);
+    if ( p{ptr} == NULL )
+        return NULL;
 """.format(
                 **strdict
             )
@@ -282,14 +282,14 @@ PyObject *Py{interfacename}::{method}(PyObject *self, PyObject *args)
         strdict["cleanup"] = cleanup
         strdict["cleanup_gil"] = cleanup_gil
         f.write(
-            """	HRESULT hr;
-	PY_INTERFACE_PRECALL;
-	hr = p{ptr}->{method}({argsCOM} );
+            """    HRESULT hr;
+    PY_INTERFACE_PRECALL;
+    hr = p{ptr}->{method}({argsCOM} );
 {cleanup}
-	PY_INTERFACE_POSTCALL;
+    PY_INTERFACE_POSTCALL;
 {cleanup_gil}
-	if ( FAILED(hr) )
-		return PyCom_BuildPyException(hr, p{ptr}, IID_{interfacename} );
+    if ( FAILED(hr) )
+        return PyCom_BuildPyException(hr, p{ptr}, IID_{interfacename} );
 """.format(
                 **strdict
             )
@@ -336,14 +336,14 @@ PyObject *Py{interfacename}::{method}(PyObject *self, PyObject *args)
     interfacebase = interface.base
     f.write(
         """\
-	{{ NULL }}
+    {{ NULL }}
 }};
 
 PyComTypeObject Py{name}::type("Py{name}",
-		&Py{interfacebase}::type,
-		sizeof(Py{name}),
-		Py{name}_methods,
-		GET_PYCOM_CTOR(Py{name}));
+        &Py{interfacebase}::type,
+        sizeof(Py{name}),
+        Py{name}_methods,
+        GET_PYCOM_CTOR(Py{name}));
 """.format(
             **locals()
         )
@@ -372,8 +372,8 @@ def _write_gw_h(f, interface):
 class {gname} : public {base_name}, public {name}
 {{
 protected:
-	{gname}(PyObject *instance) : {base_name}(instance) {{ ; }}
-	PYGATEWAY_MAKE_SUPPORT2({gname}, {name}, IID_{name}, {base_name})
+    {gname}(PyObject *instance) : {base_name}(instance) {{ ; }}
+    PYGATEWAY_MAKE_SUPPORT2({gname}, {name}, IID_{name}, {base_name})
 
 """
     )

--- a/com/win32com/makegw/makegwenum.py
+++ b/com/win32com/makegw/makegwenum.py
@@ -44,9 +44,9 @@ def _write_enumifc_cpp(f, interface):
 // Interface Implementation
 
 PyIEnum{enumtype}::PyIEnum{enumtype}(IUnknown *pdisp):
-	PyIUnknown(pdisp)
+    PyIUnknown(pdisp)
 {{
-	ob_type = &type;
+    ob_type = &type;
 }}
 
 PyIEnum{enumtype}::~PyIEnum{enumtype}()
@@ -55,141 +55,141 @@ PyIEnum{enumtype}::~PyIEnum{enumtype}()
 
 /* static */ IEnum{enumtype} *PyIEnum{enumtype}::GetI(PyObject *self)
 {{
-	return (IEnum{enumtype} *)PyIUnknown::GetI(self);
+    return (IEnum{enumtype} *)PyIUnknown::GetI(self);
 }}
 
 // @pymethod object|PyIEnum{enumtype}|Next|Retrieves a specified number of items in the enumeration sequence.
 PyObject *PyIEnum{enumtype}::Next(PyObject *self, PyObject *args)
 {{
-	long celt = 1;
-	// @pyparm int|num|1|Number of items to retrieve.
-	if ( !PyArg_ParseTuple(args, "|l:Next", &celt) )
-		return NULL;
+    long celt = 1;
+    // @pyparm int|num|1|Number of items to retrieve.
+    if ( !PyArg_ParseTuple(args, "|l:Next", &celt) )
+        return NULL;
 
-	IEnum{enumtype} *pIE{enumtype} = GetI(self);
-	if ( pIE{enumtype} == NULL )
-		return NULL;
+    IEnum{enumtype} *pIE{enumtype} = GetI(self);
+    if ( pIE{enumtype} == NULL )
+        return NULL;
 
-	{arraydeclare}
-	if ( rgVar == NULL ) {{
-		PyErr_SetString(PyExc_MemoryError, "allocating result {enumtype}s");
-		return NULL;
-	}}
+    {arraydeclare}
+    if ( rgVar == NULL ) {{
+        PyErr_SetString(PyExc_MemoryError, "allocating result {enumtype}s");
+        return NULL;
+    }}
 
-	int i;
-/*	for ( i = celt; i--; )
-		// *** possibly init each structure element???
+    int i;
+/*    for ( i = celt; i--; )
+        // *** possibly init each structure element???
 */
 
-	ULONG celtFetched = 0;
-	PY_INTERFACE_PRECALL;
-	HRESULT hr = pIE{enumtype}->Next(celt, rgVar, &celtFetched);
-	PY_INTERFACE_POSTCALL;
-	if (  HRESULT_CODE(hr) != ERROR_NO_MORE_ITEMS && FAILED(hr) )
-	{{
-		delete [] rgVar;
-		return PyCom_BuildPyException(hr,pIE{enumtype}, IID_IE{enumtype});
-	}}
+    ULONG celtFetched = 0;
+    PY_INTERFACE_PRECALL;
+    HRESULT hr = pIE{enumtype}->Next(celt, rgVar, &celtFetched);
+    PY_INTERFACE_POSTCALL;
+    if (  HRESULT_CODE(hr) != ERROR_NO_MORE_ITEMS && FAILED(hr) )
+    {{
+        delete [] rgVar;
+        return PyCom_BuildPyException(hr,pIE{enumtype}, IID_IE{enumtype});
+    }}
 
-	PyObject *result = PyTuple_New(celtFetched);
-	if ( result != NULL )
-	{{
-		for ( i = celtFetched; i--; )
-		{{
-			{converter}
-			if ( ob == NULL )
-			{{
-				Py_DECREF(result);
-				result = NULL;
-				break;
-			}}
-			PyTuple_SET_ITEM(result, i, ob);
-		}}
-	}}
+    PyObject *result = PyTuple_New(celtFetched);
+    if ( result != NULL )
+    {{
+        for ( i = celtFetched; i--; )
+        {{
+            {converter}
+            if ( ob == NULL )
+            {{
+                Py_DECREF(result);
+                result = NULL;
+                break;
+            }}
+            PyTuple_SET_ITEM(result, i, ob);
+        }}
+    }}
 
-/*	for ( i = celtFetched; i--; )
-		// *** possibly cleanup each structure element???
+/*    for ( i = celtFetched; i--; )
+        // *** possibly cleanup each structure element???
 */
-	delete [] rgVar;
-	return result;
+    delete [] rgVar;
+    return result;
 }}
 
 // @pymethod |PyIEnum{enumtype}|Skip|Skips over the next specified elementes.
 PyObject *PyIEnum{enumtype}::Skip(PyObject *self, PyObject *args)
 {{
-	long celt;
-	if ( !PyArg_ParseTuple(args, "l:Skip", &celt) )
-		return NULL;
+    long celt;
+    if ( !PyArg_ParseTuple(args, "l:Skip", &celt) )
+        return NULL;
 
-	IEnum{enumtype} *pIE{enumtype} = GetI(self);
-	if ( pIE{enumtype} == NULL )
-		return NULL;
+    IEnum{enumtype} *pIE{enumtype} = GetI(self);
+    if ( pIE{enumtype} == NULL )
+        return NULL;
 
-	PY_INTERFACE_PRECALL;
-	HRESULT hr = pIE{enumtype}->Skip(celt);
-	PY_INTERFACE_POSTCALL;
-	if ( FAILED(hr) )
-		return PyCom_BuildPyException(hr, pIE{enumtype}, IID_IE{enumtype});
+    PY_INTERFACE_PRECALL;
+    HRESULT hr = pIE{enumtype}->Skip(celt);
+    PY_INTERFACE_POSTCALL;
+    if ( FAILED(hr) )
+        return PyCom_BuildPyException(hr, pIE{enumtype}, IID_IE{enumtype});
 
-	Py_INCREF(Py_None);
-	return Py_None;
+    Py_INCREF(Py_None);
+    return Py_None;
 }}
 
 // @pymethod |PyIEnum{enumtype}|Reset|Resets the enumeration sequence to the beginning.
 PyObject *PyIEnum{enumtype}::Reset(PyObject *self, PyObject *args)
 {{
-	if ( !PyArg_ParseTuple(args, ":Reset") )
-		return NULL;
+    if ( !PyArg_ParseTuple(args, ":Reset") )
+        return NULL;
 
-	IEnum{enumtype} *pIE{enumtype} = GetI(self);
-	if ( pIE{enumtype} == NULL )
-		return NULL;
+    IEnum{enumtype} *pIE{enumtype} = GetI(self);
+    if ( pIE{enumtype} == NULL )
+        return NULL;
 
-	PY_INTERFACE_PRECALL;
-	HRESULT hr = pIE{enumtype}->Reset();
-	PY_INTERFACE_POSTCALL;
-	if ( FAILED(hr) )
-		return PyCom_BuildPyException(hr, pIE{enumtype}, IID_IE{enumtype});
+    PY_INTERFACE_PRECALL;
+    HRESULT hr = pIE{enumtype}->Reset();
+    PY_INTERFACE_POSTCALL;
+    if ( FAILED(hr) )
+        return PyCom_BuildPyException(hr, pIE{enumtype}, IID_IE{enumtype});
 
-	Py_INCREF(Py_None);
-	return Py_None;
+    Py_INCREF(Py_None);
+    return Py_None;
 }}
 
 // @pymethod <o PyIEnum{enumtype}>|PyIEnum{enumtype}|Clone|Creates another enumerator that contains the same enumeration state as the current one
 PyObject *PyIEnum{enumtype}::Clone(PyObject *self, PyObject *args)
 {{
-	if ( !PyArg_ParseTuple(args, ":Clone") )
-		return NULL;
+    if ( !PyArg_ParseTuple(args, ":Clone") )
+        return NULL;
 
-	IEnum{enumtype} *pIE{enumtype} = GetI(self);
-	if ( pIE{enumtype} == NULL )
-		return NULL;
+    IEnum{enumtype} *pIE{enumtype} = GetI(self);
+    if ( pIE{enumtype} == NULL )
+        return NULL;
 
-	IEnum{enumtype} *pClone;
-	PY_INTERFACE_PRECALL;
-	HRESULT hr = pIE{enumtype}->Clone(&pClone);
-	PY_INTERFACE_POSTCALL;
-	if ( FAILED(hr) )
-		return PyCom_BuildPyException(hr, pIE{enumtype}, IID_IE{enumtype});
+    IEnum{enumtype} *pClone;
+    PY_INTERFACE_PRECALL;
+    HRESULT hr = pIE{enumtype}->Clone(&pClone);
+    PY_INTERFACE_POSTCALL;
+    if ( FAILED(hr) )
+        return PyCom_BuildPyException(hr, pIE{enumtype}, IID_IE{enumtype});
 
-	return PyCom_PyObjectFromIUnknown(pClone, IID_IEnum{enumtype}, FALSE);
+    return PyCom_PyObjectFromIUnknown(pClone, IID_IEnum{enumtype}, FALSE);
 }}
 
 // @object PyIEnum{enumtype}|A Python interface to IEnum{enumtype}
 static struct PyMethodDef PyIEnum{enumtype}_methods[] =
 {{
-	{{ "Next", PyIEnum{enumtype}::Next, 1 }},    // @pymeth Next|Retrieves a specified number of items in the enumeration sequence.
-	{{ "Skip", PyIEnum{enumtype}::Skip, 1 }},	// @pymeth Skip|Skips over the next specified elementes.
-	{{ "Reset", PyIEnum{enumtype}::Reset, 1 }},	// @pymeth Reset|Resets the enumeration sequence to the beginning.
-	{{ "Clone", PyIEnum{enumtype}::Clone, 1 }},	// @pymeth Clone|Creates another enumerator that contains the same enumeration state as the current one.
-	{{ NULL }}
+    {{ "Next", PyIEnum{enumtype}::Next, 1 }},   // @pymeth Next|Retrieves a specified number of items in the enumeration sequence.
+    {{ "Skip", PyIEnum{enumtype}::Skip, 1 }},   // @pymeth Skip|Skips over the next specified elementes.
+    {{ "Reset", PyIEnum{enumtype}::Reset, 1 }}, // @pymeth Reset|Resets the enumeration sequence to the beginning.
+    {{ "Clone", PyIEnum{enumtype}::Clone, 1 }}, // @pymeth Clone|Creates another enumerator that contains the same enumeration state as the current one.
+    {{ NULL }}
 }};
 
 PyComEnumTypeObject PyIEnum{enumtype}::type("PyIEnum{enumtype}",
-		&PyIUnknown::type,
-		sizeof(PyIEnum{enumtype}),
-		PyIEnum{enumtype}_methods,
-		GET_PYCOM_CTOR(PyIEnum{enumtype}));
+        &PyIUnknown::type,
+        sizeof(PyIEnum{enumtype}),
+        PyIEnum{enumtype}_methods,
+        GET_PYCOM_CTOR(PyIEnum{enumtype}));
 """.format(
             **locals()
         )
@@ -230,103 +230,103 @@ STDMETHODIMP PyGEnum{enumtype}::Next(
             /* [length_is][size_is][out] */ {argdeclare},
             /* [out] */ ULONG __RPC_FAR *pCeltFetched)
 {{
-	PY_GATEWAY_METHOD;
-	PyObject *result;
-	HRESULT hr = InvokeViaPolicy("Next", &result, "i", celt);
-	if ( FAILED(hr) )
-		return hr;
+    PY_GATEWAY_METHOD;
+    PyObject *result;
+    HRESULT hr = InvokeViaPolicy("Next", &result, "i", celt);
+    if ( FAILED(hr) )
+        return hr;
 
-	if ( !PySequence_Check(result) )
-		goto error;
-	int len;
-	len = PyObject_Length(result);
-	if ( len == -1 )
-		goto error;
-	if ( len > (int)celt)
-		len = celt;
+    if ( !PySequence_Check(result) )
+        goto error;
+    int len;
+    len = PyObject_Length(result);
+    if ( len == -1 )
+        goto error;
+    if ( len > (int)celt)
+        len = celt;
 
-	if ( pCeltFetched )
-		*pCeltFetched = len;
+    if ( pCeltFetched )
+        *pCeltFetched = len;
 
-	int i;
-	for ( i = 0; i < len; ++i )
-	{{
-		PyObject *ob = PySequence_GetItem(result, i);
-		if ( ob == NULL )
-			goto error;
+    int i;
+    for ( i = 0; i < len; ++i )
+    {{
+        PyObject *ob = PySequence_GetItem(result, i);
+        if ( ob == NULL )
+            goto error;
 
-		{converter}
-		{{
-			Py_DECREF(result);
-			return PyCom_SetCOMErrorFromPyException(IID_IEnum{enumtype});
-		}}
-	}}
+        {converter}
+        {{
+            Py_DECREF(result);
+            return PyCom_SetCOMErrorFromPyException(IID_IEnum{enumtype});
+        }}
+    }}
 
-	Py_DECREF(result);
+    Py_DECREF(result);
 
-	return len < (int)celt ? S_FALSE : S_OK;
+    return len < (int)celt ? S_FALSE : S_OK;
 
   error:
-	PyErr_Clear();	// just in case
-	Py_DECREF(result);
-	return PyCom_HandleIEnumNoSequence(IID_IEnum{enumtype});
+    PyErr_Clear(); // just in case
+    Py_DECREF(result);
+    return PyCom_HandleIEnumNoSequence(IID_IEnum{enumtype});
 }}
 
 STDMETHODIMP PyGEnum{enumtype}::Skip( 
             /* [in] */ ULONG celt)
 {{
-	PY_GATEWAY_METHOD;
-	return InvokeViaPolicy("Skip", NULL, "i", celt);
+    PY_GATEWAY_METHOD;
+    return InvokeViaPolicy("Skip", NULL, "i", celt);
 }}
 
 STDMETHODIMP PyGEnum{enumtype}::Reset(void)
 {{
-	PY_GATEWAY_METHOD;
-	return InvokeViaPolicy("Reset");
+    PY_GATEWAY_METHOD;
+    return InvokeViaPolicy("Reset");
 }}
 
 STDMETHODIMP PyGEnum{enumtype}::Clone( 
             /* [out] */ IEnum{enumtype} __RPC_FAR *__RPC_FAR *ppEnum)
 {{
-	PY_GATEWAY_METHOD;
-	PyObject * result;
-	HRESULT hr = InvokeViaPolicy("Clone", &result);
-	if ( FAILED(hr) )
-		return hr;
+    PY_GATEWAY_METHOD;
+    PyObject * result;
+    HRESULT hr = InvokeViaPolicy("Clone", &result);
+    if ( FAILED(hr) )
+        return hr;
 
-	/*
-	** Make sure we have the right kind of object: we should have some kind
-	** of IUnknown subclass wrapped into a PyIUnknown instance.
-	*/
-	if ( !PyIBase::is_object(result, &PyIUnknown::type) )
-	{{
-		/* the wrong kind of object was returned to us */
-		Py_DECREF(result);
-		return PyCom_SetCOMErrorFromSimple(E_FAIL, IID_IEnum{enumtype});
-	}}
+    /*
+    ** Make sure we have the right kind of object: we should have some kind
+    ** of IUnknown subclass wrapped into a PyIUnknown instance.
+    */
+    if ( !PyIBase::is_object(result, &PyIUnknown::type) )
+    {{
+        /* the wrong kind of object was returned to us */
+        Py_DECREF(result);
+        return PyCom_SetCOMErrorFromSimple(E_FAIL, IID_IEnum{enumtype});
+    }}
 
-	/*
-	** Get the IUnknown out of the thing. note that the Python ob maintains
-	** a reference, so we don't have to explicitly AddRef() here.
-	*/
-	IUnknown *punk = ((PyIUnknown *)result)->m_obj;
-	if ( !punk )
-	{{
-		/* damn. the object was released. */
-		Py_DECREF(result);
-		return PyCom_SetCOMErrorFromSimple(E_FAIL, IID_IEnum{enumtype});
-	}}
+    /*
+    ** Get the IUnknown out of the thing. note that the Python ob maintains
+    ** a reference, so we don't have to explicitly AddRef() here.
+    */
+    IUnknown *punk = ((PyIUnknown *)result)->m_obj;
+    if ( !punk )
+    {{
+        /* damn. the object was released. */
+        Py_DECREF(result);
+        return PyCom_SetCOMErrorFromSimple(E_FAIL, IID_IEnum{enumtype});
+    }}
 
-	/*
-	** Get the interface we want. note it is returned with a refcount.
-	** This QI is actually going to instantiate a PyGEnum{enumtype}.
-	*/
-	hr = punk->QueryInterface(IID_IEnum{enumtype}, (LPVOID *)ppEnum);
+    /*
+    ** Get the interface we want. note it is returned with a refcount.
+    ** This QI is actually going to instantiate a PyGEnum{enumtype}.
+    */
+    hr = punk->QueryInterface(IID_IEnum{enumtype}, (LPVOID *)ppEnum);
 
-	/* done with the result; this DECREF is also for <punk> */
-	Py_DECREF(result);
+    /* done with the result; this DECREF is also for <punk> */
+    Py_DECREF(result);
 
-	return PyCom_CheckIEnumNextResult(hr, IID_IEnum{enumtype});
+    return PyCom_CheckIEnumNextResult(hr, IID_IEnum{enumtype});
 }}
 """.format(
             **locals()

--- a/com/win32com/makegw/makegwparse.py
+++ b/com/win32com/makegw/makegwparse.py
@@ -34,7 +34,7 @@ DEBUG = 0
 
 
 class ArgFormatter:
-    """An instance for a specific type of argument.	 Knows how to convert itself"""
+    """An instance for a specific type of argument. Knows how to convert itself"""
 
     def __init__(self, arg, builtinIndirection, declaredIndirection=0):
         # print("init:", arg.name, builtinIndirection, declaredIndirection, arg.indirectionLevel)
@@ -213,7 +213,7 @@ class ArgFormatter:
         )
 
     def _GetPythonTypeDesc(self):
-        "Returns a string with the description of the type.	 Used for doco purposes"
+        "Returns a string with the description of the type. Used for doco purposes"
         return None
 
     def NeedUSES_CONVERSION(self):
@@ -842,7 +842,7 @@ class Argument:
 
         if VERBOSE:
             print(
-                "	   Arg {} of type {}{} ({})".format(
+                "       Arg {} of type {}{} ({})".format(
                     self.name, self.type, "*" * self.indirectionLevel, self.inout
                 )
             )
@@ -902,7 +902,7 @@ class Method:
                     "Method %s - Only HRESULT return types are supported." % self.name
                 )
             # 				raise error_not_supported,		if VERBOSE:
-            print(f"	 Method {self.result} {self.name}(")
+            print(f"     Method {self.result} {self.name}(")
         while 1:
             arg = Argument(self.good_interface_names)
             try:

--- a/com/win32com/server/exception.py
+++ b/com/win32com/server/exception.py
@@ -2,14 +2,14 @@
 
  Exceptions
 
-	 To better support COM exceptions, the framework allows for an instance to be
-	 raised.  This instance may have a certain number of known attributes, which are
-	 translated into COM exception details.
-	
-	 This means, for example, that Python could raise a COM exception that includes details
-	 on a Help file and location, and a description for the user.
-	
-	 This module provides a class which provides the necessary attributes.
+     To better support COM exceptions, the framework allows for an instance to be
+     raised.  This instance may have a certain number of known attributes, which are
+     translated into COM exception details.
+    
+     This means, for example, that Python could raise a COM exception that includes details
+     on a Help file and location, and a description for the user.
+    
+     This module provides a class which provides the necessary attributes.
 
 """
 import sys

--- a/com/win32com/servers/perfmon.py
+++ b/com/win32com/servers/perfmon.py
@@ -1,8 +1,8 @@
 """A COM Server which exposes the NT Performance monitor in a very rudimentary way
 
 Usage from VB:
-	set ob = CreateObject("Python.PerfmonQuery")
-	freeBytes = ob.Query("Memory", "Available Bytes")
+    set ob = CreateObject("Python.PerfmonQuery")
+    freeBytes = ob.Query("Memory", "Available Bytes")
 """
 import pythoncom
 import win32pdhutil

--- a/com/win32comext/axscript/asputil.py
+++ b/com/win32comext/axscript/asputil.py
@@ -1,7 +1,7 @@
 """A utility module for ASP (Active Server Pages on MS Internet Info Server.
 
 Contains:
-	iif -- A utility function to avoid using "if" statements in ASP <% tags
+    iif -- A utility function to avoid using "if" statements in ASP <% tags
 
 """
 

--- a/com/win32comext/shell/demos/IFileOperationProgressSink.py
+++ b/com/win32comext/shell/demos/IFileOperationProgressSink.py
@@ -134,7 +134,7 @@ class FileOperationProgressSink(DesignatedWrapPolicy):
         )
         if NewlyCreated:
             print(
-                "	Moved to recycle bin - "
+                "    Moved to recycle bin - "
                 + NewlyCreated.GetDisplayName(shellcon.SHGDN_FORPARSING)
             )
 

--- a/setup.py
+++ b/setup.py
@@ -1648,7 +1648,7 @@ com_extensions += [
                         {mapi}/PyIMsgStore.i          {mapi}/PyIMsgStore.cpp
                         {mapi}/PyIProfAdmin.i         {mapi}/PyIProfAdmin.cpp
                         {mapi}/PyIProfSect.i          {mapi}/PyIProfSect.cpp
-                        {mapi}/PyIConverterSession.i	{mapi}/PyIConverterSession.cpp
+                        {mapi}/PyIConverterSession.i  {mapi}/PyIConverterSession.cpp
                         {mapi}/PyIMAPIAdviseSink.cpp
                         {mapi}/mapiutil.cpp
                         {mapi}/mapiguids.cpp

--- a/win32/Lib/win32pdhquery.py
+++ b/win32/Lib/win32pdhquery.py
@@ -17,37 +17,37 @@ but part of the point of this wrapper module is to hide that
 complexity from the end-user/programmer.
 
 EXAMPLE: A more complex Path
-	'\\\\RAISTLIN\\PhysicalDisk(_Total)\\Avg. Disk Bytes/Read'
-	Raistlin --> Computer Name
-	PhysicalDisk --> Object Name
-	_Total --> The particular Instance (in this case, all instances, i.e. all drives)
-	Avg. Disk Bytes/Read --> The piece of data being monitored.
+    '\\\\RAISTLIN\\PhysicalDisk(_Total)\\Avg. Disk Bytes/Read'
+    Raistlin --> Computer Name
+    PhysicalDisk --> Object Name
+    _Total --> The particular Instance (in this case, all instances, i.e. all drives)
+    Avg. Disk Bytes/Read --> The piece of data being monitored.
 
 EXAMPLE: Collecting Data with a Query
-	As an example, the following code implements a logger which allows the
-	user to choose what counters they would like to log, and logs those
-	counters for 30 seconds, at two-second intervals.
-	
-	query = Query()
-	query.addcounterbybrowsing()
-	query.collectdatafor(30,2)
-	
-	The data is now stored in a list of lists as:
-	query.curresults
-	
-	The counters(paths) which were used to collect the data are:
-	query.curpaths
-	
-	You can use the win32pdh.ParseCounterPath(path) utility function
-	to turn the paths into more easily read values for your task, or
-	write the data to a file, or do whatever you want with it.
+    As an example, the following code implements a logger which allows the
+    user to choose what counters they would like to log, and logs those
+    counters for 30 seconds, at two-second intervals.
+    
+    query = Query()
+    query.addcounterbybrowsing()
+    query.collectdatafor(30,2)
+    
+    The data is now stored in a list of lists as:
+    query.curresults
+    
+    The counters(paths) which were used to collect the data are:
+    query.curpaths
+    
+    You can use the win32pdh.ParseCounterPath(path) utility function
+    to turn the paths into more easily read values for your task, or
+    write the data to a file, or do whatever you want with it.
 
 OTHER NOTABLE METHODS:
-	query.collectdatawhile(period) # start a logging thread for collecting data
-	query.collectdatawhile_stop() # signal the logging thread to stop logging
-	query.collectdata() # run the query only once
-	query.addperfcounter(object, counter, machine=None) # add a standard performance counter
-	query.addinstcounter(object, counter,machine=None,objtype = 'Process',volatile=1,format = win32pdh.PDH_FMT_LONG) # add a possibly volatile counter
+    query.collectdatawhile(period) # start a logging thread for collecting data
+    query.collectdatawhile_stop() # signal the logging thread to stop logging
+    query.collectdata() # run the query only once
+    query.addperfcounter(object, counter, machine=None) # add a standard performance counter
+    query.addinstcounter(object, counter,machine=None,objtype = 'Process',volatile=1,format = win32pdh.PDH_FMT_LONG) # add a possibly volatile counter
 
 ### Known bugs and limitations ###
 Due to a problem with threading under the PythonWin interpreter, there


### PR DESCRIPTION
Avoids mixing tabs and spaces in strings in python files. This wasn't formatted by black because it's in a string obviously.

Also closes #2161