### PR TITLE
Enhance CredDelete to work with dictionaries

### DIFF
--- a/win32/test/test_win32cred.py
+++ b/win32/test/test_win32cred.py
@@ -1,0 +1,73 @@
+import copy
+import unittest
+
+import win32cred
+
+
+class TestCredFunctions(unittest.TestCase):
+
+    def setUp(self):
+        self.flags = 0
+        self.dummy_cred = {
+            "TargetName": "DumyyUser",
+            "Type": win32cred.CRED_TYPE_GENERIC,
+            "Flags": self.flags,
+        }
+
+    def create_dummy_cred(self):
+        cred = copy.deepcopy(self.dummy_cred)
+        cred.update(
+            {
+                "Persist": win32cred.CRED_PERSIST_SESSION,
+            }
+        )
+        try:
+            win32cred.CredWrite(cred, self.flags)
+        except Exception as e:
+            print(e)
+
+    def is_dummy_cred(self):
+        return (
+            len(
+                [
+                    e
+                    for e in win32cred.CredEnumerate()
+                    if e["TargetName"] == self.dummy_cred["TargetName"]
+                ]
+            )
+            == 1
+        )
+
+    def test_creddelete(self):
+        self.create_dummy_cred()
+        self.assertTrue(self.is_dummy_cred())
+        self.assertIsNone(win32cred.CredDelete(**self.dummy_cred))
+        self.assertFalse(self.is_dummy_cred())
+        self.create_dummy_cred()
+        self.assertTrue(self.is_dummy_cred())
+        self.assertIsNone(win32cred.CredDelete(*self.dummy_cred.values()))
+        self.assertFalse(self.is_dummy_cred())
+        self.create_dummy_cred()
+        self.assertTrue(self.is_dummy_cred())
+        self.assertIsNone(
+            win32cred.CredDelete(self.dummy_cred["TargetName"], self.dummy_cred["Type"])
+        )
+        self.assertFalse(self.is_dummy_cred())
+        self.create_dummy_cred()
+        self.assertTrue(self.is_dummy_cred())
+        self.assertIsNone(win32cred.CredDelete(self.dummy_cred))
+        self.assertFalse(self.is_dummy_cred())
+        self.create_dummy_cred()
+        self.assertTrue(self.is_dummy_cred())
+        self.assertIsNone(win32cred.CredDelete(Target=self.dummy_cred))
+        self.assertFalse(self.is_dummy_cred())
+        self.create_dummy_cred()
+        self.assertTrue(self.is_dummy_cred())
+        self.assertRaises(TypeError, win32cred.CredDelete, "")
+        self.assertRaises(KeyError, win32cred.CredDelete, {})
+        self.assertRaises(KeyError, win32cred.CredDelete, {"TargetName": ""})
+        self.assertRaises(
+            TypeError, win32cred.CredDelete, {"TargetName": "", "Type": 3.141593}
+        )
+        self.assertIsNone(win32cred.CredDelete(self.dummy_cred))
+        self.assertFalse(self.is_dummy_cred())


### PR DESCRIPTION
Fix for #1775.

As a rule of thumb I consider that if there's a pair of functions: a getter and a setter, the latter should work with whatever the former returns. Applied to current situation *CredDelete* (and maybe others?) should work with a *CREDENTIAL* structure (converted to a dictionary). In most of the cases that should be the only thing that it should work with, but in this current scenario this doesn't apply.
