### PR TITLE
adsi: avoid usage from star import and avoid global reassignement overrides

### DIFF
--- a/com/win32comext/adsi/__init__.py
+++ b/com/win32comext/adsi/__init__.py
@@ -25,7 +25,7 @@ else:
 # interface, as well as via IDispatch.
 import pythoncom
 
-from .adsi import *  # nopycln: import  # win32comext/adsi/adsi.pyd
+from .adsi import *  # nopycln: import # Re-export everything from win32comext/adsi/adsi.pyd
 
 LCID = 0
 
@@ -51,8 +51,8 @@ def _get_good_ret(
 class ADSIEnumerator:
     def __init__(self, ob):
         # Query the object for the container interface.
-        self._cont_ = ob.QueryInterface(IID_IADsContainer)
-        self._oleobj_ = ADsBuildEnumerator(self._cont_)  # a PyIADsEnumVARIANT
+        self._cont_ = ob.QueryInterface(adsi.IID_IADsContainer)
+        self._oleobj_ = adsi.ADsBuildEnumerator(self._cont_)  # a PyIADsEnumVARIANT
         self.index = -1
 
     def __getitem__(self, index):
@@ -68,12 +68,12 @@ class ADSIEnumerator:
             # Index requested out of sequence.
             raise ValueError("You must index this object sequentially")
         self.index = index
-        result = ADsEnumerateNext(self._oleobj_, 1)
+        result = adsi.ADsEnumerateNext(self._oleobj_, 1)
         if len(result):
             return _get_good_ret(result[0])
         # Failed - reset for next time around.
         self.index = -1
-        self._oleobj_ = ADsBuildEnumerator(self._cont_)  # a PyIADsEnumVARIANT
+        self._oleobj_ = adsi.ADsBuildEnumerator(self._cont_)  # a PyIADsEnumVARIANT
         raise IndexError("list index out of range")
 
 
@@ -105,18 +105,12 @@ class ADSIDispatch(win32com.client.CDispatch):
         return _get_good_ret(ret)
 
 
-# We override the global methods to do the right thing.
-_ADsGetObject = ADsGetObject  # The one in the .pyd
-
-
+# We override the adsi.pyd methods to do the right thing.
 def ADsGetObject(path, iid=pythoncom.IID_IDispatch):
-    ret = _ADsGetObject(path, iid)
+    ret = adsi.ADsGetObject(path, iid)
     return _get_good_ret(ret)
 
 
-_ADsOpenObject = ADsOpenObject
-
-
 def ADsOpenObject(path, username, password, reserved=0, iid=pythoncom.IID_IDispatch):
-    ret = _ADsOpenObject(path, username, password, reserved, iid)
+    ret = adsi.ADsOpenObject(path, username, password, reserved, iid)
     return _get_good_ret(ret)


### PR DESCRIPTION
As title says.

Split off from #2102 for ease of review.
Checkers no longer think the symbols are potentially unbound (because of the * import from a pyd that doesn,t exist at development).
Also avoids global name reassignement for cleaner overrides.