### PR TITLE
Using augmented assignements (in-place operators) where possible

### DIFF
--- a/AutoDuck/BuildHHP.py
+++ b/AutoDuck/BuildHHP.py
@@ -41,7 +41,7 @@ def handle_globs(lGlobs):
         new = glob.glob(g)
         if len(new) == 0:
             print(f"The pattern '{g}' yielded no files!")
-        lFiles += new
+        lFiles.extend(new)
     # lFiles is now the list of origin files.
     # Normalize all of the paths:
     cFiles = len(lFiles)

--- a/AutoDuck/BuildHHP.py
+++ b/AutoDuck/BuildHHP.py
@@ -41,7 +41,7 @@ def handle_globs(lGlobs):
         new = glob.glob(g)
         if len(new) == 0:
             print(f"The pattern '{g}' yielded no files!")
-        lFiles = lFiles + new
+        lFiles += new
     # lFiles is now the list of origin files.
     # Normalize all of the paths:
     cFiles = len(lFiles)
@@ -52,9 +52,9 @@ def handle_globs(lGlobs):
     while i < cFiles:
         if not os.path.isfile(lFiles[i]):
             del lFiles[i]
-            cFiles = cFiles - 1
+            cFiles -= 1
             continue
-        i = i + 1
+        i += 1
     # Find the common prefix of all of the files
     sCommonPrefix = os.path.commonprefix(lFiles)
     # Damn - more commonprefix problems
@@ -111,12 +111,12 @@ def main():
             shutil.copyfile(lSrcFiles[i], file)
 
         for file in lDestFiles:
-            html_files = html_files + f"{html_dir}\\{file}\n"
+            html_files += f"{html_dir}\\{file}\n"
 
     for cat in doc:
-        html_files = html_files + f"{output_dir}\\{cat.id}.html\n"
+        html_files += f"{output_dir}\\{cat.id}.html\n"
         for suffix in "_overview _modules _objects _constants".split():
-            html_files = html_files + f"{output_dir}\\{cat.id}{suffix}.html\n"
+            html_files += f"{output_dir}\\{cat.id}{suffix}.html\n"
 
     f.write(sHHPFormat % {"output": output, "target": target, "html_files": html_files})
     f.close()

--- a/AutoDuck/InsertExternalOverviews.py
+++ b/AutoDuck/InsertExternalOverviews.py
@@ -25,21 +25,21 @@ def processFile(input, out, extLinksHTML, extTopicHTML, importantHTML):
 def genHTML(doc):
     s = ""
     for cat in doc:
-        s = s + f"<H3>{cat.label}</H3>\n"
+        s += f"<H3>{cat.label}</H3>\n"
         dict = {}
         for item in cat.overviewItems.items:
             dict[item.name] = item.href
         keys = list(dict.keys())
         keys.sort()
         for k in keys:
-            s = s + f'<LI><A HREF="html/{dict[k]}">{k}</A>\n'
+            s += f'<LI><A HREF="html/{dict[k]}">{k}</A>\n'
     return s
 
 
 def genLinksHTML(links):
     s = ""
     for link in links:
-        s = s + f'<LI><A HREF="{link.href}">{link.name}</A>\n'
+        s += f'<LI><A HREF="{link.href}">{link.name}</A>\n'
     return s
 
 

--- a/AutoDuck/makedfromi.py
+++ b/AutoDuck/makedfromi.py
@@ -13,7 +13,7 @@ def GetComments(line, lineNo, lines):
     doc = ""
     if len(data) == 2:
         doc = data[1].strip()
-    lineNo = lineNo + 1
+    lineNo += 1
     while lineNo < len(lines):
         line = lines[lineNo]
         data = line.split("//", 2)
@@ -25,9 +25,9 @@ def GetComments(line, lineNo, lines):
             # new command
             break
         doc = doc + "\n// " + data[1].strip()
-        lineNo = lineNo + 1
+        lineNo += 1
     # This line doesnt match - step back
-    lineNo = lineNo - 1
+    lineNo -= 1
     return doc, lineNo
 
 
@@ -87,7 +87,7 @@ def make_doc_summary(inFile, outFile):
             _, msg, _ = sys.exc_info()
             print("Line %d is badly formed - %s" % (lineNo, msg))
 
-        lineNo = lineNo + 1
+        lineNo += 1
 
     # autoduck seems to crash when > ~97 methods.  Loop multiple times,
     # creating a synthetic module name when this happens.
@@ -106,9 +106,9 @@ def make_doc_summary(inFile, outFile):
         if chunk_number == 0:
             pass
         elif chunk_number == 1:
-            thisModName = thisModName + " (more)"
+            thisModName += " (more)"
         else:
-            thisModName = thisModName + " (more %d)" % (chunk_number + 1,)
+            thisModName += " (more %d)" % (chunk_number + 1,)
 
         outFile.write("\n")
         for meth, extras in these_methods:

--- a/AutoDuck/makedfromi.py
+++ b/AutoDuck/makedfromi.py
@@ -24,7 +24,7 @@ def GetComments(line, lineNo, lines):
         if data[1].strip().startswith("@"):
             # new command
             break
-        doc = doc + "\n// " + data[1].strip()
+        doc += "\n// " + data[1].strip()
         lineNo += 1
     # This line doesnt match - step back
     lineNo -= 1

--- a/Pythonwin/pywin/Demos/app/basictimerapp.py
+++ b/Pythonwin/pywin/Demos/app/basictimerapp.py
@@ -144,9 +144,9 @@ class TimerManager:
             if nextTime:
                 timeDiffSeconds = nextTime - now
                 timeDiffMinutes = int(timeDiffSeconds / 60)
-                timeDiffSeconds = timeDiffSeconds % 60
+                timeDiffSeconds %= 60
                 timeDiffHours = int(timeDiffMinutes / 60)
-                timeDiffMinutes = timeDiffMinutes % 60
+                timeDiffMinutes %= 60
                 self.dlg.prompt1.SetWindowText(
                     "Next connection due in %02d:%02d:%02d"
                     % (timeDiffHours, timeDiffMinutes, timeDiffSeconds)
@@ -200,7 +200,7 @@ class EachAnyIntervaler(TimerIntervaler):
             lst[pos] = 0
         ret = time.mktime(tuple(lst))
         if bAdd:
-            ret = ret + self.timeAdd
+            ret += self.timeAdd
         return ret
 
     def SetNextTime(self, lastTime, now):

--- a/Pythonwin/pywin/Demos/app/customprint.py
+++ b/Pythonwin/pywin/Demos/app/customprint.py
@@ -47,7 +47,7 @@ class PrintDemoView(docview.ScrollView):
         delta = 2
         colors = list(self.colors.keys())
         colors.sort()
-        colors = colors * 2
+        colors *= 2
         for color in colors:
             if oldPen is None:
                 oldPen = dc.SelectObject(self.pens[color])
@@ -58,7 +58,7 @@ class PrintDemoView(docview.ScrollView):
             dc.LineTo((x - delta, y - delta))
             dc.LineTo((delta, y - delta))
             dc.LineTo((delta, delta))
-            delta = delta + 4
+            delta += 4
             if x - delta <= 0 or y - delta <= 0:
                 break
         dc.SelectObject(oldPen)
@@ -108,10 +108,10 @@ class PrintDemoView(docview.ScrollView):
         cyChar = metrics["tmHeight"]
         left, top, right, bottom = pInfo.GetDraw()
         dc.TextOut(0, 2 * cyChar, doc.GetTitle())
-        top = top + (7 * cyChar) / 2
+        top += 7 * cyChar / 2
         dc.MoveTo(left, top)
         dc.LineTo(right, top)
-        top = top + cyChar
+        top += cyChar
         # this seems to have not effect...
         # get what I want with the dc.SetWindowOrg calls
         pInfo.SetDraw((left, top, right, bottom))
@@ -131,7 +131,7 @@ class PrintDemoView(docview.ScrollView):
         y = (3 * cyChar) / 2
 
         dc.TextOut(x, y, doc.GetTitle())
-        y = y + cyChar
+        y += cyChar
 
 
 class PrintDemoApp(app.CApp):

--- a/Pythonwin/pywin/Demos/cmdserver.py
+++ b/Pythonwin/pywin/Demos/cmdserver.py
@@ -52,7 +52,7 @@ def Test():
     while num < 1000:
         print("Hello there no " + str(num))
         win32api.Sleep(50)
-        num = num + 1
+        num += 1
 
 
 class flags:

--- a/Pythonwin/pywin/Demos/dlgtest.py
+++ b/Pythonwin/pywin/Demos/dlgtest.py
@@ -50,7 +50,7 @@ class TestDialog(dialog.Dialog):
     # kill focus for the edit box.
     # Simply increment the value in the text box.
     def KillFocus(self, msg):
-        self.counter = self.counter + 1
+        self.counter += 1
         if self.edit is not None:
             self.edit.SetWindowText(str(self.counter))
 

--- a/Pythonwin/pywin/Demos/ocx/flash.py
+++ b/Pythonwin/pywin/Demos/ocx/flash.py
@@ -33,9 +33,9 @@ class MyFlashComponent(activex.Control, FlashModule.ShockwaveFlash):
 
     def OnFSCommand(self, command, args):
         print("FSCommend", command, args)
-        self.x = self.x + 20
-        self.y = self.y + 20
-        self.angle = self.angle + 20
+        self.x += 20
+        self.y += 20
+        self.angle += 20
         if self.x > 200 or self.y > 200:
             self.x = 0
             self.y = 0

--- a/Pythonwin/pywin/Demos/openGLDemo.py
+++ b/Pythonwin/pywin/Demos/openGLDemo.py
@@ -50,13 +50,13 @@ def ComponentFromIndex(i, nbits, shift):
     # val = (unsigned char) (i >> shift);
     val = (i >> shift) & 0xF
     if nbits == 1:
-        val &= 1
+        val &= 0x1
         return oneto8[val]
     elif nbits == 2:
-        val &= 3
+        val &= 0x3
         return twoto8[val]
     elif nbits == 3:
-        val &= 7
+        val &= 0x7
         return threeto8[val]
     else:
         return 0

--- a/Pythonwin/pywin/Demos/openGLDemo.py
+++ b/Pythonwin/pywin/Demos/openGLDemo.py
@@ -72,7 +72,7 @@ class OpenGLView(OpenGLViewParent):
         # include CS_PARENTDC for the class style. Refer to SetPixelFormat
         # documentation in the "Comments" section for further information.
         style = cc[5]
-        style = style | win32con.WS_CLIPSIBLINGS | win32con.WS_CLIPCHILDREN
+        style |= win32con.WS_CLIPSIBLINGS | win32con.WS_CLIPCHILDREN
         cc = cc[0], cc[1], cc[2], cc[3], cc[4], style, cc[6], cc[7], cc[8]
         cc = self._obj_.PreCreateWindow(cc)
         return cc

--- a/Pythonwin/pywin/Demos/openGLDemo.py
+++ b/Pythonwin/pywin/Demos/openGLDemo.py
@@ -50,13 +50,13 @@ def ComponentFromIndex(i, nbits, shift):
     # val = (unsigned char) (i >> shift);
     val = (i >> shift) & 0xF
     if nbits == 1:
-        val = val & 0x1
+        val &= 1
         return oneto8[val]
     elif nbits == 2:
-        val = val & 0x3
+        val &= 3
         return twoto8[val]
     elif nbits == 3:
-        val = val & 0x7
+        val &= 7
         return threeto8[val]
     else:
         return 0
@@ -287,9 +287,9 @@ class CubeView(OpenGLView):
         glRotatef(self.wAngleY, 0.0, 1.0, 0.0)
         glRotatef(self.wAngleZ, 0.0, 0.0, 1.0)
 
-        self.wAngleX = self.wAngleX + 1.0
-        self.wAngleY = self.wAngleY + 10.0
-        self.wAngleZ = self.wAngleZ + 5.0
+        self.wAngleX += 1.0
+        self.wAngleY += 10.0
+        self.wAngleZ += 5.0
 
         glBegin(GL_QUAD_STRIP)
         glColor3f(1.0, 0.0, 1.0)

--- a/Pythonwin/pywin/Demos/progressbar.py
+++ b/Pythonwin/pywin/Demos/progressbar.py
@@ -86,7 +86,7 @@ class TestDialog(dialog.Dialog):
     def OnOK(self):
         # NB: StepIt wraps at the end if you increment past the upper limit!
         # self.pbar.StepIt()
-        self.progress = self.progress + self.pincr
+        self.progress += self.pincr
         if self.progress > 100:
             self.progress = 100
         if self.progress <= 100:

--- a/Pythonwin/pywin/Demos/threadedgui.py
+++ b/Pythonwin/pywin/Demos/threadedgui.py
@@ -51,7 +51,7 @@ class FontWindow(window.Wnd):
         timer.kill_timer(self.timerid)
 
     def OnTimer(self, id, timeVal):
-        self.index = self.index + self.incr
+        self.index += self.incr
         if self.index > len(self.text):
             self.incr = -1
             self.index = len(self.text)

--- a/Pythonwin/pywin/debugger/debugger.py
+++ b/Pythonwin/pywin/debugger/debugger.py
@@ -289,7 +289,7 @@ class DebuggerListViewWindow(DebuggerWindow):
         list.InsertColumn(0, itemDetails)
         col = 1
         for title, width in self.columns[1:]:
-            col = col + 1
+            col += 1
             itemDetails = (commctrl.LVCFMT_LEFT, width, title, 0)
             list.InsertColumn(col, itemDetails)
         parent.HookNotify(self.OnListEndLabelEdit, LVN_ENDLABELEDIT)
@@ -746,7 +746,7 @@ class Debugger(debugger_parent):
             self.prep_run(cmd)
             sys.settrace(self.trace_dispatch)
             if not isinstance(cmd, types.CodeType):
-                cmd = cmd + "\n"
+                cmd += "\n"
             try:
                 try:
                     if start_stepping:

--- a/Pythonwin/pywin/dialogs/list.py
+++ b/Pythonwin/pywin/dialogs/list.py
@@ -103,7 +103,7 @@ class ListsDialog(ListDialog):
         for col in self.colHeadings:
             itemDetails = (commctrl.LVCFMT_LEFT, int(width / numCols), col, 0)
             self.itemsControl.InsertColumn(index, itemDetails)
-            index = index + 1
+            index += 1
         index = 0
         for items in self.items:
             index = self.itemsControl.InsertItem(index + 1, str(items[0]), 0)

--- a/Pythonwin/pywin/docking/DockingBar.py
+++ b/Pythonwin/pywin/docking/DockingBar.py
@@ -356,10 +356,10 @@ class DockingBar(window.Wnd):
         # Convert unsigned 16 bit to signed 32 bit.
         x = win32api.LOWORD(lparam)
         if x & 32768:
-            x = x | -65536
+            x |= -65536
         y = win32api.HIWORD(lparam)
         if y & 32768:
-            y = y | -65536
+            y |= -65536
         pt = x, y
         cpt = CenterPoint(self.rectTracker)
         pt = self.ClientToWnd(pt)
@@ -388,11 +388,11 @@ class DockingBar(window.Wnd):
         dwBorderStyle = self._obj_.dwStyle | afxres.CBRS_BORDER_ANY
 
         if self.nDockBarID == afxres.AFX_IDW_DOCKBAR_TOP:
-            dwBorderStyle = dwBorderStyle & ~afxres.CBRS_BORDER_BOTTOM
-            rc0.left = rc0.left + self.cxGripper
-            rc0.bottom = rc0.bottom - self.cxEdge
-            rc0.top = rc0.top + self.cxBorder
-            rc0.right = rc0.right - self.cxBorder
+            dwBorderStyle &= ~afxres.CBRS_BORDER_BOTTOM
+            rc0.left += self.cxGripper
+            rc0.bottom -= self.cxEdge
+            rc0.top += self.cxBorder
+            rc0.right -= self.cxBorder
             self.rectBorder = (
                 self.rectBorder[0],
                 self.rectBorder[3] - self.cxEdge,
@@ -400,11 +400,11 @@ class DockingBar(window.Wnd):
                 self.rectBorder[3],
             )
         elif self.nDockBarID == afxres.AFX_IDW_DOCKBAR_BOTTOM:
-            dwBorderStyle = dwBorderStyle & ~afxres.CBRS_BORDER_TOP
-            rc0.left = rc0.left + self.cxGripper
-            rc0.top = rc0.top + self.cxEdge
-            rc0.bottom = rc0.bottom - self.cxBorder
-            rc0.right = rc0.right - self.cxBorder
+            dwBorderStyle &= ~afxres.CBRS_BORDER_TOP
+            rc0.left += self.cxGripper
+            rc0.top += self.cxEdge
+            rc0.bottom -= self.cxBorder
+            rc0.right -= self.cxBorder
             self.rectBorder = (
                 self.rectBorder[0],
                 self.rectBorder[1],
@@ -412,11 +412,11 @@ class DockingBar(window.Wnd):
                 self.rectBorder[1] + self.cxEdge,
             )
         elif self.nDockBarID == afxres.AFX_IDW_DOCKBAR_LEFT:
-            dwBorderStyle = dwBorderStyle & ~afxres.CBRS_BORDER_RIGHT
-            rc0.right = rc0.right - self.cxEdge
-            rc0.left = rc0.left + self.cxBorder
-            rc0.bottom = rc0.bottom - self.cxBorder
-            rc0.top = rc0.top + self.cxGripper
+            dwBorderStyle &= ~afxres.CBRS_BORDER_RIGHT
+            rc0.right -= self.cxEdge
+            rc0.left += self.cxBorder
+            rc0.bottom -= self.cxBorder
+            rc0.top += self.cxGripper
             self.rectBorder = (
                 self.rectBorder[2] - self.cxEdge,
                 self.rectBorder[1],
@@ -424,11 +424,11 @@ class DockingBar(window.Wnd):
                 self.rectBorder[3],
             )
         elif self.nDockBarID == afxres.AFX_IDW_DOCKBAR_RIGHT:
-            dwBorderStyle = dwBorderStyle & ~afxres.CBRS_BORDER_LEFT
-            rc0.left = rc0.left + self.cxEdge
-            rc0.right = rc0.right - self.cxBorder
-            rc0.bottom = rc0.bottom - self.cxBorder
-            rc0.top = rc0.top + self.cxGripper
+            dwBorderStyle &= ~afxres.CBRS_BORDER_LEFT
+            rc0.left += self.cxEdge
+            rc0.right -= self.cxBorder
+            rc0.bottom -= self.cxBorder
+            rc0.top += self.cxGripper
             self.rectBorder = (
                 self.rectBorder[0],
                 self.rectBorder[1],
@@ -486,7 +486,7 @@ class DockingBar(window.Wnd):
         self.rectTracker = self.rectBorder
         if not self.IsHorz():
             l, t, r, b = self.rectTracker
-            b = b - 4
+            b -= 4
             self.rectTracker = l, t, r, b
 
         self.OnInvertTracker(self.rectTracker)
@@ -517,13 +517,13 @@ class DockingBar(window.Wnd):
 
         pt = CenterPoint(self.rectTracker)
         if self.nDockBarID == afxres.AFX_IDW_DOCKBAR_TOP:
-            newsize = newsize + (pt[1] - self.ptOld[1])
+            newsize += pt[1] - self.ptOld[1]
         elif self.nDockBarID == afxres.AFX_IDW_DOCKBAR_BOTTOM:
-            newsize = newsize + (-pt[1] + self.ptOld[1])
+            newsize += -pt[1] + self.ptOld[1]
         elif self.nDockBarID == afxres.AFX_IDW_DOCKBAR_LEFT:
-            newsize = newsize + (pt[0] - self.ptOld[0])
+            newsize += pt[0] - self.ptOld[0]
         elif self.nDockBarID == afxres.AFX_IDW_DOCKBAR_RIGHT:
-            newsize = newsize + (-pt[0] + self.ptOld[0])
+            newsize += -pt[0] + self.ptOld[0]
         newsize = max(minsize, min(maxsize, newsize))
         if self.IsHorz():
             self.sizeHorz = self.sizeHorz[0], newsize
@@ -565,9 +565,9 @@ class DockingBar(window.Wnd):
     def ClientToWnd(self, pt):
         x, y = pt
         if self.nDockBarID == afxres.AFX_IDW_DOCKBAR_BOTTOM:
-            y = y + self.cxEdge
+            y += self.cxEdge
         elif self.nDockBarID == afxres.AFX_IDW_DOCKBAR_RIGHT:
-            x = x + self.cxEdge
+            x += self.cxEdge
         return x, y
 
     def DrawGripper(self, dc):
@@ -600,9 +600,9 @@ class DockingBar(window.Wnd):
                 self.rectUndock, win32con.DFC_CAPTION, win32con.DFCS_CAPTIONMAX
             )
 
-            gt = gt + 38
-            gb = gb - 10
-            gl = gl + 10
+            gt += 38
+            gb -= 10
+            gl += 10
             gr = gl + 3
             gripper = gl, gt, gr, gb
             dc.Draw3dRect(gripper, clrBtnHilight, clrBtnShadow)
@@ -620,9 +620,9 @@ class DockingBar(window.Wnd):
             dc.DrawFrameControl(
                 self.rectUndock, win32con.DFC_CAPTION, win32con.DFCS_CAPTIONMAX
             )
-            gr = gr - 38
-            gl = gl + 10
-            gt = gt + 10
+            gr -= 38
+            gl += 10
+            gt += 10
             gb = gt + 3
 
             gripper = gl, gt, gr, gb

--- a/Pythonwin/pywin/framework/app.py
+++ b/Pythonwin/pywin/framework/app.py
@@ -25,7 +25,7 @@ def SaveWindowSize(section, rect, state=""):
                  (same format as CREATESTRUCT position tuples)."""
     left, top, right, bottom = rect
     if state:
-        state = state + " "
+        state += " "
     win32ui.WriteProfileVal(section, state + "left", left)
     win32ui.WriteProfileVal(section, state + "top", top)
     win32ui.WriteProfileVal(section, state + "right", right)
@@ -35,7 +35,7 @@ def SaveWindowSize(section, rect, state=""):
 def LoadWindowSize(section, state=""):
     """Loads a section from an INI file, and returns a rect in a tuple (see SaveWindowSize)"""
     if state:
-        state = state + " "
+        state += " "
     left = win32ui.GetProfileVal(section, state + "left", 0)
     top = win32ui.GetProfileVal(section, state + "top", 0)
     right = win32ui.GetProfileVal(section, state + "right", 0)

--- a/Pythonwin/pywin/framework/cmdline.py
+++ b/Pythonwin/pywin/framework/cmdline.py
@@ -12,13 +12,13 @@ def ParseArgs(str):
     while pos < length:
         try:
             while str[pos] in string.whitespace:
-                pos = pos + 1
+                pos += 1
         except IndexError:
             break
         if pos >= length:
             break
         if str[pos] == '"':
-            pos = pos + 1
+            pos += 1
             try:
                 endPos = str.index('"', pos) - 1
                 nextPos = endPos + 2
@@ -28,7 +28,7 @@ def ParseArgs(str):
         else:
             endPos = pos
             while endPos < length and not str[endPos] in string.whitespace:
-                endPos = endPos + 1
+                endPos += 1
             nextPos = endPos + 1
         ret.append(str[pos : endPos + 1].strip())
         pos = nextPos

--- a/Pythonwin/pywin/framework/editor/color/coloreditor.py
+++ b/Pythonwin/pywin/framework/editor/color/coloreditor.py
@@ -609,7 +609,7 @@ class SyntEditTemplate(EditorTemplateBase):
                     event, ["editor"]
                 )
                 if keyname is not None:
-                    text = text + "\t" + keyname
+                    text += "\t" + keyname
                 submenu.AppendMenu(flags, id, text)
 
         mainMenu = self.GetSharedMenu()

--- a/Pythonwin/pywin/framework/editor/configui.py
+++ b/Pythonwin/pywin/framework/editor/configui.py
@@ -253,7 +253,7 @@ class EditorWhitespacePropertyPage(dialog.PropertyPage):
         for c in paletteVGA:
             if tt_color == win32api.RGB(c[1], c[2], c[3]):
                 break
-            sel = sel + 1
+            sel += 1
         else:
             sel = -1
         self.cbo.SetCurSel(sel)

--- a/Pythonwin/pywin/framework/editor/document.py
+++ b/Pythonwin/pywin/framework/editor/document.py
@@ -245,7 +245,7 @@ class EditorDocumentBase(ParentEditorDocument):
         except win32ui.error:
             title = filename
         if self._IsReadOnly():
-            title = title + " (read-only)"
+            title += " (read-only)"
         self.SetTitle(title)
 
     def MakeDocumentWritable(self):
@@ -261,7 +261,7 @@ class EditorDocumentBase(ParentEditorDocument):
         msg = "Would you like to check this file out?"
         defButton = win32con.MB_YESNO
         if self.IsModified():
-            msg = msg + "\r\n\r\nALL CHANGES IN THE EDITOR WILL BE LOST"
+            msg += "\r\n\r\nALL CHANGES IN THE EDITOR WILL BE LOST"
             defButton = win32con.MB_YESNO
         if win32ui.MessageBox(msg, None, defButton) != win32con.IDYES:
             return 0

--- a/Pythonwin/pywin/framework/editor/editor.py
+++ b/Pythonwin/pywin/framework/editor/editor.py
@@ -236,7 +236,7 @@ class EditorView(ParentEditorView):
             try:
                 if color is None:
                     color = self.defCharFormat[4]
-                lineNo = lineNo - 1
+                lineNo -= 1
                 startIndex = self.LineIndex(lineNo)
                 if startIndex != -1:
                     self.SetSel(startIndex, self.LineIndex(lineNo + 1))
@@ -261,7 +261,7 @@ class EditorView(ParentEditorView):
             if ch == "\t":
                 curCol = ((curCol / self.tabSize) + 1) * self.tabSize
             else:
-                curCol = curCol + 1
+                curCol += 1
         nextColumn = ((curCol / self.indentSize) + 1) * self.indentSize
         # print("curCol is", curCol, "nextColumn is", nextColumn)
         ins = None
@@ -274,7 +274,7 @@ class EditorView(ParentEditorView):
                     if check in ("\t", " "):
                         ins = check
                         break
-                    lookLine = lookLine - 1
+                    lookLine -= 1
             else:  # See if the previous char can tell us
                 check = line[realCol - 1]
                 if check in ("\t", " "):
@@ -290,7 +290,7 @@ class EditorView(ParentEditorView):
 
         if ins == " ":
             # Calc the number of spaces to take us to the next stop
-            ins = ins * (nextColumn - curCol)
+            ins *= nextColumn - curCol
 
         self._obj_.ReplaceSel(ins)
 

--- a/Pythonwin/pywin/framework/help.py
+++ b/Pythonwin/pywin/framework/help.py
@@ -97,7 +97,7 @@ def _ListAllHelpFilesInRoot(root):
                 helpDesc = win32api.RegEnumKey(key, keyNo)
                 helpFile = win32api.RegQueryValue(key, helpDesc)
                 retList.append((helpDesc, helpFile))
-                keyNo = keyNo + 1
+                keyNo += 1
             except win32api.error as exc:
                 import winerror
 
@@ -149,7 +149,7 @@ def SetHelpMenuOtherHelp(mainMenu):
             if fname not in excludeFnames:
                 helpIDMap[cmdID] = (desc, fname)
                 win32ui.GetMainFrame().HookCommand(HandleHelpOtherCommand, cmdID)
-                cmdID = cmdID + 1
+                cmdID += 1
 
     helpMenu = mainMenu.GetSubMenu(
         mainMenu.GetMenuItemCount() - 1

--- a/Pythonwin/pywin/framework/interact.py
+++ b/Pythonwin/pywin/framework/interact.py
@@ -211,7 +211,7 @@ class InteractiveFormatter(FormatterParent):
                 # and ask the Python colorizer to color that.
                 end = startSeg
                 while end < lengthDoc and cdoc[end] not in b"\r\n":
-                    end = end + 1
+                    end += 1
                 self.ColorizePythonCode(cdoc[:end], startSeg, state)
                 stylePyStart = self.GetStringStyle(end - 1)
                 if stylePyStart is None:
@@ -224,7 +224,7 @@ class InteractiveFormatter(FormatterParent):
                 state = STYLE_INTERACTIVE_EOL
             if lastState != state:
                 lastState = state
-            i = i + 1
+            i += 1
         # and the rest
         if startSeg < i:
             self.ColorSeg(startSeg, i - 1, state)
@@ -243,7 +243,7 @@ class InteractiveFormatter(FormatterParent):
             # If TQString, we continue it.  Otherwise, we reset.
             look = start - 1
             while look and self.scintilla.SCIGetCharAt(look) in "\n\r":
-                look = look - 1
+                look -= 1
             if look and look < start - 1:  # Did we find a char before the \n\r sets?
                 strstyle = self.GetStringStyle(look)
                 quote_char = None
@@ -454,12 +454,12 @@ class InteractiveCore:
             while startLineNo > 0:
                 if GetPromptPrefix(self.DoGetLine(startLineNo - 1)) is not None:
                     break  # there _is_ a prompt
-                startLineNo = startLineNo - 1
+                startLineNo -= 1
             endLineNo = lineNo
             while endLineNo < maxLineNo:
                 if GetPromptPrefix(self.DoGetLine(endLineNo + 1)) is not None:
                     break  # there _is_ a prompt
-                endLineNo = endLineNo + 1
+                endLineNo += 1
         else:  # Code block
             flag = 1
             startLineNo = lineNo
@@ -468,7 +468,7 @@ class InteractiveCore:
                 if prefix is None:
                     break
                     # there is no prompt.
-                startLineNo = startLineNo - 1
+                startLineNo -= 1
             endLineNo = lineNo
             while endLineNo < maxLineNo:
                 prefix = GetPromptPrefix(self.DoGetLine(endLineNo + 1))
@@ -476,7 +476,7 @@ class InteractiveCore:
                     break  # there is no prompt
                 if prefix == str(sys.ps1):
                     break  # this is another command
-                endLineNo = endLineNo + 1
+                endLineNo += 1
                 # continue until end of buffer, or no prompt
         return (startLineNo, endLineNo, flag)
 
@@ -487,7 +487,7 @@ class InteractiveCore:
             thisLine = self.DoGetLine(end)
             promptLen = len(GetPromptPrefix(thisLine))
             retList = [thisLine[promptLen:]] + retList
-            end = end - 1
+            end -= 1
         return retList
 
     def OutputGrab(self):
@@ -584,10 +584,10 @@ class InteractiveCore:
             pos = 0
             indent = ""
             while len(curLine) > pos and curLine[pos] in string.whitespace:
-                indent = indent + curLine[pos]
-                pos = pos + 1
+                indent += curLine[pos]
+                pos += 1
             if _is_block_opener(curLine):
-                indent = indent + "\t"
+                indent += "\t"
             elif _is_block_closer(curLine):
                 indent = indent[:-1]
             # use ReplaceSel to ensure it goes at the cursor rather than end of buffer.

--- a/Pythonwin/pywin/framework/intpyapp.py
+++ b/Pythonwin/pywin/framework/intpyapp.py
@@ -489,7 +489,7 @@ class InteractivePythonApp(app.CApp):
             except AttributeError:
                 # Template does not provide property pages!
                 continue
-            pages += getter()
+            pages.extend(getter())
 
         # Debugger template goes at the end
         try:

--- a/Pythonwin/pywin/framework/intpyapp.py
+++ b/Pythonwin/pywin/framework/intpyapp.py
@@ -489,7 +489,7 @@ class InteractivePythonApp(app.CApp):
             except AttributeError:
                 # Template does not provide property pages!
                 continue
-            pages = pages + getter()
+            pages += getter()
 
         # Debugger template goes at the end
         try:

--- a/Pythonwin/pywin/framework/mdi_pychecker.py
+++ b/Pythonwin/pywin/framework/mdi_pychecker.py
@@ -54,7 +54,7 @@ def getsubdirs(d):
     for f in flist:
         if os.path.isdir(f):
             dlist.append(f)
-            dlist += getsubdirs(f)
+            dlist.extend(getsubdirs(f))
     return dlist
 
 
@@ -234,9 +234,9 @@ class TheDocument(docview.RichEditDoc):
             paramstr = win32ui.GetProfileVal("Pychecker", "Params", "\t\t\t1\t0\t0")
         params = paramstr.split("\t")
         if len(params) < 3:
-            params += [""] * (3 - len(params))
+            params.extend([""] * (3 - len(params)))
         if len(params) < 6:
-            params += [0] * (6 - len(params))
+            params.extend([0] * (6 - len(params)))
         self.dirpattern = params[0]
         self.filpattern = params[1]
         self.greppattern = params[2] or "-#1000 --only"
@@ -712,7 +712,7 @@ class TheDialog(dialog.Dialog):
             i = 0
             newitems = dlg.getNew()
             if newitems:
-                items += newitems
+                items.extend(newitems)
                 for item in items:
                     win32api.WriteProfileVal(section, repr(i), item, ini)
                     i += 1

--- a/Pythonwin/pywin/framework/mdi_pychecker.py
+++ b/Pythonwin/pywin/framework/mdi_pychecker.py
@@ -54,7 +54,7 @@ def getsubdirs(d):
     for f in flist:
         if os.path.isdir(f):
             dlist.append(f)
-            dlist = dlist + getsubdirs(f)
+            dlist += getsubdirs(f)
     return dlist
 
 
@@ -234,9 +234,9 @@ class TheDocument(docview.RichEditDoc):
             paramstr = win32ui.GetProfileVal("Pychecker", "Params", "\t\t\t1\t0\t0")
         params = paramstr.split("\t")
         if len(params) < 3:
-            params = params + [""] * (3 - len(params))
+            params += [""] * (3 - len(params))
         if len(params) < 6:
-            params = params + [0] * (6 - len(params))
+            params += [0] * (6 - len(params))
         self.dirpattern = params[0]
         self.filpattern = params[1]
         self.greppattern = params[2] or "-#1000 --only"
@@ -381,7 +381,7 @@ class TheDocument(docview.RichEditDoc):
             self.SetModifiedFlag(0)
 
     def _inactive_idleHandler(self, handler, count):
-        self.fndx = self.fndx + 1
+        self.fndx += 1
         if self.fndx < len(self.flist):
             f = self.flist[self.fndx]
             if self.verbose:
@@ -394,14 +394,14 @@ class TheDocument(docview.RichEditDoc):
                     self.GetFirstView().Append(f + "(" + repr(i + 1) + ") " + line)
         else:
             self.fndx = -1
-            self.fpndx = self.fpndx + 1
+            self.fpndx += 1
             if self.fpndx < len(self.fplist):
                 self.flist = glob.glob(
                     self.dp[self.dpndx] + "\\" + self.fplist[self.fpndx]
                 )
             else:
                 self.fpndx = 0
-                self.dpndx = self.dpndx + 1
+                self.dpndx += 1
                 if self.dpndx < len(self.dp):
                     self.flist = glob.glob(
                         self.dp[self.dpndx] + "\\" + self.fplist[self.fpndx]
@@ -712,10 +712,10 @@ class TheDialog(dialog.Dialog):
             i = 0
             newitems = dlg.getNew()
             if newitems:
-                items = items + newitems
+                items += newitems
                 for item in items:
                     win32api.WriteProfileVal(section, repr(i), item, ini)
-                    i = i + 1
+                    i += 1
             self.UpdateData(0)
 
     def OnOK(self):

--- a/Pythonwin/pywin/framework/scriptutils.py
+++ b/Pythonwin/pywin/framework/scriptutils.py
@@ -280,7 +280,7 @@ def RunScript(defName=None, defArgs=None, bShowDialog=1, debuggingType=None):
     if (
         len(os.path.splitext(script)[1]) == 0
     ):  # check if no extension supplied, and give one.
-        script = script + ".py"
+        script += ".py"
     # If no path specified, try and locate the file
     path, fnameonly = os.path.split(script)
     if len(path) == 0:
@@ -675,7 +675,7 @@ def LocatePythonFile(fileName, bBrowseIfDir=1):
                     else:
                         return None
             else:
-                fileName = fileName + ".py"
+                fileName += ".py"
                 if os.path.isfile(fileName):
                     break  # Found it!
 

--- a/Pythonwin/pywin/framework/sgrepmdi.py
+++ b/Pythonwin/pywin/framework/sgrepmdi.py
@@ -36,7 +36,7 @@ def getsubdirs(d):
     for f in flist:
         if os.path.isdir(f):
             dlist.append(f)
-            dlist = dlist + getsubdirs(f)
+            dlist += getsubdirs(f)
     return dlist
 
 
@@ -218,9 +218,9 @@ class GrepDocument(docview.RichEditDoc):
             paramstr = win32ui.GetProfileVal("Grep", "Params", "\t\t\t1\t0\t0")
         params = paramstr.split("\t")
         if len(params) < 3:
-            params = params + [""] * (3 - len(params))
+            params += [""] * (3 - len(params))
         if len(params) < 6:
-            params = params + [0] * (6 - len(params))
+            params += [0] * (6 - len(params))
         self.dirpattern = params[0]
         self.filpattern = params[1]
         self.greppattern = params[2]
@@ -290,7 +290,7 @@ class GrepDocument(docview.RichEditDoc):
             win32ui.GetApp().AddIdleHandler(self.SearchFile)
 
     def SearchFile(self, handler, count):
-        self.fndx = self.fndx + 1
+        self.fndx += 1
         if self.fndx < len(self.flist):
             f = self.flist[self.fndx]
             if self.verbose:
@@ -306,14 +306,14 @@ class GrepDocument(docview.RichEditDoc):
                         self.GetFirstView().Append(f + "(" + repr(i + 1) + ") " + line)
         else:
             self.fndx = -1
-            self.fpndx = self.fpndx + 1
+            self.fpndx += 1
             if self.fpndx < len(self.fplist):
                 self.flist = glob.glob(
                     self.dp[self.dpndx] + "\\" + self.fplist[self.fpndx]
                 )
             else:
                 self.fpndx = 0
-                self.dpndx = self.dpndx + 1
+                self.dpndx += 1
                 if self.dpndx < len(self.dp):
                     self.flist = glob.glob(
                         self.dp[self.dpndx] + "\\" + self.fplist[self.fpndx]
@@ -624,10 +624,10 @@ class GrepDialog(dialog.Dialog):
             i = 0
             newitems = dlg.getNew()
             if newitems:
-                items = items + newitems
+                items += newitems
                 for item in items:
                     win32api.WriteProfileVal(section, repr(i), item, ini)
-                    i = i + 1
+                    i += 1
             self.UpdateData(0)
 
     def OnOK(self):

--- a/Pythonwin/pywin/framework/sgrepmdi.py
+++ b/Pythonwin/pywin/framework/sgrepmdi.py
@@ -218,9 +218,9 @@ class GrepDocument(docview.RichEditDoc):
             paramstr = win32ui.GetProfileVal("Grep", "Params", "\t\t\t1\t0\t0")
         params = paramstr.split("\t")
         if len(params) < 3:
-            params += [""] * (3 - len(params))
+            params.extend([""] * (3 - len(params)))
         if len(params) < 6:
-            params += [0] * (6 - len(params))
+            params.extend([0] * (6 - len(params)))
         self.dirpattern = params[0]
         self.filpattern = params[1]
         self.greppattern = params[2]
@@ -624,7 +624,7 @@ class GrepDialog(dialog.Dialog):
             i = 0
             newitems = dlg.getNew()
             if newitems:
-                items += newitems
+                items.extend(newitems)
                 for item in items:
                     win32api.WriteProfileVal(section, repr(i), item, ini)
                     i += 1

--- a/Pythonwin/pywin/framework/stdin.py
+++ b/Pythonwin/pywin/framework/stdin.py
@@ -119,7 +119,7 @@ class Stdin:
             line = self.readline()
             if line == "":
                 break
-            total_read = total_read + len(line)
+            total_read += len(line)
             result.append(line)
         return result
 

--- a/Pythonwin/pywin/framework/toolmenu.py
+++ b/Pythonwin/pywin/framework/toolmenu.py
@@ -41,7 +41,7 @@ def LoadToolMenuItems():
             break
         cmd = win32ui.GetProfileVal("Tools Menu\\%s" % lookNo, "Command", "")
         items.append((menu, cmd))
-        lookNo = lookNo + 1
+        lookNo += 1
 
     if len(items) == 0:
         items = defaultToolMenuItems
@@ -71,7 +71,7 @@ def WriteToolMenuItems(items):
     for menu, cmd in items:
         win32ui.WriteProfileVal("Tools Menu\\%s" % itemNo, "", menu)
         win32ui.WriteProfileVal("Tools Menu\\%s" % itemNo, "Command", cmd)
-        itemNo = itemNo + 1
+        itemNo += 1
 
 
 def SetToolsMenu(menu, menuPos=None):
@@ -90,7 +90,7 @@ def SetToolsMenu(menu, menuPos=None):
             win32con.MF_ENABLED | win32con.MF_STRING, idPos, menuString
         )
         win32ui.GetMainFrame().HookCommand(HandleToolCommand, idPos)
-        idPos = idPos + 1
+        idPos += 1
 
     # Find the correct spot to insert the new tools menu.
     if menuPos is None:
@@ -191,7 +191,7 @@ class ToolMenuPropPage(dialog.PropertyPage):
         for desc, cmd in LoadToolMenuItems():
             lc.InsertItem(itemNo, desc)
             lc.SetItemText(itemNo, 1, cmd)
-            itemNo = itemNo + 1
+            itemNo += 1
 
         self.listControl = lc
         return dialog.PropertyPage.OnInitDialog(self)
@@ -209,7 +209,7 @@ class ToolMenuPropPage(dialog.PropertyPage):
             except win32ui.error:
                 # no more items!
                 break
-            itemLook = itemLook + 1
+            itemLook += 1
         WriteToolMenuItems(items)
         return self._obj_.OnOK()
 

--- a/Pythonwin/pywin/framework/winout.py
+++ b/Pythonwin/pywin/framework/winout.py
@@ -463,7 +463,7 @@ class WindowOutput(docview.DocTemplate):
         except KeyboardInterrupt:
             # First interrupt since idle we just pass on.
             # later ones we dump the queue and give up.
-            self.interruptCount = self.interruptCount + 1
+            self.interruptCount += 1
             if self.interruptCount > 1:
                 # Drop the queue quickly as the user is already annoyed :-)
                 self.outputQueue = queue.Queue(-1)
@@ -511,7 +511,7 @@ class WindowOutput(docview.DocTemplate):
                 rc = 1
                 break
             if max is not None:
-                max = max - 1
+                max -= 1
         if len(items) != 0:
             if not self.CheckRecreateWindow():
                 debug(":Recreate failed!\n")

--- a/Pythonwin/pywin/idle/AutoExpand.py
+++ b/Pythonwin/pywin/idle/AutoExpand.py
@@ -91,5 +91,5 @@ class AutoExpand:
         line = self.text.get("insert linestart", "insert")
         i = len(line)
         while i > 0 and line[i - 1] in self.wordchars:
-            i = i - 1
+            i -= 1
         return line[i:]

--- a/Pythonwin/pywin/idle/AutoIndent.py
+++ b/Pythonwin/pywin/idle/AutoIndent.py
@@ -148,7 +148,7 @@ class AutoIndent:
         ncharsdeleted = 0
         while 1:
             chars = chars[:-1]
-            ncharsdeleted = ncharsdeleted + 1
+            ncharsdeleted += 1
             have = len(chars.expandtabs(self.tabwidth))
             if have <= want or chars[-1] not in " \t":
                 break
@@ -203,7 +203,7 @@ class AutoIndent:
             line = text.get("insert linestart", "insert")
             i, n = 0, len(line)
             while i < n and line[i] in " \t":
-                i = i + 1
+                i += 1
             if i == n:
                 # the cursor is in or at leading indentation; just inject
                 # an empty line at the start and strip space from current line
@@ -215,7 +215,7 @@ class AutoIndent:
             i = 0
             while line and line[-1] in " \t":
                 line = line[:-1]
-                i = i + 1
+                i += 1
             if i:
                 text.delete("insert - %d chars" % i, "insert")
             # strip whitespace after insert point
@@ -298,7 +298,7 @@ class AutoIndent:
             line = lines[pos]
             if line:
                 raw, effective = classifyws(line, self.tabwidth)
-                effective = effective + self.indentwidth
+                effective += self.indentwidth
                 lines[pos] = self._make_blanks(effective) + line[raw:]
         self.set_region(head, tail, chars, lines)
         return "break"
@@ -473,10 +473,10 @@ def classifyws(s, tabwidth):
     raw = effective = 0
     for ch in s:
         if ch == " ":
-            raw = raw + 1
-            effective = effective + 1
+            raw += 1
+            effective += 1
         elif ch == "\t":
-            raw = raw + 1
+            raw += 1
             effective = (effective // tabwidth + 1) * tabwidth
         else:
             break

--- a/Pythonwin/pywin/idle/CallTips.py
+++ b/Pythonwin/pywin/idle/CallTips.py
@@ -88,7 +88,7 @@ class CallTips:
         chars = text.get("insert linestart", "insert")
         i = len(chars)
         while i and chars[i - 1] in wordchars:
-            i = i - 1
+            i -= 1
         word = chars[i:]
         if word:
             # How is this for a hack!
@@ -147,8 +147,8 @@ def get_arg_text(ob):
                 if pos < 0 or pos > 70:
                     pos = 70
                 if argText:
-                    argText = argText + "\n"
-                argText = argText + doc[:pos]
+                    argText += "\n"
+                argText += doc[:pos]
 
     return argText
 

--- a/Pythonwin/pywin/idle/FormatParagraph.py
+++ b/Pythonwin/pywin/idle/FormatParagraph.py
@@ -141,7 +141,7 @@ def reformat_paragraph(data, limit=70):
             if len((partial + word).expandtabs()) > limit and partial != indent1:
                 new.append(partial.rstrip())
                 partial = indent2
-            partial = partial + word + " "
+            partial += word + " "
             if j + 1 < len(words) and words[j + 1] != " ":
                 partial += " "
         i += 1

--- a/Pythonwin/pywin/idle/FormatParagraph.py
+++ b/Pythonwin/pywin/idle/FormatParagraph.py
@@ -91,7 +91,7 @@ def find_paragraph(text, mark):
     lineno, col = list(map(int, mark.split(".")))
     line = text.get("%d.0" % lineno, "%d.0 lineend" % lineno)
     while text.compare("%d.0" % lineno, "<", "end") and is_all_white(line):
-        lineno = lineno + 1
+        lineno += 1
         line = text.get("%d.0" % lineno, "%d.0 lineend" % lineno)
     first_lineno = lineno
     comment_header = get_comment_header(line)
@@ -99,7 +99,7 @@ def find_paragraph(text, mark):
     while get_comment_header(line) == comment_header and not is_all_white(
         line[comment_header_len:]
     ):
-        lineno = lineno + 1
+        lineno += 1
         line = text.get("%d.0" % lineno, "%d.0 lineend" % lineno)
     last = "%d.0" % lineno
     # Search back to beginning of paragraph
@@ -110,7 +110,7 @@ def find_paragraph(text, mark):
         and get_comment_header(line) == comment_header
         and not is_all_white(line[comment_header_len:])
     ):
-        lineno = lineno - 1
+        lineno -= 1
         line = text.get("%d.0" % lineno, "%d.0 lineend" % lineno)
     first = "%d.0" % (lineno + 1)
     return first, last, comment_header, text.get(first, last)
@@ -121,7 +121,7 @@ def reformat_paragraph(data, limit=70):
     i = 0
     n = len(lines)
     while i < n and is_all_white(lines[i]):
-        i = i + 1
+        i += 1
     if i >= n:
         return data
     indent1 = get_indent(lines[i])
@@ -143,8 +143,8 @@ def reformat_paragraph(data, limit=70):
                 partial = indent2
             partial = partial + word + " "
             if j + 1 < len(words) and words[j + 1] != " ":
-                partial = partial + " "
-        i = i + 1
+                partial += " "
+        i += 1
     new.append(partial.rstrip())
     # XXX Should reformat remaining paragraphs as well
     new.extend(lines[i:])

--- a/Pythonwin/pywin/idle/IdleHistory.py
+++ b/Pythonwin/pywin/idle/IdleHistory.py
@@ -45,9 +45,9 @@ class History:
         nprefix = len(prefix)
         while 1:
             if reverse:
-                pointer = pointer - 1
+                pointer -= 1
             else:
-                pointer = pointer + 1
+                pointer += 1
             if pointer < 0 or pointer >= nhist:
                 self.text.bell()
                 if self._get_source("iomark", "end-1c") != prefix:

--- a/Pythonwin/pywin/idle/PyParse.py
+++ b/Pythonwin/pywin/idle/PyParse.py
@@ -252,26 +252,26 @@ class Parser:
         i, n = 0, len(str)
         while i < n:
             ch = str[i]
-            i = i + 1
+            i += 1
 
             # cases are checked in decreasing order of frequency
             if ch == "x":
                 continue
 
             if ch == "\n":
-                lno = lno + 1
+                lno += 1
                 if level == 0:
                     push_good(lno)
                     # else we're in an unclosed bracket structure
                 continue
 
             if ch == "(":
-                level = level + 1
+                level += 1
                 continue
 
             if ch == ")":
                 if level:
-                    level = level - 1
+                    level -= 1
                     # else the program is invalid, but we can't complain
                 continue
 
@@ -279,22 +279,22 @@ class Parser:
                 # consume the string
                 quote = ch
                 if str[i - 1 : i + 2] == quote * 3:
-                    quote = quote * 3
+                    quote *= 3
                 w = len(quote) - 1
-                i = i + w
+                i += w
                 while i < n:
                     ch = str[i]
-                    i = i + 1
+                    i += 1
 
                     if ch == "x":
                         continue
 
                     if str[i - 1 : i + w] == quote:
-                        i = i + w
+                        i += w
                         break
 
                     if ch == "\n":
-                        lno = lno + 1
+                        lno += 1
                         if w == 0:
                             # unterminated single-quoted string
                             if level == 0:
@@ -305,8 +305,8 @@ class Parser:
                     if ch == "\\":
                         assert i < n
                         if str[i] == "\n":
-                            lno = lno + 1
-                        i = i + 1
+                            lno += 1
+                        i += 1
                         continue
 
                     # else comment char or paren inside string
@@ -326,10 +326,10 @@ class Parser:
             assert ch == "\\"
             assert i < n
             if str[i] == "\n":
-                lno = lno + 1
+                lno += 1
                 if i + 1 == n:
                     continuation = C_BACKSLASH
-            i = i + 1
+            i += 1
 
         # The last stmt may be continued for all 3 reasons.
         # String continuation takes precedence over bracket
@@ -381,7 +381,7 @@ class Parser:
             # The stmt str[p:q] isn't a continuation, but may be blank
             # or a non-indenting comment line.
             if _junkre(str, p):
-                i = i - 1
+                i -= 1
             else:
                 break
         if i == 0:
@@ -404,7 +404,7 @@ class Parser:
                 # back up over totally boring whitespace
                 i = newp - 1  # index of last boring char
                 while i >= p and str[i] in " \t\n":
-                    i = i - 1
+                    i -= 1
                 if i >= p:
                     lastch = str[i]
                 p = newp
@@ -416,14 +416,14 @@ class Parser:
             if ch in "([{":
                 push_stack(p)
                 lastch = ch
-                p = p + 1
+                p += 1
                 continue
 
             if ch in ")]}":
                 if stack:
                     del stack[-1]
                 lastch = ch
-                p = p + 1
+                p += 1
                 continue
 
             if ch == '"' or ch == "'":
@@ -445,12 +445,12 @@ class Parser:
                 continue
 
             assert ch == "\\"
-            p = p + 1  # beyond backslash
+            p += 1  # beyond backslash
             assert p < q
             if str[p] != "\n":
                 # the program is invalid, but can't complain
                 lastch = ch + str[p]
-            p = p + 1  # beyond escaped char
+            p += 1  # beyond escaped char
 
         # end while p < q:
 
@@ -468,7 +468,7 @@ class Parser:
         str = self.str
         n = len(str)
         origi = i = str.rfind("\n", 0, j) + 1
-        j = j + 1  # one beyond open bracket
+        j += 1  # one beyond open bracket
         # find first list item; set i to start of its line
         while j < n:
             m = _itemre(str, j)
@@ -484,7 +484,7 @@ class Parser:
             # reproduce the bracket line's indentation + a level
             j = i = origi
             while str[j] in " \t":
-                j = j + 1
+                j += 1
             extra = self.indentwidth
         return len(str[i:j].expandtabs(self.tabwidth)) + extra
 
@@ -507,7 +507,7 @@ class Parser:
         str = self.str
         i = self.stmt_start
         while str[i] in " \t":
-            i = i + 1
+            i += 1
         startpos = i
 
         # See whether the initial line starts an assignment stmt; i.e.,
@@ -517,12 +517,12 @@ class Parser:
         while i < endpos:
             ch = str[i]
             if ch in "([{":
-                level = level + 1
-                i = i + 1
+                level += 1
+                i += 1
             elif ch in ")]}":
                 if level:
-                    level = level - 1
-                i = i + 1
+                    level -= 1
+                i += 1
             elif ch == '"' or ch == "'":
                 i = _match_stringre(str, i, endpos).end()
             elif ch == "#":
@@ -536,12 +536,12 @@ class Parser:
                 found = 1
                 break
             else:
-                i = i + 1
+                i += 1
 
         if found:
             # found a legit =, but it may be the last interesting
             # thing on the line
-            i = i + 1  # move beyond the =
+            i += 1  # move beyond the =
             found = re.match(r"\s*\\", str[i:endpos]) is None
 
         if not found:
@@ -549,7 +549,7 @@ class Parser:
             # of non-whitespace chars
             i = startpos
             while str[i] not in " \t\n":
-                i = i + 1
+                i += 1
 
         return len(str[self.stmt_start : i].expandtabs(self.tabwidth)) + 1
 
@@ -562,7 +562,7 @@ class Parser:
         j = i
         str = self.str
         while j < n and str[j] in " \t":
-            j = j + 1
+            j += 1
         return str[i:j]
 
     # Did the last interesting stmt open a block?

--- a/Pythonwin/pywin/scintilla/IDLEenvironment.py
+++ b/Pythonwin/pywin/scintilla/IDLEenvironment.py
@@ -208,19 +208,19 @@ def _NextTok(str, pos):
     if pos >= end:
         return None, 0
     while pos < end and str[pos] in string.whitespace:
-        pos = pos + 1
+        pos += 1
     # Special case for +-
     if str[pos] in "+-":
         return str[pos], pos + 1
     # Digits also a special case.
     endPos = pos
     while endPos < end and str[endPos] in string.digits + ".":
-        endPos = endPos + 1
+        endPos += 1
     if pos != endPos:
         return str[pos:endPos], endPos
     endPos = pos
     while endPos < end and str[endPos] not in string.whitespace + string.digits + "+-":
-        endPos = endPos + 1
+        endPos += 1
     if pos != endPos:
         return str[pos:endPos], endPos
     return None, 0
@@ -253,7 +253,7 @@ def TkIndexToOffset(bm, edit, marks):
                     pos = edit.LineIndex(line)
                     if pos == -1:
                         pos = edit.GetTextLength()
-                    pos = pos + int(col)
+                    pos += int(col)
         except (ValueError, IndexError):
             raise ValueError("Unexpected literal in '%s'" % base)
     elif base == "insert":
@@ -262,7 +262,7 @@ def TkIndexToOffset(bm, edit, marks):
         pos = edit.GetTextLength()
         # Pretend there is a trailing '\n' if necessary
         if pos and edit.SCIGetCharAt(pos - 1) != "\n":
-            pos = pos + 1
+            pos += 1
     else:
         try:
             pos = marks[base]
@@ -283,23 +283,23 @@ def TkIndexToOffset(bm, edit, marks):
             if what[0] != "c":
                 raise ValueError("+/- only supports chars")
             if word == "+":
-                pos = pos + int(num)
+                pos += int(num)
             else:
-                pos = pos - int(num)
+                pos -= int(num)
         elif word == "wordstart":
             while pos > 0 and edit.SCIGetCharAt(pos - 1) in wordchars:
-                pos = pos - 1
+                pos -= 1
         elif word == "wordend":
             end = edit.GetTextLength()
             while pos < end and edit.SCIGetCharAt(pos) in wordchars:
-                pos = pos + 1
+                pos += 1
         elif word == "linestart":
             while pos > 0 and edit.SCIGetCharAt(pos - 1) not in "\n\r":
-                pos = pos - 1
+                pos -= 1
         elif word == "lineend":
             end = edit.GetTextLength()
             while pos < end and edit.SCIGetCharAt(pos) not in "\n\r":
-                pos = pos + 1
+                pos += 1
         else:
             raise ValueError("Unsupported relative offset '%s'" % word)
     return max(pos, 0)  # Tkinter is tollerant of -ve indexes - we aren't
@@ -351,13 +351,13 @@ class TkText:
             and self.edit.SCIGetCharAt(start) == "\n"
             and self.edit.SCIGetCharAt(start - 1) == "\r"
         ):
-            start = start - 1
+            start -= 1
         if (
             end < self.edit.GetTextLength()
             and self.edit.SCIGetCharAt(end - 1) == "\r"
             and self.edit.SCIGetCharAt(end) == "\n"
         ):
-            end = end + 1
+            end += 1
         return start, end
 
     ##	def get_tab_width(self):
@@ -397,7 +397,7 @@ class TkText:
         ret = self.edit.GetTextRange(start, end)
         # pretend a trailing '\n' exists if necessary.
         if checkEnd and (not ret or ret[-1] != "\n"):
-            ret = ret + "\n"
+            ret += "\n"
         return ret.replace("\r", "")
 
     def index(self, spec):
@@ -447,7 +447,7 @@ class TkText:
         if old >= start and old < end:
             old = start
         elif old >= end:
-            old = old - (end - start)
+            old -= end - start
         self.edit.SetSel(old)
 
     def bell(self):

--- a/Pythonwin/pywin/scintilla/bindings.py
+++ b/Pythonwin/pywin/scintilla/bindings.py
@@ -25,7 +25,7 @@ def assign_command_id(event, id=0):
         id = event_to_commands.get(event, 0)
         if id == 0:
             id = next_id
-            next_id = next_id + 1
+            next_id += 1
         # Only map the ones we allocated - specified ones are assumed to have a handler
         command_to_events[id] = event
     event_to_commands[event] = id
@@ -168,7 +168,7 @@ class BindingsManager:
                 keyState | win32con.RIGHT_CTRL_PRESSED | win32con.LEFT_CTRL_PRESSED
             )
         if win32api.GetKeyState(win32con.VK_SHIFT) & 0x8000:
-            keyState = keyState | win32con.SHIFT_PRESSED
+            keyState |= win32con.SHIFT_PRESSED
         if win32api.GetKeyState(win32con.VK_MENU) & 0x8000:
             keyState = keyState | win32con.LEFT_ALT_PRESSED | win32con.RIGHT_ALT_PRESSED
         keyinfo = key, keyState

--- a/Pythonwin/pywin/scintilla/bindings.py
+++ b/Pythonwin/pywin/scintilla/bindings.py
@@ -164,13 +164,11 @@ class BindingsManager:
         key = msg[2]
         keyState = 0
         if win32api.GetKeyState(win32con.VK_CONTROL) & 0x8000:
-            keyState = (
-                keyState | win32con.RIGHT_CTRL_PRESSED | win32con.LEFT_CTRL_PRESSED
-            )
+            keyState |= win32con.RIGHT_CTRL_PRESSED | win32con.LEFT_CTRL_PRESSED
         if win32api.GetKeyState(win32con.VK_SHIFT) & 0x8000:
             keyState |= win32con.SHIFT_PRESSED
         if win32api.GetKeyState(win32con.VK_MENU) & 0x8000:
-            keyState = keyState | win32con.LEFT_ALT_PRESSED | win32con.RIGHT_ALT_PRESSED
+            keyState |= win32con.LEFT_ALT_PRESSED | win32con.RIGHT_ALT_PRESSED
         keyinfo = key, keyState
         # Special hacks for the dead-char key on non-US keyboards.
         # (XXX - which do not work :-(

--- a/Pythonwin/pywin/scintilla/config.py
+++ b/Pythonwin/pywin/scintilla/config.py
@@ -133,7 +133,7 @@ class ConfigManager:
                 line = fp.readline()
                 if not line:
                     break
-                lineno = lineno + 1
+                lineno += 1
                 section, subsection = get_section_header(line)
             if not line:
                 break
@@ -151,7 +151,7 @@ class ConfigManager:
                     f"Unrecognised section header '{section}:{subsection}'"
                 )
                 line = fp.readline()
-                lineno = lineno + 1
+                lineno += 1
         if b_close:
             fp.close()
         # Check critical data.
@@ -201,7 +201,7 @@ class ConfigManager:
                 for name, func in list(ns.items()):
                     if isinstance(func, types.FunctionType) and name[:1] != "_":
                         bindings.bind(name, func)
-                        num = num + 1
+                        num += 1
                 trace("Configuration Extension code loaded", num, "events")
         # Load the idle extensions
         for subsection in subsections:
@@ -218,7 +218,7 @@ class ConfigManager:
         for subsection in subsections:
             keymap = subsection_keymap.get(subsection, {})
             bindings.update_keymap(keymap)
-            num_bound = num_bound + len(keymap)
+            num_bound += len(keymap)
         trace("Configuration bound", num_bound, "keys")
 
     def get_key_binding(self, event, subsections=None):
@@ -250,7 +250,7 @@ class ConfigManager:
 
     def _readline(self, fp, lineno, bStripComments=1):
         line = fp.readline()
-        lineno = lineno + 1
+        lineno += 1
         if line:
             bBreak = (
                 get_section_header(line)[0] is not None

--- a/Pythonwin/pywin/scintilla/configui.py
+++ b/Pythonwin/pywin/scintilla/configui.py
@@ -230,7 +230,7 @@ class ScintillaFormatPropertyPage(dialog.PropertyPage):
             if format[4] == c[1]:
                 # print("Style", style.name, "is", c[0])
                 break
-            sel = sel + 1
+            sel += 1
         else:
             sel = -1
         self.cbo.SetCurSel(sel)

--- a/Pythonwin/pywin/scintilla/document.py
+++ b/Pythonwin/pywin/scintilla/document.py
@@ -240,7 +240,7 @@ class CScintillaDocument(ParentScintillaDocument):
 
     def MarkerCheck(self, lineNo, marker):
         v = self.GetEditorView()
-        lineNo = lineNo - 1  # Make 0 based
+        lineNo -= 1  # Make 0 based
         markerState = v.SCIMarkerGet(lineNo)
         return markerState & (1 << marker) != 0
 

--- a/Pythonwin/pywin/scintilla/find.py
+++ b/Pythonwin/pywin/scintilla/find.py
@@ -84,9 +84,9 @@ def _FindIt(control, searchParams):
     # Move to the next char, so we find the next one.
     flags = 0
     if searchParams.matchWords:
-        flags = flags | win32con.FR_WHOLEWORD
+        flags |= win32con.FR_WHOLEWORD
     if searchParams.matchCase:
-        flags = flags | win32con.FR_MATCHCASE
+        flags |= win32con.FR_MATCHCASE
     if searchParams.sel == (-1, -1):
         sel = control.GetSel()
         # If the position is the same as we found last time,
@@ -500,7 +500,7 @@ class ReplaceDialog(FindReplaceDialog):
                 num = 1
                 lastSearch.replaceText = self.editReplaceText.GetWindowText()
                 while _ReplaceIt(control) == FOUND_NORMAL:
-                    num = num + 1
+                    num += 1
 
             win32ui.SetStatusText("Replaced %d occurrences" % num)
             if num > 0 and not self.butKeepDialogOpen.GetCheck():

--- a/Pythonwin/pywin/scintilla/formatter.py
+++ b/Pythonwin/pywin/scintilla/formatter.py
@@ -265,18 +265,18 @@ class Formatter(FormatterBase):
         self.Colorize(endStyled, notify.position)
 
     def ColorSeg(self, start, end, styleName):
-        end = end + 1
+        end += 1
         # 		assert end-start>=0, "Can't have negative styling"
         stylenum = self.styles[styleName].stylenum
         while start < end:
             self.style_buffer[start] = stylenum
-            start = start + 1
+            start += 1
         # self.scintilla.SCISetStyling(end - start + 1, stylenum)
 
     def RegisterStyle(self, style, stylenum=None):
         if stylenum is None:
             stylenum = self.nextstylenum
-            self.nextstylenum = self.nextstylenum + 1
+            self.nextstylenum += 1
         FormatterBase.RegisterStyle(self, style, stylenum)
 
     def ColorizeString(self, str, styleStart):
@@ -519,7 +519,7 @@ class PythonSourceFormatter(Formatter):
                     startSeg = i
                     state = STYLE_COMMENT
                     if chNext == '"' and chNext2 == '"':
-                        i = i + 2
+                        i += 2
                         state = STYLE_TQDSTRING
                         ch = " "
                         chPrev = " "
@@ -533,7 +533,7 @@ class PythonSourceFormatter(Formatter):
                     startSeg = i
                     state = STYLE_COMMENT
                     if chNext == "'" and chNext2 == "'":
-                        i = i + 2
+                        i += 2
                         state = STYLE_TQSSTRING
                         ch = " "
                         chPrev = " "
@@ -558,7 +558,7 @@ class PythonSourceFormatter(Formatter):
                             state = STYLE_COMMENT
                     elif ch == '"':
                         if chNext == '"' and chNext2 == '"':
-                            i = i + 2
+                            i += 2
                             state = STYLE_TQDSTRING
                             ch = " "
                             chPrev = " "
@@ -569,7 +569,7 @@ class PythonSourceFormatter(Formatter):
                             state = STYLE_STRING
                     elif ch == "'":
                         if chNext == "'" and chNext2 == "'":
-                            i = i + 2
+                            i += 2
                             state = STYLE_TQSSTRING
                             ch = " "
                             chPrev = " "
@@ -589,7 +589,7 @@ class PythonSourceFormatter(Formatter):
             elif state == STYLE_STRING:
                 if ch == "\\":
                     if chNext == '"' or chNext == "'" or chNext == "\\":
-                        i = i + 1
+                        i += 1
                         ch = chNext
                         chNext = " "
                         if i + 1 < lengthDoc:
@@ -601,7 +601,7 @@ class PythonSourceFormatter(Formatter):
             elif state == STYLE_SQSTRING:
                 if ch == "\\":
                     if chNext == '"' or chNext == "'" or chNext == "\\":
-                        i = i + 1
+                        i += 1
                         ch = chNext
                         chNext = " "
                         if i + 1 < lengthDoc:
@@ -628,7 +628,7 @@ class PythonSourceFormatter(Formatter):
             chPrev3 = chPrev2
             chPrev2 = chPrev
             chPrev = ch
-            i = i + 1
+            i += 1
         if startSeg < lengthDoc:
             if state == STYLE_KEYWORD:
                 self.ClassifyWord(cdoc, startSeg, lengthDoc - 1, prevWord)
@@ -668,7 +668,7 @@ class BuiltinSourceFormatter(FormatterBase):
         assert style.stylenum is None, "Style has already been registered"
         if stylenum is None:
             stylenum = self.nextstylenum
-            self.nextstylenum = self.nextstylenum + 1
+            self.nextstylenum += 1
         assert self.styles.get(stylenum) is None, "We are reusing a style number!"
         style.stylenum = stylenum
         self.styles[style.name] = style

--- a/Pythonwin/pywin/scintilla/keycodes.py
+++ b/Pythonwin/pywin/scintilla/keycodes.py
@@ -70,7 +70,7 @@ modifiers = {
 
 
 def parse_key_name(name):
-    name = name + "-"  # Add a sentinal
+    name += "-"  # Add a sentinal
     start = pos = 0
     max = len(name)
     toks = []
@@ -121,7 +121,7 @@ def make_key_name(vk, flags):
         for name, checkflag in moddata:
             if flags & checkflag:
                 parts.append(name)
-                flags_done = flags_done & checkflag
+                flags_done &= checkflag
                 break
     if flags_done & flags:
         parts.append(hex(flags & ~flags_done))

--- a/Pythonwin/pywin/scintilla/view.py
+++ b/Pythonwin/pywin/scintilla/view.py
@@ -130,7 +130,7 @@ def _get_class_attributes(ob):
     # Recurse into base classes looking for attributes
     items = []
     try:
-        items += dir(ob)
+        items.extend(dir(ob))
         for i in ob.__bases__:
             for item in _get_class_attributes(i):
                 if item not in items:

--- a/Pythonwin/pywin/scintilla/view.py
+++ b/Pythonwin/pywin/scintilla/view.py
@@ -341,7 +341,7 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
                 return
             keyname = configManager.get_key_binding(event, self._GetSubConfigNames())
             if keyname is not None:
-                text = text + "\t" + keyname
+                text += "\t" + keyname
         if flags is None:
             flags = win32con.MF_STRING | win32con.MF_ENABLED
         if checked:

--- a/Pythonwin/pywin/scintilla/view.py
+++ b/Pythonwin/pywin/scintilla/view.py
@@ -130,7 +130,7 @@ def _get_class_attributes(ob):
     # Recurse into base classes looking for attributes
     items = []
     try:
-        items = items + dir(ob)
+        items += dir(ob)
         for i in ob.__bases__:
             for item in _get_class_attributes(i):
                 if item not in items:
@@ -295,7 +295,7 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
     def OnMouseWheel(self, msg):
         zDelta = msg[2] >> 16
         vpos = self.GetScrollPos(win32con.SB_VERT)
-        vpos = vpos - zDelta / 40  # 3 lines per notch
+        vpos -= zDelta / 40  # 3 lines per notch
         self.SetScrollPos(win32con.SB_VERT, vpos)
         self.SendScintilla(
             win32con.WM_VSCROLL, (vpos << 16) | win32con.SB_THUMBPOSITION, 0
@@ -322,7 +322,7 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
         lineEnd = self.LineFromChar(max(start, end))
         while lineStart <= lineEnd:
             self.SCIEnsureVisible(lineStart)
-            lineStart = lineStart + 1
+            lineStart += 1
 
     # Helper to add an event to a menu.
     def AppendMenu(self, menu, text="", event=None, flags=None, checked=0):
@@ -345,7 +345,7 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
         if flags is None:
             flags = win32con.MF_STRING | win32con.MF_ENABLED
         if checked:
-            flags = flags | win32con.MF_CHECKED
+            flags |= win32con.MF_CHECKED
         menu.AppendMenu(flags, cmdid, text)
 
     def OnKeyDown(self, msg):
@@ -677,20 +677,20 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
         index = pos - 1
         wordbreaks_use = wordbreaks
         if bAllowCalls:
-            wordbreaks_use = wordbreaks_use + "()[]"
+            wordbreaks_use += "()[]"
         while index >= 0:
             char = self.SCIGetCharAt(index)
             if char not in wordbreaks_use:
                 break
             before.insert(0, char)
-            index = index - 1
+            index -= 1
         index = pos
         while index <= limit:
             char = self.SCIGetCharAt(index)
             if char not in wordbreaks_use:
                 break
             after.append(char)
-            index = index + 1
+            index += 1
         return "".join(before), "".join(after)
 
     def OnPrepareDC(self, dc, pInfo):
@@ -745,7 +745,7 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
         textLen = self.GetTextLength()
         while pageStart < textLen:
             pageStart = self.FormatRange(dc, pageStart, textLen, rc, 0)
-            maxPage = maxPage + 1
+            maxPage += 1
             self.starts[maxPage] = pageStart
         # And a sentinal for one page past the end
         self.starts[maxPage + 1] = textLen
@@ -805,10 +805,10 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
         dc.SetTextAlign(win32con.TA_RIGHT)
         dc.TextOut(right, 2 * cyChar, pagenum_str)
         dc.SetTextAlign(win32con.TA_LEFT)
-        top = top + int((7 * cyChar) / 2)
+        top += int(7 * cyChar / 2)
         dc.MoveTo(left, top)
         dc.LineTo(right, top)
-        top = top + cyChar
+        top += cyChar
         rc = (left, top, right, bottom)
         nextPageStart = self.FormatRange(
             dc, self.starts[pageNum], self.starts[pageNum + 1], rc, 1
@@ -829,7 +829,7 @@ def LoadConfiguration():
             configManager.last_error,
         )
         if configName != "default":
-            msg = msg + "\n\nThe default configuration will be loaded."
+            msg += "\n\nThe default configuration will be loaded."
             bTryDefault = 1
         win32ui.MessageBox(msg)
         if bTryDefault:

--- a/Pythonwin/pywin/tools/browseProjects.py
+++ b/Pythonwin/pywin/tools/browseProjects.py
@@ -188,7 +188,7 @@ class HLIDirectoryItem(hierlist.HierListItem):
                 path = win32api.GetFullPathName(
                     os.path.join(self.path, "..\\win32comext")
                 )
-                ret += MakePathSubList(path)
+                ret.extend(MakePathSubList(path))
             except win32ui.error:
                 pass
         return ret

--- a/Pythonwin/pywin/tools/browseProjects.py
+++ b/Pythonwin/pywin/tools/browseProjects.py
@@ -188,7 +188,7 @@ class HLIDirectoryItem(hierlist.HierListItem):
                 path = win32api.GetFullPathName(
                     os.path.join(self.path, "..\\win32comext")
                 )
-                ret = ret + MakePathSubList(path)
+                ret += MakePathSubList(path)
             except win32ui.error:
                 pass
         return ret
@@ -233,7 +233,7 @@ class HLIRoot(hierlist.HierListItem):
             while 1:
                 try:
                     ret.append(HLIProjectRoot(win32api.RegEnumKey(hKey, index)))
-                    index = index + 1
+                    index += 1
                 except win32api.error:
                     break
             return ret

--- a/Pythonwin/pywin/tools/browser.py
+++ b/Pythonwin/pywin/tools/browser.py
@@ -175,7 +175,7 @@ class HLIClass(HLIPythonObject):
         ret = []
         for base in self.myobject.__bases__:
             ret.append(MakeHLI(base, "Base class: " + base.__name__))
-        ret += HLIPythonObject.GetSubList(self)
+        ret.extend(HLIPythonObject.GetSubList(self))
         return ret
 
 
@@ -224,7 +224,7 @@ class HLIInstance(HLIPythonObject):
     def GetSubList(self):
         ret = []
         ret.append(MakeHLI(self.myobject.__class__))
-        ret += HLIPythonObject.GetSubList(self)
+        ret.extend(HLIPythonObject.GetSubList(self))
         return ret
 
 

--- a/Pythonwin/pywin/tools/browser.py
+++ b/Pythonwin/pywin/tools/browser.py
@@ -175,7 +175,7 @@ class HLIClass(HLIPythonObject):
         ret = []
         for base in self.myobject.__bases__:
             ret.append(MakeHLI(base, "Base class: " + base.__name__))
-        ret = ret + HLIPythonObject.GetSubList(self)
+        ret += HLIPythonObject.GetSubList(self)
         return ret
 
 
@@ -224,7 +224,7 @@ class HLIInstance(HLIPythonObject):
     def GetSubList(self):
         ret = []
         ret.append(MakeHLI(self.myobject.__class__))
-        ret = ret + HLIPythonObject.GetSubList(self)
+        ret += HLIPythonObject.GetSubList(self)
         return ret
 
 
@@ -261,7 +261,7 @@ class HLISeq(HLIPythonObject):
         pos = 0
         for item in self.myobject:
             ret.append(MakeHLI(item, "[" + str(pos) + "]"))
-            pos = pos + 1
+            pos += 1
         self.InsertDocString(ret)
         return ret
 

--- a/Pythonwin/pywin/tools/hierlist.py
+++ b/Pythonwin/pywin/tools/hierlist.py
@@ -217,7 +217,7 @@ class HierList(object.Object):
                 if old_items[iold] == new_items[inewlook]:
                     matched = 1
                     break
-                inewlook = inewlook + 1
+                inewlook += 1
             if matched:
                 # Insert the new items.
                 # print("Inserting after", old_items[iold], old_handles[iold])

--- a/Pythonwin/pywin/tools/regedit.py
+++ b/Pythonwin/pywin/tools/regedit.py
@@ -197,7 +197,7 @@ class RegistryValueView(docview.ListView):
                     name = "(Default)"
                 self.InsertItem(valNum, name)
                 self.SetItemText(valNum, 1, str(res[1]))
-                valNum = valNum + 1
+                valNum += 1
         finally:
             win32api.RegCloseKey(hkey)
 
@@ -216,7 +216,7 @@ class RegistryValueView(docview.ListView):
                 style = win32api.GetWindowLong(
                     self.edit.GetSafeHwnd(), win32con.GWL_STYLE
                 )
-                style = style & (~win32con.ES_WANTRETURN)
+                style &= ~win32con.ES_WANTRETURN
                 win32api.SetWindowLong(
                     self.edit.GetSafeHwnd(), win32con.GWL_STYLE, style
                 )
@@ -364,7 +364,7 @@ class HLIRegistryKey(hierlist.HierListItem):
                 except win32api.error:
                     break
                 ret.append(HLIRegistryKey(self.keyRoot, self.keyName + "\\" + key, key))
-                keyNum = keyNum + 1
+                keyNum += 1
         finally:
             win32api.RegCloseKey(hkey)
             win32ui.DoWaitCursor(0)

--- a/com/win32com/client/__init__.py
+++ b/com/win32com/client/__init__.py
@@ -130,7 +130,7 @@ def DispatchEx(
     if clsctx is None:
         clsctx = pythoncom.CLSCTX_SERVER
         if machine is not None:
-            clsctx = clsctx & ~pythoncom.CLSCTX_INPROC
+            clsctx &= ~pythoncom.CLSCTX_INPROC
     if machine is None:
         serverInfo = None
     else:

--- a/com/win32com/client/build.py
+++ b/com/win32com/client/build.py
@@ -328,15 +328,15 @@ class DispatchItem(OleItem):
         for argCheck in argTuple:
             inOut = argCheck[1]
             if inOut == 0:
-                ins = ins + 1
-                out = out + 1
+                ins += 1
+                out += 1
             else:
                 if inOut & pythoncom.PARAMFLAG_FIN:
-                    ins = ins + 1
+                    ins += 1
                 if inOut & pythoncom.PARAMFLAG_FOPT:
-                    opts = opts + 1
+                    opts += 1
                 if inOut & pythoncom.PARAMFLAG_FOUT:
-                    out = out + 1
+                    out += 1
         return ins, out, opts
 
     def MakeFuncMethod(self, entry, name, bMakeClass=1):
@@ -422,42 +422,30 @@ class DispatchItem(OleItem):
                     repr(argsDesc),
                     _BuildArgList(fdesc, names),
                 )
-                s = s + f"{linePrefix}\tif ret is not None:\n"
+                s += f"{linePrefix}\tif ret is not None:\n"
                 if rd == pythoncom.VT_UNKNOWN:
-                    s = (
-                        s
-                        + "{}\t\t# See if this IUnknown is really an IDispatch\n".format(
-                            linePrefix,
-                        )
+                    s += "{}\t\t# See if this IUnknown is really an IDispatch\n".format(
+                        linePrefix
                     )
-                    s = s + f"{linePrefix}\t\ttry:\n"
-                    s = (
-                        s
-                        + "{}\t\t\tret = ret.QueryInterface(pythoncom.IID_IDispatch)\n".format(
-                            linePrefix
-                        )
+                    s += f"{linePrefix}\t\ttry:\n"
+                    s += "{}\t\t\tret = ret.QueryInterface(pythoncom.IID_IDispatch)\n".format(
+                        linePrefix
                     )
-                    s = s + f"{linePrefix}\t\texcept pythoncom.error:\n"
-                    s = s + f"{linePrefix}\t\t\treturn ret\n"
-                s = s + "{}\t\tret = Dispatch(ret, {}, {})\n".format(
-                    linePrefix,
-                    repr(name),
-                    resclsid,
+                    s += f"{linePrefix}\t\texcept pythoncom.error:\n"
+                    s += f"{linePrefix}\t\t\treturn ret\n"
+                s += "{}\t\tret = Dispatch(ret, {}, {})\n".format(
+                    linePrefix, repr(name), resclsid
                 )
-                s = s + "%s\treturn ret" % (linePrefix)
+                s += "%s\treturn ret" % linePrefix
             elif rd == pythoncom.VT_BSTR:
                 s = f"{linePrefix}\t# Result is a Unicode object\n"
-                s = (
-                    s
-                    + "%s\treturn self._oleobj_.InvokeTypes(%d, LCID, %s, %s, %s%s)"
-                    % (
-                        linePrefix,
-                        id,
-                        fdesc[4],
-                        retDesc,
-                        repr(argsDesc),
-                        _BuildArgList(fdesc, names),
-                    )
+                s += "%s\treturn self._oleobj_.InvokeTypes(%d, LCID, %s, %s, %s%s)" % (
+                    linePrefix,
+                    id,
+                    fdesc[4],
+                    retDesc,
+                    repr(argsDesc),
+                    _BuildArgList(fdesc, names),
                 )
             # else s remains None
         if s is None:
@@ -629,7 +617,7 @@ def _BuildArgList(fdesc, names):
     # As per BuildCallList(), avoid huge lines.
     # Hack a "\n" at the end of every 5th name
     for i in range(0, len(names), 5):
-        names[i] = names[i] + "\n\t\t\t"
+        names[i] += "\n\t\t\t"
     return "," + ", ".join(names)
 
 
@@ -731,7 +719,7 @@ def BuildCallList(
     strval = ""
     if numOptArgs == -1:  # Special value that says "var args after here"
         firstOptArg = numArgs
-        numArgs = numArgs - 1
+        numArgs -= 1
     else:
         firstOptArg = numArgs - numOptArgs
     for arg in range(numArgs):
@@ -768,10 +756,10 @@ def BuildCallList(
         # This may still fail if the arg names are insane, but that seems
         # unlikely.  See also _BuildArgList()
         if (arg + 1) % 5 == 0:
-            strval = strval + "\n"
+            strval += "\n"
             if is_comment:
-                strval = strval + "#"
-            strval = strval + "\t\t\t"
+                strval += "#"
+            strval += "\t\t\t"
         strval = strval + ", " + argName
         if defArgVal:
             strval = strval + "=" + defArgVal

--- a/com/win32com/client/build.py
+++ b/com/win32com/client/build.py
@@ -760,11 +760,11 @@ def BuildCallList(
             if is_comment:
                 strval += "#"
             strval += "\t\t\t"
-        strval = strval + ", " + argName
+        strval += ", " + argName
         if defArgVal:
-            strval = strval + "=" + defArgVal
+            strval += "=" + defArgVal
     if numOptArgs == -1:
-        strval = strval + ", *" + names[-1]
+        strval += ", *" + names[-1]
 
     return strval
 

--- a/com/win32com/client/combrowse.py
+++ b/com/win32com/client/combrowse.py
@@ -462,7 +462,7 @@ class HLITypeLibFunction(HLICOM):
             first = returnTypeDesc[0]
             result = self.MakeReturnType(first)
             if first != pythoncom.VT_USERDEFINED:
-                result = result + " " + self.MakeReturnType(returnTypeDesc[1])
+                result += " " + self.MakeReturnType(returnTypeDesc[1])
             return result
         else:
             return self.MakeReturnTypeName(returnTypeDesc)

--- a/com/win32com/client/combrowse.py
+++ b/com/win32com/client/combrowse.py
@@ -235,11 +235,11 @@ class HLIRegisteredTypeLibrary(HLICOM):
                             except win32api.error:
                                 fname = ""
                             collected.append((lcid, platform, fname))
-                            lcidnum = lcidnum + 1
+                            lcidnum += 1
                         win32api.RegCloseKey(lcidkey)
                     except ValueError:
                         pass
-                num = num + 1
+                num += 1
         finally:
             win32ui.DoWaitCursor(0)
             win32api.RegCloseKey(key)
@@ -581,12 +581,12 @@ class HLIHeadingRegisterdTypeLibs(HLICOM):
                         if versionFlt > bestVersion:
                             bestVersion = versionFlt
                             name = win32api.RegQueryValue(subKey, versionStr)
-                        subNum = subNum + 1
+                        subNum += 1
                 finally:
                     win32api.RegCloseKey(subKey)
                 if name is not None:
                     ret.append(HLIRegisteredTypeLibrary((keyName, versionStr), name))
-                num = num + 1
+                num += 1
         finally:
             win32api.RegCloseKey(key)
             win32ui.DoWaitCursor(0)

--- a/com/win32com/client/combrowse.py
+++ b/com/win32com/client/combrowse.py
@@ -481,16 +481,16 @@ class HLITypeLibFunction(HLICOM):
             typ, flags, default = fd[8]
             val = self.MakeReturnType(typ)
             if flags:
-                val = "%s (Flags=%d, default=%s)" % (val, flags, default)
+                val += f" (Flags={flags}, default={default})"
             ret.append(browser.MakeHLI(val, "Return Type"))
 
         for argDesc in fd[2]:
             typ, flags, default = argDesc
             val = self.MakeReturnType(typ)
             if flags:
-                val = "%s (Flags=%d)" % (val, flags)
+                val += f" (Flags={flags})"
             if default is not None:
-                val = f"{val} (Default={default})"
+                val += f" (Default={default})"
             ret.append(browser.MakeHLI(val, "Argument"))
 
         try:

--- a/com/win32com/client/gencache.py
+++ b/com/win32com/client/gencache.py
@@ -520,9 +520,9 @@ def EnsureModule(
             filePath = filePathPrefix + ".py"
             filePathPyc = filePathPrefix + ".py"
             if __debug__:
-                filePathPyc = filePathPyc + "c"
+                filePathPyc += "c"
             else:
-                filePathPyc = filePathPyc + "o"
+                filePathPyc += "o"
             # Verify that type library is up to date.
             # If we have a differing MinorVersion or genpy has bumped versions, update the file
             from . import genpy

--- a/com/win32com/client/genpy.py
+++ b/com/win32com/client/genpy.py
@@ -272,7 +272,7 @@ class VTableItem(build.VTableItem, WritableItem):
             print("\t((", end=" ", file=stream)
             for name in names:
                 print(repr(name), ",", end=" ", file=stream)
-                item_num = item_num + 1
+                item_num += 1
                 if item_num % 5 == 0:
                     print("\n\t\t\t", end=" ", file=stream)
             print(
@@ -281,7 +281,7 @@ class VTableItem(build.VTableItem, WritableItem):
                 file=stream,
             )
             for arg in desc.args:
-                item_num = item_num + 1
+                item_num += 1
                 if item_num % 5 == 0:
                     print("\n\t\t\t", end=" ", file=stream)
                 defval = build.MakeDefaultArgRepr(arg)
@@ -610,7 +610,7 @@ class DispatchItem(build.DispatchItem, WritableItem):
                 if defArgDesc is None:
                     defArgDesc = ""
                 else:
-                    defArgDesc = defArgDesc + ","
+                    defArgDesc += ","
                 print(
                     '\t\t"%s" : ((%s, LCID, %d, 0),(%s)),'
                     % (

--- a/com/win32com/client/makepy.py
+++ b/com/win32com/client/makepy.py
@@ -391,9 +391,9 @@ def main():
             elif o == "-o":
                 outputName = v
             elif o == "-v":
-                verboseLevel = verboseLevel + 1
+                verboseLevel += 1
             elif o == "-q":
-                verboseLevel = verboseLevel - 1
+                verboseLevel -= 1
             elif o == "-i":
                 if len(args) == 0:
                     ShowInfo(None)

--- a/com/win32com/client/selecttlb.py
+++ b/com/win32com/client/selecttlb.py
@@ -83,7 +83,7 @@ def EnumKeys(root):
             val = ""  # code using this assumes a string.
 
         ret.append((item, val))
-        index = index + 1
+        index += 1
     return ret
 
 

--- a/com/win32com/client/tlbrowse.py
+++ b/com/win32com/client/tlbrowse.py
@@ -155,13 +155,11 @@ class TypeBrowseDialog(TypeBrowseDialog_Parent):
             typeFlags = attr[11]
 
             desc = doc[0]
-            desc = desc + ", Flags=0x{:x}, typeKind=0x{:x}, typeFlags=0x{:x}".format(
-                flags,
-                typeKind,
-                typeFlags,
+            desc += ", Flags=0x{:x}, typeKind=0x{:x}, typeFlags=0x{:x}".format(
+                flags, typeKind, typeFlags
             )
             if flags & pythoncom.IMPLTYPEFLAG_FSOURCE:
-                desc = desc + "(Source)"
+                desc += "(Source)"
             infos.append(("Implements", desc))
 
         return infos

--- a/com/win32com/makegw/makegw.py
+++ b/com/win32com/makegw/makegw.py
@@ -235,20 +235,18 @@ PyObject *Py{interfacename}::{method}(PyObject *self, PyObject *args)
                     val = argCvt.GetFormatChar()
                     if val:
                         f.write("\t" + argCvt.GetAutoduckString() + "\n")
-                        formatChars = formatChars + val
+                        formatChars += val
                         argsParseTuple = (
                             argsParseTuple + ", " + argCvt.GetParseTupleArg()
                         )
-                        codePobjects = (
-                            codePobjects + argCvt.DeclareParseArgTupleInputConverter()
-                        )
-                        codePost = codePost + argCvt.GetParsePostCode()
+                        codePobjects += argCvt.DeclareParseArgTupleInputConverter()
+                        codePost += argCvt.GetParsePostCode()
                         needConversion = needConversion or argCvt.NeedUSES_CONVERSION()
-                        cleanup = cleanup + argCvt.GetInterfaceArgCleanup()
-                        cleanup_gil = cleanup_gil + argCvt.GetInterfaceArgCleanupGIL()
+                        cleanup += argCvt.GetInterfaceArgCleanup()
+                        cleanup_gil += argCvt.GetInterfaceArgCleanupGIL()
                 comArgName, comArgDeclString = argCvt.GetInterfaceCppObjectInfo()
                 if comArgDeclString:  # If we should declare a variable
-                    codeCobjects = codeCobjects + "\t%s;\n" % (comArgDeclString)
+                    codeCobjects += "\t%s;\n" % comArgDeclString
                 argsCOM = argsCOM + ", " + comArgName
             except makegwparse.error_not_supported as why:
                 f.write(
@@ -263,18 +261,15 @@ PyObject *Py{interfacename}::{method}(PyObject *self, PyObject *args)
                         arg.type, arg.name, arg.name
                     )
                 )
-                codePost = (
-                    codePost
-                    + "\tif (bPythonIsHappy && !PyObject_As{}( ob{}, &{} )) bPythonIsHappy = FALSE;\n".format(
-                        arg.type, arg.name, arg.name
-                    )
+                codePost += "\tif (bPythonIsHappy && !PyObject_As{}( ob{}, &{} )) bPythonIsHappy = FALSE;\n".format(
+                    arg.type, arg.name, arg.name
                 )
 
-                formatChars = formatChars + "O"
-                argsParseTuple = argsParseTuple + ", &ob%s" % (arg.name)
+                formatChars += "O"
+                argsParseTuple += ", &ob%s" % arg.name
 
                 argsCOM = argsCOM + ", " + arg.name
-                cleanup = cleanup + f"\tPyObject_Free{arg.type}({arg.name});\n"
+                cleanup += f"\tPyObject_Free{arg.type}({arg.name});\n"
 
         if needConversion:
             f.write("\tUSES_CONVERSION;\n")
@@ -313,11 +308,11 @@ PyObject *Py{interfacename}::{method}(PyObject *self, PyObject *args)
                 argCvt = makegwparse.make_arg_converter(arg)
                 formatChar = argCvt.GetFormatChar()
                 if formatChar:
-                    formatChars = formatChars + formatChar
-                    codePre = codePre + argCvt.GetBuildForInterfacePreCode()
-                    codePost = codePost + argCvt.GetBuildForInterfacePostCode()
+                    formatChars += formatChar
+                    codePre += argCvt.GetBuildForInterfacePreCode()
+                    codePost += argCvt.GetBuildForInterfacePostCode()
                     codeVarsPass = codeVarsPass + ", " + argCvt.GetBuildValueArg()
-                    codeDecl = codeDecl + argCvt.DeclareParseArgTupleInputConverter()
+                    codeDecl += argCvt.DeclareParseArgTupleInputConverter()
             except makegwparse.error_not_supported as why:
                 f.write(
                     '// *** The output argument {} of type "{}" was not processed ***\n//     {}\n'.format(
@@ -461,7 +456,7 @@ STDMETHODIMP {gname}::{method.name}(
         if method.args:
             for arg in method.args:
                 if arg.HasAttribute("out"):
-                    cout = cout + 1
+                    cout += 1
                     if arg.indirectionLevel == 2:
                         f.write("\tif (%s==NULL) return E_POINTER;\n" % arg.name)
                 if arg.HasAttribute("in"):
@@ -472,13 +467,11 @@ STDMETHODIMP {gname}::{method.name}(
                         needConversion = needConversion or argCvt.NeedUSES_CONVERSION()
 
                         if formatchar:
-                            formatChars = formatChars + formatchar
-                            codeVars = (
-                                codeVars + argCvt.DeclareParseArgTupleInputConverter()
-                            )
+                            formatChars += formatchar
+                            codeVars += argCvt.DeclareParseArgTupleInputConverter()
                             argStr = argStr + ", " + argCvt.GetBuildValueArg()
-                        codePre = codePre + argCvt.GetBuildForGatewayPreCode()
-                        codePost = codePost + argCvt.GetBuildForGatewayPostCode()
+                        codePre += argCvt.GetBuildForGatewayPreCode()
+                        codePost += argCvt.GetBuildForGatewayPostCode()
                     except makegwparse.error_not_supported as why:
                         f.write(
                             '// *** The input argument {} of type "{}" was not processed ***\n//   - Please ensure this conversion function exists, and is appropriate\n//   - {}\n'.format(
@@ -495,9 +488,9 @@ STDMETHODIMP {gname}::{method.name}(
                                 arg.name, method.name
                             )
                         )
-                        codePost = codePost + "\tPy_DECREF(ob%s);\n" % arg.name
-                        formatChars = formatChars + "O"
-                        argStr = argStr + ", ob%s" % (arg.name)
+                        codePost += "\tPy_DECREF(ob%s);\n" % arg.name
+                        formatChars += "O"
+                        argStr += ", ob%s" % arg.name
 
         if needConversion:
             f.write("\tUSES_CONVERSION;\n")
@@ -532,14 +525,12 @@ STDMETHODIMP {gname}::{method.name}(
                     argCvt.SetGatewayMode()
                     val = argCvt.GetFormatChar()
                     if val:
-                        formatChars = formatChars + val
+                        formatChars += val
                         argsParseTuple = (
                             argsParseTuple + ", " + argCvt.GetParseTupleArg()
                         )
-                        codePobjects = (
-                            codePobjects + argCvt.DeclareParseArgTupleInputConverter()
-                        )
-                        codePost = codePost + argCvt.GetParsePostCode()
+                        codePobjects += argCvt.DeclareParseArgTupleInputConverter()
+                        codePost += argCvt.GetParsePostCode()
                         needConversion = needConversion or argCvt.NeedUSES_CONVERSION()
                 except makegwparse.error_not_supported as why:
                     f.write(

--- a/com/win32com/makegw/makegw.py
+++ b/com/win32com/makegw/makegw.py
@@ -236,9 +236,7 @@ PyObject *Py{interfacename}::{method}(PyObject *self, PyObject *args)
                     if val:
                         f.write("\t" + argCvt.GetAutoduckString() + "\n")
                         formatChars += val
-                        argsParseTuple = (
-                            argsParseTuple + ", " + argCvt.GetParseTupleArg()
-                        )
+                        argsParseTuple += ", " + argCvt.GetParseTupleArg()
                         codePobjects += argCvt.DeclareParseArgTupleInputConverter()
                         codePost += argCvt.GetParsePostCode()
                         needConversion = needConversion or argCvt.NeedUSES_CONVERSION()
@@ -247,7 +245,7 @@ PyObject *Py{interfacename}::{method}(PyObject *self, PyObject *args)
                 comArgName, comArgDeclString = argCvt.GetInterfaceCppObjectInfo()
                 if comArgDeclString:  # If we should declare a variable
                     codeCobjects += "\t%s;\n" % comArgDeclString
-                argsCOM = argsCOM + ", " + comArgName
+                argsCOM += ", " + comArgName
             except makegwparse.error_not_supported as why:
                 f.write(
                     '// *** The input argument {} of type "{}" was not processed ***\n//     Please check the conversion function is appropriate and exists!\n'.format(
@@ -268,7 +266,7 @@ PyObject *Py{interfacename}::{method}(PyObject *self, PyObject *args)
                 formatChars += "O"
                 argsParseTuple += ", &ob%s" % arg.name
 
-                argsCOM = argsCOM + ", " + arg.name
+                argsCOM += ", " + arg.name
                 cleanup += f"\tPyObject_Free{arg.type}({arg.name});\n"
 
         if needConversion:
@@ -311,7 +309,7 @@ PyObject *Py{interfacename}::{method}(PyObject *self, PyObject *args)
                     formatChars += formatChar
                     codePre += argCvt.GetBuildForInterfacePreCode()
                     codePost += argCvt.GetBuildForInterfacePostCode()
-                    codeVarsPass = codeVarsPass + ", " + argCvt.GetBuildValueArg()
+                    codeVarsPass += ", " + argCvt.GetBuildValueArg()
                     codeDecl += argCvt.DeclareParseArgTupleInputConverter()
             except makegwparse.error_not_supported as why:
                 f.write(
@@ -469,7 +467,7 @@ STDMETHODIMP {gname}::{method.name}(
                         if formatchar:
                             formatChars += formatchar
                             codeVars += argCvt.DeclareParseArgTupleInputConverter()
-                            argStr = argStr + ", " + argCvt.GetBuildValueArg()
+                            argStr += ", " + argCvt.GetBuildValueArg()
                         codePre += argCvt.GetBuildForGatewayPreCode()
                         codePost += argCvt.GetBuildForGatewayPostCode()
                     except makegwparse.error_not_supported as why:
@@ -526,9 +524,7 @@ STDMETHODIMP {gname}::{method.name}(
                     val = argCvt.GetFormatChar()
                     if val:
                         formatChars += val
-                        argsParseTuple = (
-                            argsParseTuple + ", " + argCvt.GetParseTupleArg()
-                        )
+                        argsParseTuple += ", " + argCvt.GetParseTupleArg()
                         codePobjects += argCvt.DeclareParseArgTupleInputConverter()
                         codePost += argCvt.GetParsePostCode()
                         needConversion = needConversion or argCvt.NeedUSES_CONVERSION()

--- a/com/win32com/makegw/makegwparse.py
+++ b/com/win32com/makegw/makegwparse.py
@@ -254,9 +254,9 @@ class ArgFormatterFloat(ArgFormatter):
     def GetParsePostCode(self):
         s = "\t"
         if self.gatewayMode:
-            s = s + self._IndirectPrefix(self._GetDeclaredIndirection(), 0)
-        s = s + self.arg.name
-        s = s + " = (float)dbl%s;\n" % self.arg.name
+            s += self._IndirectPrefix(self._GetDeclaredIndirection(), 0)
+        s += self.arg.name
+        s += " = (float)dbl%s;\n" % self.arg.name
         return s
 
 
@@ -293,9 +293,9 @@ class ArgFormatterShort(ArgFormatter):
     def GetParsePostCode(self):
         s = "\t"
         if self.gatewayMode:
-            s = s + self._IndirectPrefix(self._GetDeclaredIndirection(), 0)
-        s = s + self.arg.name
-        s = s + " = i%s;\n" % self.arg.name
+            s += self._IndirectPrefix(self._GetDeclaredIndirection(), 0)
+        s += self.arg.name
+        s += " = i%s;\n" % self.arg.name
         return s
 
 
@@ -471,7 +471,7 @@ class ArgFormatterTime(ArgFormatterPythonCOM):
         if arg.indirectionLevel == 0 and arg.unc_type[:2] == "LP":
             arg.unc_type = arg.unc_type[2:]
             # reduce the builtin and increment the declaration
-            arg.indirectionLevel = arg.indirectionLevel + 1
+            arg.indirectionLevel += 1
             builtinIndirection = 0
         ArgFormatterPythonCOM.__init__(
             self, arg, builtinIndirection, declaredIndirection
@@ -873,7 +873,7 @@ class Argument:
     def GetRawDeclaration(self):
         ret = f"{self.raw_type} {self.name}"
         if self.arrayDecl:
-            ret = ret + "[]"
+            ret += "[]"
         return ret
 
 

--- a/com/win32com/server/connect.py
+++ b/com/win32com/server/connect.py
@@ -52,7 +52,7 @@ class ConnectableServer:
             )
         except pythoncom.com_error:
             raise COMException(scode=olectl.CONNECT_E_NOCONNECTION)
-        self.cookieNo = self.cookieNo + 1
+        self.cookieNo += 1
         self.connections[self.cookieNo] = interface
         return self.cookieNo
 

--- a/com/win32com/server/policy.py
+++ b/com/win32com/server/policy.py
@@ -608,7 +608,7 @@ class DesignatedWrapPolicy(MappedWrapPolicy):
 
     def _allocnextdispid(self, last_dispid):
         while 1:
-            last_dispid = last_dispid + 1
+            last_dispid += 1
             if (
                 last_dispid not in self._dispid_to_func_
                 and last_dispid not in self._dispid_to_get_

--- a/com/win32com/server/register.py
+++ b/com/win32com/server/register.py
@@ -214,9 +214,9 @@ def RegisterServer(
             sys.frozen
         ), "pythoncom is frozen, but sys.frozen is not set - don't know the context!"
         if sys.frozen == "dll":
-            clsctx = clsctx & pythoncom.CLSCTX_INPROC_SERVER
+            clsctx &= pythoncom.CLSCTX_INPROC_SERVER
         else:
-            clsctx = clsctx & pythoncom.CLSCTX_LOCAL_SERVER
+            clsctx &= pythoncom.CLSCTX_LOCAL_SERVER
     # Now setup based on the clsctx left over.
     if clsctx & pythoncom.CLSCTX_INPROC_SERVER:
         # get the module to use for registration.
@@ -304,7 +304,7 @@ def RegisterServer(
     if addPyComCat is None:
         addPyComCat = pythoncom.frozen == 0
     if addPyComCat:
-        catids = catids + [CATID_PythonCOMServer]
+        catids += [CATID_PythonCOMServer]
 
     # Set up the implemented categories
     if catids:
@@ -360,7 +360,7 @@ def GetUnregisterServerKeys(clsid, progID=None, verProgID=None, customKeys=None)
     ret.append(("AppID\\%s" % str(clsid), win32con.HKEY_CLASSES_ROOT))
     # Any custom keys?
     if customKeys:
-        ret = ret + customKeys
+        ret += customKeys
 
     return ret
 
@@ -536,7 +536,7 @@ def UnregisterInfoClasses(*classes, **flags):
         verProgID = _get(cls, "_reg_verprogid_")
         customKeys = _get(cls, "_reg_remove_keys_")
 
-        ret = ret + GetUnregisterServerKeys(clsid, progID, verProgID, customKeys)
+        ret += GetUnregisterServerKeys(clsid, progID, verProgID, customKeys)
     return ret
 
 

--- a/com/win32com/server/register.py
+++ b/com/win32com/server/register.py
@@ -304,7 +304,7 @@ def RegisterServer(
     if addPyComCat is None:
         addPyComCat = pythoncom.frozen == 0
     if addPyComCat:
-        catids += [CATID_PythonCOMServer]
+        catids.append(CATID_PythonCOMServer)
 
     # Set up the implemented categories
     if catids:
@@ -360,7 +360,7 @@ def GetUnregisterServerKeys(clsid, progID=None, verProgID=None, customKeys=None)
     ret.append(("AppID\\%s" % str(clsid), win32con.HKEY_CLASSES_ROOT))
     # Any custom keys?
     if customKeys:
-        ret += customKeys
+        ret.extend(customKeys)
 
     return ret
 
@@ -536,7 +536,7 @@ def UnregisterInfoClasses(*classes, **flags):
         verProgID = _get(cls, "_reg_verprogid_")
         customKeys = _get(cls, "_reg_remove_keys_")
 
-        ret += GetUnregisterServerKeys(clsid, progID, verProgID, customKeys)
+        ret.extend(GetUnregisterServerKeys(clsid, progID, verProgID, customKeys))
     return ret
 
 

--- a/com/win32com/test/testGIT.py
+++ b/com/win32com/test/testGIT.py
@@ -110,7 +110,7 @@ def test(fn):
             if rc >= win32event.WAIT_OBJECT_0 and rc < win32event.WAIT_OBJECT_0 + len(
                 events
             ):
-                numFinished = numFinished + 1
+                numFinished += 1
                 if numFinished >= len(events):
                     break
             elif rc == win32event.WAIT_OBJECT_0 + len(events):  # a message

--- a/com/win32com/test/testGatewayAddresses.py
+++ b/com/win32com/test/testGatewayAddresses.py
@@ -59,7 +59,7 @@ def CheckObjectIdentity(ob1, ob2):
 def FailObjectIdentity(ob1, ob2, when):
     if not CheckObjectIdentity(ob1, ob2):
         global numErrors
-        numErrors = numErrors + 1
+        numErrors += 1
         print(when, f"are not identical ({repr(ob1)}, {repr(ob2)})")
 
 

--- a/com/win32com/test/testMarshal.py
+++ b/com/win32com/test/testMarshal.py
@@ -125,7 +125,7 @@ class ThreadInterpCase(InterpCase):
                     rc >= win32event.WAIT_OBJECT_0
                     and rc < win32event.WAIT_OBJECT_0 + len(events)
                 ):
-                    numFinished = numFinished + 1
+                    numFinished += 1
                     if numFinished >= len(events):
                         break
                 elif rc == win32event.WAIT_OBJECT_0 + len(events):  # a message

--- a/com/win32com/test/testPersist.py
+++ b/com/win32com/test/testPersist.py
@@ -50,7 +50,7 @@ class LockBytes:
             newdata = self.data[0:offset] + data
         print(len(newdata))
         if len(self.data) >= offset + len(data):
-            newdata = newdata + self.data[offset + len(data) :]
+            newdata += self.data[offset + len(data) :]
         print(len(newdata))
         self.data = newdata
         return len(data)
@@ -64,7 +64,7 @@ class LockBytes:
     def SetSize(self, size):
         print("Set Size" + str(size))
         if size > len(self.data):
-            self.data = self.data + b"\000" * (size - len(self.data))
+            self.data += b"\x00" * (size - len(self.data))
         else:
             self.data = self.data[0:size]
         return S_OK

--- a/com/win32com/test/testPersist.py
+++ b/com/win32com/test/testPersist.py
@@ -64,7 +64,7 @@ class LockBytes:
     def SetSize(self, size):
         print("Set Size" + str(size))
         if size > len(self.data):
-            self.data += b"\x00" * (size - len(self.data))
+            self.data += b"\000" * (size - len(self.data))
         else:
             self.data = self.data[0:size]
         return S_OK

--- a/com/win32com/test/testPyComTest.py
+++ b/com/win32com/test/testPyComTest.py
@@ -96,7 +96,7 @@ class RandomEventHandler:
 
     def OnFire(self, no):
         try:
-            self.fireds[no] = self.fireds[no] + 1
+            self.fireds[no] += 1
         except KeyError:
             self.fireds[no] = 0
 
@@ -625,7 +625,7 @@ def TestCounter(counter, bIsGenerated):
         counter.SetBounds(bounds[0], bounds[1])
 
     for item in counter:
-        num = num + 1
+        num += 1
     assert num == len(
         counter
     ), "*** Length of counter and loop iterations dont match ***"
@@ -640,7 +640,7 @@ def TestCounter(counter, bIsGenerated):
     counter.Reset()
     num = 0
     for item in counter:
-        num = num + 1
+        num += 1
     assert num == 10, f"*** Unexpected number of loop iterations - got {num} ***"
     progress("Finished testing counter")
 

--- a/com/win32com/test/testStreams.py
+++ b/com/win32com/test/testStreams.py
@@ -51,7 +51,7 @@ class Stream:
 
     def Read(self, amount):
         result = self.data[self.index : self.index + amount]
-        self.index = self.index + amount
+        self.index += amount
         return result
 
     def Write(self, data):
@@ -63,7 +63,7 @@ class Stream:
         if origin == pythoncom.STREAM_SEEK_SET:
             self.index = dist
         elif origin == pythoncom.STREAM_SEEK_CUR:
-            self.index = self.index + dist
+            self.index += dist
         elif origin == pythoncom.STREAM_SEEK_END:
             self.index = len(self.data) + dist
         else:

--- a/com/win32com/test/util.py
+++ b/com/win32com/test/util.py
@@ -105,7 +105,7 @@ def ExecuteShellCommand(
     tracebacks_ok=0,  # OK if the output contains a t/b?
 ):
     output_name = tempfile.mktemp("win32com_test")
-    cmd = cmd + ' > "%s" 2>&1' % output_name
+    cmd += ' > "%s" 2>&1' % output_name
     rc = os.system(cmd)
     output = open(output_name, "r").read().strip()
     os.remove(output_name)

--- a/com/win32com/universal.py
+++ b/com/win32com/universal.py
@@ -141,7 +141,7 @@ class Method:
         for argDesc in arg_defs:
             arg = Arg(argDesc)
             arg.offset = cbArgs
-            cbArgs = cbArgs + arg.size
+            cbArgs += arg.size
             self.args.append(arg)
         self.cbArgs = cbArgs
         self._gw_in_args = self._GenerateInArgTuple()

--- a/com/win32comext/adsi/demos/test.py
+++ b/com/win32comext/adsi/demos/test.py
@@ -73,15 +73,15 @@ def DumpSchema():
         class_name = child.Class
         if class_name == "classSchema":
             _DumpClass(child)
-            nclasses = nclasses + 1
+            nclasses += 1
         elif class_name == "attributeSchema":
             _DumpAttribute(child)
-            nattr = nattr + 1
+            nattr += 1
         elif class_name == "subSchema":
-            nsub = nsub + 1
+            nsub += 1
         else:
             print("Unknown class:", class_name)
-            nunk = nunk + 1
+            nunk += 1
     if verbose_level:
         print("Processed", nclasses, "classes")
         print("Processed", nattr, "attributes")
@@ -162,7 +162,7 @@ def DumpSchema2():
                         item.Name, desc, iid_name
                     )
                 )
-            nclass = nclass + 1
+            nclass += 1
         elif item_class == "property":
             if item.MultiValued:
                 val_type = "Multi-Valued"
@@ -170,12 +170,12 @@ def DumpSchema2():
                 val_type = "Single-Valued"
             if verbose_level >= 2:
                 print(f"Property: Name={item.Name}, {val_type}")
-            nprop = nprop + 1
+            nprop += 1
         elif item_class == "syntax":
             data_type = vt_map.get(item.OleAutoDataType, "<unknown type>")
             if verbose_level >= 2:
                 print(f"Syntax: Name={item.Name}, Datatype = {data_type}")
-            nsyntax = nsyntax + 1
+            nsyntax += 1
     if verbose_level >= 1:
         print("Processed", nclass, "classes")
         print("Processed", nprop, "properties")
@@ -238,14 +238,14 @@ def main():
     for opt, val in opts:
         if opt == "-s":
             if val[-1] not in "\\/":
-                val = val + "/"
+                val += "/"
             global server
             server = val
         if opt == "-h":
             usage(tests)
         if opt == "-v":
             global verbose_level
-            verbose_level = verbose_level + 1
+            verbose_level += 1
 
     if len(args) == 0:
         print("Running all tests - use '-h' to see command-line options...")

--- a/com/win32comext/axdebug/Test/host.py
+++ b/com/win32comext/axdebug/Test/host.py
@@ -15,11 +15,11 @@ class ExternalConnection:
     numExtRefs = 0
 
     def AddConnection(self, extconn, reserved):
-        self.numExtRefs = self.numExtRefs + 1
+        self.numExtRefs += 1
         return self.numExtRefs
 
     def ReleaseConnection(self, extconn, reserved, fLastReleaseCloses):
-        self.numExtRefs = self.numExtRefs - 1
+        self.numExtRefs -= 1
         return self.numExtRefs
 
 

--- a/com/win32comext/axdebug/codecontainer.py
+++ b/com/win32comext/axdebug/codecontainer.py
@@ -75,7 +75,7 @@ class SourceCodeContainer:
             if lineOffset > charPos:
                 break
             lastOffset = lineOffset
-            lineNo = lineNo + 1
+            lineNo += 1
         else:  # for not broken.
             # print("Cant find", charPos, "in", self.lineOffsets)
             raise COMException(scode=winerror.S_FALSE)
@@ -87,7 +87,7 @@ class SourceCodeContainer:
             self.nextLineNo = 0  # auto-reset.
             return ""
         rc = self.lines[self.nextLineNo]
-        self.nextLineNo = self.nextLineNo + 1
+        self.nextLineNo += 1
         return rc
 
     def GetLine(self, num):
@@ -261,9 +261,9 @@ if __name__ == "__main__":
     attrlen = 0
     for attr in attrs:
         if isinstance(attr, tuple):
-            attrlen = attrlen + attr[1]
+            attrlen += attr[1]
         else:
-            attrlen = attrlen + 1
+            attrlen += 1
     text = sc.GetText()
     if attrlen != len(text):
         print(f"Lengths dont match!!! ({attrlen}/{len(text)})")

--- a/com/win32comext/axdebug/gateways.py
+++ b/com/win32comext/axdebug/gateways.py
@@ -440,7 +440,7 @@ class DebugDocumentTextConnectServer:
         # Creates a connection to the client.  Simply allocate a new cookie,
         # find the clients interface, and store it in a dictionary.
         interface = pUnk.QueryInterface(axdebug.IID_IDebugDocumentTextEvents, 1)
-        self.cookieNo = self.cookieNo + 1
+        self.cookieNo += 1
         self.connections[self.cookieNo] = interface
         return self.cookieNo
 

--- a/com/win32comext/axdebug/stackframe.py
+++ b/com/win32comext/axdebug/stackframe.py
@@ -107,11 +107,11 @@ class DebugStackFrame(gateways.DebugStackFrame):
         filename = self.frame.f_code.co_filename
         s = ""
         if 0:  # fLong:
-            s = s + filename
+            s += filename
         if self.frame.f_code.co_name:
-            s = s + self.frame.f_code.co_name
+            s += self.frame.f_code.co_name
         else:
-            s = s + "<lambda>"
+            s += "<lambda>"
         return s
 
     def GetLanguageString(self, fLong):

--- a/com/win32comext/axscript/client/framework.py
+++ b/com/win32comext/axscript/client/framework.py
@@ -487,7 +487,7 @@ class ScriptItem:
                     fdesc = defaultType.GetFuncDesc(index)
                 except pythoncom.com_error:
                     break  # No more funcs
-                index = index + 1
+                index += 1
                 dispid = fdesc[0]
                 funckind = fdesc[3]
                 invkind = fdesc[4]
@@ -690,9 +690,9 @@ class COMScript:
             or self.scriptState == axscript.SCRIPTSTATE_CONNECTED
             or self.scriptState == axscript.SCRIPTSTATE_DISCONNECTED
         ):
-            flags = flags | SCRIPTTEXT_FORCEEXECUTION
+            flags |= SCRIPTTEXT_FORCEEXECUTION
         else:
-            flags = flags & (~SCRIPTTEXT_FORCEEXECUTION)
+            flags &= ~SCRIPTTEXT_FORCEEXECUTION
 
         if flags & SCRIPTTEXT_FORCEEXECUTION:
             # About to execute the code.

--- a/com/win32comext/axscript/client/pyscript.py
+++ b/com/win32comext/axscript/client/pyscript.py
@@ -238,7 +238,7 @@ class PyScript(framework.COMScript):
         return framework.COMScript.Reset(self)
 
     def _GetNextCodeBlockNumber(self):
-        self.codeBlockCounter = self.codeBlockCounter + 1
+        self.codeBlockCounter += 1
         return self.codeBlockCounter
 
     def RegisterNamedItem(self, item):
@@ -342,7 +342,7 @@ class PyScript(framework.COMScript):
             realCode = "def %s():\n" % funcName
             for line in framework.RemoveCR(codeBlock.codeText).split("\n"):
                 realCode = realCode + "\t" + line + "\n"
-            realCode = realCode + "\n"
+            realCode += "\n"
             if not self.CompileInScriptedSection(codeBlock, "exec", realCode):
                 return
             dict = {}

--- a/com/win32comext/axscript/client/pyscript.py
+++ b/com/win32comext/axscript/client/pyscript.py
@@ -382,7 +382,7 @@ class PyScript(framework.COMScript):
         num = self._GetNextCodeBlockNumber()
         if num == 1:
             num = ""
-        name = f"{name} {num}"
+        name += f" {num}"
         codeBlock = AXScriptCodeBlock(
             name, code, sourceContextCookie, startLineNumber, flags
         )

--- a/com/win32comext/axscript/client/pyscript.py
+++ b/com/win32comext/axscript/client/pyscript.py
@@ -341,7 +341,7 @@ class PyScript(framework.COMScript):
         if codeBlock is not None:
             realCode = "def %s():\n" % funcName
             for line in framework.RemoveCR(codeBlock.codeText).split("\n"):
-                realCode = realCode + "\t" + line + "\n"
+                realCode += "\t" + line + "\n"
             realCode += "\n"
             if not self.CompileInScriptedSection(codeBlock, "exec", realCode):
                 return

--- a/com/win32comext/mapi/mapiutil.py
+++ b/com/win32comext/mapi/mapiutil.py
@@ -86,7 +86,7 @@ def GetMapiTypeName(propType, rawType=True):
                 ptTable[value] = name
 
     if rawType:
-        propType = propType & ~mapitags.MV_FLAG
+        propType &= ~mapitags.MV_FLAG
     return ptTable.get(propType, str(hex(propType)))
 
 
@@ -206,6 +206,6 @@ def SetProperties(msg, propDict):
                     f"The type of object {repr(val)}({type(val)}) can not be written"
                 )
             key = mapitags.PROP_TAG(tagType, mapitags.PROP_ID(newIds[newIdNo]))
-            newIdNo = newIdNo + 1
+            newIdNo += 1
         newProps.append((key, val))
     msg.SetProps(newProps)

--- a/com/win32comext/shell/demos/IFileOperationProgressSink.py
+++ b/com/win32comext/shell/demos/IFileOperationProgressSink.py
@@ -15,7 +15,7 @@ def decode_flags(flags):
     for k, v in tsf_flags:
         if flags & v:
             if flag_txt:
-                flag_txt = flag_txt + "|" + k
+                flag_txt += "|" + k
             else:
                 flag_txt = k
     return flag_txt

--- a/com/win32comext/shell/demos/ITransferAdviseSink.py
+++ b/com/win32comext/shell/demos/ITransferAdviseSink.py
@@ -19,7 +19,7 @@ def decode_flags(flags):
     for k, v in tsf_flags:
         if flags & v:
             if flag_txt:
-                flag_txt = flag_txt + "|" + k
+                flag_txt += "|" + k
             else:
                 flag_txt = k
     return flag_txt

--- a/isapi/install.py
+++ b/isapi/install.py
@@ -364,7 +364,7 @@ def _AssignScriptMapsReplace(target, script_maps):
 
 def _AssignScriptMapsEnd(target, script_maps):
     unique_new_maps = get_unique_items(script_maps, target.ScriptMaps)
-    target.ScriptMaps = target.ScriptMaps + unique_new_maps
+    target.ScriptMaps += unique_new_maps
 
 
 def _AssignScriptMapsStart(target, script_maps):

--- a/pywin32_testall.py
+++ b/pywin32_testall.py
@@ -76,7 +76,7 @@ def main():
 
     extras = []
     if args.user_interaction:
-        extras += ["-user-interaction"]
+        extras.append("-user-interaction")
     extras.extend(remains)
     scripts = [
         "win32/test/testall.py",

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ else:
 
 build_id_patch = build_id
 if not "." in build_id_patch:
-    build_id_patch = build_id_patch + ".0"
+    build_id_patch += ".0"
 pywin32_version = "%d.%d.%s" % (
     sys.version_info.major,
     sys.version_info.minor,
@@ -1043,7 +1043,7 @@ class my_compiler(MSVCCompiler):
             # We want mt.exe run with the original manifest
             for i in range(len(cmd)):
                 if cmd[i] == "-manifest":
-                    cmd[i + 1] = cmd[i + 1] + ".orig"
+                    cmd[i + 1] += ".orig"
                     break
         super().spawn(cmd)
         if is_link:

--- a/win32/Demos/FileSecurityTest.py
+++ b/win32/Demos/FileSecurityTest.py
@@ -131,7 +131,7 @@ else:
         calc_mask = 0  # calculate the mask so we can see if we are printing all of the permissions
         for i in permissions:
             if getattr(ntsecuritycon, i) & ace[1] == getattr(ntsecuritycon, i):
-                calc_mask = calc_mask | getattr(ntsecuritycon, i)
+                calc_mask |= getattr(ntsecuritycon, i)
                 print("    ", i)
         print("  ", "Calculated Check Mask=", hex(calc_mask))
         print("  -SID\n    ", win32security.LookupAccountSid(None, ace[2]))

--- a/win32/Demos/desktopmanager.py
+++ b/win32/Demos/desktopmanager.py
@@ -81,7 +81,7 @@ def get_new_desktop_name(parent_hwnd):
 def new_icon(hdesk, desktop_name):
     """Runs as a thread on each desktop to create a new tray icon and handle its messages"""
     global id
-    id = id + 1
+    id += 1
     hdesk.SetThreadDesktop()
     ## apparently the threads can't use same hinst, so each needs its own window class
     windowclassname = "PythonDesktopManager" + desktop_name
@@ -187,7 +187,7 @@ def icon_wndproc(hwnd, msg, wp, lp):
             if desktops[d - 1].lower() in ("winlogon", "disconnect"):
                 mf_flags = mf_flags | win32con.MF_GRAYED | win32con.MF_DISABLED
             if desktops[d - 1] == curr_desktop_name:
-                mf_flags = mf_flags | win32con.MF_CHECKED
+                mf_flags |= win32con.MF_CHECKED
             win32gui.AppendMenu(m, mf_flags, d, desktops[d - 1])
         win32gui.AppendMenu(m, win32con.MF_STRING, desktop_cnt + 1, "Create new ...")
         win32gui.AppendMenu(m, win32con.MF_STRING, desktop_cnt + 2, "Exit")

--- a/win32/Demos/desktopmanager.py
+++ b/win32/Demos/desktopmanager.py
@@ -185,7 +185,7 @@ def icon_wndproc(hwnd, msg, wp, lp):
             mf_flags = win32con.MF_STRING
             ## if you switch to winlogon yourself, there's nothing there and you're stuck
             if desktops[d - 1].lower() in ("winlogon", "disconnect"):
-                mf_flags = mf_flags | win32con.MF_GRAYED | win32con.MF_DISABLED
+                mf_flags |= win32con.MF_GRAYED | win32con.MF_DISABLED
             if desktops[d - 1] == curr_desktop_name:
                 mf_flags |= win32con.MF_CHECKED
             win32gui.AppendMenu(m, mf_flags, d, desktops[d - 1])

--- a/win32/Demos/eventLogDemo.py
+++ b/win32/Demos/eventLogDemo.py
@@ -48,7 +48,7 @@ def ReadLog(computer, logType="Application", dumpEachRecord=0):
                     print("(unicode error printing message: repr() follows...)")
                     print(repr(msg))
 
-        num = num + len(objects)
+        num += len(objects)
 
     if numRecords == num:
         print("Successfully read all", numRecords, "records")
@@ -104,7 +104,7 @@ def test():
         if opt == "-w":
             do_write = 0
         if opt == "-v":
-            verbose = verbose + 1
+            verbose += 1
     if do_write:
         ph = win32api.GetCurrentProcess()
         th = win32security.OpenProcessToken(ph, win32con.TOKEN_READ)

--- a/win32/Demos/security/security_enums.py
+++ b/win32/Demos/security/security_enums.py
@@ -37,7 +37,7 @@ class Enum:
         for k, v in self.__dict__.items():
             if flags & v == v:
                 flag_names.append(k)
-                unknown_flags = unknown_flags & ~v
+                unknown_flags &= ~v
         return flag_names, unknown_flags
 
 

--- a/win32/Demos/service/pipeTestService.py
+++ b/win32/Demos/service/pipeTestService.py
@@ -77,7 +77,7 @@ class TestPipeService(win32serviceutil.ServiceFramework):
                 hr = winerror.ERROR_MORE_DATA
                 while hr == winerror.ERROR_MORE_DATA:
                     hr, thisd = ReadFile(pipeHandle, 256)
-                    d = d + thisd
+                    d += thisd
                 print("Read", d)
                 ok = 1
             except error:
@@ -162,7 +162,7 @@ class TestPipeService(win32serviceutil.ServiceFramework):
             else:
                 # Pipe event - spawn thread to deal with it.
                 _thread.start_new_thread(self.ProcessClient, (pipeHandle,))
-                num_connections = num_connections + 1
+                num_connections += 1
 
         # Sleep to ensure that any new threads are in the list, and then
         # wait for all current threads to finish.

--- a/win32/Demos/service/pipeTestServiceClient.py
+++ b/win32/Demos/service/pipeTestServiceClient.py
@@ -38,7 +38,7 @@ def CallPipe(fn, args):
     ret = None
     retryCount = 0
     while retryCount < 8:  # Keep looping until user cancels.
-        retryCount = retryCount + 1
+        retryCount += 1
         try:
             return fn(*args)
         except win32api.error as exc:

--- a/win32/Demos/timer_demo.py
+++ b/win32/Demos/timer_demo.py
@@ -26,7 +26,7 @@ class glork:
 
     def increment(self, id, time):
         print("x = %d" % self.x)
-        self.x = self.x + 1
+        self.x += 1
         # if we've reached the max count,
         # kill off the timer.
         if self.x > self.max:

--- a/win32/Demos/win32gui_dialog.py
+++ b/win32/Demos/win32gui_dialog.py
@@ -69,7 +69,7 @@ class _WIN32MASKEDSTRUCT:
                     # alternate strategy would be to use unicode natively
                     # and use the 'W' version of the messages - eg,
                     # LVM_SETITEMW etc.
-                    val = val + "\0"
+                    val += "\x00"
                     if isinstance(val, str):
                         val = val.encode("mbcs")
                     str_buf = array.array("b", val)

--- a/win32/Demos/win32netdemo.py
+++ b/win32/Demos/win32netdemo.py
@@ -59,7 +59,7 @@ def UserEnum():
         )
         for user in data:
             verbose("Found user %s" % user["name"])
-            nuser = nuser + 1
+            nuser += 1
         if not resume:
             break
     assert nuser, "Could not find any users!"
@@ -82,7 +82,7 @@ def GroupEnum():
                 )
                 for member in memberdata:
                     verbose(" Member {name}".format(**member))
-                    nmembers = nmembers + 1
+                    nmembers += 1
                 if memberresume == 0:
                     break
         if not resume:
@@ -109,7 +109,7 @@ def LocalGroupEnum():
                     username, domain, type = win32security.LookupAccountSid(
                         server, member["sid"]
                     )
-                    nmembers = nmembers + 1
+                    nmembers += 1
                     verbose(" Member {} ({})".format(username, member["domainandname"]))
                 if memberresume == 0:
                     break
@@ -242,7 +242,7 @@ def main():
             usage(tests)
         if opt == "-v":
             global verbose_level
-            verbose_level = verbose_level + 1
+            verbose_level += 1
         if opt == "-c":
             create_user = True
 

--- a/win32/Lib/pywin32_testutil.py
+++ b/win32/Lib/pywin32_testutil.py
@@ -31,7 +31,7 @@ class LeakTestCase(unittest.TestCase):
         self.num_test_cases = 1
         self.num_leak_iters = 2  # seems to be enough!
         if hasattr(sys, "gettotalrefcount"):
-            self.num_test_cases = self.num_test_cases + self.num_leak_iters
+            self.num_test_cases += self.num_leak_iters
 
     def countTestCases(self):
         return self.num_test_cases

--- a/win32/Lib/regcheck.py
+++ b/win32/Lib/regcheck.py
@@ -77,7 +77,7 @@ def CheckPythonPaths(verbose):
                 else:
                     if verbose:
                         print("(empty)")
-                keyNo = keyNo + 1
+                keyNo += 1
             except win32api.error:
                 break
     finally:
@@ -116,7 +116,7 @@ def CheckHelpFiles(verbose):
                         print(helpFile)
                 except OSError:
                     print("** Help file %s does not exist" % helpFile)
-                keyNo = keyNo + 1
+                keyNo += 1
             except win32api.error as exc:
                 import winerror
 

--- a/win32/Lib/regutil.py
+++ b/win32/Lib/regutil.py
@@ -107,7 +107,7 @@ def RegisterNamedPath(name, path):
     """Register a named path - ie, a named PythonPath entry."""
     keyStr = BuildDefaultPythonKey() + "\\PythonPath"
     if name:
-        keyStr = keyStr + "\\" + name
+        keyStr += "\\" + name
     win32api.RegSetValue(GetRootKey(), keyStr, win32con.REG_SZ, path)
 
 
@@ -128,7 +128,7 @@ def GetRegisteredNamedPath(name):
     """Get a registered named path, or None if it doesnt exist."""
     keyStr = BuildDefaultPythonKey() + "\\PythonPath"
     if name:
-        keyStr = keyStr + "\\" + name
+        keyStr += "\\" + name
     try:
         return win32api.RegQueryValue(GetRootKey(), keyStr)
     except win32api.error as exc:

--- a/win32/Lib/sspi.py
+++ b/win32/Lib/sspi.py
@@ -39,7 +39,7 @@ class _BaseAuth:
         implementation is to increment a counter
         """
         ret = self.next_seq_num
-        self.next_seq_num = self.next_seq_num + 1
+        self.next_seq_num += 1
         return ret
 
     def encrypt(self, data):

--- a/win32/Lib/win32gui_struct.py
+++ b/win32/Lib/win32gui_struct.py
@@ -80,9 +80,9 @@ def UnpackNMITEMACTIVATE(lparam):
     if is64bit:
         # the struct module doesn't handle this correctly as some of the items
         # are actually structs in structs, which get individually aligned.
-        format = format + "iiiiiiixxxxP"
+        format += "iiiiiiixxxxP"
     else:
-        format = format + "iiiiiiiP"
+        format += "iiiiiiiP"
     buf = win32gui.PyMakeBuffer(struct.calcsize(format), lparam)
     return _MakeResult(
         "NMITEMACTIVATE hwndFrom idFrom code iItem iSubItem uNewState uOldState uChanged actionx actiony lParam",
@@ -522,10 +522,10 @@ def UnpackTVNOTIFY(lparam):
     item_size = struct.calcsize(_tvitem_fmt)
     format = _nmhdr_fmt + _nmhdr_align_padding
     if is64bit:
-        format = format + "ixxxx"
+        format += "ixxxx"
     else:
-        format = format + "i"
-    format = format + "%ds%ds" % (item_size, item_size)
+        format += "i"
+    format += "%ds%ds" % (item_size, item_size)
     buf = win32gui.PyGetMemory(lparam, struct.calcsize(format))
     hwndFrom, id, code, action, buf_old, buf_new = struct.unpack(format, buf)
     item_old = UnpackTVITEM(buf_old)
@@ -670,8 +670,8 @@ def UnpackLVDISPINFO(lparam):
 def UnpackLVNOTIFY(lparam):
     format = _nmhdr_fmt + _nmhdr_align_padding + "7i"
     if is64bit:
-        format = format + "xxxx"  # point needs padding.
-    format = format + "P"
+        format += "xxxx"  # point needs padding.
+    format += "P"
     buf = win32gui.PyGetMemory(lparam, struct.calcsize(format))
     (
         hwndFrom,

--- a/win32/Lib/win32pdhquery.py
+++ b/win32/Lib/win32pdhquery.py
@@ -443,7 +443,7 @@ class Query(BaseQuery):
         try:
             while instances[cur + 1] == object:
                 temp.append(object)
-                cur = cur + 1
+                cur += 1
         except IndexError:  # if we went over the end
             pass
         paths = []

--- a/win32/Lib/win32pdhutil.py
+++ b/win32/Lib/win32pdhutil.py
@@ -103,7 +103,7 @@ def FindPerformanceAttributesByName(
     instance_dict = {}
     for instance in instances:
         try:
-            instance_dict[instance] = instance_dict[instance] + 1
+            instance_dict[instance] += 1
         except KeyError:
             instance_dict[instance] = 0
 
@@ -128,7 +128,7 @@ def ShowAllProcesses():
     instance_dict = {}
     for instance in instances:
         try:
-            instance_dict[instance] = instance_dict[instance] + 1
+            instance_dict[instance] += 1
         except KeyError:
             instance_dict[instance] = 0
 

--- a/win32/Lib/win32serviceutil.py
+++ b/win32/Lib/win32serviceutil.py
@@ -218,7 +218,7 @@ def InstallService(
         startType = win32service.SERVICE_DEMAND_START
     serviceType = win32service.SERVICE_WIN32_OWN_PROCESS
     if bRunInteractive:
-        serviceType = serviceType | win32service.SERVICE_INTERACTIVE_PROCESS
+        serviceType |= win32service.SERVICE_INTERACTIVE_PROCESS
     if errorControl is None:
         errorControl = win32service.SERVICE_ERROR_NORMAL
 
@@ -304,7 +304,7 @@ def ChangeServiceConfig(
     hscm = win32service.OpenSCManager(None, None, win32service.SC_MANAGER_ALL_ACCESS)
     serviceType = win32service.SERVICE_WIN32_OWN_PROCESS
     if bRunInteractive:
-        serviceType = serviceType | win32service.SERVICE_INTERACTIVE_PROCESS
+        serviceType |= win32service.SERVICE_INTERACTIVE_PROCESS
     commandLine = _GetCommandLine(exeName, exeArgs)
     try:
         hs = SmartOpenService(hscm, serviceName, win32service.SERVICE_ALL_ACCESS)
@@ -452,7 +452,7 @@ def __FindSvcDeps(findName):
             svc = win32api.RegEnumKey(k, num)
         except win32api.error:
             break
-        num = num + 1
+        num += 1
         sk = win32api.RegOpenKey(k, svc)
         try:
             deps, typ = win32api.RegQueryValueEx(sk, "DependOnService")
@@ -981,11 +981,11 @@ class ServiceFramework:
         # override this.
         accepted = 0
         if hasattr(self, "SvcStop"):
-            accepted = accepted | win32service.SERVICE_ACCEPT_STOP
+            accepted |= win32service.SERVICE_ACCEPT_STOP
         if hasattr(self, "SvcPause") and hasattr(self, "SvcContinue"):
-            accepted = accepted | win32service.SERVICE_ACCEPT_PAUSE_CONTINUE
+            accepted |= win32service.SERVICE_ACCEPT_PAUSE_CONTINUE
         if hasattr(self, "SvcShutdown"):
-            accepted = accepted | win32service.SERVICE_ACCEPT_SHUTDOWN
+            accepted |= win32service.SERVICE_ACCEPT_SHUTDOWN
         return accepted
 
     def ReportServiceStatus(
@@ -1004,7 +1004,7 @@ class ServiceFramework:
         ]:
             checkPoint = 0
         else:
-            self.checkPoint = self.checkPoint + 1
+            self.checkPoint += 1
             checkPoint = self.checkPoint
 
         # Now report the status to the control manager

--- a/win32/Lib/win32verstamp.py
+++ b/win32/Lib/win32verstamp.py
@@ -71,7 +71,7 @@ def String(key, value):
     key = nullterm(key)
     value = nullterm(value)
     result = struct.pack("hh", len(value) // 2, 1)  # wValueLength, wType
-    result = result + key
+    result += key
     result = pad32(result) + value
     return addlen(result)
 
@@ -79,16 +79,16 @@ def String(key, value):
 def StringTable(key, data):
     key = nullterm(key)
     result = struct.pack("hh", 0, 1)  # wValueLength, wType
-    result = result + key
+    result += key
     for k, v in data.items():
-        result = result + String(k, v)
+        result += String(k, v)
         result = pad32(result)
     return addlen(result)
 
 
 def StringFileInfo(data):
     result = struct.pack("hh", 0, 1)  # wValueLength, wType
-    result = result + nullterm("StringFileInfo")
+    result += nullterm("StringFileInfo")
     #  result = pad32(result) + StringTable('040904b0', data)
     result = pad32(result) + StringTable("040904E4", data)
     return addlen(result)
@@ -96,24 +96,24 @@ def StringFileInfo(data):
 
 def Var(key, value):
     result = struct.pack("hh", len(value), 0)  # wValueLength, wType
-    result = result + nullterm(key)
+    result += nullterm(key)
     result = pad32(result) + value
     return addlen(result)
 
 
 def VarFileInfo(data):
     result = struct.pack("hh", 0, 1)  # wValueLength, wType
-    result = result + nullterm("VarFileInfo")
+    result += nullterm("VarFileInfo")
     result = pad32(result)
     for k, v in data.items():
-        result = result + Var(k, v)
+        result += Var(k, v)
     return addlen(result)
 
 
 def VS_VERSION_INFO(maj, min, sub, build, sdata, vdata, debug=0, is_dll=1):
     ffi = VS_FIXEDFILEINFO(maj, min, sub, build, debug, is_dll)
     result = struct.pack("hh", len(ffi), 0)  # wValueLength, wType
-    result = result + nullterm("VS_VERSION_INFO")
+    result += nullterm("VS_VERSION_INFO")
     result = pad32(result) + ffi
     result = pad32(result) + StringFileInfo(sdata) + VarFileInfo(vdata)
     return addlen(result)

--- a/win32/scripts/ControlService.py
+++ b/win32/scripts/ControlService.py
@@ -315,7 +315,7 @@ class ServiceDlg(dialog.Dialog):
                     svc[0],
                 )
             )
-            i = i + 1
+            i += 1
 
             if service and service[1] == svc[0]:
                 self.listCtrl.SetCurSel(pos)

--- a/win32/scripts/VersionStamp/bulkstamp.py
+++ b/win32/scripts/VersionStamp/bulkstamp.py
@@ -63,7 +63,7 @@ def walk(arg, dirname, names):
                     desc = descriptions[os.path.normcase(name)]
                     try:
                         verstamp.stamp(vars, pathname, desc, is_dll=is_dll)
-                        numStamped = numStamped + 1
+                        numStamped += 1
                     except win32api.error as exc:
                         print(
                             "Could not stamp",

--- a/win32/scripts/VersionStamp/vssutil.py
+++ b/win32/scripts/VersionStamp/vssutil.py
@@ -74,14 +74,14 @@ def VssLog(project, linePrefix="", noLabels=5, maxItems=150):
     num = 0
     labelNum = 0
     for i in project.GetVersions(constants.VSSFLAG_RECURSYES):
-        num = num + 1
+        num += 1
         if num > maxItems:
             break
         commentDesc = itemDesc = ""
         if i.Action[:5] == "Added":
             continue
         if len(i.Label):
-            labelNum = labelNum + 1
+            labelNum += 1
             itemDesc = i.Action
         else:
             itemDesc = i.VSSItem.Name
@@ -128,10 +128,10 @@ def CountCheckouts(item):
     num = 0
     if item.Type == constants.VSSITEM_PROJECT:
         for sub in item.Items:
-            num = num + CountCheckouts(sub)
+            num += CountCheckouts(sub)
     else:
         if item.IsCheckedOut:
-            num = num + 1
+            num += 1
     return num
 
 
@@ -170,7 +170,7 @@ def MakeNewBuildNo(project, buildDesc=None, auto=0, bRebrand=0):
         try:
             buildNo = int(buildNo)
             if not bRebrand:
-                buildNo = buildNo + 1
+                buildNo += 1
             buildNo = str(buildNo)
         except ValueError:
             raise error("The previous label could not be incremented: %s" % (oldBuild))

--- a/win32/scripts/backupEventLog.py
+++ b/win32/scripts/backupEventLog.py
@@ -23,7 +23,7 @@ def BackupClearLog(logType):
             os.stat(fname)
         except OSError:
             fileExists = 0
-        retry = retry + 1
+        retry += 1
     # OK - have unique file name.
     try:
         hlog = win32evtlog.OpenEventLog(None, logType)

--- a/win32/scripts/rasutil.py
+++ b/win32/scripts/rasutil.py
@@ -42,7 +42,7 @@ def Connect(rasEntryName, numRetries=5):
             break
         print("Retrying...")
         win32api.Sleep(5000)
-        retryCount = retryCount - 1
+        retryCount -= 1
 
     if errCode:
         raise ConnectionError(errCode, win32ras.GetErrorString(errCode))

--- a/win32/test/test_win32file.py
+++ b/win32/test/test_win32file.py
@@ -313,7 +313,7 @@ class TestOverlapped(unittest.TestCase):
         for i in range(num_loops):
             win32file.WriteFile(h, chunk_data, overlapped)
             win32event.WaitForSingleObject(overlapped.hEvent, win32event.INFINITE)
-            overlapped.Offset = overlapped.Offset + len(chunk_data)
+            overlapped.Offset += len(chunk_data)
         h.Close()
         # Now read the data back overlapped
         overlapped = pywintypes.OVERLAPPED()
@@ -328,7 +328,7 @@ class TestOverlapped(unittest.TestCase):
             try:
                 hr, data = win32file.ReadFile(h, buffer, overlapped)
                 win32event.WaitForSingleObject(overlapped.hEvent, win32event.INFINITE)
-                overlapped.Offset = overlapped.Offset + len(data)
+                overlapped.Offset += len(data)
                 if not data is buffer:
                     self.fail(
                         "Unexpected result from ReadFile - should be the same buffer we passed it"

--- a/win32/test/test_win32trace.py
+++ b/win32/test/test_win32trace.py
@@ -238,7 +238,7 @@ class TestHugeChunks(unittest.TestCase):
         data = "*" * 1023 + "\n"
         while len(data) <= self.BiggestChunk:
             win32trace.write(data)
-            data = data + data
+            data += data
         # If we made it here, we passed.
 
     def tearDown(self):


### PR DESCRIPTION
Most where found thanks to https://docs.astral.sh/ruff/rules/non-augmented-assignment/

Then, since Ruff/PLR6104 doesn't support associative operations (yet https://github.com/astral-sh/ruff/issues/11656), I used the following regex to find more:
` (\w+?) = (\(\n\s+)\1 ([\+\-\*/\|&%~]|>>|<<|\*\*|//)` --> ` $1 $3= (`
` (\w+?) = \1 ([\+\-\*/\|&%~]|>>|<<|\*\*|//)` --> ` $1 $2=`
` (\w+?) = f('|")\{\1\}` --> ` $1 = f$2`


Then manually reviewed the whole thing.