### PR TITLE
Stop using `printf`-style string formatting for direct string interpolation (`%s`)

### DIFF
--- a/AutoDuck/Dump2HHC.py
+++ b/AutoDuck/Dump2HHC.py
@@ -284,7 +284,7 @@ def genCategoryHTML(output_dir, cats):
 
 
 def _genItemsFromDict(dict, cat, output, target, do_children=1):
-    CHM = "mk:@MSITStore:%s.chm::/" % target
+    CHM = "mk:@MSITStore:{}.chm::/".format(target)
     keys = list(dict.keys())
     keys.sort()
     for k in keys:
@@ -324,7 +324,7 @@ def _genItemsFromDict(dict, cat, output, target, do_children=1):
 
 
 def genTOC(cats, output, title, target):
-    CHM = "mk:@MSITStore:%s.chm::/" % target
+    CHM = "mk:@MSITStore:{}.chm::/".format(target)
     output.write(
         """
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">

--- a/AutoDuck/InsertExternalOverviews.py
+++ b/AutoDuck/InsertExternalOverviews.py
@@ -60,7 +60,7 @@ def main():
     processFile(input, out, linksHTML, extTopicHTML, importantHTML)
     input.close()
     out.close()
-    sCmd = 'del "%s"' % file
+    sCmd = 'del "{}"'.format(file)
     os.unlink(file)
     os.rename(file + ".2", file)
 

--- a/AutoDuck/fixHelpCompression.py
+++ b/AutoDuck/fixHelpCompression.py
@@ -10,7 +10,7 @@ fname = sys.argv[1]
 try:
     os.stat(fname)
 except OSError:
-    sys.stderr.write("The project file '%s' was not found\n" % (fname))
+    sys.stderr.write("The project file '{}' was not found\n".format(fname))
     sys.exit(1)
 
 win32api.WriteProfileVal("options", "COMPRESS", "12 Hall Zeck", fname)

--- a/AutoDuck/makedfromi.py
+++ b/AutoDuck/makedfromi.py
@@ -114,7 +114,7 @@ def make_doc_summary(inFile, outFile):
         for meth, extras in these_methods:
             fields = meth.split("|")
             if len(fields) != 3:
-                print("**Error - %s does not have enough fields" % meth)
+                print("**Error - {} does not have enough fields".format(meth))
             else:
                 outFile.write(
                     f"// @pymethod {fields[0]}|{thisModName}|{fields[1]}|{fields[2]}\n"
@@ -123,7 +123,7 @@ def make_doc_summary(inFile, outFile):
                 outFile.write(extra)
         if g_com_parent:
             outFile.write(f"\n// @object {thisModName}|{modDoc}")
-            outFile.write("\n// <nl>Derived from <o %s>\n" % (g_com_parent))
+            outFile.write("\n// <nl>Derived from <o {}>\n".format(g_com_parent))
         else:
             outFile.write(f"\n// @module {thisModName}|{modDoc}\n")
         for meth, extras in these_methods:
@@ -134,7 +134,7 @@ def make_doc_summary(inFile, outFile):
 
     outFile.write("\n")
     for extra in extra_tags:
-        outFile.write("%s\n" % (extra))
+        outFile.write("{}\n".format(extra))
     for cname, doc in constants:
         outFile.write(f"// @const {modName}|{cname}|{doc}\n")
 
@@ -153,7 +153,7 @@ def doit():
     except getopt.error:
         _, msg, _ = sys.exc_info()
         print(msg)
-        print("Usage: %s [-o output_name] [-p com_parent] filename" % sys.argv[0])
+        print("Usage: {} [-o output_name] [-p com_parent] filename".format(sys.argv[0]))
         return
 
     inName = args[0]
@@ -162,8 +162,9 @@ def doit():
     inFile = open(inName)
     outFile = open(outName, "w")
     outFile.write(
-        "// @doc\n// Generated file - built from %s\n// DO NOT CHANGE - CHANGES WILL BE LOST!\n\n"
-        % inName
+        "// @doc\n// Generated file - built from {}\n// DO NOT CHANGE - CHANGES WILL BE LOST!\n\n".format(
+            inName
+        )
     )
     make_doc_summary(inFile, outFile)
     inFile.close()

--- a/Pythonwin/pywin/Demos/app/demoutils.py
+++ b/Pythonwin/pywin/Demos/app/demoutils.py
@@ -53,10 +53,10 @@ def NeedApp():
         try:
             parent = win32ui.GetMainFrame().GetSafeHwnd()
             win32api.ShellExecute(
-                parent, None, "pythonwin.exe", '/app "%s"' % sys.argv[0], None, 1
+                parent, None, "pythonwin.exe", '/app "{}"'.format(sys.argv[0]), None, 1
             )
         except win32api.error as details:
-            win32ui.MessageBox("Error executing command - %s" % (details), "Demos")
+            win32ui.MessageBox("Error executing command - {}".format(details), "Demos")
 
 
 if __name__ == "__main__":

--- a/Pythonwin/pywin/Demos/app/dlgappdemo.py
+++ b/Pythonwin/pywin/Demos/app/dlgappdemo.py
@@ -40,7 +40,7 @@ class TestAppDialog(dlgappcore.AppDialog):
             # translate \n to \n\r
             self.edit.ReplaceSel(str.replace("\n", "\r\n"))
         else:
-            win32ui.OutputDebug("dlgapp - no edit control! >>\n%s\n<<\n" % str)
+            win32ui.OutputDebug("dlgapp - no edit control! >>\n{}\n<<\n".format(str))
 
 
 app = TestDialogApp()

--- a/Pythonwin/pywin/Demos/cmdserver.py
+++ b/Pythonwin/pywin/Demos/cmdserver.py
@@ -75,7 +75,7 @@ def StartServer(cmd, title=None, bCloseOnEnd=0, serverFlags=flags.SERVER_BEST):
 def ServerThread(myout, cmd, title, bCloseOnEnd):
     try:
         writer.register(myout)
-        print('Executing "%s"\n' % cmd)
+        print('Executing "{}"\n'.format(cmd))
         bOK = 1
         try:
             import __main__

--- a/Pythonwin/pywin/Demos/demoutils.py
+++ b/Pythonwin/pywin/Demos/demoutils.py
@@ -53,10 +53,10 @@ def NeedApp():
         try:
             parent = win32ui.GetMainFrame().GetSafeHwnd()
             win32api.ShellExecute(
-                parent, None, "pythonwin.exe", '/app "%s"' % sys.argv[0], None, 1
+                parent, None, "pythonwin.exe", '/app "{}"'.format(sys.argv[0]), None, 1
             )
         except win32api.error as details:
-            win32ui.MessageBox("Error executing command - %s" % (details), "Demos")
+            win32ui.MessageBox("Error executing command - {}".format(details), "Demos")
 
 
 if __name__ == "__main__":

--- a/Pythonwin/pywin/Demos/objdoc.py
+++ b/Pythonwin/pywin/Demos/objdoc.py
@@ -41,7 +41,7 @@ class object_document(docview.Document):
 
 class object_view(docview.EditView):
     def OnInitialUpdate(self):
-        self.ReplaceSel("Object is %s" % repr(self.GetDocument().object))
+        self.ReplaceSel("Object is {}".format(repr(self.GetDocument().object)))
 
 
 def demo():

--- a/Pythonwin/pywin/Demos/ocx/demoutils.py
+++ b/Pythonwin/pywin/Demos/ocx/demoutils.py
@@ -53,10 +53,10 @@ def NeedApp():
         try:
             parent = win32ui.GetMainFrame().GetSafeHwnd()
             win32api.ShellExecute(
-                parent, None, "pythonwin.exe", '/app "%s"' % sys.argv[0], None, 1
+                parent, None, "pythonwin.exe", '/app "{}"'.format(sys.argv[0]), None, 1
             )
         except win32api.error as details:
-            win32ui.MessageBox("Error executing command - %s" % (details), "Demos")
+            win32ui.MessageBox("Error executing command - {}".format(details), "Demos")
 
 
 if __name__ == "__main__":

--- a/Pythonwin/pywin/Demos/ocx/ocxserialtest.py
+++ b/Pythonwin/pywin/Demos/ocx/ocxserialtest.py
@@ -106,8 +106,9 @@ class TestSerDialog(dialog.Dialog):
                 self.olectl.PortOpen = 1
             except pythoncom.com_error as details:
                 print(
-                    "Could not open the specified serial port - %s"
-                    % (details.excepinfo[2])
+                    "Could not open the specified serial port - {}".format(
+                        details.excepinfo[2]
+                    )
                 )
                 self.EndDialog(win32con.IDCANCEL)
         return rc
@@ -117,7 +118,7 @@ class TestSerDialog(dialog.Dialog):
             try:
                 self.olectl.PortOpen = 0
             except pythoncom.com_error as details:
-                print("Error closing port - %s" % (details.excepinfo[2]))
+                print("Error closing port - {}".format(details.excepinfo[2]))
         return dialog.Dialog.OnDestroy(self, msg)
 
 

--- a/Pythonwin/pywin/dialogs/login.py
+++ b/Pythonwin/pywin/dialogs/login.py
@@ -153,4 +153,4 @@ if __name__ == "__main__":
             what = ""
             if newpassword != password:
                 what = "not "
-            print("The passwords did %smatch" % (what))
+            print("The passwords did {}match".format(what))

--- a/Pythonwin/pywin/docking/DockingBar.py
+++ b/Pythonwin/pywin/docking/DockingBar.py
@@ -99,9 +99,9 @@ class DockingBar(window.Wnd):
         self.dialog = childCreator(*(self,) + childCreatorArgs)
 
         # use the dialog dimensions as default base dimensions
-        assert self.dialog.IsWindow(), (
-            "The childCreator function %s did not create a window!" % childCreator
-        )
+        assert (
+            self.dialog.IsWindow()
+        ), "The childCreator function {} did not create a window!".format(childCreator)
         rect = self.dialog.GetWindowRect()
         self.sizeHorz = self.sizeVert = self.sizeFloat = (
             rect[2] - rect[0],

--- a/Pythonwin/pywin/framework/app.py
+++ b/Pythonwin/pywin/framework/app.py
@@ -164,7 +164,7 @@ class CApp(WinApp):
                 try:
                     thisRet = handler(handler, count)
                 except:
-                    print("Idle handler %s failed" % (repr(handler)))
+                    print("Idle handler {} failed".format(repr(handler)))
                     traceback.print_exc()
                     print("Idle handler removed from list")
                     try:
@@ -347,7 +347,7 @@ class AboutBox(dialog.Dialog):
             build_no = (
                 open(os.path.join(site_packages, "pywin32.version.txt")).read().strip()
             )
-            ver = "pywin32 build %s" % build_no
+            ver = "pywin32 build {}".format(build_no)
         except OSError:
             ver = None
         if ver is None:

--- a/Pythonwin/pywin/framework/bitmap.py
+++ b/Pythonwin/pywin/framework/bitmap.py
@@ -29,7 +29,7 @@ class BitmapDocument(docview.Document):
             try:
                 self.bitmap.LoadBitmapFile(f)
             except OSError:
-                win32ui.MessageBox("Could not load the bitmap from %s" % filename)
+                win32ui.MessageBox("Could not load the bitmap from {}".format(filename))
                 return 0
         finally:
             f.close()

--- a/Pythonwin/pywin/framework/editor/document.py
+++ b/Pythonwin/pywin/framework/editor/document.py
@@ -83,11 +83,11 @@ class EditorDocumentBase(ParentEditorDocument):
         try:
             self.SaveFile(fileName)
         except OSError as details:
-            win32ui.MessageBox("Error - could not save file\r\n\r\n%s" % details)
+            win32ui.MessageBox("Error - could not save file\r\n\r\n{}".format(details))
             return 0
         except (UnicodeEncodeError, LookupError) as details:
             rc = win32ui.MessageBox(
-                "Encoding failed: \r\n%s" % details
+                "Encoding failed: \r\n{}".format(details)
                 + "\r\nPlease add desired source encoding as first line of file, eg \r\n"
                 + "# -*- coding: mbcs -*-\r\n\r\n"
                 + "If you continue, the file will be saved as binary and will\r\n"
@@ -101,7 +101,7 @@ class EditorDocumentBase(ParentEditorDocument):
                     self.SaveFile(fileName, encoding="latin-1")
                 except OSError as details:
                     win32ui.MessageBox(
-                        "Error - could not save file\r\n\r\n%s" % details
+                        "Error - could not save file\r\n\r\n{}".format(details)
                     )
                     return 0
             else:
@@ -183,16 +183,14 @@ class EditorDocumentBase(ParentEditorDocument):
         if changed:
             question = None
             if self.IsModified():
-                question = (
-                    "%s\r\n\r\nThis file has been modified outside of the source editor.\r\nDo you want to reload it and LOSE THE CHANGES in the source editor?"
-                    % self.GetPathName()
+                question = "{}\r\n\r\nThis file has been modified outside of the source editor.\r\nDo you want to reload it and LOSE THE CHANGES in the source editor?".format(
+                    self.GetPathName()
                 )
                 mbStyle = win32con.MB_YESNO | win32con.MB_DEFBUTTON2  # Default to "No"
             else:
                 if not self.bAutoReload:
-                    question = (
-                        "%s\r\n\r\nThis file has been modified outside of the source editor.\r\nDo you want to reload it?"
-                        % self.GetPathName()
+                    question = "{}\r\n\r\nThis file has been modified outside of the source editor.\r\nDo you want to reload it?".format(
+                        self.GetPathName()
                     )
                     mbStyle = win32con.MB_YESNO  # Default to "Yes"
             if question:

--- a/Pythonwin/pywin/framework/editor/editor.py
+++ b/Pythonwin/pywin/framework/editor/editor.py
@@ -366,7 +366,7 @@ class EditorView(ParentEditorView):
         flags = win32con.MF_STRING | win32con.MF_ENABLED
         if patImport.match(line) == len(line):
             menu.AppendMenu(
-                flags, ID_LOCATE_FILE, "&Locate %s.py" % patImport.group("name")
+                flags, ID_LOCATE_FILE, "&Locate {}.py".format(patImport.group("name"))
             )
             menu.AppendMenu(win32con.MF_SEPARATOR)
         menu.AppendMenu(flags, win32ui.ID_EDIT_UNDO, "&Undo")
@@ -393,7 +393,7 @@ class EditorView(ParentEditorView):
 
         fileName = pywin.framework.scriptutils.LocatePythonFile(modName)
         if fileName is None:
-            win32ui.SetStatusText("Can't locate module %s" % modName)
+            win32ui.SetStatusText("Can't locate module {}".format(modName))
         else:
             win32ui.GetApp().OpenDocumentFile(fileName)
         return 0

--- a/Pythonwin/pywin/framework/editor/vss.py
+++ b/Pythonwin/pywin/framework/editor/vss.py
@@ -53,7 +53,7 @@ def FindVssProjectInfo(fullfname):
         retPaths.insert(0, addpath)
     if not project:
         win32ui.MessageBox(
-            "%s\r\n\r\nThis directory is not configured for Python/VSS" % origPath
+            "{}\r\n\r\nThis directory is not configured for Python/VSS".format(origPath)
         )
         return
     return project, "/".join(retPaths), database

--- a/Pythonwin/pywin/framework/interact.py
+++ b/Pythonwin/pywin/framework/interact.py
@@ -357,7 +357,7 @@ class InteractiveCore:
                 )
             except:
                 sys.stderr.write(
-                    ">>> \nError executing PYTHONSTARTUP script %r\n" % (rcfile)
+                    ">>> \nError executing PYTHONSTARTUP script {!r}\n".format(rcfile)
                 )
                 traceback.print_exc(file=sys.stderr)
         self.AppendToPrompt([])
@@ -370,8 +370,8 @@ class InteractiveCore:
             sys.ps2 = "... "
             locals = globals = __main__.__dict__
         else:
-            sys.ps1 = "[%s]>>> " % name
-            sys.ps2 = "[%s]... " % name
+            sys.ps1 = "[{}]>>> ".format(name)
+            sys.ps2 = "[{}]... ".format(name)
         self.interp.locals = locals
         self.interp.globals = globals
         self.AppendToPrompt([], oldPrompt)

--- a/Pythonwin/pywin/framework/intpyapp.py
+++ b/Pythonwin/pywin/framework/intpyapp.py
@@ -299,7 +299,7 @@ class InteractivePythonApp(app.CApp):
                     dde.Exec(
                         "from pywin.framework import scriptutils\n"
                         "ed = scriptutils.GetActiveEditControl()\n"
-                        "if ed: ed.SetSel(ed.LineIndex(%s - 1))" % gotoline
+                        "if ed: ed.SetSel(ed.LineIndex({} - 1))".format(gotoline)
                     )
                 else:
                     from . import scriptutils
@@ -325,7 +325,9 @@ class InteractivePythonApp(app.CApp):
                     )
                     continue
                 if dde:
-                    dde.Exec("win32ui.GetApp().OpenDocumentFile(%s)" % (repr(fname)))
+                    dde.Exec(
+                        "win32ui.GetApp().OpenDocumentFile({})".format(repr(fname))
+                    )
                 else:
                     win32ui.GetApp().OpenDocumentFile(par)
             elif argType == "/rundlg":
@@ -365,7 +367,9 @@ class InteractivePythonApp(app.CApp):
                     )
                 i += 1
             else:
-                raise ValueError("Command line argument not recognised: %s" % argType)
+                raise ValueError(
+                    "Command line argument not recognised: {}".format(argType)
+                )
 
     def LoadSystemModules(self):
         self.DoLoadModules("pywin.framework.editor,pywin.framework.stdin")
@@ -386,7 +390,7 @@ class InteractivePythonApp(app.CApp):
                 __import__(module)
             except:  # Catch em all, else the app itself dies! 'ImportError:
                 traceback.print_exc()
-                msg = 'Startup import of user module "%s" failed' % module
+                msg = 'Startup import of user module "{}" failed'.format(module)
                 print(msg)
                 win32ui.MessageBox(msg)
 
@@ -463,7 +467,9 @@ class InteractivePythonApp(app.CApp):
         lastLocateFileName = lastLocateFileName.replace(".", "\\")
         newName = scriptutils.LocatePythonFile(lastLocateFileName)
         if newName is None:
-            win32ui.MessageBox("The file '%s' can not be located" % lastLocateFileName)
+            win32ui.MessageBox(
+                "The file '{}' can not be located".format(lastLocateFileName)
+            )
         else:
             win32ui.GetApp().OpenDocumentFile(newName)
 

--- a/Pythonwin/pywin/framework/mdi_pychecker.py
+++ b/Pythonwin/pywin/framework/mdi_pychecker.py
@@ -85,7 +85,7 @@ class dirpath:
                         root = eval("win32con." + keystr[0])
                     except:
                         win32ui.MessageBox(
-                            "Can't interpret registry key name '%s'" % keystr[0]
+                            "Can't interpret registry key name '{}'".format(keystr[0])
                         )
                     try:
                         subkey = "\\".join(keystr[1:])
@@ -94,14 +94,16 @@ class dirpath:
                             x = dirpath(val)
                         else:
                             win32ui.MessageBox(
-                                "Registry path '%s' did not return a path entry" % d
+                                "Registry path '{}' did not return a path entry".format(
+                                    d
+                                )
                             )
                     except:
                         win32ui.MessageBox(
-                            "Can't interpret registry key value: %s" % keystr[1:]
+                            "Can't interpret registry key value: {}".format(keystr[1:])
                         )
                 else:
-                    win32ui.MessageBox("Directory '%s' not found" % d)
+                    win32ui.MessageBox("Directory '{}' not found".format(d))
                 if x:
                     for xd in x:
                         if xd not in dirs:
@@ -289,7 +291,7 @@ class TheDocument(docview.RichEditDoc):
         )
         # self.text = []
         self.GetFirstView().Append(
-            "#Pychecker Run in " + self.dirpattern + "  %s\n" % time.asctime()
+            "#Pychecker Run in " + self.dirpattern + "  {}\n".format(time.asctime())
         )
         if self.verbose:
             self.GetFirstView().Append("#   =" + repr(self.dp.dirs) + "\n")
@@ -304,8 +306,9 @@ class TheDocument(docview.RichEditDoc):
         self.fndx = -1
         if not self.dp:
             self.GetFirstView().Append(
-                "# ERROR: '%s' does not resolve to any search locations"
-                % self.dirpattern
+                "# ERROR: '{}' does not resolve to any search locations".format(
+                    self.dirpattern
+                )
             )
             self.SetModifiedFlag(0)
         else:

--- a/Pythonwin/pywin/framework/scriptutils.py
+++ b/Pythonwin/pywin/framework/scriptutils.py
@@ -292,7 +292,7 @@ def RunScript(defName=None, defArgs=None, bShowDialog=1, debuggingType=None):
         except OSError:
             fullScript = LocatePythonFile(script)
             if fullScript is None:
-                win32ui.MessageBox("The file '%s' can not be located" % script)
+                win32ui.MessageBox("The file '{}' can not be located".format(script))
                 return
             script = fullScript
     else:
@@ -336,7 +336,7 @@ def RunScript(defName=None, defArgs=None, bShowDialog=1, debuggingType=None):
     base = os.path.split(script)[1]
     # Allow windows to repaint before starting.
     win32ui.PumpWaitingMessages()
-    win32ui.SetStatusText("Running script %s..." % base, 1)
+    win32ui.SetStatusText("Running script {}...".format(base), 1)
     exitCode = 0
     from pywin.framework import interact
 
@@ -401,7 +401,7 @@ def RunScript(defName=None, defArgs=None, bShowDialog=1, debuggingType=None):
     if bWorked:
         win32ui.SetStatusText(f"Script '{script}' returned exit code {exitCode}")
     else:
-        win32ui.SetStatusText("Exception raised while running script  %s" % base)
+        win32ui.SetStatusText("Exception raised while running script  {}".format(base))
     try:
         sys.stdout.flush()
     except AttributeError:
@@ -485,7 +485,7 @@ def ImportFile():
             + what
             + "ed module '"
             + modName
-            + "': %s" % getattr(mod, "__file__", "<unkown file>")
+            + "': {}".format(getattr(mod, "__file__", "<unkown file>"))
         )
     except:
         _HandlePythonFailure(what)
@@ -614,7 +614,7 @@ def _HandlePythonFailure(what, syntaxErrorPathName=None):
             _JumpToPosition(fileName, line, col)
         except (TypeError, ValueError):
             msg = str(details)
-        win32ui.SetStatusText("Failed to " + what + " - syntax error - %s" % msg)
+        win32ui.SetStatusText("Failed to " + what + " - syntax error - {}".format(msg))
     else:
         traceback.print_exc()
         win32ui.SetStatusText("Failed to " + what + " - " + str(details))
@@ -632,13 +632,13 @@ def FindTabNanny():
     try:
         path = win32api.RegQueryValue(
             win32con.HKEY_LOCAL_MACHINE,
-            "SOFTWARE\\Python\\PythonCore\\%s\\InstallPath" % (sys.winver),
+            "SOFTWARE\\Python\\PythonCore\\{}\\InstallPath".format(sys.winver),
         )
     except win32api.error:
         print("WARNING - The Python registry does not have an 'InstallPath' setting")
-        print("          The file '%s' can not be located" % (filename))
+        print("          The file '{}' can not be located".format(filename))
         return None
-    fname = os.path.join(path, "Tools\\Scripts\\%s" % filename)
+    fname = os.path.join(path, "Tools\\Scripts\\{}".format(filename))
     try:
         os.stat(fname)
     except OSError:

--- a/Pythonwin/pywin/framework/sgrepmdi.py
+++ b/Pythonwin/pywin/framework/sgrepmdi.py
@@ -67,7 +67,7 @@ class dirpath:
                         root = eval("win32con." + keystr[0])
                     except:
                         win32ui.MessageBox(
-                            "Can't interpret registry key name '%s'" % keystr[0]
+                            "Can't interpret registry key name '{}'".format(keystr[0])
                         )
                     try:
                         subkey = "\\".join(keystr[1:])
@@ -76,14 +76,16 @@ class dirpath:
                             x = dirpath(val)
                         else:
                             win32ui.MessageBox(
-                                "Registry path '%s' did not return a path entry" % d
+                                "Registry path '{}' did not return a path entry".format(
+                                    d
+                                )
                             )
                     except:
                         win32ui.MessageBox(
-                            "Can't interpret registry key value: %s" % keystr[1:]
+                            "Can't interpret registry key value: {}".format(keystr[1:])
                         )
                 else:
-                    win32ui.MessageBox("Directory '%s' not found" % d)
+                    win32ui.MessageBox("Directory '{}' not found".format(d))
                 if x:
                     for xd in x:
                         if xd not in dirs:
@@ -281,8 +283,9 @@ class GrepDocument(docview.RichEditDoc):
         self.fndx = -1
         if not self.dp:
             self.GetFirstView().Append(
-                "# ERROR: '%s' does not resolve to any search locations"
-                % self.dirpattern
+                "# ERROR: '{}' does not resolve to any search locations".format(
+                    self.dirpattern
+                )
             )
             self.SetModifiedFlag(0)
         else:

--- a/Pythonwin/pywin/framework/toolmenu.py
+++ b/Pythonwin/pywin/framework/toolmenu.py
@@ -36,10 +36,10 @@ def LoadToolMenuItems():
     items = []
     lookNo = 1
     while 1:
-        menu = win32ui.GetProfileVal("Tools Menu\\%s" % lookNo, "", "")
+        menu = win32ui.GetProfileVal("Tools Menu\\{}".format(lookNo), "", "")
         if menu == "":
             break
-        cmd = win32ui.GetProfileVal("Tools Menu\\%s" % lookNo, "Command", "")
+        cmd = win32ui.GetProfileVal("Tools Menu\\{}".format(lookNo), "Command", "")
         items.append((menu, cmd))
         lookNo += 1
 
@@ -69,8 +69,8 @@ def WriteToolMenuItems(items):
         return
     itemNo = 1
     for menu, cmd in items:
-        win32ui.WriteProfileVal("Tools Menu\\%s" % itemNo, "", menu)
-        win32ui.WriteProfileVal("Tools Menu\\%s" % itemNo, "Command", cmd)
+        win32ui.WriteProfileVal("Tools Menu\\{}".format(itemNo), "", menu)
+        win32ui.WriteProfileVal("Tools Menu\\{}".format(itemNo), "Command", cmd)
         itemNo += 1
 
 
@@ -115,7 +115,7 @@ def HandleToolCommand(cmd, code):
 
     global tools
     (menuString, pyCmd, desc) = tools[cmd]
-    win32ui.SetStatusText("Executing tool %s" % desc, 1)
+    win32ui.SetStatusText("Executing tool {}".format(desc), 1)
     pyCmd = re.sub(r"\\n", "\n", pyCmd)
     win32ui.DoWaitCursor(1)
     oldFlag = None
@@ -126,13 +126,13 @@ def HandleToolCommand(cmd, code):
         pass
 
     try:
-        exec("%s\n" % pyCmd)
+        exec("{}\n".format(pyCmd))
         worked = 1
     except SystemExit:
         # The program raised a SystemExit - ignore it.
         worked = 1
     except:
-        print("Failed to execute command:\n%s" % pyCmd)
+        print("Failed to execute command:\n{}".format(pyCmd))
         traceback.print_exc()
         worked = 0
     if oldFlag is not None:
@@ -141,7 +141,7 @@ def HandleToolCommand(cmd, code):
     if worked:
         text = "Completed successfully."
     else:
-        text = "Error executing %s." % desc
+        text = "Error executing {}.".format(desc)
     win32ui.SetStatusText(text, 1)
 
 

--- a/Pythonwin/pywin/framework/winout.py
+++ b/Pythonwin/pywin/framework/winout.py
@@ -56,7 +56,7 @@ class WindowOutputDocument(WindowOutputDocumentParent):
         try:
             self.SaveFile(fileName)
         except OSError as details:
-            win32ui.MessageBox("Error - could not save file\r\n\r\n%s" % details)
+            win32ui.MessageBox("Error - could not save file\r\n\r\n{}".format(details))
             return 0
         win32ui.SetStatusText("Ready")
         return 1
@@ -153,7 +153,7 @@ class WindowOutputViewImpl:
                 return 1
             except win32api.error as details:
                 win32ui.SetStatusText(
-                    "The help file could not be opened - %s" % details.strerror
+                    "The help file could not be opened - {}".format(details.strerror)
                 )
                 return 1
             except:
@@ -182,7 +182,7 @@ class WindowOutputViewImpl:
                 if fileName is None:
                     # Don't force update, so it replaces the idle prompt.
                     win32ui.SetStatusText(
-                        "Can't locate the file '%s'" % (fileNameSpec), 0
+                        "Can't locate the file '{}'".format(fileNameSpec), 0
                     )
                     return 1
 
@@ -190,7 +190,7 @@ class WindowOutputViewImpl:
                     "Jumping to line " + lineNoString + " of file " + fileName, 1
                 )
                 if not scriptutils.JumpToDocument(fileName, int(lineNoString)):
-                    win32ui.SetStatusText("Could not open %s" % fileName)
+                    win32ui.SetStatusText("Could not open {}".format(fileName))
                     return 1  # still was an error message.
                 return 1
         return 0  # not an error line

--- a/Pythonwin/pywin/idle/AutoIndent.py
+++ b/Pythonwin/pywin/idle/AutoIndent.py
@@ -101,7 +101,7 @@ class AutoIndent:
             elif key == "context_use_ps1":
                 self.context_use_ps1 = value
             else:
-                raise KeyError("bad option name: %s" % repr(key))
+                raise KeyError("bad option name: {}".format(repr(key)))
 
     # If ispythonsource and guess are true, guess a good value for
     # indentwidth based on file content (if possible), and if

--- a/Pythonwin/pywin/scintilla/IDLEenvironment.py
+++ b/Pythonwin/pywin/scintilla/IDLEenvironment.py
@@ -255,7 +255,7 @@ def TkIndexToOffset(bm, edit, marks):
                         pos = edit.GetTextLength()
                     pos += int(col)
         except (ValueError, IndexError):
-            raise ValueError("Unexpected literal in '%s'" % base)
+            raise ValueError("Unexpected literal in '{}'".format(base))
     elif base == "insert":
         pos = edit.GetSel()[0]
     elif base == "end":
@@ -267,7 +267,9 @@ def TkIndexToOffset(bm, edit, marks):
         try:
             pos = marks[base]
         except KeyError:
-            raise ValueError("Unsupported base offset or undefined mark '%s'" % base)
+            raise ValueError(
+                "Unsupported base offset or undefined mark '{}'".format(base)
+            )
 
     while 1:
         word, nextTokPos = _NextTok(bm, nextTokPos)
@@ -301,7 +303,7 @@ def TkIndexToOffset(bm, edit, marks):
             while pos < end and edit.SCIGetCharAt(pos) not in "\n\r":
                 pos += 1
         else:
-            raise ValueError("Unsupported relative offset '%s'" % word)
+            raise ValueError("Unsupported relative offset '{}'".format(word))
     return max(pos, 0)  # Tkinter is tollerant of -ve indexes - we aren't
 
 
@@ -462,7 +464,7 @@ class TkText:
         try:
             pos = self._getoffset(pos)
         except EmptyRange:
-            raise TextError("Empty range '%s'" % pos)
+            raise TextError("Empty range '{}'".format(pos))
         if name == "insert":
             self.edit.SetSel(pos)
         else:

--- a/Pythonwin/pywin/scintilla/bindings.py
+++ b/Pythonwin/pywin/scintilla/bindings.py
@@ -124,7 +124,7 @@ class BindingsManager:
             handler = getattr(self.parent_view, event + "Event", None)
             if handler is None:
                 # Can't decide if I should report an error??
-                self.report_error("The event name '%s' can not be found." % event)
+                self.report_error("The event name '{}' can not be found.".format(event))
                 # Either way, just let the default handlers grab it.
                 return 1
             binding = self._new_binding(handler, HANDLER_ARGS_NATIVE)
@@ -153,7 +153,7 @@ class BindingsManager:
                 else:
                     rc = 1
         except:
-            message = "Firing event '%s' failed." % event
+            message = "Firing event '{}' failed.".format(event)
             print(message)
             traceback.print_exc()
             self.report_error(message)

--- a/Pythonwin/pywin/scintilla/config.py
+++ b/Pythonwin/pywin/scintilla/config.py
@@ -92,7 +92,7 @@ class ConfigManager:
                 f = find_config_file(f)
                 src_stat = os.stat(f)
             except OSError:
-                self.report_error("Config file '%s' not found" % f)
+                self.report_error("Config file '{}' not found".format(f))
                 return
             self.filename = f
             self.basename = os.path.basename(f)
@@ -210,7 +210,9 @@ class ConfigManager:
                     editor.idle.IDLEExtension(ext)
                     trace("Loaded IDLE extension", ext)
                 except:
-                    self.report_error("Can not load the IDLE extension '%s'" % ext)
+                    self.report_error(
+                        "Can not load the IDLE extension '{}'".format(ext)
+                    )
 
         # Now bind up the key-map (remembering a reverse map
         subsection_keymap = self.get_data("keys")

--- a/Pythonwin/pywin/scintilla/document.py
+++ b/Pythonwin/pywin/scintilla/document.py
@@ -49,8 +49,9 @@ class CScintillaDocument(ParentScintillaDocument):
                 f.close()
         except OSError:
             rc = win32ui.MessageBox(
-                "Could not load the file from %s\n\nDo you want to create a new file?"
-                % filename,
+                "Could not load the file from {}\n\nDo you want to create a new file?".format(
+                    filename
+                ),
                 "Pythonwin",
                 win32con.MB_YESNO | win32con.MB_ICONWARNING,
             )
@@ -64,7 +65,7 @@ class CScintillaDocument(ParentScintillaDocument):
                 finally:
                     f.close()
             except OSError as e:
-                rc = win32ui.MessageBox("Cannot create the file %s" % filename)
+                rc = win32ui.MessageBox("Cannot create the file {}".format(filename))
         return 1
 
     def SaveFile(self, fileName, encoding=None):
@@ -134,14 +135,16 @@ class CScintillaDocument(ParentScintillaDocument):
             dec = text.decode(source_encoding)
         except UnicodeError:
             print(
-                "WARNING: Failed to decode bytes from '%s' encoding - treating as latin1"
-                % source_encoding
+                "WARNING: Failed to decode bytes from '{}' encoding - treating as latin1".format(
+                    source_encoding
+                )
             )
             dec = text.decode("latin1")
         except LookupError:
             print(
-                "WARNING: Invalid encoding '%s' specified - treating as latin1"
-                % source_encoding
+                "WARNING: Invalid encoding '{}' specified - treating as latin1".format(
+                    source_encoding
+                )
             )
             dec = text.decode("latin1")
         # and put it back as utf8 - this shouldn't fail.

--- a/Pythonwin/pywin/scintilla/find.py
+++ b/Pythonwin/pywin/scintilla/find.py
@@ -161,7 +161,7 @@ def _FindIt(control, searchParams):
             rc = FOUND_LOOPED_BACK
         else:
             lastSearch.sel = -1, -1
-            win32ui.SetStatusText("Can not find '%s'" % searchParams.findText)
+            win32ui.SetStatusText("Can not find '{}'".format(searchParams.findText))
 
     if rc != FOUND_NOTHING:
         lastSearch.sel = foundSel
@@ -184,7 +184,7 @@ def _FindIt(control, searchParams):
 
 def _ReplaceIt(control):
     control = _GetControl(control)
-    statusText = "Can not find '%s'." % lastSearch.findText
+    statusText = "Can not find '{}'.".format(lastSearch.findText)
     rc = FOUND_NOTHING
     if control is not None and lastSearch.sel != (-1, -1):
         control.ReplaceSel(lastSearch.replaceText)

--- a/Pythonwin/pywin/scintilla/view.py
+++ b/Pythonwin/pywin/scintilla/view.py
@@ -437,7 +437,7 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
             modName = m.group("name")
             fileName = pywin.framework.scriptutils.LocatePythonFile(modName)
             if fileName is None:
-                win32ui.SetStatusText("Can't locate module %s" % modName)
+                win32ui.SetStatusText("Can't locate module {}".format(modName))
                 return 1  # Let the default get it.
             else:
                 win32ui.GetApp().OpenDocumentFile(fileName)
@@ -836,8 +836,9 @@ def LoadConfiguration():
             configManager = ConfigManager("default")
             if configManager.last_error:
                 win32ui.MessageBox(
-                    "Error loading configuration 'default'\n\n%s"
-                    % (configManager.last_error)
+                    "Error loading configuration 'default'\n\n{}".format(
+                        configManager.last_error
+                    )
                 )
 
 

--- a/Pythonwin/pywin/test/test_exe.py
+++ b/Pythonwin/pywin/test/test_exe.py
@@ -68,7 +68,7 @@ class TestPythonwinExe(unittest.TestCase):
 
     def tearDown(self):
         os.remove(self.tfn)
-        print("-- removed '%s' --" % self.tfn, file=sys.stderr)
+        print("-- removed '{}' --".format(self.tfn), file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/Pythonwin/pywin/tools/regedit.py
+++ b/Pythonwin/pywin/tools/regedit.py
@@ -248,7 +248,7 @@ class RegistryValueView(docview.ListView):
             try:
                 self.SetItemsCurrentValue(item, keyVal, d.newvalue)
             except win32api.error as exc:
-                win32ui.MessageBox("Error setting value\r\n\n%s" % exc.strerror)
+                win32ui.MessageBox("Error setting value\r\n\n{}".format(exc.strerror))
             self.UpdateForRegItem(item)
 
     def GetItemsCurrentValue(self, item, valueName):

--- a/com/win32com/__init__.py
+++ b/com/win32com/__init__.py
@@ -36,7 +36,9 @@ def SetupEnvironment():
     KEY_QUERY_VALUE = 0x1
     # Open the root key once, as this is quite slow on NT.
     try:
-        keyName = "SOFTWARE\\Python\\PythonCore\\%s\\PythonPath\\win32com" % sys.winver
+        keyName = "SOFTWARE\\Python\\PythonCore\\{}\\PythonPath\\win32com".format(
+            sys.winver
+        )
         key = win32api.RegOpenKey(HKEY_LOCAL_MACHINE, keyName, 0, KEY_QUERY_VALUE)
     except (win32api.error, AttributeError):
         key = None

--- a/com/win32com/client/build.py
+++ b/com/win32com/client/build.py
@@ -383,7 +383,7 @@ class DispatchItem(OleItem):
 
         resclsid = entry.GetResultCLSID()
         if resclsid:
-            resclsid = "'%s'" % resclsid
+            resclsid = "'{}'".format(resclsid)
         else:
             resclsid = "None"
         # Strip the default values from the arg desc
@@ -434,7 +434,7 @@ class DispatchItem(OleItem):
                 s += "{}\t\tret = Dispatch(ret, {}, {})\n".format(
                     linePrefix, repr(name), resclsid
                 )
-                s += "%s\treturn ret" % linePrefix
+                s += "{}\treturn ret".format(linePrefix)
             elif rd == pythoncom.VT_BSTR:
                 s = f"{linePrefix}\t# Result is a Unicode object\n"
                 s += "%s\treturn self._oleobj_.InvokeTypes(%d, LCID, %s, %s, %s%s)" % (

--- a/com/win32com/client/combrowse.py
+++ b/com/win32com/client/combrowse.py
@@ -173,7 +173,7 @@ class HLIHelpFile(HLICOM):
 
         fname, ctx = self.myobject
         base = os.path.split(fname)[1]
-        return "Help reference in %s" % (base)
+        return "Help reference in {}".format(base)
 
     def TakeDefaultAction(self):
         fname, ctx = self.myobject
@@ -252,10 +252,10 @@ class HLIRegisteredTypeLibrary(HLICOM):
             if platform != "win32":
                 extraDescs.append(platform)
             if lcid:
-                extraDescs.append("locale=%s" % lcid)
+                extraDescs.append("locale={}".format(lcid))
             extraDesc = ""
             if extraDescs:
-                extraDesc = " (%s)" % ", ".join(extraDescs)
+                extraDesc = " ({})".format(", ".join(extraDescs))
             ret.append(HLITypeLib(fname, "Type Library" + extraDesc))
         ret.sort()
         return ret
@@ -534,7 +534,7 @@ class HLITypeLib(HLICOM):
         try:
             tlb = pythoncom.LoadTypeLib(self.myobject)
         except pythoncom.com_error:
-            return [browser.MakeHLI("%s can not be loaded" % self.myobject)]
+            return [browser.MakeHLI("{} can not be loaded".format(self.myobject))]
 
         for i in range(tlb.GetTypeInfoCount()):
             try:

--- a/com/win32com/client/dynamic.py
+++ b/com/win32com/client/dynamic.py
@@ -220,7 +220,7 @@ class CDispatch:
         # desirable???
 
     def __repr__(self):
-        return "<COMObject %s>" % (self._username_)
+        return "<COMObject {}>".format(self._username_)
 
     def __str__(self):
         # __str__ is used when the user does "print(object)", so we gracefully
@@ -407,7 +407,9 @@ class CDispatch:
         try:
             # print(f"Method code for {self._username_} is:\n", methodCode)
             # self._print_details_()
-            codeObject = compile(methodCode, "<COMObject %s>" % self._username_, "exec")
+            codeObject = compile(
+                methodCode, "<COMObject {}>".format(self._username_), "exec"
+            )
             # Exec the code object
             tempNameSpace = {}
             # "Dispatch" in the exec'd code is win32com.client.Dispatch, not ours.
@@ -606,13 +608,13 @@ class CDispatch:
                 debug_attr_print("Cached items has attribute!", ret)
                 return ret
             except (KeyError, AttributeError):
-                debug_attr_print("Attribute %s not in cache" % attr)
+                debug_attr_print("Attribute {} not in cache".format(attr))
 
         # If we are still here, and have a retEntry, get the OLE item
         if retEntry is not None:
             invoke_type = _GetDescInvokeType(retEntry, pythoncom.INVOKE_PROPERTYGET)
             debug_attr_print(
-                "Getting property Id 0x%x from OLE object" % retEntry.dispid
+                "Getting property Id 0x{:x} from OLE object".format(retEntry.dispid)
             )
             try:
                 ret = self._oleobj_.Invoke(retEntry.dispid, 0, invoke_type, 1)

--- a/com/win32com/client/gencache.py
+++ b/com/win32com/client/gencache.py
@@ -77,7 +77,9 @@ pickleVersion = 1
 def _SaveDicts():
     if is_readonly:
         raise RuntimeError(
-            "Trying to write to a readonly gencache ('%s')!" % win32com.__gen_path__
+            "Trying to write to a readonly gencache ('{}')!".format(
+                win32com.__gen_path__
+            )
         )
     f = open(os.path.join(GetGeneratePath(), "dicts.dat"), "wb")
     try:
@@ -729,7 +731,7 @@ def GetGeneratedInfos():
 
 def _GetModule(fname):
     """Given the name of a module in the gen_py directory, import and return it."""
-    mod_name = "win32com.gen_py.%s" % fname
+    mod_name = "win32com.gen_py.{}".format(fname)
     mod = __import__(mod_name)
     return sys.modules[mod_name]
 

--- a/com/win32com/client/genpy.py
+++ b/com/win32com/client/genpy.py
@@ -339,7 +339,8 @@ class DispatchItem(build.DispatchItem, WritableItem):
         try:
             progId = pythoncom.ProgIDFromCLSID(self.clsid)
             print(
-                "\t# This class is creatable by the name '%s'" % (progId), file=stream
+                "\t# This class is creatable by the name '{}'".format(progId),
+                file=stream,
             )
         except pythoncom.com_error:
             pass
@@ -361,7 +362,8 @@ class DispatchItem(build.DispatchItem, WritableItem):
         try:
             progId = pythoncom.ProgIDFromCLSID(self.clsid)
             print(
-                "\t# This class is creatable by the name '%s'" % (progId), file=stream
+                "\t# This class is creatable by the name '{}'".format(progId),
+                file=stream,
             )
         except pythoncom.com_error:
             pass
@@ -490,8 +492,9 @@ class DispatchItem(build.DispatchItem, WritableItem):
                     print("\t# Result is of type " + entry.GetResultName(), file=stream)
                 if entry.wasProperty:
                     print(
-                        "\t# The method %s is actually a property, but must be used as a method to correctly pass the arguments"
-                        % name,
+                        "\t# The method {} is actually a property, but must be used as a method to correctly pass the arguments".format(
+                            name
+                        ),
                         file=stream,
                     )
                 ret = self.MakeFuncMethod(entry, build.MakePublicAttributeName(name))
@@ -648,8 +651,9 @@ class DispatchItem(build.DispatchItem, WritableItem):
             else:
                 typename = "property"
                 ret = [
-                    "\tdef __call__(self):\n\t\treturn self._ApplyTypes_(*%s)"
-                    % propArgs
+                    "\tdef __call__(self):\n\t\treturn self._ApplyTypes_(*{})".format(
+                        propArgs
+                    )
                 ]
             print(
                 f"\t# Default {typename} for this class is '{entry.names[0]}'",
@@ -694,7 +698,7 @@ class DispatchItem(build.DispatchItem, WritableItem):
         )
         # Iterator is wrapped as PyIEnumVariant, and each result of __next__ is Dispatch'ed if necessary
         print(
-            "\t\treturn win32com.client.util.Iterator(ob, %s)" % resultCLSID,
+            "\t\treturn win32com.client.util.Iterator(ob, {})".format(resultCLSID),
             file=stream,
         )
 
@@ -728,11 +732,14 @@ class DispatchItem(build.DispatchItem, WritableItem):
             else:
                 typename = "property"
                 ret = [
-                    "\tdef __len__(self):\n\t\treturn self._ApplyTypes_(*%s)" % propArgs
+                    "\tdef __len__(self):\n\t\treturn self._ApplyTypes_(*{})".format(
+                        propArgs
+                    )
                 ]
             print(
-                "\t#This class has Count() %s - allow len(ob) to provide this"
-                % (typename),
+                "\t#This class has Count() {} - allow len(ob) to provide this".format(
+                    typename
+                ),
                 file=stream,
             )
             for line in ret:
@@ -787,11 +794,14 @@ class CoClassItem(build.OleItem, WritableItem):
                 ref.bWritten = 1
         try:
             progId = pythoncom.ProgIDFromCLSID(self.clsid)
-            print("# This CoClass is known by the name '%s'" % (progId), file=stream)
+            print(
+                "# This CoClass is known by the name '{}'".format(progId), file=stream
+            )
         except pythoncom.com_error:
             pass
         print(
-            "class %s(CoClassBaseClass): # A CoClass" % (self.python_name), file=stream
+            "class {}(CoClassBaseClass): # A CoClass".format(self.python_name),
+            file=stream,
         )
         if doc and doc[1]:
             print("\t# " + doc[1], file=stream)
@@ -807,7 +817,7 @@ class CoClassItem(build.OleItem, WritableItem):
                 key = item.python_name
             else:
                 key = repr(str(item.clsid))  # really the iid.
-            print("\t\t%s," % (key), file=stream)
+            print("\t\t{},".format(key), file=stream)
         print("\t]", file=stream)
         if defItem:
             if defItem.bWritten:
@@ -1107,7 +1117,7 @@ class Generator:
                 f"# From type library '{os.path.split(self.sourceFilename)[1]}'",
                 file=self.file,
             )
-        print("# On %s" % time.ctime(time.time()), file=self.file)
+        print("# On {}".format(time.ctime(time.time())), file=self.file)
 
         print(build._makeDocString(docDesc), file=self.file)
 

--- a/com/win32com/client/makepy.py
+++ b/com/win32com/client/makepy.py
@@ -89,7 +89,9 @@ def ShowInfo(spec):
             )
         except pythoncom.com_error:  # May be badly registered.
             sys.stderr.write(
-                "Warning - could not load registered typelib '%s'\n" % (tlbSpec.clsid)
+                "Warning - could not load registered typelib '{}'\n".format(
+                    tlbSpec.clsid
+                )
             )
             tlb = None
 
@@ -100,7 +102,7 @@ def ShowInfo(spec):
         desc = tlbSpec.desc
         if desc is None:
             if tlb is None:
-                desc = "<Could not load typelib %s>" % (tlbSpec.dll)
+                desc = "<Could not load typelib {}>".format(tlbSpec.dll)
             else:
                 desc = tlb.GetDocumentation(-1)[0]
         print(desc)
@@ -143,7 +145,7 @@ class SimpleProgress(genpy.GeneratorProgress):
             sys.stderr.write(desc + "\n")
 
     def LogBeginGenerate(self, filename):
-        self.VerboseProgress("Generating to %s" % filename, 1)
+        self.VerboseProgress("Generating to {}".format(filename), 1)
 
     def LogWarning(self, desc):
         self.VerboseProgress("WARNING: " + desc, 1)
@@ -209,7 +211,7 @@ def GetTypeLibsForSpec(arg):
                 except pythoncom.com_error:
                     pass
             if len(tlbs) == 0:
-                print("Could not locate a type library matching '%s'" % (arg))
+                print("Could not locate a type library matching '{}'".format(arg))
             for spec in tlbs:
                 # Version numbers not always reliable if enumerated from registry.
                 # (as some libs use hex, other's don't.  Both examples from MS, of course.)

--- a/com/win32com/demos/connect.py
+++ b/com/win32com/demos/connect.py
@@ -65,7 +65,7 @@ def CheckEvent(server, client, val, verbose):
     if client.last_event_arg != val:
         raise RuntimeError(f"Sent {val!r}, but got back {client.last_event_arg!r}")
     if verbose:
-        print("Sent and received %r" % val)
+        print("Sent and received {!r}".format(val))
 
 
 # A simple test script for all this.

--- a/com/win32com/demos/dump_clipboard.py
+++ b/com/win32com/demos/dump_clipboard.py
@@ -46,7 +46,7 @@ def DumpClipboard():
             elif medium.tymed == pythoncom.TYMED_HGLOBAL:
                 data = "%d bytes via HGLOBAL" % len(medium.data)
             elif medium.tymed == pythoncom.TYMED_FILE:
-                data = "filename '%s'" % data
+                data = "filename '{}'".format(data)
             elif medium.tymed == pythoncom.TYMED_ISTREAM:
                 stream = medium.data
                 stream.Seek(0, 0)

--- a/com/win32com/demos/excelRTDServer.py
+++ b/com/win32com/demos/excelRTDServer.py
@@ -152,7 +152,7 @@ class ExcelRTDServer:
         GetNewValues = True
         result = self.topics[TopicID]
         if result is None:
-            result = "# %s: Waiting for update" % self.__class__.__name__
+            result = "# {}: Waiting for update".format(self.__class__.__name__)
         else:
             result = result.GetValue()
 
@@ -391,7 +391,7 @@ class TimeTopic(RTDTopic):
             # We could simply return a "# ERROR" type string as the
             # topic value, but explosions like this should be able to get handled by
             # the VBA-side "On Error" stuff.
-            raise ValueError("Invalid topic strings: %s" % str(TopicStrings))
+            raise ValueError("Invalid topic strings: {}".format(str(TopicStrings)))
 
         # self.cmd = str(self.cmd)
         self.delay = float(self.delay)

--- a/com/win32com/demos/iebutton.py
+++ b/com/win32com/demos/iebutton.py
@@ -90,7 +90,7 @@ class IEButton:
         # put stubs for non-implemented methods
         for method in self._public_methods_:
             if not hasattr(self, method):
-                print("providing default stub for %s" % method)
+                print("providing default stub for {}".format(method))
                 setattr(self, method, Stub(method))
 
     def QueryStatus(self, pguidCmdGroup, prgCmds, cmdtextf):

--- a/com/win32com/demos/ietoolbar.py
+++ b/com/win32com/demos/ietoolbar.py
@@ -194,7 +194,7 @@ class IEToolbar:
         # put stubs for non-implemented methods
         for method in self._public_methods_:
             if not hasattr(self, method):
-                print("providing default stub for %s" % method)
+                print("providing default stub for {}".format(method))
                 setattr(self, method, Stub(method))
 
     def GetWindow(self):

--- a/com/win32com/makegw/makegw.py
+++ b/com/win32com/makegw/makegw.py
@@ -111,8 +111,9 @@ def make_framework_support(
         #    if interface.base not in ["IUnknown", "IDispatch"]:
         #      fout.write('#include "Py%s.h"\n' % interface.base)
         fout.write(
-            '#include "Py%s.h"\n\n// @doc - This file contains autoduck documentation\n'
-            % interface.name
+            '#include "Py{}.h"\n\n// @doc - This file contains autoduck documentation\n'.format(
+                interface.name
+            )
         )
         if bMakeInterface:
             ifc_cpp_writer(fout, interface)
@@ -166,7 +167,9 @@ public:
     )
     for method in interface.methods:
         f.write(
-            "\tstatic PyObject *%s(PyObject *self, PyObject *args);\n" % method.name
+            "\tstatic PyObject *{}(PyObject *self, PyObject *args);\n".format(
+                method.name
+            )
         )
     f.write(
         f"""\
@@ -244,7 +247,7 @@ PyObject *Py{interfacename}::{method}(PyObject *self, PyObject *args)
                         cleanup_gil += argCvt.GetInterfaceArgCleanupGIL()
                 comArgName, comArgDeclString = argCvt.GetInterfaceCppObjectInfo()
                 if comArgDeclString:  # If we should declare a variable
-                    codeCobjects += "\t%s;\n" % comArgDeclString
+                    codeCobjects += "\t{};\n".format(comArgDeclString)
                 argsCOM += ", " + comArgName
             except makegwparse.error_not_supported as why:
                 f.write(
@@ -264,7 +267,7 @@ PyObject *Py{interfacename}::{method}(PyObject *self, PyObject *args)
                 )
 
                 formatChars += "O"
-                argsParseTuple += ", &ob%s" % arg.name
+                argsParseTuple += ", &ob{}".format(arg.name)
 
                 argsCOM += ", " + arg.name
                 cleanup += f"\tPyObject_Free{arg.type}({arg.name});\n"
@@ -328,8 +331,8 @@ PyObject *Py{interfacename}::{method}(PyObject *self, PyObject *args)
             f.write("\tPy_RETURN_NONE;\n")
         f.write("\n}\n\n")
 
-    f.write("// @object Py%s|Description of the interface\n" % (name))
-    f.write("static struct PyMethodDef Py%s_methods[] =\n{\n" % name)
+    f.write("// @object Py{}|Description of the interface\n".format(name))
+    f.write("static struct PyMethodDef Py{}_methods[] =\n{{\n".format(name))
     for method in interface.methods:
         f.write(
             '\t{{ "{}", Py{}::{}, 1 }}, // @pymeth {}|Description of {}\n'.format(
@@ -390,15 +393,15 @@ protected:
     else:
         f.write("\n\n")
 
-    f.write("\t// %s\n" % name)
+    f.write("\t// {}\n".format(name))
 
     for method in interface.methods:
-        f.write("\tSTDMETHOD(%s)(\n" % method.name)
+        f.write("\tSTDMETHOD({})(\n".format(method.name))
         if method.args:
             for arg in method.args[:-1]:
-                f.write("\t\t%s,\n" % (arg.GetRawDeclaration()))
+                f.write("\t\t{},\n".format(arg.GetRawDeclaration()))
             arg = method.args[-1]
-            f.write("\t\t%s);\n\n" % (arg.GetRawDeclaration()))
+            f.write("\t\t{});\n\n".format(arg.GetRawDeclaration()))
         else:
             f.write("\t\tvoid);\n\n")
 
@@ -456,7 +459,7 @@ STDMETHODIMP {gname}::{method.name}(
                 if arg.HasAttribute("out"):
                     cout += 1
                     if arg.indirectionLevel == 2:
-                        f.write("\tif (%s==NULL) return E_POINTER;\n" % arg.name)
+                        f.write("\tif ({}==NULL) return E_POINTER;\n".format(arg.name))
                 if arg.HasAttribute("in"):
                     try:
                         argCvt = makegwparse.make_arg_converter(arg)
@@ -486,9 +489,9 @@ STDMETHODIMP {gname}::{method.name}(
                                 arg.name, method.name
                             )
                         )
-                        codePost += "\tPy_DECREF(ob%s);\n" % arg.name
+                        codePost += "\tPy_DECREF(ob{});\n".format(arg.name)
                         formatChars += "O"
-                        argStr += ", ob%s" % arg.name
+                        argStr += ", ob{}".format(arg.name)
 
         if needConversion:
             f.write("\tUSES_CONVERSION;\n")
@@ -551,8 +554,9 @@ STDMETHODIMP {gname}::{method.name}(
                 f.write("\tBOOL bPythonIsHappy = TRUE;\n")
                 f.write(codePost)
                 f.write(
-                    '\tif (!bPythonIsHappy) hr = MAKE_PYCOM_GATEWAY_FAILURE_CODE("%s");\n'
-                    % method.name
+                    '\tif (!bPythonIsHappy) hr = MAKE_PYCOM_GATEWAY_FAILURE_CODE("{}");\n'.format(
+                        method.name
+                    )
                 )
             f.write("\tPy_DECREF(result);\n")
         f.write("\treturn hr;\n}\n\n")

--- a/com/win32com/makegw/makegwparse.py
+++ b/com/win32com/makegw/makegwparse.py
@@ -127,7 +127,9 @@ class ArgFormatter:
     def GetInterfaceArgCleanup(self):
         "Return cleanup code for C++ args passed to the interface method."
         if DEBUG:
-            return "/* GetInterfaceArgCleanup output goes here: %s */\n" % self.arg.name
+            return "/* GetInterfaceArgCleanup output goes here: {} */\n".format(
+                self.arg.name
+            )
         else:
             return ""
 
@@ -136,8 +138,9 @@ class ArgFormatter:
         method that must be executed with the GIL held"""
         if DEBUG:
             return (
-                "/* GetInterfaceArgCleanup (GIL held) output goes here: %s */\n"
-                % self.arg.name
+                "/* GetInterfaceArgCleanup (GIL held) output goes here: {} */\n".format(
+                    self.arg.name
+                )
             )
         else:
             return ""
@@ -163,9 +166,8 @@ class ArgFormatter:
         # 	return "\t%s %s;\n" % (self.arg.type, self.arg.name)
         # else:
         if DEBUG:
-            return (
-                "/* Declare ParseArgTupleInputConverter goes here: %s */\n"
-                % self.arg.name
+            return "/* Declare ParseArgTupleInputConverter goes here: {} */\n".format(
+                self.arg.name
             )
         else:
             return ""
@@ -173,14 +175,16 @@ class ArgFormatter:
     def GetParsePostCode(self):
         "Get a string of C++ code to be executed after (ie, to finalise) the PyArg_ParseTuple conversion"
         if DEBUG:
-            return "/* GetParsePostCode code goes here: %s */\n" % self.arg.name
+            return "/* GetParsePostCode code goes here: {} */\n".format(self.arg.name)
         else:
             return ""
 
     def GetBuildForInterfacePreCode(self):
         "Get a string of C++ code to be executed before (ie, to initialise) the Py_BuildValue conversion for Interfaces"
         if DEBUG:
-            return "/* GetBuildForInterfacePreCode goes here: %s */\n" % self.arg.name
+            return "/* GetBuildForInterfacePreCode goes here: {} */\n".format(
+                self.arg.name
+            )
         else:
             return ""
 
@@ -189,13 +193,17 @@ class ArgFormatter:
         s = self.GetBuildForInterfacePreCode()  # Usually the same
         if DEBUG:
             if s[:4] == "/* G":
-                s = "/* GetBuildForGatewayPreCode goes here: %s */\n" % self.arg.name
+                s = "/* GetBuildForGatewayPreCode goes here: {} */\n".format(
+                    self.arg.name
+                )
         return s
 
     def GetBuildForInterfacePostCode(self):
         "Get a string of C++ code to be executed after (ie, to finalise) the Py_BuildValue conversion for Interfaces"
         if DEBUG:
-            return "/* GetBuildForInterfacePostCode goes here: %s */\n" % self.arg.name
+            return "/* GetBuildForInterfacePostCode goes here: {} */\n".format(
+                self.arg.name
+            )
         return ""
 
     def GetBuildForGatewayPostCode(self):
@@ -203,7 +211,9 @@ class ArgFormatter:
         s = self.GetBuildForInterfacePostCode()  # Usually the same
         if DEBUG:
             if s[:4] == "/* G":
-                s = "/* GetBuildForGatewayPostCode goes here: %s */\n" % self.arg.name
+                s = "/* GetBuildForGatewayPostCode goes here: {} */\n".format(
+                    self.arg.name
+                )
         return s
 
     def GetAutoduckString(self):
@@ -229,7 +239,7 @@ class ArgFormatterFloat(ArgFormatter):
 
     def DeclareParseArgTupleInputConverter(self):
         # Declare a double variable
-        return "\tdouble dbl%s;\n" % self.arg.name
+        return "\tdouble dbl{};\n".format(self.arg.name)
 
     def GetParseTupleArg(self):
         return "&dbl" + self.arg.name
@@ -245,7 +255,7 @@ class ArgFormatterFloat(ArgFormatter):
 
     def GetBuildForGatewayPreCode(self):
         return (
-            "\tdbl%s = " % self.arg.name
+            "\tdbl{} = ".format(self.arg.name)
             + self._IndirectPrefix(self._GetDeclaredIndirection(), 0)
             + self.arg.name
             + ";\n"
@@ -256,7 +266,7 @@ class ArgFormatterFloat(ArgFormatter):
         if self.gatewayMode:
             s += self._IndirectPrefix(self._GetDeclaredIndirection(), 0)
         s += self.arg.name
-        s += " = (float)dbl%s;\n" % self.arg.name
+        s += " = (float)dbl{};\n".format(self.arg.name)
         return s
 
 
@@ -268,7 +278,7 @@ class ArgFormatterShort(ArgFormatter):
 
     def DeclareParseArgTupleInputConverter(self):
         # Declare a double variable
-        return "\tINT i%s;\n" % self.arg.name
+        return "\tINT i{};\n".format(self.arg.name)
 
     def GetParseTupleArg(self):
         return "&i" + self.arg.name
@@ -284,7 +294,7 @@ class ArgFormatterShort(ArgFormatter):
 
     def GetBuildForGatewayPreCode(self):
         return (
-            "\ti%s = " % self.arg.name
+            "\ti{} = ".format(self.arg.name)
             + self._IndirectPrefix(self._GetDeclaredIndirection(), 0)
             + self.arg.name
             + ";\n"
@@ -295,7 +305,7 @@ class ArgFormatterShort(ArgFormatter):
         if self.gatewayMode:
             s += self._IndirectPrefix(self._GetDeclaredIndirection(), 0)
         s += self.arg.name
-        s += " = i%s;\n" % self.arg.name
+        s += " = i{};\n".format(self.arg.name)
         return s
 
 
@@ -306,7 +316,7 @@ class ArgFormatterLONG_PTR(ArgFormatter):
 
     def DeclareParseArgTupleInputConverter(self):
         # Declare a PyObject variable
-        return "\tPyObject *ob%s;\n" % self.arg.name
+        return "\tPyObject *ob{};\n".format(self.arg.name)
 
     def GetParseTupleArg(self):
         return "&ob" + self.arg.name
@@ -318,7 +328,7 @@ class ArgFormatterLONG_PTR(ArgFormatter):
         return "ob" + self.arg.name
 
     def GetBuildForInterfacePostCode(self):
-        return "\tPy_XDECREF(ob%s);\n" % self.arg.name
+        return "\tPy_XDECREF(ob{});\n".format(self.arg.name)
 
     def GetParsePostCode(self):
         return "\tif (bPythonIsHappy && !PyWinLong_AsULONG_PTR(ob{}, (ULONG_PTR *){})) bPythonIsHappy = FALSE;\n".format(
@@ -330,7 +340,7 @@ class ArgFormatterLONG_PTR(ArgFormatter):
         return f"\tob{self.arg.name} = PyWinObject_FromULONG_PTR({notdirected});\n"
 
     def GetBuildForGatewayPostCode(self):
-        return "\tPy_XDECREF(ob%s);\n" % self.arg.name
+        return "\tPy_XDECREF(ob{});\n".format(self.arg.name)
 
 
 class ArgFormatterPythonCOM(ArgFormatter):
@@ -344,19 +354,19 @@ class ArgFormatterPythonCOM(ArgFormatter):
     # 		"%s %s%s" % (self.arg.unc_type, "*" * self._GetDeclaredIndirection(), self.arg.name)
     def DeclareParseArgTupleInputConverter(self):
         # Declare a PyObject variable
-        return "\tPyObject *ob%s;\n" % self.arg.name
+        return "\tPyObject *ob{};\n".format(self.arg.name)
 
     def GetParseTupleArg(self):
         return "&ob" + self.arg.name
 
     def _GetPythonTypeDesc(self):
-        return "<o Py%s>" % self.arg.type
+        return "<o Py{}>".format(self.arg.type)
 
     def GetBuildValueArg(self):
         return "ob" + self.arg.name
 
     def GetBuildForInterfacePostCode(self):
-        return "\tPy_XDECREF(ob%s);\n" % self.arg.name
+        return "\tPy_XDECREF(ob{});\n".format(self.arg.name)
 
 
 class ArgFormatterBSTR(ArgFormatterPythonCOM):
@@ -379,7 +389,7 @@ class ArgFormatterBSTR(ArgFormatterPythonCOM):
         )
 
     def GetBuildForGatewayPostCode(self):
-        return "\tPy_XDECREF(ob%s);\n" % self.arg.name
+        return "\tPy_XDECREF(ob{});\n".format(self.arg.name)
 
 
 class ArgFormatterOLECHAR(ArgFormatterPythonCOM):
@@ -398,7 +408,7 @@ class ArgFormatterOLECHAR(ArgFormatterPythonCOM):
         )
 
     def GetInterfaceArgCleanup(self):
-        return "\tSysFreeString(%s);\n" % self.GetIndirectedArgName(None, 1)
+        return "\tSysFreeString({});\n".format(self.GetIndirectedArgName(None, 1))
 
     def GetBuildForInterfacePreCode(self):
         # the variable was declared with just its builtin indirection
@@ -413,7 +423,7 @@ class ArgFormatterOLECHAR(ArgFormatterPythonCOM):
         )
 
     def GetBuildForGatewayPostCode(self):
-        return "\tPy_XDECREF(ob%s);\n" % self.arg.name
+        return "\tPy_XDECREF(ob{});\n".format(self.arg.name)
 
 
 class ArgFormatterTCHAR(ArgFormatterPythonCOM):
@@ -432,7 +442,9 @@ class ArgFormatterTCHAR(ArgFormatterPythonCOM):
         )
 
     def GetInterfaceArgCleanup(self):
-        return "\tPyWinObject_FreeTCHAR(%s);\n" % self.GetIndirectedArgName(None, 1)
+        return "\tPyWinObject_FreeTCHAR({});\n".format(
+            self.GetIndirectedArgName(None, 1)
+        )
 
     def GetBuildForInterfacePreCode(self):
         # the variable was declared with just its builtin indirection
@@ -443,7 +455,7 @@ class ArgFormatterTCHAR(ArgFormatterPythonCOM):
         return "// ??? - TCHAR post code\n"
 
     def GetBuildForGatewayPostCode(self):
-        return "\tPy_XDECREF(ob%s);\n" % self.arg.name
+        return "\tPy_XDECREF(ob{});\n".format(self.arg.name)
 
 
 class ArgFormatterIID(ArgFormatterPythonCOM):
@@ -462,7 +474,7 @@ class ArgFormatterIID(ArgFormatterPythonCOM):
         return f"\tob{self.arg.name} = PyWinObject_FromIID({notdirected});\n"
 
     def GetInterfaceCppObjectInfo(self):
-        return self.arg.name, "IID %s" % (self.arg.name)
+        return self.arg.name, "IID {}".format(self.arg.name)
 
 
 class ArgFormatterTime(ArgFormatterPythonCOM):
@@ -499,7 +511,7 @@ class ArgFormatterTime(ArgFormatterPythonCOM):
         ret = ""
         if self.builtinIndirection + self.arg.indirectionLevel > 1:
             # memory returned into an OLECHAR should be freed
-            ret = "\tCoTaskMemFree(%s);\n" % self.arg.name
+            ret = "\tCoTaskMemFree({});\n".format(self.arg.name)
         return ret + ArgFormatterPythonCOM.GetBuildForInterfacePostCode(self)
 
 
@@ -524,7 +536,7 @@ class ArgFormatterSTATSTG(ArgFormatterPythonCOM):
 
 class ArgFormatterGeneric(ArgFormatterPythonCOM):
     def _GetPythonTypeDesc(self):
-        return "<o %s>" % self.arg.type
+        return "<o {}>".format(self.arg.type)
 
     def GetParsePostCode(self):
         return "\tif (!PyObject_As{}(ob{}, &{}) bPythonIsHappy = FALSE;\n".format(
@@ -587,7 +599,7 @@ class ArgFormatterLARGE_INTEGER(ArgFormatterPythonCOM):
         return "LARGE_INTEGER"
 
     def _GetPythonTypeDesc(self):
-        return "<o %s>" % self.GetKeyName()
+        return "<o {}>".format(self.GetKeyName())
 
     def GetParsePostCode(self):
         return "\tif (!PyWinObject_As{}(ob{}, {})) bPythonIsHappy = FALSE;\n".format(
@@ -661,7 +673,7 @@ class ArgFormatterVARIANT(ArgFormatterPythonCOM):
         return f"\tob{self.arg.name} = PyCom_PyObjectFromVariant({notdirected});\n"
 
     def GetBuildForGatewayPostCode(self):
-        return "\tPy_XDECREF(ob%s);\n" % self.arg.name
+        return "\tPy_XDECREF(ob{});\n".format(self.arg.name)
 
         # Key :		, Python Type Description, ParseTuple format char
 
@@ -913,7 +925,9 @@ class Method:
                 )
             else:
                 print(
-                    "Method %s - Only HRESULT return types are supported." % self.name
+                    "Method {} - Only HRESULT return types are supported.".format(
+                        self.name
+                    )
                 )
             # 				raise error_not_supported,		if VERBOSE:
             print(f"     Method {self.result} {self.name}(")

--- a/com/win32com/server/connect.py
+++ b/com/win32com/server/connect.py
@@ -82,4 +82,4 @@ class ConnectableServer:
                 self._OnNotifyFail(interface, details)
 
     def _OnNotifyFail(self, interface, details):
-        print("Ignoring COM error to connection - %s" % (repr(details)))
+        print("Ignoring COM error to connection - {}".format(repr(details)))

--- a/com/win32com/server/dispatcher.py
+++ b/com/win32com/server/dispatcher.py
@@ -223,7 +223,7 @@ class DispatcherWin32trace(DispatcherTrace):
             # If we have no logger, setup our output.
             import win32traceutil  # Sets up everything.
         self._trace_(
-            "Object with win32trace dispatcher created (object=%s)" % repr(object)
+            "Object with win32trace dispatcher created (object={})".format(repr(object))
         )
 
 

--- a/com/win32com/server/register.py
+++ b/com/win32com/server/register.py
@@ -115,14 +115,14 @@ def _find_localserver_exe(mustfind):
     if not os.path.exists(exeName):
         # See if the registry has some info.
         try:
-            key = "SOFTWARE\\Python\\PythonCore\\%s\\InstallPath" % sys.winver
+            key = "SOFTWARE\\Python\\PythonCore\\{}\\InstallPath".format(sys.winver)
             path = win32api.RegQueryValue(win32con.HKEY_LOCAL_MACHINE, key)
             exeName = os.path.join(path, exeBaseName)
         except (AttributeError, win32api.error):
             pass
     if not os.path.exists(exeName):
         if mustfind:
-            raise RuntimeError("Can not locate the program '%s'" % exeBaseName)
+            raise RuntimeError("Can not locate the program '{}'".format(exeBaseName))
         return None
     return exeName
 
@@ -146,7 +146,7 @@ def _find_localserver_module():
             os.stat(pyfile)
         except OSError:
             raise RuntimeError(
-                "Can not locate the Python module 'win32com.server.%s'" % baseName
+                "Can not locate the Python module 'win32com.server.{}'".format(baseName)
             )
     return pyfile
 
@@ -198,11 +198,11 @@ def RegisterServer(
             "You must specify either the Python Class or Python Policy which implement the COM object."
         )
 
-    keyNameRoot = "CLSID\\%s" % str(clsid)
+    keyNameRoot = "CLSID\\{}".format(str(clsid))
     _set_string(keyNameRoot, desc)
 
     # Also register as an "Application" so DCOM etc all see us.
-    _set_string("AppID\\%s" % clsid, progID)
+    _set_string("AppID\\{}".format(clsid), progID)
     # Depending on contexts requested, register the specified server type.
     # Set default clsctx.
     if not clsctx:
@@ -347,7 +347,7 @@ def GetUnregisterServerKeys(clsid, progID=None, verProgID=None, customKeys=None)
     and uncondtionally deleted at unregister or uninstall time.
     """
     # remove the main CLSID registration
-    ret = [("CLSID\\%s" % str(clsid), win32con.HKEY_CLASSES_ROOT)]
+    ret = [("CLSID\\{}".format(str(clsid)), win32con.HKEY_CLASSES_ROOT)]
     # remove the versioned ProgID registration
     if verProgID:
         ret.append((verProgID, win32con.HKEY_CLASSES_ROOT))
@@ -357,7 +357,7 @@ def GetUnregisterServerKeys(clsid, progID=None, verProgID=None, customKeys=None)
     if progID:
         ret.append((progID, win32con.HKEY_CLASSES_ROOT))
     # The DCOM config tool may write settings to the AppID key for our CLSID
-    ret.append(("AppID\\%s" % str(clsid), win32con.HKEY_CLASSES_ROOT))
+    ret.append(("AppID\\{}".format(str(clsid)), win32con.HKEY_CLASSES_ROOT))
     # Any custom keys?
     if customKeys:
         ret.extend(customKeys)
@@ -589,10 +589,12 @@ def ReExecuteElevated(flags):
             print("@echo off", file=batf)
             # nothing is 'inherited' by the elevated process, including the
             # environment.  I wonder if we need to set more?
-            print("set PYTHONPATH=%s" % os.environ.get("PYTHONPATH", ""), file=batf)
+            print(
+                "set PYTHONPATH={}".format(os.environ.get("PYTHONPATH", "")), file=batf
+            )
             # may be on a different drive - select that before attempting to CD.
             print(os.path.splitdrive(cwd)[0], file=batf)
-            print('cd "%s"' % os.getcwd(), file=batf)
+            print('cd "{}"'.format(os.getcwd()), file=batf)
             print(
                 '{} {} > "{}" 2>&1'.format(
                     win32api.GetShortPathName(exe_to_run), new_params, outfile
@@ -607,7 +609,7 @@ def ReExecuteElevated(flags):
             fMask=shellcon.SEE_MASK_NOCLOSEPROCESS,
             lpVerb="runas",
             lpFile=executable,
-            lpParameters='/C "%s"' % batfile,
+            lpParameters='/C "{}"'.format(batfile),
             nShow=win32con.SW_SHOW,
         )
         hproc = rc["hProcess"]
@@ -621,7 +623,7 @@ def ReExecuteElevated(flags):
 
         if exit_code:
             # Even if quiet you get to see this message.
-            print("Error: registration failed (exit code %s)." % exit_code)
+            print("Error: registration failed (exit code {}).".format(exit_code))
         # if we are quiet then the output if likely to already be nearly
         # empty, so always print it.
         print(output, end=" ")
@@ -669,7 +671,7 @@ if not pythoncom.frozen:
     try:
         win32api.RegQueryValue(
             win32con.HKEY_CLASSES_ROOT,
-            "Component Categories\\%s" % CATID_PythonCOMServer,
+            "Component Categories\\{}".format(CATID_PythonCOMServer),
         )
     except win32api.error:
         try:

--- a/com/win32com/test/testADOEvents.py
+++ b/com/win32com/test/testADOEvents.py
@@ -66,7 +66,7 @@ def TestConnection(dbname):
     c = DispatchWithEvents("ADODB.Connection", ADOEvents)
 
     # Initiate the asynchronous open
-    dsn = "Driver={Microsoft Access Driver (*.mdb)};Dbq=%s" % dbname
+    dsn = "Driver={{Microsoft Access Driver (*.mdb)}};Dbq={}".format(dbname)
     user = "system"
     pw = "manager"
     c.Open(dsn, user, pw, constants.adAsyncConnect)

--- a/com/win32com/test/testAXScript.py
+++ b/com/win32com/test/testAXScript.py
@@ -35,7 +35,7 @@ class AXScript(win32com.test.util.TestCase):
                 next(iter(win32com.axscript.__path__)), "Demos\\Client\\wsh\\test.pys"
             )
         )
-        cmd = 'cscript.exe "%s"' % (file)
+        cmd = 'cscript.exe "{}"'.format(file)
         if verbose:
             print("Testing Windows Scripting host with Python script")
         win32com.test.util.ExecuteShellCommand(cmd, self)

--- a/com/win32com/test/testAccess.py
+++ b/com/win32com/test/testAccess.py
@@ -115,7 +115,7 @@ def DoDumpAccessInfo(dbname):
     try:
         sys.stderr.write("Creating Access Application...\n")
         a = Dispatch("Access.Application")
-        print("Opening database %s" % dbname)
+        print("Opening database {}".format(dbname))
         a.OpenCurrentDatabase(dbname)
         db = a.CurrentDb()
         daodump.DumpDB(db, 1)
@@ -168,7 +168,7 @@ def test(dbname=None):
             print("*** Can not import the MSAccess type libraries - tests skipped")
             return
         dbname = CreateTestAccessDatabase()
-        print("A test database at '%s' was created" % dbname)
+        print("A test database at '{}' was created".format(dbname))
 
     DumpAccessInfo(dbname)
 

--- a/com/win32com/test/testDCOM.py
+++ b/com/win32com/test/testDCOM.py
@@ -40,7 +40,7 @@ def test(serverName):
             )
         )
     else:
-        print("Object created and tested OK on server '%s'" % serverName)
+        print("Object created and tested OK on server '{}'".format(serverName))
 
 
 if __name__ == "__main__":

--- a/com/win32com/test/testall.py
+++ b/com/win32com/test/testall.py
@@ -53,7 +53,7 @@ def CleanGenerated():
 
     if os.path.isdir(win32com.__gen_path__):
         if verbosity > 1:
-            print("Deleting files from %s" % (win32com.__gen_path__))
+            print("Deleting files from {}".format(win32com.__gen_path__))
         shutil.rmtree(win32com.__gen_path__)
     import win32com.client.gencache
 

--- a/com/win32com/test/util.py
+++ b/com/win32com/test/util.py
@@ -43,7 +43,7 @@ def RegisterPythonServer(filename, progids=None, verbose=0):
                 break
             try:
                 HKCR = winreg.HKEY_CLASSES_ROOT
-                hk = winreg.OpenKey(HKCR, "CLSID\\%s" % clsid)
+                hk = winreg.OpenKey(HKCR, "CLSID\\{}".format(clsid))
                 dll = winreg.QueryValue(hk, "InprocServer32")
             except OSError:
                 # no CLSID or InProcServer32 - not registered
@@ -77,12 +77,11 @@ def RegisterPythonServer(filename, progids=None, verbose=0):
             # old, less-secure OS - assume *is* admin.
             is_admin = True
     if not is_admin:
-        msg = (
-            "%r isn't registered, but I'm not an administrator who can register it."
-            % progids[0]
+        msg = "{!r} isn't registered, but I'm not an administrator who can register it.".format(
+            progids[0]
         )
         if why_not:
-            msg += "\n(registration check failed as %s)" % why_not
+            msg += "\n(registration check failed as {})".format(why_not)
         # throw a normal "class not registered" exception - we don't report
         # them the same way as "real" errors.
         raise pythoncom.com_error(winerror.CO_E_CLASSSTRING, msg, None, -1)
@@ -95,7 +94,7 @@ def RegisterPythonServer(filename, progids=None, verbose=0):
     if rc:
         print("Registration command was:")
         print(cmd)
-        raise RuntimeError("Registration of engine '%s' failed" % filename)
+        raise RuntimeError("Registration of engine '{}' failed".format(filename))
 
 
 def ExecuteShellCommand(
@@ -105,7 +104,7 @@ def ExecuteShellCommand(
     tracebacks_ok=0,  # OK if the output contains a t/b?
 ):
     output_name = tempfile.mktemp("win32com_test")
-    cmd += ' > "%s" 2>&1' % output_name
+    cmd += ' > "{}" 2>&1'.format(output_name)
     rc = os.system(cmd)
     output = open(output_name, "r").read().strip()
     os.remove(output_name)
@@ -122,7 +121,7 @@ def ExecuteShellCommand(
             raise Failed("traceback in program output")
         return output
     except Failed as why:
-        print("Failed to exec command '%r'" % cmd)
+        print("Failed to exec command '{!r}'".format(cmd))
         print("Failed as", why)
         print("** start of program output **")
         print(output)
@@ -136,7 +135,7 @@ def assertRaisesCOM_HRESULT(testcase, hresult, func, *args, **kw):
     except pythoncom.com_error as details:
         if details.hresult == hresult:
             return
-    testcase.fail("Excepected COM exception with HRESULT 0x%x" % hresult)
+    testcase.fail("Excepected COM exception with HRESULT 0x{:x}".format(hresult))
 
 
 class CaptureWriter:
@@ -237,7 +236,7 @@ class _CapturingFunctionTestCase(unittest.FunctionTestCase):  # , TestCaseMixin)
 
     def checkOutput(self, output, result):
         if output.find("Traceback") >= 0:
-            msg = "Test output contained a traceback\n---\n%s\n---" % output
+            msg = "Test output contained a traceback\n---\n{}\n---".format(output)
             result.errors.append((self, msg))
 
 

--- a/com/win32com/universal.py
+++ b/com/win32com/universal.py
@@ -133,7 +133,7 @@ class Method:
         # We don't use this ATM.
         #        self.ret = Arg(ret_def)
         if isEventSink and name[:2] != "On":
-            name = "On%s" % name
+            name = "On{}".format(name)
         self.name = name
         cbArgs = 0
         self.args = []

--- a/com/win32com/util.py
+++ b/com/win32com/util.py
@@ -26,7 +26,7 @@ def IIDToInterfaceName(iid):
         try:
             try:
                 return win32api.RegQueryValue(
-                    win32con.HKEY_CLASSES_ROOT, "Interface\\%s" % iid
+                    win32con.HKEY_CLASSES_ROOT, "Interface\\{}".format(iid)
                 )
             except win32api.error:
                 pass

--- a/com/win32comext/adsi/__init__.py
+++ b/com/win32comext/adsi/__init__.py
@@ -43,7 +43,7 @@ def _get_good_ret(
     if hasattr(ob, "Invoke"):
         import win32com.client.dynamic
 
-        name = "Dispatch wrapper around %r" % ob
+        name = "Dispatch wrapper around {!r}".format(ob)
         return win32com.client.dynamic.Dispatch(ob, name, ADSIDispatch)
     return ob
 

--- a/com/win32comext/adsi/demos/scp.py
+++ b/com/win32comext/adsi/demos/scp.py
@@ -219,9 +219,9 @@ def SpnRegister(
     spns,  # List of SPNs to register
     operation,  # Add, replace, or delete SPNs
 ):
-    assert not isinstance(spns, str) and hasattr(spns, "__iter__"), (
-        "spns must be a sequence of strings (got %r)" % spns
-    )
+    assert not isinstance(spns, str) and hasattr(
+        spns, "__iter__"
+    ), "spns must be a sequence of strings (got {!r})".format(spns)
     # Bind to a domain controller.
     # Get the domain for the current user.
     samName = win32api.GetUserNameEx(win32api.NameSamCompatible)
@@ -279,7 +279,9 @@ def _get_option(po, opt_name, default=_NoDefault):
     parser, options = po
     ret = getattr(options, opt_name, default)
     if not ret and default is _NoDefault:
-        parser.error("The '%s' option must be specified for this operation" % opt_name)
+        parser.error(
+            "The '{}' option must be specified for this operation".format(opt_name)
+        )
     if not ret:
         ret = default
     return ret
@@ -512,7 +514,9 @@ def main():
         parser.error("No command specified (use --help for valid commands)")
     for arg in args:
         if arg.lower() not in _handlers_dict:
-            parser.error("Invalid command '%s' (use --help for valid commands)" % arg)
+            parser.error(
+                "Invalid command '{}' (use --help for valid commands)".format(arg)
+            )
 
     # Patch up account-name.
     if options.account_name:
@@ -530,7 +534,7 @@ def main():
     for arg in args:
         handler = _handlers_dict[arg.lower()]  # already been validated
         if handler is None:
-            parser.error("Invalid command '%s'" % arg)
+            parser.error("Invalid command '{}'".format(arg))
         err_msg = None
         try:
             try:

--- a/com/win32comext/adsi/demos/test.py
+++ b/com/win32comext/adsi/demos/test.py
@@ -13,7 +13,7 @@ local_name = win32api.GetComputerName()
 
 def DumpRoot():
     "Dumps the root DSE"
-    path = "LDAP://%srootDSE" % server
+    path = "LDAP://{}rootDSE".format(server)
     rootdse = ADsGetObject(path)
 
     for item in rootdse.Get("SupportedLDAPVersion"):
@@ -57,7 +57,7 @@ def _DumpTheseAttributes(child, attrs):
 def DumpSchema():
     "Dumps the default DSE schema"
     # Bind to rootDSE to get the schemaNamingContext property.
-    path = "LDAP://%srootDSE" % server
+    path = "LDAP://{}rootDSE".format(server)
     rootdse = ADsGetObject(path)
     name = rootdse.Get("schemaNamingContext")
 
@@ -113,7 +113,7 @@ def _DumpObject(ob, level=0):
 
 def DumpAllObjects():
     "Recursively dump the entire directory!"
-    path = "LDAP://%srootDSE" % server
+    path = "LDAP://{}rootDSE".format(server)
     rootdse = ADsGetObject(path)
     name = rootdse.Get("defaultNamingContext")
 
@@ -215,7 +215,9 @@ def DumpLocalGroups():
 def usage(tests):
     import os
 
-    print("Usage: %s [-s server ] [-v] [Test ...]" % os.path.basename(sys.argv[0]))
+    print(
+        "Usage: {} [-s server ] [-v] [Test ...]".format(os.path.basename(sys.argv[0]))
+    )
     print("  -v : Verbose - print more information")
     print("  -s : server - execute the tests against the named server")
     print("where Test is one of:")
@@ -258,7 +260,7 @@ def main():
                     dotests.append(t)
                     break
             else:
-                print("Test '%s' unknown - skipping" % arg)
+                print("Test '{}' unknown - skipping".format(arg))
     if not len(dotests):
         print("Nothing to do!")
         usage(tests)
@@ -266,7 +268,7 @@ def main():
         try:
             test()
         except:
-            print("Test %s failed" % test.__name__)
+            print("Test {} failed".format(test.__name__))
             traceback.print_exc()
 
 

--- a/com/win32comext/axscript/client/error.py
+++ b/com/win32comext/axscript/client/error.py
@@ -245,8 +245,8 @@ def ProcessAXScriptException(
         result = scriptingSite.OnScriptError(gateway)
     except pythoncom.com_error as details:
         print("**OnScriptError failed:", details)
-        print("Exception description:'%s'" % (repr(exceptionInstance.description)))
-        print("Exception text:'%s'" % (repr(exceptionInstance.linetext)))
+        print("Exception description:'{}'".format(repr(exceptionInstance.description)))
+        print("Exception text:'{}'".format(repr(exceptionInstance.linetext)))
         result = winerror.S_FALSE
 
     if result == winerror.S_OK:

--- a/com/win32comext/axscript/client/framework.py
+++ b/com/win32comext/axscript/client/framework.py
@@ -142,7 +142,7 @@ class AXScriptCodeBlock:
     def GetFileName(self):
         # Gets the "file name" for Python - uses <...> so Python doesn't think
         # it is a real file.
-        return "<%s>" % self.name
+        return "<{}>".format(self.name)
 
     def GetDisplayName(self):
         return self.name

--- a/com/win32comext/axscript/client/pydumper.py
+++ b/com/win32comext/axscript/client/pydumper.py
@@ -52,7 +52,7 @@ def Register():
     lcid = 0x0409  # // english
     policy = None  # "win32com.axscript.client.axspolicy.AXScriptPolicy"
 
-    print("Registering COM server%s..." % debug_desc)
+    print("Registering COM server{}...".format(debug_desc))
     from win32com.server.register import RegisterServer, _set_string
 
     languageName = "PyDump"

--- a/com/win32comext/axscript/client/pyscript.py
+++ b/com/win32comext/axscript/client/pyscript.py
@@ -322,7 +322,11 @@ class PyScript(framework.COMScript):
         funcName = self.MakeEventMethodName(subItemName, eventName)
 
         codeBlock = AXScriptCodeBlock(
-            "Script Event %s" % funcName, code, sourceContextCookie, startLineNumber, 0
+            "Script Event {}".format(funcName),
+            code,
+            sourceContextCookie,
+            startLineNumber,
+            0,
         )
         self._AddScriptCodeBlock(codeBlock)
         subItem.scriptlets[funcName] = codeBlock
@@ -339,7 +343,7 @@ class PyScript(framework.COMScript):
         except KeyError:
             pass
         if codeBlock is not None:
-            realCode = "def %s():\n" % funcName
+            realCode = "def {}():\n".format(funcName)
             for line in framework.RemoveCR(codeBlock.codeText).split("\n"):
                 realCode += "\t" + line + "\n"
             realCode += "\n"

--- a/com/win32comext/mapi/demos/mapisend.py
+++ b/com/win32comext/mapi/demos/mapisend.py
@@ -48,7 +48,7 @@ def SendEMAPIMail(
     (tag, eid) = props[0]
     # check for errors
     if mapitags.PROP_TYPE(tag) == mapitags.PT_ERROR:
-        raise TypeError("got PT_ERROR instead of PT_BINARY: %s" % eid)
+        raise TypeError("got PT_ERROR instead of PT_BINARY: {}".format(eid))
     outboxfolder = msgstore.OpenEntry(eid, None, mapi.MAPI_BEST_ACCESS)
 
     # create the message and the addrlist

--- a/com/win32comext/shell/demos/ITransferAdviseSink.py
+++ b/com/win32comext/shell/demos/ITransferAdviseSink.py
@@ -57,7 +57,7 @@ class TransferAdviseSink(DesignatedWrapPolicy):
     def UpdateTransferState(self, State):
         print(
             "Current state: ",
-            TRANSFER_ADVISE_STATES.get(State, "??? Unknown state %s ???" % State),
+            TRANSFER_ADVISE_STATES.get(State, "??? Unknown state {} ???".format(State)),
         )
 
     def ConfirmOverwrite(self, Source, DestParent, Name):

--- a/com/win32comext/shell/demos/browse_for_folder.py
+++ b/com/win32comext/shell/demos/browse_for_folder.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
     shell.SHBrowseForFolder(
         0,  # parent HWND
         None,  # root PIDL.
-        "Default of %s" % os.getcwd(),  # title
+        "Default of {}".format(os.getcwd()),  # title
         flags,  # flags
         BrowseCallbackProc,  # callback function
         os.getcwd(),  # 'data' param for the callback
@@ -41,5 +41,5 @@ if __name__ == "__main__":
     shell.SHBrowseForFolder(
         0,  # parent HWND
         pidl,  # root PIDL.
-        "From %s down only" % os.getcwd(),  # title
+        "From {} down only".format(os.getcwd()),  # title
     )

--- a/com/win32comext/shell/demos/create_link.py
+++ b/com/win32comext/shell/demos/create_link.py
@@ -44,8 +44,7 @@ if __name__ == "__main__":
         shortcut.load(file)
         # now print data...
         print(
-            "Shortcut in file %s to file:\n\t%s\nArguments:\n\t%s\nDescription:\n\t%s\nWorking Directory:\n\t%s\nItemIDs:\n\t<skipped>"
-            % (
+            "Shortcut in file {} to file:\n\t{}\nArguments:\n\t{}\nDescription:\n\t{}\nWorking Directory:\n\t{}\nItemIDs:\n\t<skipped>".format(
                 file,
                 shortcut.GetPath(shell.SLGP_SHORTPATH)[0],
                 shortcut.GetArguments(),

--- a/com/win32comext/shell/demos/servers/column_provider.py
+++ b/com/win32comext/shell/demos/servers/column_provider.py
@@ -54,7 +54,7 @@ class ColumnProvider:
             else:
                 ext = ".pyo"
             title = ext + " size"
-            description = "Size of compiled %s file" % ext
+            description = "Size of compiled {} file".format(ext)
             col_id = (self._reg_clsid_, index)  # fmtid  # pid
             col_info = (
                 col_id,  # scid

--- a/com/win32comext/shell/demos/servers/context_menu.py
+++ b/com/win32comext/shell/demos/servers/context_menu.py
@@ -35,7 +35,7 @@ class ShellExtension:
             msg = "&Hello from Python (with %d files selected)" % num_files
         else:
             fname = shell.DragQueryFile(sm.data_handle, 0)
-            msg = "&Hello from Python (with '%s' selected)" % fname
+            msg = "&Hello from Python (with '{}' selected)".format(fname)
         idCmd = idCmdFirst
         items = ["First Python content menu item"]
         if (

--- a/isapi/install.py
+++ b/isapi/install.py
@@ -188,7 +188,7 @@ def LocateWebServerPath(description):
         ]
         if description in site_attributes:
             return site.AdsPath
-    msg = "No web sites match the description '%s'" % description
+    msg = "No web sites match the description '{}'".format(description)
     raise ItemNotFound(msg)
 
 
@@ -344,7 +344,7 @@ def AssignScriptMaps(script_maps, target, update="replace"):
     try:
         script_map_func = eval(script_map_func)
     except NameError:
-        msg = "Unknown ScriptMapUpdate option '%s'" % update
+        msg = "Unknown ScriptMapUpdate option '{}'".format(update)
         raise ConfigurationError(msg)
     # use the str method to format the script maps for IIS
     script_maps = [str(s) for s in script_maps]
@@ -483,7 +483,7 @@ def _DeleteExtensionFileRecord(module, options):
     try:
         ob = GetObject(_IIS_OBJECT)
         ob.DeleteExtensionFileRecord(module)
-        log(2, "Deleted extension file record for '%s'" % module)
+        log(2, "Deleted extension file record for '{}'".format(module))
     except (pythoncom.com_error, AttributeError) as details:
         log(2, f"Failed to remove extension file '{module}': {details}")
 
@@ -557,7 +557,7 @@ def RemoveDirectory(params, options):
         rc = _GetWin32ErrorCode(details)
         if rc != winerror.ERROR_PATH_NOT_FOUND:
             raise
-        log(2, "VirtualDirectory '%s' did not exist" % params.Name)
+        log(2, "VirtualDirectory '{}' did not exist".format(params.Name))
         directory = None
     if directory is not None:
         # Be robust should IIS get upset about unloading.
@@ -809,4 +809,4 @@ def HandleCommandLine(
             traceback.print_exc()
         print(f"{details.__class__.__name__}: {details}")
     except KeyError:
-        parser.error("Invalid arg '%s'" % arg)
+        parser.error("Invalid arg '{}'".format(arg))

--- a/isapi/samples/redirector.py
+++ b/isapi/samples/redirector.py
@@ -60,7 +60,7 @@ class Extension(threaded_extension.ThreadPoolExtension):
         url = ecb.GetServerVariable("URL").decode("ascii")
         for exclude in excludes:
             if url.lower().startswith(exclude):
-                print("excluding %s" % url)
+                print("excluding {}".format(url))
                 if ecb.Version < 0x60000:
                     print("(but this is IIS5 or earlier - can't do 'excludes')")
                 else:
@@ -76,7 +76,7 @@ class Extension(threaded_extension.ThreadPoolExtension):
                     return isapicon.HSE_STATUS_PENDING
 
         new_url = proxy + url
-        print("Opening %s" % new_url)
+        print("Opening {}".format(new_url))
         fp = urlopen(new_url)
         headers = fp.info()
         # subtle breakage: str(headers) normalizes \r\n

--- a/isapi/samples/redirector_asynch.py
+++ b/isapi/samples/redirector_asynch.py
@@ -45,7 +45,7 @@ class Extension(threaded_extension.ThreadPoolExtension):
         url = ecb.GetServerVariable("URL")
 
         new_url = proxy + url
-        print("Opening %s" % new_url)
+        print("Opening {}".format(new_url))
         fp = urllib.request.urlopen(new_url)
         headers = fp.info()
         ecb.SendResponseHeaders("200 OK", str(headers) + "\r\n", False)

--- a/isapi/test/extension_simple.py
+++ b/isapi/test/extension_simple.py
@@ -79,7 +79,9 @@ class Extension(threaded_extension.ThreadPoolExtension):
         # effective way from an extension.
         ver = float(ecb.GetServerVariable("SERVER_SOFTWARE").split("/")[1])
         if ver < 6.0:
-            return "This is IIS version %g - unicode only works in IIS6 and later" % ver
+            return "This is IIS version {:g} - unicode only works in IIS6 and later".format(
+                ver
+            )
 
         us = ecb.GetServerVariable("UNICODE_SERVER_NAME")
         assert isinstance(us, str), "unexpected type!"

--- a/pywin32_postinstall.py
+++ b/pywin32_postinstall.py
@@ -443,7 +443,7 @@ def install(lib_dir):
             for fname in files:
                 base = os.path.basename(fname)
                 dst = os.path.join(dest_dir, base)
-                CopyTo("installing %s" % base, fname, dst)
+                CopyTo("installing {}".format(base), fname, dst)
                 if verbose:
                     print(f"Copied {base} to {dst}")
                 # Register the files with the uninstaller
@@ -471,9 +471,9 @@ def install(lib_dir):
                 # in that place - otherwise that one will still get used!
                 if os.path.exists(dst):
                     msg = (
-                        "The file '%s' exists, but can not be replaced "
+                        "The file '{}' exists, but can not be replaced "
                         "due to insufficient permissions.  You must "
-                        "reinstall this software as an Administrator" % dst
+                        "reinstall this software as an Administrator".format(dst)
                     )
                     print(msg)
                     raise RuntimeError(msg)
@@ -668,7 +668,7 @@ def uninstall(lib_dir):
                         os.remove(dst)
                         worked = 1
                         if verbose:
-                            print("Removed file %s" % (dst))
+                            print("Removed file {}".format(dst))
                     except Exception:
                         print(f"FAILED to remove {dst}")
             if worked:

--- a/pywin32_testall.py
+++ b/pywin32_testall.py
@@ -22,7 +22,7 @@ def run_test(script, cmdline_extras):
     dirname, scriptname = os.path.split(script)
     # some tests prefer to be run from their directory.
     cmd = [sys.executable, "-u", scriptname] + cmdline_extras
-    print("--- Running '%s' ---" % script)
+    print("--- Running '{}' ---".format(script))
     sys.stdout.flush()
     result = subprocess.run(cmd, check=False, cwd=dirname)
     print(f"*** Test script '{script}' exited with {result.returncode}")
@@ -38,7 +38,7 @@ def find_and_run(possible_locations, extras):
             break
     else:
         raise RuntimeError(
-            "Failed to locate a test script in one of %s" % possible_locations
+            "Failed to locate a test script in one of {}".format(possible_locations)
         )
 
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -18,8 +18,8 @@ select = [
   "ISC001", # single-line-implicit-string-concatenation
   "UP025", # Remove unicode literals from strings
   "UP030", # Use implicit references for positional format fields
+  "UP031", # Use format specifiers instead of percent format
   # TODO: Still lots of manual fixes needed
-  # "UP031", # Use format specifiers instead of percent format
   # "UP032", # Use f-string instead of format call
 
   # Ensure modern type annotation syntax and best practices
@@ -37,7 +37,7 @@ select = [
 # Explicit re-exports is fine in __init__.py, still a code smell elsewhere.
 "__init__.py" = ["PLC0414"]
 # TODO: Make adodbapi changes in their own PRs
-"adodbapi/*" = ["C4", "YTT301", "UP031", "UP032", "ISC002"]
+"adodbapi/*" = ["C4", "YTT301", "UP031", "UP032"]
 
 [lint.isort]
 combine-as-imports = true

--- a/setup.py
+++ b/setup.py
@@ -170,7 +170,9 @@ class WinExt(Extension):
             if build_ext.plat_name == "win32":
                 self.extra_link_args.append("/MACHINE:x86")
             else:
-                self.extra_link_args.append("/MACHINE:%s" % build_ext.plat_name[4:])
+                self.extra_link_args.append(
+                    "/MACHINE:{}".format(build_ext.plat_name[4:])
+                )
 
             # like Python, always use debug info, even in release builds
             # (note the compiler doesn't include debug info, so you only get
@@ -193,7 +195,7 @@ class WinExt(Extension):
             if self.delay_load_libraries:
                 self.libraries.append("delayimp")
                 for delay_lib in self.delay_load_libraries:
-                    self.extra_link_args.append("/delayload:%s.dll" % delay_lib)
+                    self.extra_link_args.append("/delayload:{}.dll".format(delay_lib))
 
             # If someone needs a specially named implib created, handle that
             if self.implib_name:
@@ -212,7 +214,7 @@ class WinExt(Extension):
                     check = os.path.join(incl, candidate)
                     if os.path.isfile(check):
                         self.extra_compile_args.append(
-                            '/DMFC_OCC_IMPL_H=\\"%s\\"' % candidate
+                            '/DMFC_OCC_IMPL_H=\\"{}\\"'.format(candidate)
                         )
                         found_mfc = True
                         break
@@ -359,7 +361,7 @@ class my_build(build):
         ver_fname = os.path.join(gettempdir(), "pywin32.version.txt")
         try:
             f = open(ver_fname, "w")
-            f.write("%s\n" % build_id)
+            f.write("{}\n".format(build_id))
             f.close()
         except OSError as why:
             print(f"Failed to open '{ver_fname}': {why}")
@@ -432,7 +434,7 @@ class my_build_ext(build_ext):
                 found = self.compiler.find_library_file(look_dirs, lib, self.debug)
                 if not found:
                     logging.debug("Lib '%s' not found in %s", lib, look_dirs)
-                    return "No library '%s'" % lib
+                    return "No library '{}'".format(lib)
                 self.found_libraries[lib.lower()] = found
             patched_libs.append(os.path.splitext(os.path.basename(found))[0])
 
@@ -468,9 +470,9 @@ class my_build_ext(build_ext):
             cmd = cs + ' /c for %I in ("' + build_temp + '",) do @echo %~sI'
             build_temp = os.popen(cmd).read().strip()
             assert os.path.isdir(build_temp), build_temp
-        makeargs.append("SUB_DIR_O=%s" % build_temp)
-        makeargs.append("SUB_DIR_BIN=%s" % build_temp)
-        makeargs.append("DIR_PYTHON=%s" % sys.prefix)
+        makeargs.append("SUB_DIR_O={}".format(build_temp))
+        makeargs.append("SUB_DIR_BIN={}".format(build_temp))
+        makeargs.append("DIR_PYTHON={}".format(sys.prefix))
 
         nmake = "nmake.exe"
         # Attempt to resolve nmake to the same one that our compiler object
@@ -628,7 +630,7 @@ class my_build_ext(build_ext):
             return
         if not vcbase:
             raise RuntimeError("Can't find MFC redist DLLs with unkown VC base path")
-        redist_globs = [vcbase + r"redist\%s\*MFC\mfc140u.dll" % self.plat_dir]
+        redist_globs = [vcbase + r"redist\{}\*MFC\mfc140u.dll".format(self.plat_dir)]
         m = re.search(r"\\VC\\Tools\\", vcbase)
         if m:
             # typical path on newer Visual Studios
@@ -646,7 +648,9 @@ class my_build_ext(build_ext):
         # Only mfcNNNu DLL is required (mfcmNNNX is Windows Forms, rest is ANSI)
         mfc_contents = next(filter(None, map(glob.glob, redist_globs)), [])[:1]
         if not mfc_contents:
-            raise RuntimeError("MFC redist DLLs not found like %r!" % redist_globs)
+            raise RuntimeError(
+                "MFC redist DLLs not found like {!r}!".format(redist_globs)
+            )
 
         target_dir = os.path.join(self.build_lib, win32ui_ext.get_pywin32_dir())
         for mfc_content in mfc_contents:
@@ -1079,7 +1083,7 @@ class my_install_data(install_data):
         if self.install_dir is None:
             installobj = self.distribution.get_command_obj("install")
             self.install_dir = installobj.install_lib
-        print("Installing data files to %s" % self.install_dir)
+        print("Installing data files to {}".format(self.install_dir))
         install_data.finalize_options(self)
 
 
@@ -2111,10 +2115,10 @@ def convert_data_files(files: Iterable[str]):
                 if not ("\\CVS\\" in file or path.suffix in {".pyc", ".pyo"})
             )
             if not files_use:
-                raise RuntimeError("No files match '%s'" % file)
+                raise RuntimeError("No files match '{}'".format(file))
         else:
             if not os.path.isfile(file):
-                raise RuntimeError("No file '%s'" % file)
+                raise RuntimeError("No file '{}'".format(file))
             files_use = (file,)
         for fname in files_use:
             path_use = os.path.dirname(fname)
@@ -2377,7 +2381,7 @@ if "build_ext" in dist.command_obj:
     if excluded_extensions:
         skip_whitelist = {"exchdapi", "exchange", "axdebug"}
         skipped_ex = []
-        print("*** NOTE: The following extensions were NOT %s:" % what_string)
+        print("*** NOTE: The following extensions were NOT {}:".format(what_string))
         for ext, why in excluded_extensions:
             print(f" {ext.name}: {why}")
             if ext.name not in skip_whitelist:
@@ -2386,8 +2390,9 @@ if "build_ext" in dist.command_obj:
         print("please execute this script with no arguments (or see the docstring)")
         if skipped_ex:
             print(
-                "*** Non-zero exit status. Missing for complete release build: %s"
-                % skipped_ex
+                "*** Non-zero exit status. Missing for complete release build: {}".format(
+                    skipped_ex
+                )
             )
             sys.exit(1000 + len(skipped_ex))
     else:

--- a/win32/Demos/EvtSubscribe_pull.py
+++ b/win32/Demos/EvtSubscribe_pull.py
@@ -20,7 +20,7 @@ while 1:
             break
         ##for event in events:
         ##	print(win32evtlog.EvtRender(event, win32evtlog.EvtRenderEventXml))
-        print("retrieved %s events" % len(events))
+        print("retrieved {} events".format(len(events)))
     while 1:
         print("waiting...")
         w = win32event.WaitForSingleObjectEx(h, 2000, True)

--- a/win32/Demos/desktopmanager.py
+++ b/win32/Demos/desktopmanager.py
@@ -115,7 +115,7 @@ def new_icon(hdesk, desktop_name):
         flags,
         win32con.WM_USER + 20,
         hicon,
-        "Desktop Manager (%s)" % desktop_name,
+        "Desktop Manager ({})".format(desktop_name),
     )
     window_info[hwnd] = notify_info
     ## wait for explorer to initialize system tray for new desktop

--- a/win32/Demos/rastest.py
+++ b/win32/Demos/rastest.py
@@ -28,7 +28,7 @@ def Callback(hras, msg, state, error, exterror):
         win32event.SetEvent(callbackEvent)
     if error != 0 or int(state) == win32ras.RASCS_Disconnected:
         # we know for sure this is a good place to hangup....
-        print("Detected call failure: %s" % win32ras.GetErrorString(error))
+        print("Detected call failure: {}".format(win32ras.GetErrorString(error)))
         HangUp(hras)
         win32event.SetEvent(callbackEvent)
 
@@ -70,7 +70,7 @@ def Connect(entryName, bUseCallback):
     try:
         dp, b = win32ras.GetEntryDialParams(None, entryName)
     except:
-        print("Couldn't find DUN entry: %s" % entryName)
+        print("Couldn't find DUN entry: {}".format(entryName))
     else:
         hras, rc = win32ras.Dial(
             None, None, (entryName, "", "", dp[3], dp[4], ""), theCallback

--- a/win32/Demos/security/security_enums.py
+++ b/win32/Demos/security/security_enums.py
@@ -18,8 +18,9 @@ class Enum:
                         const_val = getattr(winnt, const_name)
                     except AttributeError:
                         raise AttributeError(
-                            'Constant "%s" not found in win32security, ntsecuritycon, or winnt.'
-                            % const_name
+                            'Constant "{}" not found in win32security, ntsecuritycon, or winnt.'.format(
+                                const_name
+                            )
                         )
             setattr(self, const_name, const_val)
 
@@ -28,7 +29,7 @@ class Enum:
         for k, v in self.__dict__.items():
             if v == const_val:
                 return k
-        raise AttributeError("Value %s not found in enum" % const_val)
+        raise AttributeError("Value {} not found in enum".format(const_val))
 
     def lookup_flags(self, flags):
         """Returns the names of all recognized flags in input, and any flags not found in the enum."""

--- a/win32/Demos/service/pipeTestServiceClient.py
+++ b/win32/Demos/service/pipeTestServiceClient.py
@@ -56,10 +56,10 @@ def testClient(server, msg):
         print("Sending", msg)
     data = CallPipe(
         CallNamedPipe,
-        ("\\\\%s\\pipe\\PyPipeTest" % server, msg, 256, NMPWAIT_WAIT_FOREVER),
+        ("\\\\{}\\pipe\\PyPipeTest".format(server), msg, 256, NMPWAIT_WAIT_FOREVER),
     )
     if verbose:
-        print("Server sent back '%s'" % data)
+        print("Server sent back '{}'".format(data))
     print("Sent and received a message!")
 
 
@@ -69,7 +69,7 @@ def testLargeMessage(server, size=4096):
     msg = "*" * size
     data = CallPipe(
         CallNamedPipe,
-        ("\\\\%s\\pipe\\PyPipeTest" % server, msg, 512, NMPWAIT_WAIT_FOREVER),
+        ("\\\\{}\\pipe\\PyPipeTest".format(server), msg, 512, NMPWAIT_WAIT_FOREVER),
     )
     if len(data) - size:
         print("Sizes are all wrong - send %d, got back %d" % (size, len(data)))
@@ -82,7 +82,7 @@ def stressThread(server, numMessages, wait):
                 r = CallPipe(
                     CallNamedPipe,
                     (
-                        "\\\\%s\\pipe\\PyPipeTest" % server,
+                        "\\\\{}\\pipe\\PyPipeTest".format(server),
                         "#" * 512,
                         1024,
                         NMPWAIT_WAIT_FOREVER,
@@ -134,8 +134,9 @@ def main():
         print(msg)
         my_name = os.path.split(sys.argv[0])[1]
         print(
-            "Usage: %s [-v] [-s server] [-t thread_count=0] [-m msg_count=500] msg ..."
-            % my_name
+            "Usage: {} [-v] [-s server] [-t thread_count=0] [-m msg_count=500] msg ...".format(
+                my_name
+            )
         )
         print("       -v = verbose")
         print(

--- a/win32/Demos/service/serviceEvents.py
+++ b/win32/Demos/service/serviceEvents.py
@@ -65,7 +65,7 @@ class EventDemoService(win32serviceutil.ServiceFramework):
         elif control == win32service.SERVICE_CONTROL_HARDWAREPROFILECHANGE:
             msg = f"A hardware profile changed: type={event_type}, data={data}"
         elif control == win32service.SERVICE_CONTROL_POWEREVENT:
-            msg = "A power event: setting %s" % data
+            msg = "A power event: setting {}".format(data)
         elif control == win32service.SERVICE_CONTROL_SESSIONCHANGE:
             # data is a single elt tuple, but this could potentially grow
             # in the future if the win32 struct does

--- a/win32/Demos/win32console_demo.py
+++ b/win32/Demos/win32console_demo.py
@@ -82,7 +82,7 @@ while not breakout:
                     newbuffer.WriteConsole(
                         virtual_keys.get(
                             input_record.VirtualKeyCode,
-                            "VirtualKeyCode: %s" % input_record.VirtualKeyCode,
+                            "VirtualKeyCode: {}".format(input_record.VirtualKeyCode),
                         )
                     )
                 else:

--- a/win32/Demos/win32netdemo.py
+++ b/win32/Demos/win32netdemo.py
@@ -58,7 +58,7 @@ def UserEnum():
             "Call to NetUserEnum obtained %d entries of %d total" % (len(data), total)
         )
         for user in data:
-            verbose("Found user %s" % user["name"])
+            verbose("Found user {}".format(user["name"]))
             nuser += 1
         if not resume:
             break
@@ -127,7 +127,7 @@ def ServerEnum():
             server, 100, win32netcon.SV_TYPE_ALL, None, resume
         )
         for s in data:
-            verbose("Found server %s" % s["name"])
+            verbose("Found server {}".format(s["name"]))
             # Now loop over the shares.
             shareresume = 0
             while 1:
@@ -199,7 +199,9 @@ def SetInfo(userName=None):
         win32net.NetUserSetInfo(server, userName, 3, d)
         new = win32net.NetUserGetInfo(server, userName, 3)["usr_comment"]
         if str(new) != "Test comment":
-            raise RuntimeError("Could not read the same comment back - got %s" % new)
+            raise RuntimeError(
+                "Could not read the same comment back - got {}".format(new)
+            )
         print("Changed the data for the user")
     finally:
         win32net.NetUserSetInfo(server, userName, 3, oldData)
@@ -215,7 +217,9 @@ def SetComputerInfo():
 def usage(tests):
     import os
 
-    print("Usage: %s [-s server ] [-v] [Test ...]" % os.path.basename(sys.argv[0]))
+    print(
+        "Usage: {} [-s server ] [-v] [Test ...]".format(os.path.basename(sys.argv[0]))
+    )
     print("  -v : Verbose - print more information")
     print("  -s : server - execute the tests against the named server")
     print("  -c : include the CreateUser test by default")
@@ -259,7 +263,7 @@ def main():
                     dotests.append(t)
                     break
             else:
-                print("Test '%s' unknown - skipping" % arg)
+                print("Test '{}' unknown - skipping".format(arg))
     if not len(dotests):
         print("Nothing to do!")
         usage(tests)
@@ -267,7 +271,7 @@ def main():
         try:
             test()
         except:
-            print("Test %s failed" % test.__name__)
+            print("Test {} failed".format(test.__name__))
             traceback.print_exc()
 
 

--- a/win32/Demos/winprocess.py
+++ b/win32/Demos/winprocess.py
@@ -216,7 +216,7 @@ _this_is_a_test_of_stderr_\r
         print(
             "NOTEPAD exit code:",
             run(
-                "notepad.exe %s" % out.name,
+                "notepad.exe {}".format(out.name),
                 show=win32con.SW_MAXIMIZE,
                 mSec=timeoutSeconds * 1000,
             ),

--- a/win32/Lib/regcheck.py
+++ b/win32/Lib/regcheck.py
@@ -24,13 +24,13 @@ def CheckRegisteredExe(exename):
             )
         )
     except (OSError, win32api.error):
-        print("Registration of %s - Not registered correctly" % exename)
+        print("Registration of {} - Not registered correctly".format(exename))
 
 
 def CheckPathString(pathString):
     for path in pathString.split(";"):
         if not os.path.isdir(path):
-            return "'%s' is not a valid directory!" % path
+            return "'{}' is not a valid directory!".format(path)
     return None
 
 
@@ -115,7 +115,7 @@ def CheckHelpFiles(verbose):
                     if verbose:
                         print(helpFile)
                 except OSError:
-                    print("** Help file %s does not exist" % helpFile)
+                    print("** Help file {} does not exist".format(helpFile))
                 keyNo += 1
             except win32api.error as exc:
                 import winerror

--- a/win32/Lib/regutil.py
+++ b/win32/Lib/regutil.py
@@ -150,10 +150,10 @@ def RegisterModule(modName, modPath):
 
         os.stat(modPath)
     except OSError:
-        print("Warning: Registering non-existant module %s" % modPath)
+        print("Warning: Registering non-existant module {}".format(modPath))
     win32api.RegSetValue(
         GetRootKey(),
-        BuildDefaultPythonKey() + "\\Modules\\%s" % modName,
+        BuildDefaultPythonKey() + "\\Modules\\{}".format(modName),
         win32con.REG_SZ,
         modPath,
     )
@@ -166,7 +166,7 @@ def UnregisterModule(modName):
     """
     try:
         win32api.RegDeleteKey(
-            GetRootKey(), BuildDefaultPythonKey() + "\\Modules\\%s" % modName
+            GetRootKey(), BuildDefaultPythonKey() + "\\Modules\\{}".format(modName)
         )
     except win32api.error as exc:
         import winerror
@@ -212,7 +212,7 @@ def RegisterHelpFile(helpFile, helpPath, helpDesc=None, bCheckFile=1):
     # Now register with Python itself.
     win32api.RegSetValue(
         GetRootKey(),
-        BuildDefaultPythonKey() + "\\Help\\%s" % helpDesc,
+        BuildDefaultPythonKey() + "\\Help\\{}".format(helpDesc),
         win32con.REG_SZ,
         fullHelpFile,
     )
@@ -246,7 +246,7 @@ def UnregisterHelpFile(helpFile, helpDesc=None):
         helpDesc = helpFile
     try:
         win32api.RegDeleteKey(
-            GetRootKey(), BuildDefaultPythonKey() + "\\Help\\%s" % helpDesc
+            GetRootKey(), BuildDefaultPythonKey() + "\\Help\\{}".format(helpDesc)
         )
     except win32api.error as exc:
         import winerror
@@ -268,7 +268,7 @@ def RegisterCoreDLL(coredllName=None):
         try:
             os.stat(coredllName)
         except OSError:
-            print("Warning: Registering non-existant core DLL %s" % coredllName)
+            print("Warning: Registering non-existant core DLL {}".format(coredllName))
 
     hKey = win32api.RegCreateKey(GetRootKey(), BuildDefaultPythonKey())
     try:
@@ -301,17 +301,17 @@ def RegisterFileExtensions(defPyIcon, defPycIcon, runCommand):
     )
     win32api.RegSetValue(
         win32con.HKEY_CLASSES_ROOT,
-        "%s\\CLSID" % pythonFileId,
+        "{}\\CLSID".format(pythonFileId),
         win32con.REG_SZ,
         CLSIDPyFile,
     )
     win32api.RegSetValue(
         win32con.HKEY_CLASSES_ROOT,
-        "%s\\DefaultIcon" % pythonFileId,
+        "{}\\DefaultIcon".format(pythonFileId),
         win32con.REG_SZ,
         defPyIcon,
     )
-    base = "%s\\Shell" % RegistryIDPyFile
+    base = "{}\\Shell".format(RegistryIDPyFile)
     win32api.RegSetValue(
         win32con.HKEY_CLASSES_ROOT, base + "\\Open", win32con.REG_SZ, "Run"
     )
@@ -335,11 +335,11 @@ def RegisterFileExtensions(defPyIcon, defPycIcon, runCommand):
     )
     win32api.RegSetValue(
         win32con.HKEY_CLASSES_ROOT,
-        "%s\\DefaultIcon" % pythonFileId,
+        "{}\\DefaultIcon".format(pythonFileId),
         win32con.REG_SZ,
         defPycIcon,
     )
-    base = "%s\\Shell" % pythonFileId
+    base = "{}\\Shell".format(pythonFileId)
     win32api.RegSetValue(
         win32con.HKEY_CLASSES_ROOT, base + "\\Open", win32con.REG_SZ, "Run"
     )
@@ -356,40 +356,40 @@ def RegisterShellCommand(shellCommand, exeCommand, shellUserCommand=None):
     # or shell execute (eg, just entering "foo.py"), the Command must be "Open",
     # but you may associate a different name for the right-click menu.
     # In our case, normally we have "Open=Run"
-    base = "%s\\Shell" % RegistryIDPyFile
+    base = "{}\\Shell".format(RegistryIDPyFile)
     if shellUserCommand:
         win32api.RegSetValue(
             win32con.HKEY_CLASSES_ROOT,
-            base + "\\%s" % (shellCommand),
+            base + "\\{}".format(shellCommand),
             win32con.REG_SZ,
             shellUserCommand,
         )
 
     win32api.RegSetValue(
         win32con.HKEY_CLASSES_ROOT,
-        base + "\\%s\\Command" % (shellCommand),
+        base + "\\{}\\Command".format(shellCommand),
         win32con.REG_SZ,
         exeCommand,
     )
 
 
 def RegisterDDECommand(shellCommand, ddeApp, ddeTopic, ddeCommand):
-    base = "%s\\Shell" % RegistryIDPyFile
+    base = "{}\\Shell".format(RegistryIDPyFile)
     win32api.RegSetValue(
         win32con.HKEY_CLASSES_ROOT,
-        base + "\\%s\\ddeexec" % (shellCommand),
+        base + "\\{}\\ddeexec".format(shellCommand),
         win32con.REG_SZ,
         ddeCommand,
     )
     win32api.RegSetValue(
         win32con.HKEY_CLASSES_ROOT,
-        base + "\\%s\\ddeexec\\Application" % (shellCommand),
+        base + "\\{}\\ddeexec\\Application".format(shellCommand),
         win32con.REG_SZ,
         ddeApp,
     )
     win32api.RegSetValue(
         win32con.HKEY_CLASSES_ROOT,
-        base + "\\%s\\ddeexec\\Topic" % (shellCommand),
+        base + "\\{}\\ddeexec\\Topic".format(shellCommand),
         win32con.REG_SZ,
         ddeTopic,
     )

--- a/win32/Lib/sspi.py
+++ b/win32/Lib/sspi.py
@@ -375,13 +375,13 @@ if __name__ == "__main__":
     while not sspiclient.authenticated or (sec_buffer and len(sec_buffer[0].Buffer)):
         client_step += 1
         err, sec_buffer = sspiclient.authorize(sec_buffer)
-        print("Client step %s" % client_step)
+        print("Client step {}".format(client_step))
         if sspiserver.authenticated and len(sec_buffer[0].Buffer) == 0:
             break
 
         server_step += 1
         err, sec_buffer = sspiserver.authorize(sec_buffer)
-        print("Server step %s" % server_step)
+        print("Server step {}".format(server_step))
 
     # Authentication process is finished.
     print("Initiator name from the service side:", sspiserver.initiator_name)

--- a/win32/Lib/win32pdhquery.py
+++ b/win32/Lib/win32pdhquery.py
@@ -566,6 +566,6 @@ class QueryError:
         self.query = query
 
     def __repr__(self):
-        return "<Query Error in %s>" % repr(self.query)
+        return "<Query Error in {}>".format(repr(self.query))
 
     __str__ = __repr__

--- a/win32/Lib/win32pdhutil.py
+++ b/win32/Lib/win32pdhutil.py
@@ -177,7 +177,7 @@ def BrowseCallBackDemo(counters):
         result = GetPerformanceAttributes(
             object, counterName, instance, index, win32pdh.PDH_FMT_DOUBLE, machine
         )
-        print("Value of '%s' is" % counter, result)
+        print("Value of '{}' is".format(counter), result)
         print(
             "Added '%s' on object '%s' (machine %s), instance %s(%d)-parent of %s"
             % (counterName, object, machine, instance, index, parentInstance)

--- a/win32/Lib/win32rcparser.py
+++ b/win32/Lib/win32rcparser.py
@@ -329,7 +329,7 @@ class RCParser:
                     # We don't know what the resource type is, but we
                     # have already consumed the next, which can cause problems,
                     # so push it back.
-                    self.debug("Skipping top-level '%s'" % base_token)
+                    self.debug("Skipping top-level '{}'".format(base_token))
                     self.ungetToken()
 
     def addId(self, id_name):
@@ -616,9 +616,9 @@ def GenerateFrozenResource(rc_name, output_name, h_name=None):
     in_stat = os.stat(rc_name)
 
     out = open(output_name, "wt")
-    out.write("#%s\n" % output_name)
-    out.write("#This is a generated file. Please edit %s instead.\n" % rc_name)
-    out.write("__version__=%r\n" % __version__)
+    out.write("#{}\n".format(output_name))
+    out.write("#This is a generated file. Please edit {} instead.\n".format(rc_name))
+    out.write("__version__={!r}\n".format(__version__))
     out.write(
         "_rc_size_=%d\n_rc_mtime_=%d\n"
         % (in_stat[stat.ST_SIZE], in_stat[stat.ST_MTIME])
@@ -656,7 +656,7 @@ if __name__ == "__main__":
         filename = sys.argv[1]
         if "-v" in sys.argv:
             RCParser.debugEnabled = True
-        print("Dumping all resources in '%s'" % filename)
+        print("Dumping all resources in '{}'".format(filename))
         resources = Parse(filename)
         for id, ddef in resources.dialogs.items():
             print("Dialog %s (%d controls)" % (id, len(ddef)))

--- a/win32/Lib/win32serviceutil.py
+++ b/win32/Lib/win32serviceutil.py
@@ -119,7 +119,7 @@ def LocateSpecificServiceExe(serviceName):
     # Return the .exe name of any service.
     hkey = win32api.RegOpenKey(
         win32con.HKEY_LOCAL_MACHINE,
-        "SYSTEM\\CurrentControlSet\\Services\\%s" % (serviceName),
+        "SYSTEM\\CurrentControlSet\\Services\\{}".format(serviceName),
         0,
         win32con.KEY_QUERY_VALUE,
     )
@@ -150,7 +150,7 @@ def InstallPerfmonForService(serviceName, iniName, dllName=None):
     # Now setup all the required "Performance" entries.
     hkey = win32api.RegOpenKey(
         win32con.HKEY_LOCAL_MACHINE,
-        "SYSTEM\\CurrentControlSet\\Services\\%s" % (serviceName),
+        "SYSTEM\\CurrentControlSet\\Services\\{}".format(serviceName),
         0,
         win32con.KEY_ALL_ACCESS,
     )
@@ -222,7 +222,7 @@ def InstallService(
     if errorControl is None:
         errorControl = win32service.SERVICE_ERROR_NORMAL
 
-    exeName = '"%s"' % LocatePythonServiceExe(exeName)
+    exeName = '"{}"'.format(LocatePythonServiceExe(exeName))
     commandLine = _GetCommandLine(exeName, exeArgs)
     hscm = win32service.OpenSCManager(None, None, win32service.SC_MANAGER_ALL_ACCESS)
     try:
@@ -293,7 +293,7 @@ def ChangeServiceConfig(
         pass
 
     # The EXE location may have changed
-    exeName = '"%s"' % LocatePythonServiceExe(exeName)
+    exeName = '"{}"'.format(LocatePythonServiceExe(exeName))
 
     # Handle the default arguments.
     if startType is None:
@@ -357,7 +357,7 @@ def InstallPythonClassString(pythonClassString, serviceName):
     if pythonClassString:
         key = win32api.RegCreateKey(
             win32con.HKEY_LOCAL_MACHINE,
-            "System\\CurrentControlSet\\Services\\%s\\PythonClass" % serviceName,
+            "System\\CurrentControlSet\\Services\\{}\\PythonClass".format(serviceName),
         )
         try:
             win32api.RegSetValue(key, None, win32con.REG_SZ, pythonClassString)
@@ -373,7 +373,7 @@ def SetServiceCustomOption(serviceName, option, value):
         pass
     key = win32api.RegCreateKey(
         win32con.HKEY_LOCAL_MACHINE,
-        "System\\CurrentControlSet\\Services\\%s\\Parameters" % serviceName,
+        "System\\CurrentControlSet\\Services\\{}\\Parameters".format(serviceName),
     )
     try:
         if isinstance(value, int):
@@ -393,7 +393,7 @@ def GetServiceCustomOption(serviceName, option, defaultValue=None):
         pass
     key = win32api.RegCreateKey(
         win32con.HKEY_LOCAL_MACHINE,
-        "System\\CurrentControlSet\\Services\\%s\\Parameters" % serviceName,
+        "System\\CurrentControlSet\\Services\\{}\\Parameters".format(serviceName),
     )
     try:
         try:
@@ -625,7 +625,7 @@ def GetServiceClassString(cls, argv=None):
                 fname = os.path.join(path, filelist[0][8])
         except win32api.error:
             raise error(
-                "Could not resolve the path name '%s' to a full path" % (argv[0])
+                "Could not resolve the path name '{}' to a full path".format(argv[0])
             )
         modName = os.path.splitext(fname)[0]
     return modName + "." + cls.__name__
@@ -650,8 +650,9 @@ def usage():
     except:
         fname = sys.argv[0]
     print(
-        "Usage: '%s [options] install|update|remove|start [...]|stop|restart [...]|debug [...]'"
-        % fname
+        "Usage: '{} [options] install|update|remove|start [...]|stop|restart [...]|debug [...]'".format(
+            fname
+        )
     )
     print("Options for 'install' and 'update' commands only:")
     print(" --username domain\\username : The Username the service is to run under")
@@ -749,7 +750,7 @@ def HandleCommandLine(
             try:
                 startup = map[val.lower()]
             except KeyError:
-                print("'%s' is not a valid startup option" % val)
+                print("'{}' is not a valid startup option".format(val))
             if val.lower() == "delayed":
                 delayedstart = True
             elif val.lower() == "auto":
@@ -767,7 +768,7 @@ def HandleCommandLine(
     # First we process all arguments which pass additional args on
     if arg == "start":
         knownArg = 1
-        print("Starting service %s" % (serviceName))
+        print("Starting service {}".format(serviceName))
         try:
             StartService(serviceName, args[1:])
             if waitSecs:
@@ -775,12 +776,12 @@ def HandleCommandLine(
                     serviceName, win32service.SERVICE_RUNNING, waitSecs
                 )
         except win32service.error as exc:
-            print("Error starting service: %s" % exc.strerror)
+            print("Error starting service: {}".format(exc.strerror))
             err = exc.winerror
 
     elif arg == "restart":
         knownArg = 1
-        print("Restarting service %s" % (serviceName))
+        print("Restarting service {}".format(serviceName))
         RestartService(serviceName, args[1:])
         if waitSecs:
             WaitForServiceStatus(serviceName, win32service.SERVICE_RUNNING, waitSecs)
@@ -865,7 +866,7 @@ def HandleCommandLine(
                 )
                 err = exc.winerror
         except ValueError as msg:  # Can be raised by custom option handler.
-            print("Error installing service: %s" % str(msg))
+            print("Error installing service: {}".format(str(msg)))
             err = -1
             # xxx - maybe I should remove after _any_ failed install - however,
             # xxx - it may be useful to help debug to leave the service as it failed.
@@ -925,7 +926,7 @@ def HandleCommandLine(
 
     elif arg == "remove":
         knownArg = 1
-        print("Removing service %s" % (serviceName))
+        print("Removing service {}".format(serviceName))
         try:
             RemoveService(serviceName)
             print("Service removed")
@@ -934,7 +935,7 @@ def HandleCommandLine(
             err = exc.winerror
     elif arg == "stop":
         knownArg = 1
-        print("Stopping service %s" % (serviceName))
+        print("Stopping service {}".format(serviceName))
         try:
             if waitSecs:
                 StopServiceWithDeps(serviceName, waitSecs=waitSecs)
@@ -945,7 +946,7 @@ def HandleCommandLine(
             err = exc.winerror
     if not knownArg:
         err = -1
-        print("Unknown command - '%s'" % arg)
+        print("Unknown command - '{}'".format(arg))
         usage()
     return err
 

--- a/win32/Lib/win32timezone.py
+++ b/win32/Lib/win32timezone.py
@@ -357,7 +357,7 @@ class TimeZoneDefinition(DYNAMIC_TIME_ZONE_INFORMATION):
         except TypeError:
             pass
 
-        raise TypeError("Invalid arguments for %s" % self.__class__)
+        raise TypeError("Invalid arguments for {}".format(self.__class__))
 
     def __init_from_bytes(
         self,
@@ -514,7 +514,7 @@ class TimeZoneInfo(datetime.tzinfo):
         try:
             result = key.subkey(timeZoneName)
         except Exception:
-            raise ValueError("Timezone Name %s not found." % timeZoneName)
+            raise ValueError("Timezone Name {} not found.".format(timeZoneName))
         return result
 
     def _LoadInfoFromKey(self):

--- a/win32/Lib/win32verstamp.py
+++ b/win32/Lib/win32verstamp.py
@@ -134,7 +134,9 @@ def stamp(pathname, options):
         bits = [int(i) for i in ver.split(".")]
         vmaj, vmin, vsub, vbuild = bits
     except (IndexError, TypeError, ValueError):
-        raise ValueError("--version must be a.b.c.d (all integers) - got %r" % ver)
+        raise ValueError(
+            "--version must be a.b.c.d (all integers) - got {!r}".format(ver)
+        )
 
     ifn = options.internal_name
     if not ifn:

--- a/win32/scripts/ControlService.py
+++ b/win32/scripts/ControlService.py
@@ -270,7 +270,7 @@ class ServiceDlg(dialog.Dialog):
         self.listCtrl = self.GetDlgItem(self.IDC_LIST)
         self.listCtrl.SetTabStops([158, 200])
         if self.machineName:
-            self.SetWindowText("Services on %s" % self.machineName)
+            self.SetWindowText("Services on {}".format(self.machineName))
         self.ReloadData()
         return dialog.Dialog.OnInitDialog(self)
 

--- a/win32/scripts/VersionStamp/BrandProject.py
+++ b/win32/scripts/VersionStamp/BrandProject.py
@@ -90,8 +90,8 @@ if __name__ == "__main__":
     try:
         os.stat(descFile)
     except OSError:
-        usage("The description file '%s' can not be found" % (descFile))
+        usage("The description file '{}' can not be found".format(descFile))
     if not os.path.isdir(path):
-        usage("The path to the files to stamp '%s' does not exist" % (path))
+        usage("The path to the files to stamp '{}' does not exist".format(path))
 
     BrandProject(vssProjectName, descFile, path, stampFiles, desc, bAuto, bRebrand)

--- a/win32/scripts/VersionStamp/bulkstamp.py
+++ b/win32/scripts/VersionStamp/bulkstamp.py
@@ -124,7 +124,7 @@ def scan(build, root, desc, **custom_vars):
     try:
         build = int(build)
     except ValueError:
-        print("ERROR: build number is not a number: %s" % build)
+        print("ERROR: build number is not a number: {}".format(build))
         sys.exit(1)
 
     debug = 0  ### maybe fix this one day

--- a/win32/scripts/backupEventLog.py
+++ b/win32/scripts/backupEventLog.py
@@ -32,7 +32,7 @@ def BackupClearLog(logType):
         return
     try:
         if win32evtlog.GetNumberOfEventLogRecords(hlog) == 0:
-            print("No records in event log %s - not backed up" % logType)
+            print("No records in event log {} - not backed up".format(logType))
             return
         win32evtlog.ClearEventLog(hlog, fname)
         print(f"Backed up {logType} log to {fname}")

--- a/win32/scripts/killProcName.py
+++ b/win32/scripts/killProcName.py
@@ -36,7 +36,7 @@ def killProcName(procname):
         pass
 
     if len(pids) == 0:
-        result = "Can't find %s" % procname
+        result = "Can't find {}".format(procname)
     elif len(pids) > 1:
         result = f"Found too many {procname}'s - pids=`{pids}`"
     else:
@@ -57,6 +57,6 @@ if __name__ == "__main__":
                 print("Dumping all processes...")
                 win32pdhutil.ShowAllProcesses()
             else:
-                print("Killed %s" % procname)
+                print("Killed {}".format(procname))
     else:
         print("Usage: killProcName.py procname ...")

--- a/win32/scripts/rasutil.py
+++ b/win32/scripts/rasutil.py
@@ -56,7 +56,7 @@ def Disconnect(handle):
                 handle = info[0]
                 break
         else:
-            raise ConnectionError(0, "Not connected to entry '%s'" % handle)
+            raise ConnectionError(0, "Not connected to entry '{}'".format(handle))
 
     win32ras.HangUp(handle)
 

--- a/win32/scripts/regsetup.py
+++ b/win32/scripts/regsetup.py
@@ -61,7 +61,7 @@ def FindPackagePath(packageName, knownFileName, searchPaths):
             # Found it
             ret = os.path.abspath(pathLook)
             return ret, ret
-    raise error("The package %s can not be located" % packageName)
+    raise error("The package {} can not be located".format(packageName))
 
 
 def FindHelpPath(helpFile, helpDesc, searchPaths):
@@ -95,7 +95,7 @@ def FindHelpPath(helpFile, helpDesc, searchPaths):
         pathLook = os.path.join(pathLook, "Help")
         if FileExists(os.path.join(pathLook, helpFile)):
             return os.path.abspath(pathLook)
-    raise error("The help file %s can not be located" % helpFile)
+    raise error("The help file {} can not be located".format(helpFile))
 
 
 def FindAppPath(appName, knownFileName, searchPaths):
@@ -167,7 +167,7 @@ def QuotedFileName(fname):
 
     try:
         fname.index(" ")  # Other chars forcing quote?
-        return '"%s"' % fname
+        return '"{}"'.format(fname)
     except ValueError:
         # No space in name.
         return fname
@@ -203,8 +203,9 @@ def LocateFileName(fileNamesString, searchPaths):
             import win32ui
         except ImportError:
             raise error(
-                "Need to locate the file %s, but the win32ui module is not available\nPlease run the program again, passing as a parameter the path to this file."
-                % fileName
+                "Need to locate the file {}, but the win32ui module is not available\nPlease run the program again, passing as a parameter the path to this file.".format(
+                    fileName
+                )
             )
         # Display a common dialog to locate the file.
         flags = win32con.OFN_FILEMUSTEXIST
@@ -268,11 +269,11 @@ def LocatePythonCore(searchPaths):
     corePath = None
     suffix = IsDebug()
     for path in presearchPaths:
-        if FileExists(os.path.join(path, "unicodedata%s.pyd" % suffix)):
+        if FileExists(os.path.join(path, "unicodedata{}.pyd".format(suffix))):
             corePath = path
             break
     if corePath is None and searchPaths is not None:
-        corePath = LocatePath("unicodedata%s.pyd" % suffix, searchPaths)
+        corePath = LocatePath("unicodedata{}.pyd".format(suffix), searchPaths)
     if corePath is None:
         raise error("The core Python path could not be located.")
 
@@ -431,11 +432,11 @@ def RegisterShellInfo(searchPaths):
 
     suffix = IsDebug()
     # Set up a pointer to the .exe's
-    exePath = FindRegisterPythonExe("Python%s.exe" % suffix, searchPaths)
+    exePath = FindRegisterPythonExe("Python{}.exe".format(suffix), searchPaths)
     regutil.SetRegistryDefaultValue(".py", "Python.File", win32con.HKEY_CLASSES_ROOT)
     regutil.RegisterShellCommand("Open", QuotedFileName(exePath) + ' "%1" %*', "&Run")
     regutil.SetRegistryDefaultValue(
-        "Python.File\\DefaultIcon", "%s,0" % exePath, win32con.HKEY_CLASSES_ROOT
+        "Python.File\\DefaultIcon", "{},0".format(exePath), win32con.HKEY_CLASSES_ROOT
     )
 
     FindRegisterHelpFile("Python.hlp", searchPaths, "Main Python Documentation")
@@ -447,14 +448,13 @@ def RegisterShellInfo(searchPaths):
 
 #       FindRegisterApp("win32", ["win32con.pyc", "win32api%s.pyd" % suffix], searchPaths)
 
-usage = (
-    """\
+usage = """\
 regsetup.py - Setup/maintain the registry for Python apps.
 
 Run without options, (but possibly search paths) to repair a totally broken
 python registry setup.  This should allow other options to work.
 
-Usage:   %s [options ...] paths ...
+Usage:   {} [options ...] paths ...
 -p packageName  -- Find and register a package.  Looks in the paths for
                    a sub-directory with the name of the package, and
                    adds a path entry for the package.
@@ -475,8 +475,8 @@ Usage:   %s [options ...] paths ...
 
 --description   -- Print a description of the usage.
 --examples      -- Print examples of usage.
-"""
-    % sys.argv[0]
+""".format(
+    sys.argv[0]
 )
 
 description = """\

--- a/win32/test/test_odbc.py
+++ b/win32/test/test_odbc.py
@@ -54,7 +54,7 @@ class TestStuff(unittest.TestCase):
         self.cur = self.conn.cursor()
         ## self.cur.setoutputsize(1000)
         try:
-            self.cur.execute("""drop table %s""" % self.tablename)
+            self.cur.execute("""drop table {}""".format(self.tablename))
         except (odbc.error, odbc.progError):
             pass
 
@@ -63,7 +63,7 @@ class TestStuff(unittest.TestCase):
         ##  - varchar -> nvarchar
         self.assertEqual(
             self.cur.execute(
-                """create table %s (
+                """create table {} (
                     userid varchar(25),
                     username varchar(25),
                     bitfield bit,
@@ -73,8 +73,9 @@ class TestStuff(unittest.TestCase):
                     rawfield varbinary(100),
                     longtextfield memo,
                     longbinaryfield image
-            )"""
-                % self.tablename
+            )""".format(
+                    self.tablename
+                )
             ),
             -1,
         )
@@ -82,9 +83,9 @@ class TestStuff(unittest.TestCase):
     def tearDown(self):
         if self.cur is not None:
             try:
-                self.cur.execute("""drop table %s""" % self.tablename)
+                self.cur.execute("""drop table {}""".format(self.tablename))
             except (odbc.error, odbc.progError) as why:
-                print("Failed to delete test table %s" % self.tablename, why)
+                print("Failed to delete test table {}".format(self.tablename), why)
 
             self.cur.close()
             self.cur = None
@@ -100,27 +101,30 @@ class TestStuff(unittest.TestCase):
     def test_insert_select(self, userid="Frank", username="Frank Millman"):
         self.assertEqual(
             self.cur.execute(
-                "insert into %s (userid, username) \
-            values (?,?)"
-                % self.tablename,
+                "insert into {} (userid, username) \
+            values (?,?)".format(
+                    self.tablename
+                ),
                 [userid, username],
             ),
             1,
         )
         self.assertEqual(
             self.cur.execute(
-                "select * from %s \
-            where userid = ?"
-                % self.tablename,
+                "select * from {} \
+            where userid = ?".format(
+                    self.tablename
+                ),
                 [userid.lower()],
             ),
             0,
         )
         self.assertEqual(
             self.cur.execute(
-                "select * from %s \
-            where username = ?"
-                % self.tablename,
+                "select * from {} \
+            where username = ?".format(
+                    self.tablename
+                ),
                 [username.lower()],
             ),
             0,
@@ -129,27 +133,30 @@ class TestStuff(unittest.TestCase):
     def test_insert_select_unicode(self, userid="Frank", username="Frank Millman"):
         self.assertEqual(
             self.cur.execute(
-                "insert into %s (userid, username)\
-            values (?,?)"
-                % self.tablename,
+                "insert into {} (userid, username)\
+            values (?,?)".format(
+                    self.tablename
+                ),
                 [userid, username],
             ),
             1,
         )
         self.assertEqual(
             self.cur.execute(
-                "select * from %s \
-            where userid = ?"
-                % self.tablename,
+                "select * from {} \
+            where userid = ?".format(
+                    self.tablename
+                ),
                 [userid.lower()],
             ),
             0,
         )
         self.assertEqual(
             self.cur.execute(
-                "select * from %s \
-            where username = ?"
-                % self.tablename,
+                "select * from {} \
+            where username = ?".format(
+                    self.tablename
+                ),
                 [username.lower()],
             ),
             0,
@@ -162,7 +169,9 @@ class TestStuff(unittest.TestCase):
 
     def _test_val(self, fieldName, value):
         for x in range(100):
-            self.cur.execute("delete from %s where userid='Frank'" % self.tablename)
+            self.cur.execute(
+                "delete from {} where userid='Frank'".format(self.tablename)
+            )
             self.assertEqual(
                 self.cur.execute(
                     f"insert into {self.tablename} (userid, {fieldName}) values (?,?)",
@@ -225,38 +234,40 @@ class TestStuff(unittest.TestCase):
     def test_set_nonzero_length(self):
         self.assertEqual(
             self.cur.execute(
-                "insert into %s (userid,username) values (?,?)" % self.tablename,
+                "insert into {} (userid,username) values (?,?)".format(self.tablename),
                 ["Frank", "Frank Millman"],
             ),
             1,
         )
         self.assertEqual(
-            self.cur.execute("update %s set username = ?" % self.tablename, ["Frank"]),
+            self.cur.execute(
+                "update {} set username = ?".format(self.tablename), ["Frank"]
+            ),
             1,
         )
-        self.assertEqual(self.cur.execute("select * from %s" % self.tablename), 0)
+        self.assertEqual(self.cur.execute("select * from {}".format(self.tablename)), 0)
         self.assertEqual(len(self.cur.fetchone()[1]), 5)
 
     def test_set_zero_length(self):
         self.assertEqual(
             self.cur.execute(
-                "insert into %s (userid,username) values (?,?)" % self.tablename,
+                "insert into {} (userid,username) values (?,?)".format(self.tablename),
                 [b"Frank", ""],
             ),
             1,
         )
-        self.assertEqual(self.cur.execute("select * from %s" % self.tablename), 0)
+        self.assertEqual(self.cur.execute("select * from {}".format(self.tablename)), 0)
         self.assertEqual(len(self.cur.fetchone()[1]), 0)
 
     def test_set_zero_length_unicode(self):
         self.assertEqual(
             self.cur.execute(
-                "insert into %s (userid,username) values (?,?)" % self.tablename,
+                "insert into {} (userid,username) values (?,?)".format(self.tablename),
                 ["Frank", ""],
             ),
             1,
         )
-        self.assertEqual(self.cur.execute("select * from %s" % self.tablename), 0)
+        self.assertEqual(self.cur.execute("select * from {}".format(self.tablename)), 0)
         self.assertEqual(len(self.cur.fetchone()[1]), 0)
 
 

--- a/win32/test/testall.py
+++ b/win32/test/testall.py
@@ -174,7 +174,7 @@ def suite():
             try:
                 mod = __import__(base)
             except:
-                print("FAILED to import test module %r" % base)
+                print("FAILED to import test module {!r}".format(base))
                 traceback.print_exc()
                 continue
             if hasattr(mod, "suite"):


### PR DESCRIPTION
Ran using `ruff check --fix --unsafe-fixes --select=UP031 --exclude=adodbapi` then `black .`
This replaces all usages of exclusively `%s` for string formatting with `.format`.
This autofix is considered "unsafe" when Ruff cannot statically establish that the following case is always false:
> A single `%s` in the string, formatted with a 1-item tuple. ie: `"foor%s" % ("bar",)`

Due to the sheer amount o changes (359) this is kept to automated changes only.

`%d` and `%d` will be done in separate PRs as they're not handled by `UP031`.
Preferring f-strings will come as a follow-up since that can make the line go over the 100 chars limit.

References:

https://docs.astral.sh/ruff/rules/printf-string-formatting/#why-is-this-bad
> `printf`-style string formatting has a number of quirks, and leads to less readable code than using `str.format` calls or f-strings. In general, prefer the newer `str.format` and f-strings constructs over `printf`-style string formatting.

https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting
> Note The formatting operations described here exhibit a variety of quirks that lead to a number of common errors (such as failing to display tuples and dictionaries correctly). Using the newer [formatted string literals](https://docs.python.org/3/reference/lexical_analysis.html#f-strings), the [str.format()](https://docs.python.org/3/library/stdtypes.html#str.format) interface, or [template strings](https://docs.python.org/3/library/string.html#template-strings) may help avoid these errors. Each of these alternatives provides their own trade-offs and benefits of simplicity, flexibility, and/or extensibility.