### PR TITLE
Remove unused error aliases by assignment

### DIFF
--- a/com/win32com/client/build.py
+++ b/com/win32com/client/build.py
@@ -29,8 +29,6 @@ from pywintypes import TimeType
 # always render the string perfectly - so just punt and fall-back to a repr()
 _makeDocString = repr
 
-error = "PythonCOM.Client.Build error"
-
 
 class NotSupportedException(Exception):
     pass  # Raised when we cant support a param type.

--- a/com/win32com/client/genpy.py
+++ b/com/win32com/client/genpy.py
@@ -22,7 +22,6 @@ import win32com
 
 from . import build
 
-error = "makepy.error"
 makepy_version = "0.5.01"  # Written to generated file.
 
 GEN_FULL = "full"

--- a/com/win32com/client/tlbrowse.py
+++ b/com/win32com/client/tlbrowse.py
@@ -10,8 +10,6 @@ class TLBrowserException(Exception):
     "TypeLib browser internal error"
 
 
-error = TLBrowserException
-
 FRAMEDLG_STD = win32con.WS_CAPTION | win32con.WS_SYSMENU
 SS_STD = win32con.WS_CHILD | win32con.WS_VISIBLE
 BS_STD = SS_STD | win32con.WS_TABSTOP
@@ -208,7 +206,7 @@ class TypeBrowseDialog(TypeBrowseDialog_Parent):
         elif pos >= 0:
             return pos, 0
         else:
-            raise error("The position is not valid")
+            raise TLBrowserException("The position is not valid")
 
     def CmdMemberListbox(self, id, code):
         if code == win32con.LBN_SELCHANGE:

--- a/com/win32com/universal.py
+++ b/com/win32com/universal.py
@@ -5,9 +5,6 @@
 import pythoncom
 from win32com.client import gencache
 
-com_error = pythoncom.com_error
-_univgw = pythoncom._univgw
-
 
 def RegisterInterfaces(typelibGUID, lcid, major, minor, interface_names=None):
     ret = []  # return a list of (dispid, funcname for our policy's benefit
@@ -86,15 +83,15 @@ def RegisterInterfaces(typelibGUID, lcid, major, minor, interface_names=None):
 
 def _doCreateVTable(iid, interface_name, is_dispatch, method_defs):
     defn = Definition(iid, is_dispatch, method_defs)
-    vtbl = _univgw.CreateVTable(defn, is_dispatch)
-    _univgw.RegisterVTable(vtbl, iid, interface_name)
+    vtbl = pythoncom._univgw.CreateVTable(defn, is_dispatch)
+    pythoncom._univgw.RegisterVTable(vtbl, iid, interface_name)
 
 
 def _CalcTypeSize(typeTuple):
     t = typeTuple[0]
     if t & (pythoncom.VT_BYREF | pythoncom.VT_ARRAY):
         # Its a pointer.
-        cb = _univgw.SizeOfVT(pythoncom.VT_PTR)[1]
+        cb = pythoncom._univgw.SizeOfVT(pythoncom.VT_PTR)[1]
     elif t == pythoncom.VT_RECORD:
         # Just because a type library uses records doesn't mean the user
         # is trying to.  We need to better place to warn about this, but it
@@ -104,10 +101,10 @@ def _CalcTypeSize(typeTuple):
         #     warnings.warn("warning: records are known to not work for vtable interfaces")
         # except ImportError:
         #     print("warning: records are known to not work for vtable interfaces")
-        cb = _univgw.SizeOfVT(pythoncom.VT_PTR)[1]
+        cb = pythoncom._univgw.SizeOfVT(pythoncom.VT_PTR)[1]
         # cb = typeInfo.GetTypeAttr().cbSizeInstance
     else:
-        cb = _univgw.SizeOfVT(t)[1]
+        cb = pythoncom._univgw.SizeOfVT(t)[1]
     return cb
 
 
@@ -191,8 +188,8 @@ class Definition:
         ob,
         index,
         argPtr,
-        ReadFromInTuple=_univgw.ReadFromInTuple,
-        WriteFromOutTuple=_univgw.WriteFromOutTuple,
+        ReadFromInTuple=pythoncom._univgw.ReadFromInTuple,
+        WriteFromOutTuple=pythoncom._univgw.WriteFromOutTuple,
     ):
         "Dispatch a call to an interface method."
         meth = self._methods[index]

--- a/win32/Lib/sspi.py
+++ b/win32/Lib/sspi.py
@@ -16,8 +16,7 @@ functions directly.
 # $Id$
 import sspicon
 import win32security
-
-error = win32security.error
+from win32security import error
 
 
 class _BaseAuth:

--- a/win32/Lib/win32evtlogutil.py
+++ b/win32/Lib/win32evtlogutil.py
@@ -6,8 +6,6 @@ import win32con
 import win32evtlog
 import winerror
 
-error = win32api.error  # The error the evtlog module raises.
-
 langid = win32api.MAKELANGID(win32con.LANG_NEUTRAL, win32con.SUBLANG_NEUTRAL)
 
 

--- a/win32/Lib/win32pdhutil.py
+++ b/win32/Lib/win32pdhutil.py
@@ -24,8 +24,6 @@ import time
 
 import win32pdh
 
-error = win32pdh.error
-
 # Handle some localization issues.
 # see http://support.microsoft.com/default.aspx?scid=http://support.microsoft.com:80/support/kb/articles/Q287/1/59.asp&NoWebContent=1
 # Build a map of english_counter_name: counter_id


### PR DESCRIPTION
Just like #2268 , this doesn't focus on a fix for #1902 yet.

These are the aliases that are easy to remove because they are unused.