### PR TITLE
Drop 3.7, add 3.13 in Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12-dev']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13-dev']
         architecture: ['x64', 'x86']
 
     steps:
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12-dev']
+        python-version: ['3.10', '3.11', '3.12', '3.13-dev']
 
     steps:
       - uses: actions/checkout@v3
@@ -119,7 +119,7 @@ jobs:
       fail-fast: false
       matrix:
         # mypy 1.5 dropped support for Python 3.7
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13-dev']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -133,7 +133,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13-dev']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4


### PR DESCRIPTION
The last officially-supported Python 3.7 release is close to a year ago, and 3.13 just had a beta release, meaning no new features will be added. Also setup-python supports 3.13.

Note that doesn't eliminate build issues, namely the usage of deprecated `PyEval_CallObject` family of functions.