### PR TITLE
Update TOML formatter config in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # You can run this locally with `pre-commit run [--all]`
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
@@ -10,10 +10,10 @@ repos:
         args: [--fix=crlf]
       - id: check-case-conflict
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-    rev: v2.12.0
+    rev: v2.13.0
     hooks:
       - id: pretty-format-toml
-        args: [--autofix, --trailing-commas]
+        args: [--autofix, --trailing-commas, --inline-comment-spaces, "1", --no-sort]
       - id: pretty-format-yaml
         args: [--autofix, --indent, "2", --offset, "2", --preserve-quotes]
       - id: pretty-format-ini
@@ -30,7 +30,7 @@ repos:
       - id: ruff # Run the linter.
         args: [--fix]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.2.0
+    rev: 24.4.2
     hooks:
       - id: black
         verbose: true

--- a/mypy.ini
+++ b/mypy.ini
@@ -35,16 +35,16 @@ disable_error_code =
     ; Cannot assign to a method (we do lots of monkey patching)
     method-assign,
 exclude = (?x)(
-    ^build/
-    ; Vendored
-    | ^Pythonwin/Scintilla/
-    ; Forked IDLE extensions predating Python 2.3. They now live in idlelib in https://github.com/python/cpython/tree/main/Lib/idlelib
-    | ^Pythonwin/pywin/idle/
-    ; TODO: adodbapi should be updated and fixed separately
-    | ^adodbapi/
-    ; TODO: Ignoring non-public APIs until all public API is typed
-    | ([Tt]est|[Dd]emos?)/
-    )
+          ^build/
+          ; Vendored
+          | ^Pythonwin/Scintilla/
+          ; Forked IDLE extensions predating Python 2.3. They now live in idlelib in https://github.com/python/cpython/tree/main/Lib/idlelib
+          | ^Pythonwin/pywin/idle/
+          ; TODO: adodbapi should be updated and fixed separately
+          | ^adodbapi/
+          ; TODO: Ignoring non-public APIs until all public API is typed
+          | ([Tt]est|[Dd]emos?)/
+          )
 
 ; C-modules that will need type-stubs
 [mypy-adsi.*,dde,exchange,exchdapi,mapi,perfmon,servicemanager,win32api,win32console,win32clipboard,win32comext.adsi.adsi,win32event,win32evtlog,win32file,win32gui,win32help,win32pdh,win32process,win32ras,win32security,win32service,win32trace,win32ui,win32uiole,win32wnet,_win32sysloader,_winxptheme]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,4 @@
-# Target the oldest supported version
-target-version = "py37"
+target-version = "py37" # Target the oldest supported version
 
 [lint]
 select = [


### PR DESCRIPTION
Since `pre-commit run [--all]` is the de-facto "format and autofix all" command now, this updates the TOML configs so that running the command against main won't lead to any change.