### PR TITLE
Annotations-only changes for type-checking

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,7 @@ jobs:
         path: |
           dist/*.whl
 
+  # This job can be run locally with the `format_all.bat` script
   checkers:
     runs-on: ubuntu-latest
     steps:

--- a/Pythonwin/pywin/framework/bitmap.py
+++ b/Pythonwin/pywin/framework/bitmap.py
@@ -128,7 +128,7 @@ class BitmapTemplate(docview.DocTemplate):
 
 # For debugging purposes, when this module may be reloaded many times.
 try:
-    win32ui.GetApp().RemoveDocTemplate(bitmapTemplate)
+    win32ui.GetApp().RemoveDocTemplate(bitmapTemplate)  # type: ignore[has-type, used-before-def]
 except NameError:
     pass
 

--- a/Pythonwin/pywin/framework/editor/color/coloreditor.py
+++ b/Pythonwin/pywin/framework/editor/color/coloreditor.py
@@ -644,7 +644,7 @@ class SyntEditTemplate(EditorTemplateBase):
 
 # For debugging purposes, when this module may be reloaded many times.
 try:
-    win32ui.GetApp().RemoveDocTemplate(editorTemplate)
+    win32ui.GetApp().RemoveDocTemplate(editorTemplate)  # type: ignore[has-type, used-before-def]
 except NameError:
     pass
 

--- a/Pythonwin/pywin/framework/editor/editor.py
+++ b/Pythonwin/pywin/framework/editor/editor.py
@@ -503,7 +503,7 @@ prefModule = GetDefaultEditorModuleName()
 if __name__ == prefModule:
     # For debugging purposes, when this module may be reloaded many times.
     try:
-        win32ui.GetApp().RemoveDocTemplate(editorTemplate)
+        win32ui.GetApp().RemoveDocTemplate(editorTemplate)  # type: ignore[has-type, used-before-def]
     except (NameError, win32ui.error):
         pass
 

--- a/Pythonwin/pywin/framework/mdi_pychecker.py
+++ b/Pythonwin/pywin/framework/mdi_pychecker.py
@@ -842,7 +842,7 @@ class TheParamsDialog(dialog.Dialog):
 
 
 try:
-    win32ui.GetApp().RemoveDocTemplate(greptemplate)
+    win32ui.GetApp().RemoveDocTemplate(greptemplate)  # type: ignore[has-type, used-before-def]
 except NameError:
     pass
 

--- a/Pythonwin/pywin/framework/sgrepmdi.py
+++ b/Pythonwin/pywin/framework/sgrepmdi.py
@@ -751,7 +751,7 @@ class GrepParamsDialog(dialog.Dialog):
 
 
 try:
-    win32ui.GetApp().RemoveDocTemplate(greptemplate)
+    win32ui.GetApp().RemoveDocTemplate(greptemplate)  # type: ignore[has-type, used-before-def]
 except NameError:
     pass
 

--- a/Pythonwin/pywin/scintilla/bindings.py
+++ b/Pythonwin/pywin/scintilla/bindings.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import traceback
 
 import win32api
@@ -13,8 +15,8 @@ HANDLER_ARGS_EXTENSION = 3
 
 next_id = 5000
 
-event_to_commands = {}  # dict of integer IDs to event names.
-command_to_events = {}  # dict of event names to int IDs
+event_to_commands: dict[str, int] = {}  # dict of event names to IDs
+command_to_events: dict[int, str] = {}  # dict of IDs to event names
 
 
 def assign_command_id(event, id=0):

--- a/Pythonwin/pywin/scintilla/find.py
+++ b/Pythonwin/pywin/scintilla/find.py
@@ -1,4 +1,6 @@
 # find.py - Find and Replace
+from __future__ import annotations
+
 import afxres
 import win32api
 import win32con
@@ -35,7 +37,7 @@ class SearchParams:
 
 curDialog = None
 lastSearch = defaultSearch = SearchParams()
-searchHistory = []
+searchHistory: list[str] = []
 
 
 def ShowFindDialog():

--- a/Pythonwin/pywin/tools/browseProjects.py
+++ b/Pythonwin/pywin/tools/browseProjects.py
@@ -24,7 +24,7 @@ class HLIErrorItem(hierlist.HierListItem):
 
 
 class HLICLBRItem(hierlist.HierListItem):
-    def __init__(self, name, file, lineno, suffix=""):
+    def __init__(self, name: str, file, lineno, suffix=""):
         # If the 'name' object itself has a .name, use it.  Not sure
         # how this happens, but seems pyclbr related.
         # See PyWin32 bug 817035

--- a/com/win32com/client/gencache.py
+++ b/com/win32com/client/gencache.py
@@ -21,10 +21,14 @@ Hacks, to do, etc
   Maybe an OLE2 compound file, or a bsddb file?
 """
 
+from __future__ import annotations
+
 import glob
 import os
 import sys
 from importlib import reload
+from types import ModuleType
+from typing import Any
 
 import pythoncom
 import pywintypes
@@ -36,11 +40,11 @@ from . import CLSIDToClass
 bForDemandDefault = 0  # Default value of bForDemand - toggle this to change the world - see also makepy.py
 
 # The global dictionary
-clsidToTypelib = {}
+clsidToTypelib: dict[str, tuple[str, int, int, int]] = {}
 
 # If we have a different version of the typelib generated, this
 # maps the "requested version" to the "generated version".
-versionRedirectMap = {}
+versionRedirectMap: dict[tuple[str, int, int, int], ModuleType | None] = {}
 
 # There is no reason we *must* be readonly in a .zip, but we are now,
 # Rather than check for ".zip" or other tricks, PEP302 defines
@@ -53,7 +57,8 @@ is_readonly = is_zip = hasattr(win32com, "__loader__") and hasattr(
 
 # A dictionary of ITypeLibrary objects for demand generation explicitly handed to us
 # Keyed by usual clsid, lcid, major, minor
-demandGeneratedTypeLibraries = {}
+# Typing as Any because PyITypeLib is not exposed
+demandGeneratedTypeLibraries: dict[tuple[str, int, int, int], Any] = {}
 
 import pickle as pickle
 

--- a/com/win32com/server/dispatcher.py
+++ b/com/win32com/server/dispatcher.py
@@ -3,6 +3,8 @@
 Please see policy.py for a discussion on dispatchers and policies
 """
 
+from __future__ import annotations
+
 import traceback
 from sys import exc_info
 
@@ -284,6 +286,6 @@ class DispatcherWin32dbg(DispatcherBase):
 try:
     import win32trace
 
-    DefaultDebugDispatcher = DispatcherWin32trace
+    DefaultDebugDispatcher: type[DispatcherTrace] = DispatcherWin32trace
 except ImportError:  # no win32trace module - just use a print based one.
     DefaultDebugDispatcher = DispatcherTrace

--- a/com/win32com/test/testvb.py
+++ b/com/win32com/test/testvb.py
@@ -4,6 +4,7 @@
 #
 
 import traceback
+from collections.abc import Callable
 
 import pythoncom
 import win32com.client

--- a/com/win32comext/adsi/demos/test.py
+++ b/com/win32comext/adsi/demos/test.py
@@ -1,4 +1,5 @@
 import sys
+from collections.abc import Callable
 
 import pythoncom
 import win32api

--- a/com/win32comext/axscript/client/framework.py
+++ b/com/win32comext/axscript/client/framework.py
@@ -7,6 +7,8 @@
   There are classes defined for the engine itself, and for ScriptItems
 """
 
+from __future__ import annotations
+
 import re
 import sys
 
@@ -175,7 +177,7 @@ class Event:
 class EventSink:
     """A set of events against an item.  Note this is a COM client for connection points."""
 
-    _public_methods_ = []
+    _public_methods_: list[str] = []
 
     def __init__(self, myItem, coDispatch):
         self.events = {}

--- a/com/win32comext/axscript/client/scriptdispatch.py
+++ b/com/win32comext/axscript/client/scriptdispatch.py
@@ -5,6 +5,8 @@
  this yet, so it is not well tested!
 """
 
+from __future__ import annotations
+
 import types
 
 import pythoncom
@@ -26,7 +28,7 @@ def _is_callable(obj):
 
 
 class ScriptDispatch:
-    _public_methods_ = []
+    _public_methods_: list[str] = []
 
     def __init__(self, engine, scriptNamespace):
         self.engine = engine

--- a/com/win32comext/mapi/mapiutil.py
+++ b/com/win32comext/mapi/mapiutil.py
@@ -1,10 +1,12 @@
 # General utilities for MAPI and MAPI objects.
+from __future__ import annotations
+
 import pythoncom
 from pywintypes import TimeType
 
 from . import mapi, mapitags
 
-prTable = {}
+prTable: dict[int, str] = {}
 
 
 def GetPropTagName(pt):
@@ -57,7 +59,7 @@ def GetPropTagName(pt):
         return ret
 
 
-mapiErrorTable = {}
+mapiErrorTable: dict[int, str] = {}
 
 
 def GetScodeString(hr):
@@ -68,7 +70,7 @@ def GetScodeString(hr):
     return mapiErrorTable.get(hr, pythoncom.GetScodeString(hr))
 
 
-ptTable = {}
+ptTable: dict[int, str] = {}
 
 
 def GetMapiTypeName(propType, rawType=True):

--- a/isapi/install.py
+++ b/isapi/install.py
@@ -2,6 +2,8 @@
 
 # this code adapted from "Tomcat JK2 ISAPI redirector", part of Apache
 # Created July 2004, Mark Hammond.
+from __future__ import annotations
+
 import importlib.machinery
 import os
 import shutil
@@ -73,7 +75,7 @@ class VirtualDirParameters:
     EnableDirBrowsing = _DEFAULT_ENABLE_DIR_BROWSING
     EnableDefaultDoc = _DEFAULT_ENABLE_DEFAULT_DOC
     DefaultDoc = None  # Only set in IIS if not None
-    ScriptMaps = []
+    ScriptMaps: list[ScriptMapParams] = []
     ScriptMapUpdate = "end"  # can be 'start', 'end', 'replace'
     Server = None
 
@@ -117,8 +119,8 @@ class ScriptMapParams:
 class ISAPIParameters:
     ServerName = _DEFAULT_SERVER_NAME
     # Description = None
-    Filters = []
-    VirtualDirs = []
+    Filters: list[FilterParameters] = []
+    VirtualDirs: list[VirtualDirParameters] = []
 
     def __init__(self, **kw):
         self.__dict__.update(kw)

--- a/isapi/samples/advanced.py
+++ b/isapi/samples/advanced.py
@@ -67,7 +67,7 @@ import winerror
 from isapi import InternalReloadException
 
 try:
-    reload_counter += 1
+    reload_counter += 1  # type: ignore[used-before-def]
 except NameError:
     reload_counter = 0
 

--- a/isapi/simple.py
+++ b/isapi/simple.py
@@ -8,6 +8,8 @@ It is not necessary to use these base-classes - but if you don't, you
 must ensure each of the required methods are implemented.
 """
 
+from __future__ import annotations
+
 
 class SimpleExtension:
     "Base class for a simple ISAPI extension"
@@ -38,7 +40,7 @@ class SimpleExtension:
 
 class SimpleFilter:
     "Base class for a a simple ISAPI filter"
-    filter_flags = None
+    filter_flags: int | None = None
 
     def __init__(self):
         pass

--- a/pywin32_postinstall.py
+++ b/pywin32_postinstall.py
@@ -72,7 +72,7 @@ try:
     # functions which write lines to PythonXX\pywin32-install.log. This is
     # a list of actions for the uninstaller, the format is inspired by what
     # the Wise installer also creates.
-    file_created
+    file_created  # type: ignore[used-before-def]
     # 3.10 stopped supporting bdist_wininst, but we can still build them with 3.9.
     # This can be kept until Python 3.9 or exe installers support is dropped.
     is_bdist_wininst = True
@@ -98,7 +98,7 @@ except NameError:
 
 
 try:
-    create_shortcut
+    create_shortcut  # type: ignore[used-before-def]
 except NameError:
     # Create a function with the same signature as create_shortcut provided
     # by bdist_wininst

--- a/win32/Lib/win32pdhutil.py
+++ b/win32/Lib/win32pdhutil.py
@@ -18,6 +18,8 @@ Example:
   the easiest way is often to simply use PerfMon to find out the names.
 """
 
+from __future__ import annotations
+
 import time
 
 import win32pdh
@@ -27,7 +29,7 @@ error = win32pdh.error
 # Handle some localization issues.
 # see http://support.microsoft.com/default.aspx?scid=http://support.microsoft.com:80/support/kb/articles/Q287/1/59.asp&NoWebContent=1
 # Build a map of english_counter_name: counter_id
-counter_english_map = {}
+counter_english_map: dict[str, int] = {}
 
 
 def find_pdh_counter_localized_name(english_name, machine_name=None):

--- a/win32/Lib/win32rcparser.py
+++ b/win32/Lib/win32rcparser.py
@@ -7,6 +7,8 @@
 This is a parser for Windows .rc files, which are text files which define
 dialogs and other Windows UI resources.
 """
+from __future__ import annotations
+
 __author__ = "Adam Walker"
 __version__ = "0.11"
 
@@ -171,8 +173,8 @@ class StringDef:
 
 class RCParser:
     next_id = 1001
-    dialogs = {}
-    _dialogs = {}
+    dialogs: dict[str, list[list[str | int | None | tuple[str | int, ...]]]] = {}
+    _dialogs: dict[str, DialogDef] = {}
     debugEnabled = False
     token = ""
 

--- a/win32/Lib/win32timezone.py
+++ b/win32/Lib/win32timezone.py
@@ -231,6 +231,8 @@ Test offsets that occur right at the DST changeover
 datetime.datetime(2011, 11, 6, 1, 0, tzinfo=TimeZoneInfo('Pacific Standard Time'))
 
 """
+from __future__ import annotations
+
 __author__ = "Jason R. Coombs <jaraco@jaraco.com>"
 
 import datetime
@@ -249,7 +251,7 @@ log = logging.getLogger(__file__)
 # A couple of objects for working with objects as if they were native C-type
 # structures.
 class _SimpleStruct:
-    _fields_ = None  # must be overridden by subclasses
+    _fields_: list[tuple[str, type]] | None = None  # must be overridden by subclasses
 
     def __init__(self, *args, **kw):
         for i, (name, typ) in enumerate(self._fields_):

--- a/win32/scripts/ce/pysynch.py
+++ b/win32/scripts/ce/pysynch.py
@@ -4,6 +4,7 @@ import fnmatch
 import getopt
 import os
 import sys
+from collections.abc import Callable
 
 import win32api
 import win32con


### PR DESCRIPTION
Extracted annotations only changes from #2102
This PR **only** includes the following, which are much easier and safer to review:
- Comments
- Python 3.7 compatible type annotations
- typing-only new imports
