### PR TITLE
Remove obsolete Python 3.6 C code

### DIFF
--- a/Pythonwin/Win32uiHostGlue.h
+++ b/Pythonwin/Win32uiHostGlue.h
@@ -186,15 +186,6 @@ inline BOOL Win32uiHostGlue::DynamicApplicationInit(const TCHAR *cmd, const TCHA
         (*pfnPyInit)();
     }
 
-// In 3.7 and up it's not necessary to call PyEval_InitThreads. In all versions
-// it's safe to call multiple times.
-#if PY_VERSION_HEX < 0x03070000
-    void(__cdecl * pfnPyEval_InitThreads)(void);
-    pfnPyEval_InitThreads = (void(__cdecl *)(void))GetProcAddress(hModCore, "PyEval_InitThreads");
-    CHECK_PFN(pfnPyEval_InitThreads);
-    pfnPyEval_InitThreads();
-#endif
-
     PyObject* (*pPyImport_ImportModule)(const char *name) = (PyObject* (*)(const char *name))GetProcAddress(hModCore, "PyImport_ImportModule");
     CHECK_PFN(pPyImport_ImportModule);
     PyObject* (*pPyObject_GetAttrString)(PyObject *o, const char *attr_name) = (PyObject* (*)(PyObject *o, const char *attr_name))GetProcAddress(hModCore, "PyObject_GetAttrString");

--- a/Pythonwin/win32thread.cpp
+++ b/Pythonwin/win32thread.cpp
@@ -294,9 +294,6 @@ static PyObject *ui_thread_create_thread(PyObject *self, PyObject *args)
     CWinThread *pThread = GetCWinThreadPtr(self);
     if (!pThread)
         return NULL;
-#if PY_VERSION_HEX < 0x03070000
-    PyEval_InitThreads();
-#endif
     GUI_BGN_SAVE;
     BOOL ok = pThread->CreateThread(createFlags, stackSize);
     GUI_END_SAVE;

--- a/com/win32com/src/dllmain.cpp
+++ b/com/win32com/src/dllmain.cpp
@@ -71,11 +71,6 @@ void PyCom_DLLAddRef(void)
                 Py_XDECREF(str);
             }
 
-            // Must force Python to start using thread locks, as
-            // we are free-threaded (maybe, I think, sometimes :-)
-#if PY_VERSION_HEX < 0x03070000
-            PyEval_InitThreads();
-#endif
             // Release Python lock, as first thing we do is re-get it.
             ptsGlobal = PyEval_SaveThread();
             bDidInitPython = TRUE;

--- a/com/win32comext/axdebug/src/AXDebug.cpp
+++ b/com/win32comext/axdebug/src/AXDebug.cpp
@@ -294,10 +294,6 @@ PYWIN_MODULE_INIT_FUNC(axdebug)
 {
     PYWIN_MODULE_INIT_PREPARE(axdebug, axdebug_methods, "A module, encapsulating the ActiveX Debugging interfaces");
 
-#if PY_VERSION_HEX < 0x03070000
-    PyEval_InitThreads();
-#endif
-
     // Add some symbolic constants to the module
     axdebug_Error = PyErr_NewException("axdebug.error", NULL, NULL);
     if (axdebug_Error == NULL || PyDict_SetItemString(dict, "error", axdebug_Error) != 0)

--- a/isapi/src/PythonEng.cpp
+++ b/isapi/src/PythonEng.cpp
@@ -66,9 +66,6 @@ bool CPythonEngine::InitMainInterp(void)
         else {
             Py_Initialize();
         }
-#if PY_VERSION_HEX < 0x03070000
-        PyEval_InitThreads();
-#endif
 
         if (!g_IsFrozen) {
             TCHAR *dll_path = GetModulePath();

--- a/win32/src/PyWinTypesmodule.cpp
+++ b/win32/src/PyWinTypesmodule.cpp
@@ -779,9 +779,6 @@ static struct PyMethodDef pywintypes_functions[] = {
 
 int PyWinGlobals_Ensure()
 {
-#if PY_VERSION_HEX < 0x03070000
-    PyEval_InitThreads();
-#endif
     PyWinInterpreterState_Ensure();
     if (PyWinExc_ApiError == NULL) {
         // Setup our exception objects so they have attributes.

--- a/win32/src/PythonService.cpp
+++ b/win32/src/PythonService.cpp
@@ -613,10 +613,6 @@ static void PyService_InitPython()
 #ifdef BUILD_FREEZE
     PyWinFreeze_ExeInit();
 #endif
-    // Ensure we are set for threading.
-#if PY_VERSION_HEX < 0x03070000
-    PyEval_InitThreads();
-#endif
     // Notes about argv: When debugging a service, the argv is currently
     // the *full* args, including the "-debug servicename" args.  This
     // isn't ideal, but has been this way for a few builds, and a good
@@ -1454,9 +1450,6 @@ int _tmain(int argc, TCHAR **argv)
         // do not free `program` since Py_SetProgramName does not copy it.
     }
     Py_Initialize();
-#if PY_VERSION_HEX < 0x03070000
-    PyEval_InitThreads();
-#endif
     module = PyImport_ImportModule("servicemanager");
     if (!module)
         goto failed;

--- a/win32/src/win32apimodule.cpp
+++ b/win32/src/win32apimodule.cpp
@@ -2175,17 +2175,11 @@ static PyObject *PyGetTempFileName(PyObject *self, PyObject *args)
 // @pymethod tuple|win32api|GetTimeZoneInformation|Retrieves the system time-zone information.
 static PyObject *PyGetTimeZoneInformation(PyObject *self, PyObject *args)
 {
-    int bTimesAsTuples =
-#if (PY_VERSION_HEX > 0x03060000)
-        1
-#else
-        0
-#endif
-        ;
+    int bTimesAsTuples = 1;
     // @pyparm bool|times_as_tuples|?|If true, the SYSTEMTIME elements are returned as tuples instead of a time
-    // object. Defaults to False on 3.5 and earlier, True otherwise, because this function
-    // returns SYSTEMTIME information with members which datetime on 3.6 and later treats as
-    // invalid. In other words, using False on 3.6 and later will result in ValueErrors
+    // object. Defaults to True, because this function
+    // returns SYSTEMTIME information with members which datetime treats as
+    // invalid. In other words, using False will result in ValueErrors
     // instead of returning.
     if (!PyArg_ParseTuple(args, "|i:GetTimeZoneInformation", &bTimesAsTuples))
         return NULL;

--- a/win32/src/win32consolemodule.cpp
+++ b/win32/src/win32consolemodule.cpp
@@ -110,11 +110,7 @@ BOOL PyWinObject_AsSingleWCHAR(PyObject *obchar, WCHAR *onechar)
         PyErr_SetString(PyExc_ValueError, "Object must be a single unicode character");
         return FALSE;
     }
-#if (PY_VERSION_HEX < 0x03020000)
-#define PUAWC_TYPE PyUnicodeObject *
-#else
 #define PUAWC_TYPE PyObject *
-#endif
     if (PyUnicode_AsWideChar((PUAWC_TYPE)obchar, onechar, 1) == -1)
         return FALSE;
     return TRUE;

--- a/win32/src/win32gui.i
+++ b/win32/src/win32gui.i
@@ -251,9 +251,6 @@ PyObject *PyWinObject_FromHDEVNOTIFY(HGDIOBJ h)
 
 // Written to the module init function.
 %init %{
-#if PY_VERSION_HEX < 0x03070000
-PyEval_InitThreads(); /* Start the interpreter's thread-awareness */
-#endif
 PyDict_SetItemString(d, "dllhandle", PyWinLong_FromVoidPtr(g_dllhandle));
 PyDict_SetItemString(d, "error", PyWinExc_ApiError);
 

--- a/win32/src/win32process.i
+++ b/win32/src/win32process.i
@@ -414,9 +414,6 @@ static PyObject *mybeginthreadex(PyObject *self, PyObject *args)
 	if (!PyWinObject_AsSECURITY_ATTRIBUTES( obSA, &pSA, TRUE ))
 		return NULL;
 
-#if PY_VERSION_HEX < 0x03070000
-	PyEval_InitThreads();
-#endif
 	PythonThreadData *ptd = new PythonThreadData(obFunc, obArgs);
 	ULONG_PTR handle;
 	unsigned tid;
@@ -462,9 +459,6 @@ static PyObject *myCreateRemoteThread(PyObject *self, PyObject *args)
 	if (!PyWinObject_AsSECURITY_ATTRIBUTES( obSA, &pSA, TRUE ))
 		return NULL;
 
-#if PY_VERSION_HEX < 0x03070000
-	PyEval_InitThreads();
-#endif
 	HANDLE handle;
 	DWORD tid;
 	handle = (*pfnCreateRemoteThread)(hprocess, pSA, stackSize,

--- a/win32/src/win32rasmodule.cpp
+++ b/win32/src/win32rasmodule.cpp
@@ -560,11 +560,6 @@ static PyObject *PyRasDial(PyObject *self, PyObject *args)
     else
         return ReturnError("The callback object must be an integer handle, None, or a callable object",
                            "<Dial param parsing>");
-    // If we have any sort of callback, we must ensure threads are init'd.
-#if PY_VERSION_HEX < 0x03070000
-    if (pNotification)
-        PyEval_InitThreads();
-#endif
     // If we have a callback, store it in our map with None as the key.
     // The callback routine will patch this once it knows the true key.
     // Before we do, we must check None is not already there


### PR DESCRIPTION
This was missed in https://github.com/mhammond/pywin32/pull/1990 because I didn't know about `PY_VERSION_HEX` back then.