### PR TITLE
Perform file move of pythonservice.exe during install

### DIFF
--- a/win32/Lib/win32serviceutil.py
+++ b/win32/Lib/win32serviceutil.py
@@ -50,8 +50,14 @@ def LocatePythonServiceExe(exe=None):
     # pywin32 installed it next to win32service.pyd (but we can't run it from there)
     maybe = os.path.join(os.path.dirname(win32service.__file__), exe)
     if os.path.exists(maybe):
-        print(f"copying host exe '{maybe}' -> '{correct}'")
-        win32api.CopyFile(maybe, correct)
+        print(f"moving host exe '{maybe}' -> '{correct}'")
+        # Handle case where MoveFile() fails. Particularly if destination file
+        # has a resource lock and can't be replaced by src file
+        try:
+            win32api.MoveFile(maybe, correct)
+        except win32api.error as exc:
+            print(f"Failed to move host exe '{exc}'")
+
 
     if not os.path.exists(correct):
         raise error(f"Can't find '{correct}'")

--- a/win32/Lib/win32serviceutil.py
+++ b/win32/Lib/win32serviceutil.py
@@ -54,10 +54,9 @@ def LocatePythonServiceExe(exe=None):
         # Handle case where MoveFile() fails. Particularly if destination file
         # has a resource lock and can't be replaced by src file
         try:
-            win32api.MoveFile(maybe, correct)
+            win32api.MoveFileEx(maybe, correct, win32con.MOVEFILE_REPLACE_EXISTING)
         except win32api.error as exc:
             print(f"Failed to move host exe '{exc}'")
-
 
     if not os.path.exists(correct):
         raise error(f"Can't find '{correct}'")


### PR DESCRIPTION
During install perform move of pythonservice.exe instead of file copy to handle .exe always being present in src location. 

Additional try-except added to handle continuation of program if fileMove fails.