### PR TITLE
Improve _d handling

### DIFF
--- a/com/win32com/server/register.py
+++ b/com/win32com/server/register.py
@@ -96,7 +96,7 @@ def _cat_registrar():
 def _find_localserver_exe(mustfind):
     if sys.platform != "win32":
         return sys.executable
-    if pythoncom.__file__.find("_d") < 0:
+    if os.path.splitext(os.path.basename(pythoncom.__file__))[0].endswith("_d"):
         exeBaseName = "pythonw.exe"
     else:
         exeBaseName = "pythonw_d.exe"
@@ -234,7 +234,7 @@ def RegisterServer(
             # Although now we prefer a 'loader' DLL if it exists to avoid some
             # manifest issues (the 'loader' DLL has a manifest, but pythoncom does not)
             pythoncom_dir = os.path.dirname(pythoncom.__file__)
-            suffix = "_d" if "_d" in pythoncom.__file__ else ""
+            suffix = "_d" if os.path.splitext(os.path.basename(pythoncom.__file__))[0].endswith("_d") else ""
             # Always register with the full path to the DLLs.
             loadername = os.path.join(
                 pythoncom_dir,

--- a/setup.py
+++ b/setup.py
@@ -200,10 +200,7 @@ class WinExt(Extension):
             # If someone needs a specially named implib created, handle that
             if self.implib_name:
                 implib = os.path.join(build_ext.build_temp, self.implib_name)
-                if build_ext.debug:
-                    suffix = "_d"
-                else:
-                    suffix = ""
+                suffix = "_d" if build_ext.debug else ""
                 self.extra_link_args.append(f"/IMPLIB:{implib}{suffix}.lib")
             # Try and find the MFC headers, so we can reach inside for
             # some of the ActiveX support we need.  We need to do this late, so
@@ -626,9 +623,7 @@ class my_build_ext(build_ext):
             target_dir = os.path.join(self.build_lib, clib_file[0], "libs")
             if not os.path.exists(target_dir):
                 self.mkpath(target_dir)
-            suffix = ""
-            if self.debug:
-                suffix = "_d"
+            suffix = "_d" if self.debug else ""
             fname = clib_file[1] % suffix
             self.copy_file(os.path.join(self.build_temp, fname), target_dir)
 
@@ -660,10 +655,9 @@ class my_build_ext(build_ext):
             self.copy_file(mfc_content, target_dir)
 
     def build_exefile(self, ext):
-        _d = self.debug and "_d" or ""
-
+        suffix = "_d" if self.debug else ""
         logging.info("building exe '%s'", ext.name)
-        leaf_name = f"{ext.get_pywin32_dir()}\\{ext.name}{_d}.exe"
+        leaf_name = f"{ext.get_pywin32_dir()}\\{ext.name}{suffix}.exe"
         full_name = os.path.join(self.build_lib, leaf_name)
 
         sources = list(ext.sources)
@@ -745,7 +739,7 @@ class my_build_ext(build_ext):
             # Convincing distutils to create .lib files with the name we
             # need is difficult, so we just hack around it by copying from
             # the created name to the name we need.
-            extra = self.debug and "_d.lib" or ".lib"
+            extra = "_d.lib" if self.debug else ".lib"
             if ext.name in ("pywintypes", "pythoncom"):
                 # The import libraries are created as PyWinTypes23.lib, but
                 # are expected to be pywintypes.lib.
@@ -782,15 +776,15 @@ class my_build_ext(build_ext):
 
     def get_ext_filename(self, name):
         # We need to fixup some target filenames.
-        _d = self.debug and "_d" or ""
+        suffix = "_d" if self.debug else ""
         if name in ["pywintypes", "pythoncom"]:
             ver = f"{sys.version_info[0]}{sys.version_info[1]}"
-            return f"{name}{ver}{_d}.dll"
+            return f"{name}{ver}{suffix}.dll"
         if name in ["perfmondata", "PyISAPI_loader"]:
-            return f"{name}{_d}.dll"
+            return f"{name}{suffix}.dll"
         # everything else a .pyd - calling base-class might give us a more
         # complicated name, so return a simple one.
-        return f"{name}{_d}.pyd"
+        return f"{name}{suffix}.pyd"
 
     def get_export_symbols(self, ext):
         if ext.is_regular_dll:

--- a/win32/Lib/win32serviceutil.py
+++ b/win32/Lib/win32serviceutil.py
@@ -17,7 +17,6 @@ import win32con
 import win32service
 import winerror
 
-_d = "_d" if "_d.pyd" in importlib.machinery.EXTENSION_SUFFIXES else ""
 error = RuntimeError
 
 
@@ -35,9 +34,11 @@ def LocatePythonServiceExe(exe=None):
     if exe and os.path.isfile(exe):
         return win32api.GetFullPathName(exe)
 
+    suffix = "_d" if "_d.pyd" in importlib.machinery.EXTENSION_SUFFIXES else ""
+
     # We are confused if we aren't now looking for our default. But if that
     # exists as specified we assume it's good.
-    exe = f"pythonservice{_d}.exe"
+    exe = f"pythonservice{suffix}.exe"
     if os.path.isfile(exe):
         return win32api.GetFullPathName(exe)
 
@@ -62,7 +63,7 @@ def LocatePythonServiceExe(exe=None):
     # (Unlike the .exe above, we don't unconditionally copy this, and possibly
     # copy it to a different place. Doesn't seem a good reason for that!?)
     python_dll = win32api.GetModuleFileName(sys.dllhandle)
-    pyw = f"pywintypes{sys.version_info[0]}{sys.version_info[1]}{_d}.dll"
+    pyw = f"pywintypes{sys.version_info[0]}{sys.version_info[1]}{suffix}.dll"
     correct_pyw = os.path.join(os.path.dirname(python_dll), pyw)
 
     if not os.path.exists(correct_pyw):

--- a/win32/scripts/VersionStamp/bulkstamp.py
+++ b/win32/scripts/VersionStamp/bulkstamp.py
@@ -56,7 +56,7 @@ def walk(arg, dirname, names):
                 # Handle the "_d" thing.
                 pathname = os.path.join(dirname, name)
                 base, ext = os.path.splitext(name)
-                if base[-2:] == "_d":
+                if base.endswith("_d"):
                     name = base[:-2] + ext
                 is_dll = ext.lower() != ".exe"
                 if os.path.normcase(name) in descriptions:

--- a/win32/scripts/setup_d.py
+++ b/win32/scripts/setup_d.py
@@ -23,7 +23,7 @@ def usage_and_die(rc):
     sys.exit(rc)
 
 
-if win32api.__file__.find("_d") > 0:
+if os.path.splitext(os.path.basename(win32api.__file__))[0].endswith("_d"):
     print("This scripts appears to be running a DEBUG version of Python.")
     print("Please run it using a normal release build (python.exe)")
     usage_and_die(1)

--- a/win32/test/testall.py
+++ b/win32/test/testall.py
@@ -142,7 +142,7 @@ def import_all():
 
     dir = os.path.dirname(win32api.__file__)
     num = 0
-    is_debug = os.path.basename(win32api.__file__).endswith("_d")
+    is_debug = os.path.splitext(os.path.basename(win32api.__file__))[0].endswith("_d")
     for name in os.listdir(dir):
         base, ext = os.path.splitext(name)
         # handle `modname.cp310-win_amd64.pyd` etc
@@ -150,12 +150,7 @@ def import_all():
         if (
             (ext == ".pyd")
             and name != "_winxptheme.pyd"
-            and (
-                is_debug
-                and base.endswith("_d")
-                or not is_debug
-                and not base.endswith("_d")
-            )
+            and is_debug == base.endswith("_d")
         ):
             try:
                 __import__(base)


### PR DESCRIPTION
Checks that the filename w/o extension ends with `_d` rather than checking for `_d` anywhere in the file path. Closes #1949
Standardized the ternary assignement of `"_d"`
Fix and simplifies a test.