### PR TITLE
Fix `pywin.tools.regpy`'s `ModuleNotFoundError: No module named 'dialog'`

### DIFF
--- a/Pythonwin/pywin/tools/regpy.py
+++ b/Pythonwin/pywin/tools/regpy.py
@@ -1,8 +1,7 @@
 # (sort-of) Registry editor
 import commctrl
-import dialog
 import win32con
-import win32ui
+from pywin.mfc import dialog
 
 
 class RegistryControl:


### PR DESCRIPTION
Extracted from #2102 

Before:
```py
>>> import pywin.tools.regpy
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Program Files\Python39\lib\site-packages\Pythonwin\pywin\tools\regpy.py", line 3, in <module>
    import dialog
ModuleNotFoundError: No module named 'dialog'
```

```powershell
PS C:\Program Files\Python39\Lib\site-packages\pythonwin\pywin\tools> python .\regpy.py
Traceback (most recent call last):
  File "C:\Program Files\Python39\Lib\site-packages\pythonwin\pywin\tools\regpy.py", line 3, in <module>
    import dialog
ModuleNotFoundError: No module named 'dialog'
```

After:
```py
>>> import pywin.tools.regpy
# (no import error)
```
![image](https://github.com/mhammond/pywin32/assets/1350584/3372f10b-5722-48ac-96a3-418eaa6f253e)



