### PR TITLE
Remove obsolete and broken unicode compatibility in `pywintypes`

### DIFF
--- a/com/win32com/test/testMSOffice.py
+++ b/com/win32com/test/testMSOffice.py
@@ -11,7 +11,6 @@ import pythoncom
 import win32api
 import win32com
 import win32com.client.dynamic
-from pywintypes import Unicode
 from win32com.client import gencache
 from win32com.test.util import CheckClean
 
@@ -112,7 +111,7 @@ def TextExcel(xl):
     if not xl.Visible:
         raise error("Visible property not true.")
 
-    if int(xl.Version[0]) >= 8:
+    if int(xl.Version.split(".")[0]) >= 8:
         xl.Workbooks.Add()
     else:
         xl.Workbooks().Add()
@@ -127,16 +126,16 @@ def TextExcel(xl):
     if xl.Range("A1").Value != "Hi 0":
         raise error("Single cell range failed")
 
-    if xl.Range("A1:B1").Value != ((Unicode("Hi 0"), 2),):
+    if xl.Range("A1:B1").Value != (("Hi 0", 2),):
         raise error("flat-horizontal cell range failed")
 
-    if xl.Range("A1:A2").Value != ((Unicode("Hi 0"),), (Unicode("x"),)):
+    if xl.Range("A1:A2").Value != (("Hi 0",), ("x",)):
         raise error("flat-vertical cell range failed")
 
     if xl.Range("A1:C3").Value != (
-        (Unicode("Hi 0"), 2, 3),
-        (Unicode("x"), Unicode("Hi 1"), Unicode("z")),
-        (3, 2, Unicode("Hi 2")),
+        ("Hi 0", 2, 3),
+        ("x", "Hi 1", "z"),
+        (3, 2, "Hi 2"),
     ):
         raise error("square cell range failed")
 
@@ -144,7 +143,7 @@ def TextExcel(xl):
 
     if xl.Range("A1:C3").Value != (
         (3, 2, 1),
-        (Unicode("x"), Unicode("y"), Unicode("z")),
+        ("x", "y", "z"),
         (1, 2, 3),
     ):
         raise error("Range was not what I set it to!")

--- a/win32/Lib/win32serviceutil.py
+++ b/win32/Lib/win32serviceutil.py
@@ -442,8 +442,6 @@ def ControlService(serviceName, code, machine=None):
 
 
 def __FindSvcDeps(findName):
-    if isinstance(findName, pywintypes.UnicodeType):
-        findName = str(findName)
     dict = {}
     k = win32api.RegOpenKey(
         win32con.HKEY_LOCAL_MACHINE, "SYSTEM\\CurrentControlSet\\Services"

--- a/win32/src/PyWinTypesmodule.cpp
+++ b/win32/src/PyWinTypesmodule.cpp
@@ -334,16 +334,6 @@ PyObject *PyWin_SetBasicCOMError(HRESULT hr)
     return NULL;
 }
 
-// @pymethod string|pywintypes|Unicode|Creates a new Unicode object
-PYWINTYPES_EXPORT PyObject *PyWin_NewUnicode(PyObject *self, PyObject *args)
-{
-    char *string;
-    int slen;
-    if (!PyArg_ParseTuple(args, "t#", &string, &slen))
-        return NULL;
-    return PyUnicode_DecodeMBCS(string, slen, NULL);
-}
-
 // @pymethod string|pywintypes|UnicodeFromRaw|Creates a new Unicode object from raw binary data
 static PyObject *PyWin_NewUnicodeFromRaw(PyObject *self, PyObject *args)
 {
@@ -760,7 +750,6 @@ static struct PyMethodDef pywintypes_functions[] = {
     {"DosDateTimeToTime", PyWin_DosDateTimeToTime,
      1},  // @pymeth DosDateTimeToTime|Converts an MS-DOS Date/Time to a standard Time object
 #endif
-    {"Unicode", PyWin_NewUnicode, 1},  // @pymeth Unicode|Creates a new string object
     {"UnicodeFromRaw", PyWin_NewUnicodeFromRaw,
      1},  // @pymeth UnicodeFromRaw|Creates a new string object from raw binary data
     {"IsTextUnicode", PyWin_IsTextUnicode,
@@ -959,10 +948,6 @@ PYWIN_MODULE_INIT_FUNC(pywintypes)
         PyDict_SetItemString(dict, "TRUE", Py_True) == -1 || PyDict_SetItemString(dict, "FALSE", Py_False) == -1)
         PYWIN_MODULE_INIT_RETURN_ERROR;
     ADD_CONSTANT(WAVE_FORMAT_PCM);
-
-    // Add a few types.
-    if (PyDict_SetItemString(dict, "UnicodeType", (PyObject *)&PyUnicode_Type) == -1)
-        PYWIN_MODULE_INIT_RETURN_ERROR;
 
     if (!_PyWinDateTime_PrepareModuleDict(dict))
         PYWIN_MODULE_INIT_RETURN_ERROR;

--- a/win32/src/win32apimodule.cpp
+++ b/win32/src/win32apimodule.cpp
@@ -5177,9 +5177,6 @@ PyObject *PyEnumResourceLanguages(PyObject *self, PyObject *args)
     return ret;
 }
 
-// @pymethod <o PyUnicode>|win32api|Unicode|Creates a new Unicode object
-PYWINTYPES_EXPORT PyObject *PyWin_NewUnicode(PyObject *self, PyObject *args);
-
 ///////////////////
 //
 // Win32 Exception Handler.
@@ -6182,7 +6179,6 @@ static struct PyMethodDef win32api_functions[] = {
     {"TerminateProcess", PyTerminateProcess, 1},  // @pymeth TerminateProcess|Terminates a process.
     {"ToAsciiEx", PyToAsciiEx, 1},  // @pymeth ToAsciiEx|Translates the specified virtual-key code and keyboard state to
                                     // the corresponding character or characters.
-    {"Unicode", PyWin_NewUnicode, 1},         // @pymeth Unicode|Creates a new <o PyUnicode> object
     {"UpdateResource", PyUpdateResource, 1},  // @pymeth UpdateResource|Updates a resource in a PE file.
     {"VkKeyScan", PyVkKeyScan,
      1},  // @pymeth VkKeyScan|Translates a character to the corresponding virtual-key code and shift state.


### PR DESCRIPTION
Follow-up to https://github.com/mhammond/pywin32/pull/2085 but on side of the exposed C API

`UnicodeType` is just an alias to `str`
Closes #697 by simply removing the broken method `Unicode`.

I couldn't find an immediate pure-python equivalent of `UnicodeFromRaw`, and the demo `E:\Users\Avasam\Documents\Git\pywin32\win32\Demos\BackupSeek_streamheaders.py` looks like it still works fine. SO I left that one alone.

Not sure about `IsTextUnicode`.

I also had to fix the Excel test to work with versions greater than 9, so I could test it myself.