### PR TITLE
Use `sys.version_info`'s namedtuple fields

### DIFF
--- a/.github/workflows/download-arm64-libs.py
+++ b/.github/workflows/download-arm64-libs.py
@@ -19,7 +19,7 @@ except IndexError:
 dest = dest.absolute()
 dest.mkdir(parents=True, exist_ok=True)
 
-VERSION = "{}.{}.{}".format(*sys.version_info[:3])
+VERSION = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
 if sys.version_info.releaselevel == "alpha":
     VERSION += f"-a{sys.version_info.serial}"
 if sys.version_info.releaselevel == "beta":

--- a/Pythonwin/pywin/test/test_exe.py
+++ b/Pythonwin/pywin/test/test_exe.py
@@ -41,7 +41,7 @@ class TestPythonwinExe(unittest.TestCase):
             # XXX Pythonwin.exe / win32uihostglue.h could be improved to search
             # the Python DLL itself via registry when local / relative search fails.
 
-            pydll = "Python{}{}.dll".format(*sys.version_info[:2])  # same for 32bit
+            pydll = f"Python{sys.version_info.major}{sys.version_info.minor}.dll"  # same for 32bit
             src = os.path.dirname(sys.executable) + os.sep + pydll
             dst = os.path.dirname(pythonwinexe_path) + os.sep + pydll
             if not os.path.isfile(dst):

--- a/com/win32com/__init__.py
+++ b/com/win32com/__init__.py
@@ -113,7 +113,7 @@ if not __gen_path__:
             __gen_path__ = os.path.join(
                 win32api.GetTempPath(),
                 "gen_py",
-                "%d.%d" % (sys.version_info[0], sys.version_info[1]),
+                "%d.%d" % (sys.version_info.major, sys.version_info.minor),
             )
 
 # we must have a __gen_path__, but may not have a gen_py module -

--- a/com/win32com/server/register.py
+++ b/com/win32com/server/register.py
@@ -246,7 +246,7 @@ def RegisterServer(
             loadername = os.path.join(
                 pythoncom_dir,
                 "pythoncomloader%d%d%s.dll"
-                % (sys.version_info[0], sys.version_info[1], suffix),
+                % (sys.version_info.major, sys.version_info.minor, suffix),
             )
             dllName = loadername if os.path.isfile(loadername) else pythoncom.__file__
 

--- a/com/win32com/test/util.py
+++ b/com/win32com/test/util.py
@@ -50,7 +50,8 @@ def RegisterPythonServer(filename, progids=None, verbose=0):
                 break
             ok_files = [
                 os.path.basename(pythoncom.__file__),
-                "pythoncomloader%d%d.dll" % (sys.version_info[0], sys.version_info[1]),
+                "pythoncomloader%d%d.dll"
+                % (sys.version_info.major, sys.version_info.minor),
             ]
             if os.path.basename(dll) not in ok_files:
                 why_not = (

--- a/pywin32_postinstall.py
+++ b/pywin32_postinstall.py
@@ -180,8 +180,8 @@ def LoadSystemModule(lib_dir, modname):
     suffix = "_d" if "_d.pyd" in importlib.machinery.EXTENSION_SUFFIXES else ""
     filename = "%s%d%d%s.dll" % (
         modname,
-        sys.version_info[0],
-        sys.version_info[1],
+        sys.version_info.major,
+        sys.version_info.minor,
         suffix,
     )
     filename = os.path.join(lib_dir, "pywin32_system32", filename)
@@ -348,8 +348,10 @@ def get_shortcuts_folder():
             get_root_hkey(), root_key_name + "\\InstallPath\\InstallGroup"
         )
     except OSError:
-        vi = sys.version_info
-        install_group = "Python %d.%d" % (vi[0], vi[1])
+        install_group = "Python %d.%d" % (
+            sys.version_info.major,
+            sys.version_info.minor,
+        )
     return os.path.join(fldr, install_group)
 
 

--- a/setup.py
+++ b/setup.py
@@ -59,8 +59,8 @@ build_id_patch = build_id
 if not "." in build_id_patch:
     build_id_patch = build_id_patch + ".0"
 pywin32_version = "%d.%d.%s" % (
-    sys.version_info[0],
-    sys.version_info[1],
+    sys.version_info.major,
+    sys.version_info.minor,
     build_id_patch,
 )
 print("Building pywin32", pywin32_version)
@@ -746,8 +746,8 @@ class my_build_ext(build_ext):
                 # are expected to be pywintypes.lib.
                 created = "%s%d%d%s" % (
                     ext.name,
-                    sys.version_info[0],
-                    sys.version_info[1],
+                    sys.version_info.major,
+                    sys.version_info.minor,
                     extra,
                 )
                 needed = f"{ext.name}{extra}"
@@ -779,7 +779,7 @@ class my_build_ext(build_ext):
         # We need to fixup some target filenames.
         suffix = "_d" if self.debug else ""
         if name in ["pywintypes", "pythoncom"]:
-            ver = f"{sys.version_info[0]}{sys.version_info[1]}"
+            ver = f"{sys.version_info.major}{sys.version_info.minor}"
             return f"{name}{ver}{suffix}.dll"
         if name in ["perfmondata", "PyISAPI_loader"]:
             return f"{name}{suffix}.dll"

--- a/win32/Lib/pywintypes.py
+++ b/win32/Lib/pywintypes.py
@@ -26,8 +26,8 @@ def __import_pywin32_system_module__(modname, globs):
     suffix = "_d" if "_d.pyd" in importlib.machinery.EXTENSION_SUFFIXES else ""
     filename = "%s%d%d%s.dll" % (
         modname,
-        sys.version_info[0],
-        sys.version_info[1],
+        sys.version_info.major,
+        sys.version_info.minor,
         suffix,
     )
     if hasattr(sys, "frozen"):

--- a/win32/Lib/win32serviceutil.py
+++ b/win32/Lib/win32serviceutil.py
@@ -63,7 +63,7 @@ def LocatePythonServiceExe(exe=None):
     # (Unlike the .exe above, we don't unconditionally copy this, and possibly
     # copy it to a different place. Doesn't seem a good reason for that!?)
     python_dll = win32api.GetModuleFileName(sys.dllhandle)
-    pyw = f"pywintypes{sys.version_info[0]}{sys.version_info[1]}{suffix}.dll"
+    pyw = f"pywintypes{sys.version_info.major}{sys.version_info.minor}{suffix}.dll"
     correct_pyw = os.path.join(os.path.dirname(python_dll), pyw)
 
     if not os.path.exists(correct_pyw):


### PR DESCRIPTION
Using a namedtuple's fields rather than indexes leads to more human-readable code.
This also goes in the direction of #2223 