### PR TITLE
Improving unit tests assertion messages

### DIFF
--- a/Pythonwin/pywin/Demos/openGLDemo.py
+++ b/Pythonwin/pywin/Demos/openGLDemo.py
@@ -160,10 +160,10 @@ class OpenGLView(OpenGLViewParent):
 
     # The methods to support OpenGL
     def DrawScene(self):
-        assert 0, "You must override this method"
+        raise NotImplementedError("You must override this method")
 
     def Init(self):
-        assert 0, "You must override this method"
+        raise NotImplementedError("You must override this method")
 
     def OnSizeChange(self, cx, cy):
         pass

--- a/Pythonwin/pywin/debugger/debugger.py
+++ b/Pythonwin/pywin/debugger/debugger.py
@@ -851,7 +851,7 @@ class Debugger(debugger_parent):
                 self.curindex = index
                 break
         else:
-            assert 0, "Can't find the frame in the stack."
+            assert False, "Can't find the frame in the stack."
         SetInteractiveContext(frame.f_globals, frame.f_locals)
         self.GUIRespondDebuggerData()
         self.ShowCurrentLine()
@@ -931,7 +931,7 @@ class Debugger(debugger_parent):
         for id, klass, float in DebuggerDialogInfos:
             if klass.title == barName:
                 return frame.GetControlBar(id)
-        assert 0, "Can't find a bar of that name!"
+        assert False, "Can't find a bar of that name!"
 
     def GUIRespondDebuggerData(self):
         if not self.inited:  # GUI not inited - no toolbars etc.

--- a/Pythonwin/pywin/framework/editor/template.py
+++ b/Pythonwin/pywin/framework/editor/template.py
@@ -1,6 +1,5 @@
 import os
 
-import pywin.framework.window
 import win32api
 import win32ui
 from pywin.mfc import docview
@@ -19,10 +18,10 @@ class EditorTemplateBase(ParentEditorTemplate):
         ParentEditorTemplate.__init__(self, res, makeDoc, makeFrame, makeView)
 
     def _CreateDocTemplate(self, resourceId):
-        assert 0, "You must override this"
+        raise NotImplementedError("You must override this")
 
     def CreateWin32uiDocument(self):
-        assert 0, "You must override this"
+        raise NotImplementedError("You must override this")
 
     def GetFileExtensions(self):
         return ".txt", ".py"

--- a/Pythonwin/pywin/idle/AutoIndent.py
+++ b/Pythonwin/pywin/idle/AutoIndent.py
@@ -262,7 +262,7 @@ class AutoIndent:
                     else:
                         self.reindent_to(y.compute_backslash_indent())
                 else:
-                    assert 0, "bogus continuation type " + repr(c)
+                    raise ValueError(f"bogus continuation type {c!r}")
                 return "break"
 
             # This line starts a brand new stmt; indent relative to

--- a/Pythonwin/pywin/test/test_exe.py
+++ b/Pythonwin/pywin/test/test_exe.py
@@ -46,7 +46,7 @@ class TestPythonwinExe(unittest.TestCase):
             dst = os.path.dirname(pythonwinexe_path) + os.sep + pydll
             if not os.path.isfile(dst):
                 try:
-                    assert os.path.isfile(src)
+                    self.assertTrue(os.path.isfile(src))
                     print(f"-- symlink {dst!r} -> {src!r}", file=sys.stderr)
                     os.symlink(src, dst)
                 except (OSError, AssertionError) as e:
@@ -62,8 +62,8 @@ class TestPythonwinExe(unittest.TestCase):
             rc = "TIMEOUT"
         with open(self.tfn) as f:
             outs = f.read()
-        assert rc == 0, f"rc is {rc!r}, outs={outs!r}"
-        assert "Success!" in outs, outs
+        self.assertEqual(rc, 0, f"outs={outs!r}")
+        self.assertIn("Success!", outs)
         print("-- test_exe Ok! --", file=sys.stderr)
 
     def tearDown(self):

--- a/com/win32com/test/testConversionErrors.py
+++ b/com/win32com/test/testConversionErrors.py
@@ -28,11 +28,7 @@ class BadConversions:
 
 class TestCase(win32com.test.util.TestCase):
     def test_float(self):
-        try:
-            test_ob().TestValue(BadConversions())
-            raise Exception("Should not have worked")
-        except Exception as e:
-            assert isinstance(e, TestException)
+        self.assertRaises(TestException, test_ob().TestValue, BadConversions())
 
 
 if __name__ == "__main__":

--- a/com/win32com/test/testall.py
+++ b/com/win32com/test/testall.py
@@ -226,7 +226,7 @@ def make_test_suite(test_level=1):
                     test = mod.suite()
                 else:
                     test = loader.loadTestsFromModule(mod)
-            assert test.countTestCases() > 0, "No tests loaded from %r" % mod
+            assert test.countTestCases() > 0, f"No tests loaded from {mod!r}"
             suite.addTest(test)
         for cmd, output in output_checked_programs[i]:
             suite.addTest(ShellTestCase(cmd, output))
@@ -247,7 +247,7 @@ def make_test_suite(test_level=1):
                 test = mod.suite()
             else:
                 test = loader.loadTestsFromModule(mod)
-            assert test.countTestCases() > 0, "No tests loaded from %r" % mod
+            assert test.countTestCases() > 0, f"No tests loaded from {mod!r}"
             suite.addTest(test)
 
     return suite, import_failures

--- a/com/win32comext/axdebug/codecontainer.py
+++ b/com/win32comext/axdebug/codecontainer.py
@@ -55,7 +55,7 @@ class SourceCodeContainer:
         return self.text
 
     def GetName(self, dnt):
-        assert 0, "You must subclass this"
+        raise NotImplementedError("You must subclass this")
 
     def GetFileName(self):
         return self.fileName

--- a/com/win32comext/shell/demos/servers/folder_view.py
+++ b/com/win32comext/shell/demos/servers/folder_view.py
@@ -538,12 +538,12 @@ class ContextMenu:
             if matches:
                 break
         else:
-            assert False, ci  # failed to find our ID
+            raise AssertionError(ci, "failed to find our ID")
         if verb_id == MENUVERB_DISPLAY:
             sia = shell.SHCreateShellItemArrayFromDataObject(self.dataobj)
             DisplayItem(hwnd, sia)
         else:
-            assert False, ci  # Got some verb we weren't expecting?
+            raise AssertionError(ci, "Got some verb we weren't expecting?")
 
     def GetCommandString(self, cmd, typ):
         raise COMException(hresult=winerror.E_NOTIMPL)

--- a/win32/Lib/pywin32_testutil.py
+++ b/win32/Lib/pywin32_testutil.py
@@ -61,7 +61,7 @@ class LeakTestCase(unittest.TestCase):
             result.addFailure(self.real_test, (exc.__class__, exc, None))
 
     def runTest(self):
-        assert 0, "not used"
+        raise NotImplementedError("not used")
 
     def _do_leak_tests(self, result=None):
         try:

--- a/win32/test/test_exceptions.py
+++ b/win32/test/test_exceptions.py
@@ -5,7 +5,6 @@ import unittest
 import pythoncom
 import pywintypes
 import win32api
-import win32file
 import winerror
 
 
@@ -100,7 +99,7 @@ class TestAPISimple(TestBase):
             raise pywintypes.error("foo")
             self.fail("Expected exception")
         except pywintypes.error as exc:
-            assert exc.args[0] == "foo"
+            self.assertEqual(exc.args[0], "foo")
             # 'winerror' always args[0]
             self.assertEqual(exc.winerror, "foo")
             self.assertEqual(exc.funcname, None)

--- a/win32/test/test_sspi.py
+++ b/win32/test/test_sspi.py
@@ -1,7 +1,6 @@
 # Some tests of the win32security sspi functions.
 # Stolen from Roger's original test_sspi.c, a version of which is in "Demos"
 # See also the other SSPI demos.
-import re
 import unittest
 
 import sspi
@@ -196,33 +195,33 @@ class TestSSPI(unittest.TestCase):
 
     def testSecBufferRepr(self):
         desc = win32security.PySecBufferDescType()
-        assert re.match(
-            r"PySecBufferDesc\(ulVersion: 0 \| cBuffers: 0 \| pBuffers: 0x[\da-fA-F]{8,16}\)",
+        self.assertRegex(
             repr(desc),
+            r"PySecBufferDesc\(ulVersion: 0 \| cBuffers: 0 \| pBuffers: 0x[\da-fA-F]{8,16}\)",
         )
 
         buffer1 = win32security.PySecBufferType(0, sspicon.SECBUFFER_TOKEN)
-        assert re.match(
-            r"PySecBuffer\(cbBuffer: 0 \| BufferType: 2 \| pvBuffer: 0x[\da-fA-F]{8,16}\)",
+        self.assertRegex(
             repr(buffer1),
+            r"PySecBuffer\(cbBuffer: 0 \| BufferType: 2 \| pvBuffer: 0x[\da-fA-F]{8,16}\)",
         )
         desc.append(buffer1)
 
-        assert re.match(
-            r"PySecBufferDesc\(ulVersion: 0 \| cBuffers: 1 \| pBuffers: 0x[\da-fA-F]{8,16}\)",
+        self.assertRegex(
             repr(desc),
+            r"PySecBufferDesc\(ulVersion: 0 \| cBuffers: 1 \| pBuffers: 0x[\da-fA-F]{8,16}\)",
         )
 
         buffer2 = win32security.PySecBufferType(4, sspicon.SECBUFFER_DATA)
-        assert re.match(
-            r"PySecBuffer\(cbBuffer: 4 \| BufferType: 1 \| pvBuffer: 0x[\da-fA-F]{8,16}\)",
+        self.assertRegex(
             repr(buffer2),
+            r"PySecBuffer\(cbBuffer: 4 \| BufferType: 1 \| pvBuffer: 0x[\da-fA-F]{8,16}\)",
         )
         desc.append(buffer2)
 
-        assert re.match(
-            r"PySecBufferDesc\(ulVersion: 0 \| cBuffers: 2 \| pBuffers: 0x[\da-fA-F]{8,16}\)",
+        self.assertRegex(
             repr(desc),
+            r"PySecBufferDesc\(ulVersion: 0 \| cBuffers: 2 \| pBuffers: 0x[\da-fA-F]{8,16}\)",
         )
 
 

--- a/win32/test/test_win32file.py
+++ b/win32/test/test_win32file.py
@@ -351,7 +351,7 @@ class TestOverlapped(unittest.TestCase):
             sock.listen(1)
             socks.append(sock)
             new = win32file.CreateIoCompletionPort(sock.fileno(), ioport, PORT, 0)
-            assert new is ioport
+            self.assertIs(new, ioport)
         for s in socks:
             s.close()
         hv = int(ioport)
@@ -552,7 +552,7 @@ class TestFindFiles(unittest.TestCase):
         set2 = set()
         for file in win32file.FindFilesIterator(dir):
             set2.add(file)
-        assert len(set2) > 5, "This directory has less than 5 files!?"
+        self.assertGreater(len(set2), 5, "This directory has less than 5 files!?")
         self.assertEqual(set1, set2)
 
     def testBadDir(self):

--- a/win32/test/test_win32inet.py
+++ b/win32/test/test_win32inet.py
@@ -53,9 +53,8 @@ class TestNetwork(unittest.TestCase):
                 break
             chunks.append(chunk)
         data = b"".join(chunks)
-        assert data.find(b"Python") > 0, repr(
-            data
-        )  # This must appear somewhere on the main page!
+        # This must appear somewhere on the main page!
+        self.assertGreater(data.find(b"Python"), 0, repr(data))
 
     def testFtpCommand(self):
         # ftp.python.org doesn't exist.  ftp.gnu.org is what Python's urllib

--- a/win32/test/test_win32profile.py
+++ b/win32/test/test_win32profile.py
@@ -10,9 +10,9 @@ class Tester(unittest.TestCase):
     def test_environment(self):
         os.environ["FOO"] = "bar=baz"
         env = win32profile.GetEnvironmentStrings()
-        assert "FOO" in env
-        assert env["FOO"] == "bar=baz"
-        assert os.environ["FOO"] == "bar=baz"
+        self.assertIn("FOO", env)
+        self.assertEqual(env["FOO"], "bar=baz")
+        self.assertEqual(os.environ["FOO"], "bar=baz")
 
 
 if __name__ == "__main__":

--- a/win32/test/test_win32trace.py
+++ b/win32/test/test_win32trace.py
@@ -152,7 +152,7 @@ class TestTraceObjectOps(BasicSetupTearDown):
 
     def testIsatty(self):
         tracer = win32trace.GetTracer()
-        assert tracer.isatty() == False
+        self.assertFalse(tracer.isatty())
 
     def testRoundTrip(self):
         traceObject = win32trace.GetTracer()
@@ -195,7 +195,7 @@ class TestMultipleThreadsWriting(unittest.TestCase):
     def areBucketsFull(self):
         bucketsAreFull = True
         for each in self.buckets:
-            assert each <= self.FullBucket, each
+            self.assertLessEqual(each, self.FullBucket)
             if each != self.FullBucket:
                 bucketsAreFull = False
                 break
@@ -207,7 +207,7 @@ class TestMultipleThreadsWriting(unittest.TestCase):
             for ch in readString:
                 integer = int(ch)
                 count = self.buckets[integer]
-                assert count != -1
+                self.assertNotEqual(count, -1)
                 self.buckets[integer] = count + 1
                 if self.buckets[integer] == self.FullBucket:
                     if self.areBucketsFull():
@@ -220,8 +220,8 @@ class TestMultipleThreadsWriting(unittest.TestCase):
         for each in self.threads:
             each.join()
         for each in self.threads:
-            assert each.verifyWritten()
-        assert self.areBucketsFull()
+            self.assertTrue(each.verifyWritten())
+        self.assertTrue(self.areBucketsFull())
 
 
 class TestHugeChunks(unittest.TestCase):
@@ -307,7 +307,7 @@ class TestOutofProcess(unittest.TestCase):
     def areBucketsFull(self):
         bucketsAreFull = True
         for each in self.buckets:
-            assert each <= self.FullBucket, each
+            self.assertLessEqual(each, self.FullBucket)
             if each != self.FullBucket:
                 bucketsAreFull = False
                 break
@@ -319,7 +319,7 @@ class TestOutofProcess(unittest.TestCase):
             for ch in readString:
                 integer = int(ch)
                 count = self.buckets[integer]
-                assert count != -1
+                self.assertNotEqual(count, -1)
                 self.buckets[integer] = count + 1
                 if self.buckets[integer] == self.FullBucket:
                     if self.areBucketsFull():
@@ -332,8 +332,8 @@ class TestOutofProcess(unittest.TestCase):
         for each in self.processes:
             each.join()
         for each in self.processes:
-            assert each.verifyWritten()
-        assert self.areBucketsFull()
+            self.assertTrue(each.verifyWritten())
+        self.assertTrue(self.areBucketsFull())
 
 
 def _RunAsTestProcess():


### PR DESCRIPTION
Using `unittest` assertion methods where possible (since this project doesn't use pytest)
Raise `NotImplementedError` for unimplemented methods
Use `raise AssertionError` instead of `assert 0` (except in `pywin/debugger`, in case that's done on purpose)