### PR TITLE
Fixed the `com/win32comext/shell/demos/create_link.py` demo for link file that don't exist

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,7 @@ Coming in build 307, as yet unreleased
 --------------------------------------
 
 ### pywin32
+* Fixed the `com/win32comext/shell/demos/create_link.py` demo for link file that don't exist (# , @Avasam)
 * Fixed accidentally trying to raise a `str` instead of an `Exception` in (#2270, @Avasam)
   * `Pythonwin/pywin/debugger/debugger.py`
   * `Pythonwin/pywin/framework/dlgappcore.py`

--- a/com/win32comext/shell/demos/create_link.py
+++ b/com/win32comext/shell/demos/create_link.py
@@ -2,6 +2,7 @@
 # From a demo by Mark Hammond, corrupted by Mike Fletcher
 # (and re-corrupted by Mark Hammond :-)
 import os
+from itertools import zip_longest
 
 import pythoncom
 from win32com.shell import shell
@@ -61,8 +62,7 @@ if __name__ == "__main__":
             )
             sys.exit(1)
         # create the shortcut using rest of args...
-        data = map(
-            None,
+        data = zip_longest(
             sys.argv[2:],
             ("SetPath", "SetArguments", "SetDescription", "SetWorkingDirectory"),
         )


### PR DESCRIPTION
`map(None, ...)` was leftover Python 2 code. It is not valid in Python 3.

This also resolves a `com\win32comext\shell\demos\create_link.py:64:16: error: No overload variant of "map" matches argument types "None", "List[str]", "Tuple[str, str, str, str]"  [call-overload]`