### PR TITLE
Remove IE version checks and fix `testExplorer.TestObjectFromWindow`

### DIFF
--- a/Pythonwin/pythonpsheet.cpp
+++ b/Pythonwin/pythonpsheet.cpp
@@ -15,21 +15,6 @@
 static char BASED_CODE THIS_FILE[] = __FILE__;
 #endif
 
-#if _MFC_VER < 0x0600
-// MSVC V 5.1 and certain version of the IE4 SDK cant agree on object sizes!
-
-// God damn - inlines and DLL dont agree on object sizes!!!
-#if defined(PROPSHEETHEADERA_V1_SIZE)
-#if !defined(_WIN32_IE)
-#error "Please update the IE4 SDK to a newer version"
-#endif
-#if _WIN32_IE > 0x0300
-#error "Please recompile with _WIN32_IE set to 0x0300"
-#endif
-#endif  // PROPSHEETHEADERA_V1_SIZE
-
-#endif  // _MFC_VER
-
 #define WM_RESIZEPAGE WM_APP + 1
 
 // helper function which sets the font for a window and all its children

--- a/Pythonwin/stdafx.h
+++ b/Pythonwin/stdafx.h
@@ -17,11 +17,6 @@
 
 #include <afxwin.h>  // MFC core and standard components
 
-#if (_MFC_VER < 0x0600)
-// See pythonpsheet.cpp for more details!
-#define _WIN32_IE 0x0300  // Screw up with header sizes and MFC!!
-#endif
-
 #include <afxext.h>    // MFC extensions
 #include <afxcmn.h>    // common controls.
 #include <afxrich.h>   // rich edit support.
@@ -32,7 +27,7 @@
 #include "limits.h"
 
 // allow memory leaks to give me the line number.
-//#define new DEBUG_NEW
+// #define new DEBUG_NEW
 
 /* dont really need to undef these anymore, but helpful to
 programmers who forget to use the new names. */

--- a/com/win32com/test/testExplorer.py
+++ b/com/win32com/test/testExplorer.py
@@ -60,20 +60,16 @@ def TestExplorerEvents():
 
 def TestObjectFromWindow():
     # Check we can use ObjectFromLresult to get the COM object from the
-    # HWND - see KB Q249232
-    # Locating the HWND is different than the KB says...
     hwnd = win32gui.FindWindow("IEFrame", None)
-    for child_class in [
+    # Thanks https://stackoverflow.com/a/10154498/18450412 for the child stack on IE8+
+    for child_class in (
+        "Frame Tab",
         "TabWindowClass",
         "Shell DocObject View",
         "Internet Explorer_Server",
-    ]:
+    ):
         hwnd = win32gui.FindWindowEx(hwnd, 0, child_class, None)
-        # ack - not working for markh on vista with IE8 (or maybe it is the
-        # lack of the 'accessibility' components mentioned in Q249232)
-        # either way - not working!
-        return
-    # But here is the point - once you have an 'Internet Explorer_Server',
+    # Once you have an 'Internet Explorer_Server',
     # you can send a message and use ObjectFromLresult to get it back.
     msg = win32gui.RegisterWindowMessage("WM_HTML_GETOBJECT")
     rc, result = win32gui.SendMessageTimeout(

--- a/com/win32comext/shell/src/shell.cpp
+++ b/com/win32comext/shell/src/shell.cpp
@@ -3977,9 +3977,6 @@ PYWIN_MODULE_INIT_FUNC(shell)
     ADD_IID(CLSID_InternetShortcut);
     ADD_IID(CLSID_ActiveDesktop);
 
-#if (_WIN32_IE >= 0x0400)
-    ADD_IID(CGID_ShellServiceObject);
-    ADD_IID(CGID_ExplorerBarDoc);
     ADD_IID(CGID_ShellServiceObject);
     ADD_IID(CGID_ExplorerBarDoc);
     ADD_IID(SID_SShellDesktop);
@@ -4013,11 +4010,7 @@ PYWIN_MODULE_INIT_FUNC(shell)
     ADD_IID(VID_Tile);
     ADD_IID(VID_Thumbnails);
     ADD_IID(VID_ThumbStrip);
-#else
-#pragma message("Please update your SDK headers - IE5 features missing!")
-#endif
 
-#if (_WIN32_IE >= 0x0500)
     ADD_IID(FMTID_ShellDetails);
     ADD_IID(FMTID_Storage);
     ADD_IID(FMTID_ImageProperties);
@@ -4041,9 +4034,6 @@ PYWIN_MODULE_INIT_FUNC(shell)
     ADD_IID(EP_PreviewPane);
     ADD_IID(EP_QueryPane);
     ADD_IID(EP_AdvQueryPane);
-#else
-#pragma message("Please update your SDK headers - IE5 features missing!")
-#endif
 
     ADD_IID(BHID_SFObject);
     ADD_IID(BHID_SFUIObject);

--- a/com/win32comext/shell/src/shell_pch.h
+++ b/com/win32comext/shell/src/shell_pch.h
@@ -1,6 +1,5 @@
 // shell_pch.h : header file for PCH generation for the shell COM extension
 
-#define _WIN32_IE _WIN32_IE_IE70
 #include <PythonCOM.h>
 #include <PythonCOMServer.h>
 #include <oleauto.h>

--- a/win32/src/_winxptheme.i
+++ b/win32/src/_winxptheme.i
@@ -15,7 +15,6 @@
 %include "pywintypes.i"
 
 %{
-#define _WIN32_IE 0x0501 // to enable balloon notifications in Shell_NotifyIcon
 #define _WIN32_WINNT 0x0501
 //#define ISOLATION_AWARE_ENABLED 1
 

--- a/win32/src/win32gui.i
+++ b/win32/src/win32gui.i
@@ -12,7 +12,6 @@
 %endif
 
 %{
-#define _WIN32_IE 0x0501 // to enable balloon notifications in Shell_NotifyIcon
 #define _WIN32_WINNT 0x0501
 #ifdef WINXPGUI
 // This changes the entire world for XP!


### PR DESCRIPTION
IE10 is out of support since January 14, 2020 https://learn.microsoft.com/en-us/lifecycle/announcements/internet-explorer-10-end-of-support

The only versions of IE available nowadays should be 11, and the code wasn't checking for any version higher than 7 already.

I also fixed the `testExplorer.TestObjectFromWindow` test since it was referencing IE8. the test now passes with flying (or flashing 😉) colors!