### PR TITLE
Error processing SyntaxError exception from a Python Script

### DIFF
--- a/com/win32comext/axscript/client/error.py
+++ b/com/win32comext/axscript/client/error.py
@@ -114,7 +114,10 @@ class AXScriptException(COMException):
         except:
             msg = f"Unknown Error ({value})"
         try:
-            (filename, lineno, offset, line) = value[1]
+            filename = value[1][0]
+            lineno   = value[1][1]
+            offset   = value[1][2]
+            line     = value[1][3]
             # Some of these may be None, which upsets us!
             if offset is None:
                 offset = 0

--- a/com/win32comext/axscript/client/error.py
+++ b/com/win32comext/axscript/client/error.py
@@ -98,7 +98,7 @@ class AXScriptException(COMException):
             linecache.clearcache()
         try:
             if issubclass(type, SyntaxError):
-                self._BuildFromSyntaxError(site, value, tb)
+                self._BuildFromSyntaxError(value)
             else:
                 self._BuildFromOther(site, type, value, tb)
         except:  # Error extracting traceback info!!!
@@ -106,30 +106,14 @@ class AXScriptException(COMException):
             # re-raise.
             raise
 
-    def _BuildFromSyntaxError(self, site, exc, tb):
-        value = exc.args
-        # All syntax errors should have a message as element 0
-        try:
-            msg = value[0]
-        except:
-            msg = f"Unknown Error ({value})"
-        try:
-            filename = value[1][0]
-            lineno   = value[1][1]
-            offset   = value[1][2]
-            line     = value[1][3]
-            # Some of these may be None, which upsets us!
-            if offset is None:
-                offset = 0
-            if line is None:
-                line = ""
-        except:
-            msg = "Unknown"
-            lineno = 0
-            offset = 0
-            line = "Unknown"
+    def _BuildFromSyntaxError(self, exc: SyntaxError):
+        # Some of these may be None, which upsets us!
+        msg = exc.msg or "Unknown Error"
+        offset = exc.offset or 0
+        line = exc.text or ""
+
         self.description = FormatForAX(msg)
-        self.lineno = lineno
+        self.lineno = exc.lineno
         self.colno = offset - 1
         self.linetext = ExpandTabs(line.rstrip())
 


### PR DESCRIPTION
When executing a Python script with a syntax error via Windows Scripting Host, the exception always comes back as "Unknown" with Python 3.10, 3.11 and 3.12

Expected behavior:
From Windows OnScriptError( IActiveScriptError * pSE )
EXCEPTINFO eiError;
pSE->GetExceptionInfo( &eiError );

eiError->bstrDescription should contain "invalid syntax" and info for line number and offset should be available.

Actual behavior:
eiError->bstrDescription contains "Unknown" and the line number and offset are 0.

The problem is in class AXScriptException:
The function _BuildFromSyntaxError that parses the SyntaxError exception has a tuple assignment that is failing because two new fields were added in 3.10 (end_lineno and end_offset).

The failing line in _BuildFromSyntaxError is:
(filename, lineno, offset, line) = value[1]
because value[1] starting with Python 3.10 now has six elements.

To be backwardly compatible with Python 3.7, 3.8 and 3.9 and not get an exception in 3.10, 3.11 and 3.12 I have coded:
filename = value[1][0]
lineno = value[1][1]
offset = value[1][2]
line = value[1][3]