### PR TITLE
Cleanly break out of windows iteration

### DIFF
--- a/win32/src/PyWinTypes.h
+++ b/win32/src/PyWinTypes.h
@@ -101,7 +101,7 @@ extern PYWINTYPES_EXPORT BOOL PyWin_RegisterErrorMessageModule(DWORD first, DWOR
 extern PYWINTYPES_EXPORT HINSTANCE PyWin_GetErrorMessageModule(DWORD err);
 
 /* A global function that sets an API style error (ie, (code, fn, errTest)) */
-PYWINTYPES_EXPORT PyObject *PyWin_SetAPIError(char *fnName, long err = 0);
+PYWINTYPES_EXPORT PyObject *PyWin_SetAPIError(const char *fnName, long err = 0, bool returnNoneOnSuccess = false);
 
 /* Basic COM Exception handling.  The main COM exception object
    is actually defined here.  However, the most useful functions

--- a/win32/src/PyWinTypesmodule.cpp
+++ b/win32/src/PyWinTypesmodule.cpp
@@ -275,9 +275,11 @@ HINSTANCE PyWin_GetErrorMessageModule(DWORD err)
 }
 
 /* error helper - GetLastError() is provided, but this is for exceptions */
-PyObject *PyWin_SetAPIError(char *fnName, long err /*= 0*/)
+PyObject *PyWin_SetAPIError(const char *fnName, long err /*= 0*/, bool returnNoneOnSuccess /*= false*/)
 {
     DWORD errorCode = err == 0 ? GetLastError() : err;
+    if ((returnNoneOnSuccess) && (!errorCode))
+        Py_RETURN_NONE;
     DWORD flags = FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_IGNORE_INSERTS;
     // try and find the hmodule providing this error.
     HMODULE hmodule = PyWin_GetErrorMessageModule(errorCode);

--- a/win32/src/win32gui.i
+++ b/win32/src/win32gui.i
@@ -2089,7 +2089,7 @@ static PyObject *PyEnumWindows(PyObject *self, PyObject *args)
 		// Callback may have raised an exception already
 		if (PyErr_Occurred())
 			return NULL;
-		return PyWin_SetAPIError("EnumWindows");
+		return PyWin_SetAPIError("EnumWindows", 0, true);
 		}
 	Py_INCREF(Py_None);
 	return Py_None;

--- a/win32/src/win32gui.i
+++ b/win32/src/win32gui.i
@@ -2053,11 +2053,11 @@ BOOL CALLBACK PyEnumWindowsProc(
 	PyObject *args = Py_BuildValue("(NO)", PyWinLong_FromHANDLE(hwnd), cb->extra);
 	if (args == NULL)
 		return FALSE;
-	PyObject *ret = PyEval_CallObject(cb->func, args);
+	PyObject *ret = PyObject_CallObject(cb->func, args);
 	Py_DECREF(args);
-	if (ret == NULL)		
+	if (ret == NULL)
 		return FALSE;
-	if (ret != Py_None){
+	if (ret != Py_None) {
 		result = PyLong_AsLong(ret);
 		if (result == -1 && PyErr_Occurred())
 			result = FALSE;
@@ -2091,8 +2091,7 @@ static PyObject *PyEnumWindows(PyObject *self, PyObject *args)
 			return NULL;
 		return PyWin_SetAPIError("EnumWindows", 0, true);
 		}
-	Py_INCREF(Py_None);
-	return Py_None;
+	Py_RETURN_NONE;
 }
 
 #ifndef MS_WINCE


### PR DESCRIPTION
This is a (proposed) fix for #2163. If the user wants to stop iteration (by returning *FALSE* (or equivalent) from the callback) *EnumWindows* (&& friends) should not raise exception. It should only raise exception if callback:
- Raised one (already implemented)
- Sets last error (as suggested in [\[MS.Learn\]: EnumWindows function (winuser.h) - Return value](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-enumwindows#return-value))

**Notes**:

- *PyWin\_SetAPIError*: considering that *0* (*SUCCESS*) is *Win*'s way of signaling non failure, I think that (logically) this should be the default behavior (if there's no error, don't raise any exception, especially since that message is not clear). But:
    - The function name clearly denotes an error
    - Most likely, lots of code (*PyWin32* and 3<sup>rd</sup-party) depends on current behavior, I think it will trigger massive regressions

    I only added this behavior as an option (disabled by default)

- **IMPORTANT** - do not merge until next question is answered:

    - As stated above, this applies to other functions from the same family (well except *EnumChildWindows* whose return value must be ignored). Since there are very little differences between behaviors, would it make sense to only have a function (with a couple of extra arguments) that does all the heavy lifting, and it's called by all the "visible" functions, instead of multiplicating the code in all of them?
