### PR TITLE
Fix MFC redist DLLs not found: prefere corresponding version but accept different version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -631,11 +631,15 @@ class my_build_ext(build_ext):
         redist_globs = [vcbase + r"redist\%s\*MFC\mfc140u.dll" % self.plat_dir]
         m = re.search(r"\\VC\\Tools\\", vcbase)
         if m:
-            # typical path on newer Visual Studios - ensure corresponding version
+            # typical path on newer Visual Studios
+            # prefere corresponding version but accept different version
+            same_version = vcverdir is not None and os.path.isdir(
+                vcbase[: m.start()] + r"\VC\Redist\MSVC\{}{}".format(
+                    vcverdir, self.plat_dir
+                ))
             redist_globs.append(
-                vcbase[: m.start()]
-                + r"\VC\Redist\MSVC\{}{}\*\mfc140u.dll".format(
-                    vcverdir or "*\\", self.plat_dir
+                vcbase[: m.start()] + r"\VC\Redist\MSVC\{}{}\*\mfc140u.dll".format(
+                    vcverdir if same_version else "*\\", self.plat_dir
                 )
             )
         # Only mfcNNNu DLL is required (mfcmNNNX is Windows Forms, rest is ANSI)


### PR DESCRIPTION
This patch fix the error "MFC redist DLLs not found" building pywin32 on system where the redist version is not the same of the vc tools, which is a normal situation ad not an anomaly.

Previous implementation "ensure corresponding version" if the vc tools version is known, else it accept everything.

This implementation "prefere corresponding version" (if the version is known) but accept different version if the corresponding one is not found and allow to build pywin32 in a lot of situation.

I think that this test for the redist version can be improved a lot, for example taking the latest version with the same major from the vc tools version, but at this stage I made the change as little as possible and as compatible as possible: Where previous version builds normally nothing will change and only where it refused to build the change will take effect and solves the problem.