### PR TITLE
Extend PyWin_SetAPIError

### DIFF
--- a/win32/src/PyWinTypes.h
+++ b/win32/src/PyWinTypes.h
@@ -103,6 +103,9 @@ extern PYWINTYPES_EXPORT HINSTANCE PyWin_GetErrorMessageModule(DWORD err);
 /* A global function that sets an API style error (ie, (code, fn, errTest)) */
 PYWINTYPES_EXPORT PyObject *PyWin_SetAPIError(char *fnName, long err = 0);
 
+// A PyWin_SetAPIError variant that returns None (Py_None) on success.
+PYWINTYPES_EXPORT PyObject *PyWin_SetAPIErrorOrReturnNone(char *fnName, long err = ERROR_SUCCESS);
+
 /* Basic COM Exception handling.  The main COM exception object
    is actually defined here.  However, the most useful functions
    for raising the exception are still in the COM package.  Therefore,

--- a/win32/src/PyWinTypes.h
+++ b/win32/src/PyWinTypes.h
@@ -101,7 +101,7 @@ extern PYWINTYPES_EXPORT BOOL PyWin_RegisterErrorMessageModule(DWORD first, DWOR
 extern PYWINTYPES_EXPORT HINSTANCE PyWin_GetErrorMessageModule(DWORD err);
 
 /* A global function that sets an API style error (ie, (code, fn, errTest)) */
-PYWINTYPES_EXPORT PyObject *PyWin_SetAPIError(char *fnName, long err = 0);
+PYWINTYPES_EXPORT PyObject *PyWin_SetAPIError(char *fnName, long err = ERROR_SUCCESS);
 
 // A PyWin_SetAPIError variant that returns None (Py_None) on success.
 PYWINTYPES_EXPORT PyObject *PyWin_SetAPIErrorOrReturnNone(char *fnName, long err = ERROR_SUCCESS);

--- a/win32/src/PyWinTypesmodule.cpp
+++ b/win32/src/PyWinTypesmodule.cpp
@@ -308,6 +308,15 @@ PyObject *PyWin_SetAPIError(char *fnName, long err /*= 0*/)
     return NULL;
 }
 
+/* error helper - like PyWin_SetAPIError, but returns None on success */
+PyObject *PyWin_SetAPIErrorOrReturnNone(char *fnName, long err /*= ERROR_SUCCESS*/)
+{
+    DWORD errorCode = err == ERROR_SUCCESS ? GetLastError() : err;
+    if (errorCode == ERROR_SUCCESS)
+        Py_RETURN_NONE;
+    return PyWin_SetAPIError(fnName, errorCode);
+}
+
 // This function sets a basic COM error - it is a valid COM
 // error, but may not contain rich error text about the error.
 // Designed to be used before pythoncom has been loaded.

--- a/win32/src/PyWinTypesmodule.cpp
+++ b/win32/src/PyWinTypesmodule.cpp
@@ -275,9 +275,9 @@ HINSTANCE PyWin_GetErrorMessageModule(DWORD err)
 }
 
 /* error helper - GetLastError() is provided, but this is for exceptions */
-PyObject *PyWin_SetAPIError(char *fnName, long err /*= 0*/)
+PyObject *PyWin_SetAPIError(char *fnName, long err /*= ERROR_SUCCESS*/)
 {
-    DWORD errorCode = err == 0 ? GetLastError() : err;
+    DWORD errorCode = err == ERROR_SUCCESS ? GetLastError() : err;
     DWORD flags = FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_IGNORE_INSERTS;
     // try and find the hmodule providing this error.
     HMODULE hmodule = PyWin_GetErrorMessageModule(errorCode);


### PR DESCRIPTION
Split this out of #2183.

This change by itself is much more significant than the other one, so it should be stand alone (rather than a prerequisite).

So far, anything is unchanged functionally (all the places that call it).
If this behavior (returning *None* on non error, instead of raising `PyWinExc_ApiError(0, "No error message is available")`) becomes the default, the (new) default argument value should be changed. But (although I don't know what the module backward compatibility / deprecation policy is), I'd just deprecate it for now:

- Keep it as it is for the next release (maybe also the one after)

- Let users know by changing the error message to something like: *(Deprecated) No error message is available*


