### PR TITLE
Ensure modern type annotation best practices and modern syntax

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
       - run: pycln . --config=pycln.toml --check
       - uses: chartboost/ruff-action@v1
         with:
-          version: '0.3.4'
+          version: "0.4.4"
       - uses: psf/black@stable
         with:
           options: "--fast --check --diff --verbose"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         args: [--config=pycln.toml]
         verbose: true
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.4
+    rev: v0.4.4
     hooks:
       - id: ruff # Run the linter.
         args: [--fix]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,7 +1,18 @@
 target-version = "py37"
 
 [lint]
-select = ["I"]
+select = [
+  "I", # isort
+  # Ensure modern type annotation syntax and best practices
+  # Not including those covered by type-checkers
+  "FA", # flake8-future-annotations
+  "F404", # late-future-import
+  "PYI", # flake8-pyi
+  "UP006", # non-pep585-annotation
+  "UP007", # non-pep604-annotation
+  "UP010", # unnecessary-future-import
+  "UP037", # quoted-annotation
+]
 
 [lint.isort]
 combine-as-imports = true
@@ -9,10 +20,10 @@ combine-as-imports = true
 # This makes import grouping more consistent
 detect-same-package = false
 known-third-party = [
-    "__main__",
-    # This forces distutils imports to always be after setuptools
-    # setuptools must be imported before distutils because it monkey-patches it.
-    # distutils is also removed in Python 3.12 and deprecated with setuptools
-    "distutils",
+  "__main__",
+  # This forces distutils imports to always be after setuptools
+  # setuptools must be imported before distutils because it monkey-patches it.
+  # distutils is also removed in Python 3.12 and deprecated with setuptools
+  "distutils",
 ]
 extra-standard-library = ["setuptools"]

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ from setuptools.command.build_ext import build_ext
 from setuptools.command.install import install
 from setuptools.command.install_lib import install_lib
 from tempfile import gettempdir
-from typing import Iterable, List, Tuple, Union
+from typing import Iterable
 
 from distutils import ccompiler
 from distutils._msvccompiler import MSVCCompiler

--- a/setup.py
+++ b/setup.py
@@ -2084,7 +2084,7 @@ swig_interface_parents = {
 swig_include_files = "mapilib adsilib".split()
 
 
-def expand_modules(module_dir: Union[str, os.PathLike[str]]):
+def expand_modules(module_dir: str | os.PathLike[str]):
     """Helper to allow our script specifications to include wildcards."""
     return [str(path.with_suffix("")) for path in Path(module_dir).rglob("*.py")]
 
@@ -2095,7 +2095,7 @@ def expand_modules(module_dir: Union[str, os.PathLike[str]]):
 # 'Lib/site-packages/pythonwin/licence.txt'.  We exploit this to
 # get 'com/win32com/whatever' installed to 'win32com/whatever'
 def convert_data_files(files: Iterable[str]):
-    ret: List[Tuple[str, Tuple[str]]] = []
+    ret: list[tuple[str, tuple[str]]] = []
     for file in files:
         file = os.path.normpath(file)
         if file.find("*") >= 0:

--- a/win32/Lib/win32gui_struct.py
+++ b/win32/Lib/win32gui_struct.py
@@ -40,7 +40,8 @@ import win32gui
 
 def _MakeResult(names_str, values):
     names = names_str.split()
-    nt = namedtuple(names[0], names[1:])
+    # TODO: Dynamic namedtuple. This could be made static, also exposing the types
+    nt = namedtuple(names[0], names[1:])  # noqa: PYI024
     return nt(*values)
 
 


### PR DESCRIPTION
As type hints and annotations are added to pywin32, now that type-checkers are fully in place, I would like to be able to ensure modern syntax and best practices for type annotations. 

This is linting and some autofixes for typing. Things that "technically pass type-checking" but aren't necessarily the best.