### PR TITLE
Fix passing a `float` to `range` in `win32pdhquery.Query.collectdatafor`

### DIFF
--- a/win32/Lib/win32pdhquery.py
+++ b/win32/Lib/win32pdhquery.py
@@ -495,7 +495,7 @@ class Query(BaseQuery):
         tempresults = []
         try:
             self.open()
-            for ind in range(totalperiod / period):
+            for ind in range(int(totalperiod / period)):
                 tempresults.append(self.collectdata())
                 time.sleep(period)
             self.curresults = tempresults


### PR DESCRIPTION
Fixes #1549
This kind of issue can be caught ahead of time by type-checkers.