### PR TITLE
Prefer Ruff over isort for more efficient and complete import sorting and grouping

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,9 +104,11 @@ jobs:
         with:
           # This job only needs to target the oldest supported version (black@stable supports Python >=3.8)
           python-version: '3.8'
-      - run: pip install isort pycln
+      - run: pip install pycln
       - run: pycln . --config=pycln.toml --check
-      - run: isort . --diff --check-only
+      - uses: chartboost/ruff-action@v1
+        with:
+          version: '0.3.4'
       - uses: psf/black@stable
         with:
           options: "--fast --check --diff --verbose"

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,7 +1,0 @@
-[isort]
-py_version = 37
-profile = black
-combine_as_imports = true
-skip = setup.py
-# TODO: Decide if this is wanted:
-# combine_straight_imports = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,12 +27,11 @@ repos:
       - id: pycln
         args: [--config=pycln.toml]
         verbose: true
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.4
     hooks:
-      - id: isort
-        name: isort (python)
-        verbose: true
+      - id: ruff # Run the linter.
+        args: [--fix]
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.2.0
     hooks:

--- a/Pythonwin/pywin/scintilla/view.py
+++ b/Pythonwin/pywin/scintilla/view.py
@@ -11,8 +11,12 @@ import win32con
 import win32ui
 from pywin.mfc import afxres, docview
 
-from . import IDLEenvironment  # IDLE emulation.
-from . import bindings, control, scintillacon
+from . import (
+    IDLEenvironment,  # IDLE emulation.
+    bindings,
+    control,
+    scintillacon,
+)
 
 PRINTDLGORD = 1538
 IDC_PRINT_MAG_EDIT = 1010

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,18 @@
+target-version = "py37"
+
+[lint]
+select = ["I"]
+
+[lint.isort]
+combine-as-imports = true
+# Because pywin32 has a mix of relative and absolute imports, with undetectable first-party c-extensions
+# This makes import grouping more consistent
+detect-same-package = false
+known-third-party = [
+    "__main__",
+    # This forces distutils imports to always be after setuptools
+    # setuptools must be imported before distutils because it monkey-patches it.
+    # distutils is also removed in Python 3.12 and deprecated with setuptools
+    "distutils",
+]
+extra-standard-library = ["setuptools"]

--- a/setup.py
+++ b/setup.py
@@ -33,16 +33,13 @@ import subprocess
 import sys
 import winreg
 from pathlib import Path
-from tempfile import gettempdir
-from typing import Iterable, List, Tuple, Union
-
-# setuptools must be imported before distutils because it monkey-patches it.
-# distutils is also removed in Python 3.12 and deprecated with setuptools
 from setuptools import Extension, setup
 from setuptools.command.build import build
 from setuptools.command.build_ext import build_ext
 from setuptools.command.install import install
 from setuptools.command.install_lib import install_lib
+from tempfile import gettempdir
+from typing import Iterable, List, Tuple, Union
 
 from distutils.command.install_data import install_data
 
@@ -2263,6 +2260,7 @@ if "bdist_wininst" in sys.argv:
     # fixup https://github.com/pypa/setuptools/issues/3284
     def maybe_fixup_exes():
         import site
+
         from distutils.command import bdist_wininst
 
         # setuptools can't find .exe stubs in `site-packages/setuptools/_distutils`


### PR DESCRIPTION
This is also a step towards automatically catching issues as mentioned in #2050, #2100, #2101, #2102, #2106, #2107, #2108, #2110, #2112, #2122 and https://github.com/mhammond/pywin32/issues/775#issuecomment-2016881225