### PR TITLE
pyright turn on reportOptionalCall

### DIFF
--- a/com/win32comext/axscript/client/framework.py
+++ b/com/win32comext/axscript/client/framework.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 
 import re
 import sys
-from typing import NoReturn
+from collections.abc import Callable
+from typing import Any, NoReturn
 
 import pythoncom  # Need simple connection point support
 import win32api
@@ -192,7 +193,9 @@ class EventSink:
         self.connection = None
         self.coDispatch = coDispatch
         self.myScriptItem = myItem
-        self.myInvokeMethod = myItem.GetEngine().ProcessScriptItemEvent
+        self.myInvokeMethod: Callable[[Any, Any, Any, Any, Any], Any] = (
+            myItem.GetEngine().ProcessScriptItemEvent
+        )  # Incomplete type
         self.iid = None
 
     def Reset(self):
@@ -218,7 +221,7 @@ class EventSink:
             event = self.events[dispid]
         except:
             raise COMException(scode=winerror.DISP_E_MEMBERNOTFOUND)
-        # print("Invoke for ", event, "on", self.myScriptItem, " - calling",  self.myInvokeMethod)
+        # print("Invoke for", event, "on", self.myScriptItem, "- calling",  self.myInvokeMethod)
         return self.myInvokeMethod(self.myScriptItem, event, lcid, wFlags, args)
 
     def GetSourceTypeInfo(self, typeinfo):

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -35,7 +35,6 @@
   // some of the fixes need to be done in types-pywin32 from typeshed
   "reportCallIssue": "warning",
   "reportOperatorIssue": "warning",
-  "reportOptionalCall": "warning",
   "reportOptionalIterable": "warning",
   "reportOptionalMemberAccess": "warning",
   "reportOptionalSubscript": "warning",


### PR DESCRIPTION
Letting type checkers know that `self.myInvokeMethod = None` shouldn't mean that `myInvokeMethod` could be None in normal circumstances (a closed `EventSink` shouldn't be used anymore).

Although maybe there's a better way of releasing resources? (like `del`, or assigning a default method that throws an error indicating that the object is already closed)