### PR TITLE
Last error wrongly set by some modules

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,7 @@ https://mhammond.github.io/pywin32_installers.html.
 Coming in build 309, as yet unreleased
 --------------------------------------
 
+* Last error wrongly set by some modules (#2302, @CristiFati)
 * Dropped support for Python 3.7 (#2207, @Avasam)
 * Implement the creation of SAFEARRAY(VT_RECORD) from a sequence of COM Records (#2317, @geppi)
 * Implement record pointers as [in, out] method parameters of a Dispatch Interface (#2304, #2310, @geppi)

--- a/win32/src/PyWinTypes.h
+++ b/win32/src/PyWinTypes.h
@@ -48,6 +48,22 @@
     if (!(dict = PyModule_GetDict(module)))                                                                 \
         return NULL;
 
+// clang-format off
+#define PYWIN_BEGIN_LOAD_LIBRARY(NAME) \
+{ \
+    DWORD lastErr = GetLastError(); \
+    HMODULE hmodule = GetModuleHandle(TEXT(NAME)); \
+    if (hmodule == NULL) \
+        hmodule = LoadLibrary(TEXT(NAME)); \
+    if (hmodule != NULL) { \
+        SetLastError(lastErr);
+
+
+#define PYWIN_END_LOAD_LIBRARY \
+    } \
+}
+// clang-format om
+
 // Helpers for our types.
 // Macro to handle PyObject layout changes in Py3k
 #define PYWIN_OBJECT_HEAD PyVarObject_HEAD_INIT(NULL, 0)

--- a/win32/src/PyWinTypes.h
+++ b/win32/src/PyWinTypes.h
@@ -83,7 +83,7 @@ typedef Py_ssize_t Py_hash_t;
 #endif  // _MSC_VER
 #endif  // BUILD_PYWINTYPES
 
-extern PYWINTYPES_EXPORT HMODULE PyWin_LibraryModule(char *name);
+extern PYWINTYPES_EXPORT HMODULE PyWin_GetOrLoadLibraryHandle(const char *name);
 
 // Py3k uses memoryview object in place of buffer, and we don't yet.
 extern PYWINTYPES_EXPORT PyObject *PyBuffer_New(Py_ssize_t size);

--- a/win32/src/PyWinTypes.h
+++ b/win32/src/PyWinTypes.h
@@ -48,22 +48,6 @@
     if (!(dict = PyModule_GetDict(module)))                                                                 \
         return NULL;
 
-// clang-format off
-#define PYWIN_BEGIN_LOAD_LIBRARY(NAME) \
-{ \
-    DWORD lastErr = GetLastError(); \
-    HMODULE hmodule = GetModuleHandle(TEXT(NAME)); \
-    if (hmodule == NULL) \
-        hmodule = LoadLibrary(TEXT(NAME)); \
-    if (hmodule != NULL) { \
-        SetLastError(lastErr);
-
-
-#define PYWIN_END_LOAD_LIBRARY \
-    } \
-}
-// clang-format om
-
 // Helpers for our types.
 // Macro to handle PyObject layout changes in Py3k
 #define PYWIN_OBJECT_HEAD PyVarObject_HEAD_INIT(NULL, 0)
@@ -98,6 +82,8 @@ typedef Py_ssize_t Py_hash_t;
 #endif  // DEBUG/_DEBUG
 #endif  // _MSC_VER
 #endif  // BUILD_PYWINTYPES
+
+extern PYWINTYPES_EXPORT HMODULE PyWin_LibraryModule(char *name);
 
 // Py3k uses memoryview object in place of buffer, and we don't yet.
 extern PYWINTYPES_EXPORT PyObject *PyBuffer_New(Py_ssize_t size);

--- a/win32/src/PyWinTypesmodule.cpp
+++ b/win32/src/PyWinTypesmodule.cpp
@@ -26,7 +26,7 @@ extern PyObject *PyWinMethod_NewHKEY(PyObject *self, PyObject *args);
 extern BOOL _PyWinDateTime_Init();
 extern BOOL _PyWinDateTime_PrepareModuleDict(PyObject *dict);
 
-HMODULE PyWin_LibraryModule(char *name)
+HMODULE PyWin_GetOrLoadLibraryHandle(const char *name)
 {
     DWORD lastErr = GetLastError();
     HMODULE hmodule = GetModuleHandleA(name);

--- a/win32/src/PyWinTypesmodule.cpp
+++ b/win32/src/PyWinTypesmodule.cpp
@@ -981,10 +981,8 @@ extern "C" __declspec(dllexport) BOOL WINAPI DllMain(HANDLE hInstance, DWORD dwR
 {
     FARPROC fp;
     // dll usually will already be loaded
-    HMODULE hmodule = GetModuleHandle(_T("AdvAPI32.dll"));
-    if (hmodule == NULL)
-        hmodule = LoadLibrary(_T("AdvAPI32.dll"));
-    if (hmodule) {
+    HMODULE hmodule = PyWin_GetOrLoadLibraryHandle("advapi32.dll");
+    if (hmodule != NULL) {
         fp = GetProcAddress(hmodule, "AddAccessAllowedAce");
         if (fp)
             addaccessallowedace = (addacefunc)(fp);

--- a/win32/src/PyWinTypesmodule.cpp
+++ b/win32/src/PyWinTypesmodule.cpp
@@ -26,6 +26,17 @@ extern PyObject *PyWinMethod_NewHKEY(PyObject *self, PyObject *args);
 extern BOOL _PyWinDateTime_Init();
 extern BOOL _PyWinDateTime_PrepareModuleDict(PyObject *dict);
 
+HMODULE PyWin_LibraryModule(char *name)
+{
+    DWORD lastErr = GetLastError();
+    HMODULE hmodule = GetModuleHandleA(name);
+    if (hmodule == NULL)
+        hmodule = LoadLibraryA(name);
+    if (hmodule != NULL)
+        SetLastError(lastErr);
+    return hmodule;
+}
+
 // XXX - Needs py3k modernization!
 // For py3k, a function that returns new memoryview object instead of buffer.
 // ??? Byte array object is mutable, maybe just use that directly as a substitute ???

--- a/win32/src/win32apimodule.cpp
+++ b/win32/src/win32apimodule.cpp
@@ -6260,14 +6260,13 @@ PYWIN_MODULE_INIT_FUNC(win32api)
     PyModule_AddIntConstant(module, "VS_FF_PRIVATEBUILD", VS_FF_PRIVATEBUILD);
     PyModule_AddIntConstant(module, "VS_FF_SPECIALBUILD", VS_FF_SPECIALBUILD);
 
-    // clang-format off
-    HMODULE hmodule = PyWin_LibraryModule("secur32.dll");
+    HMODULE hmodule = PyWin_GetOrLoadLibraryHandle("secur32.dll");
     if (hmodule != NULL) {
         pfnGetUserNameEx = (GetUserNameExfunc)GetProcAddress(hmodule, "GetUserNameExW");
         pfnGetComputerObjectName = (GetUserNameExfunc)GetProcAddress(hmodule, "GetComputerObjectNameW");
     }
 
-    hmodule = PyWin_LibraryModule("kernel32.dll");
+    hmodule = PyWin_GetOrLoadLibraryHandle("kernel32.dll");
     if (hmodule != NULL) {
         pfnGetComputerNameEx = (GetComputerNameExfunc)GetProcAddress(hmodule, "GetComputerNameExW");
         pfnGetLongPathNameA = (GetLongPathNameAfunc)GetProcAddress(hmodule, "GetLongPathNameA");
@@ -6283,7 +6282,7 @@ PYWIN_MODULE_INIT_FUNC(win32api)
         pfnGetNativeSystemInfo = (GetNativeSystemInfofunc)GetProcAddress(hmodule, "GetNativeSystemInfo");
     }
 
-    hmodule = PyWin_LibraryModule("user32.dll");
+    hmodule = PyWin_GetOrLoadLibraryHandle("user32.dll");
     if (hmodule != NULL) {
         pfnEnumDisplayMonitors = (EnumDisplayMonitorsfunc)GetProcAddress(hmodule, "EnumDisplayMonitors");
         pfnEnumDisplayDevices = (EnumDisplayDevicesfunc)GetProcAddress(hmodule, "EnumDisplayDevicesW");
@@ -6296,7 +6295,7 @@ PYWIN_MODULE_INIT_FUNC(win32api)
         pfnGetLastInputInfo = (GetLastInputInfofunc)GetProcAddress(hmodule, "GetLastInputInfo");
     }
 
-    hmodule = PyWin_LibraryModule("advapi32.dll");
+    hmodule = PyWin_GetOrLoadLibraryHandle("advapi32.dll");
     if (hmodule != NULL) {
         pfnRegRestoreKey = (RegRestoreKeyfunc)GetProcAddress(hmodule, "RegRestoreKeyW");
         pfnRegSaveKeyEx = (RegSaveKeyExfunc)GetProcAddress(hmodule, "RegSaveKeyExW");
@@ -6309,7 +6308,6 @@ PYWIN_MODULE_INIT_FUNC(win32api)
         pfnRegOpenCurrentUser = (RegOpenCurrentUserfunc)GetProcAddress(hmodule, "RegOpenCurrentUser");
         pfnRegOverridePredefKey = (RegOverridePredefKeyfunc)GetProcAddress(hmodule, "RegOverridePredefKey");
     }
-    // clang-format on
 
     PYWIN_MODULE_INIT_RETURN_SUCCESS;
 }

--- a/win32/src/win32apimodule.cpp
+++ b/win32/src/win32apimodule.cpp
@@ -6261,12 +6261,14 @@ PYWIN_MODULE_INIT_FUNC(win32api)
     PyModule_AddIntConstant(module, "VS_FF_SPECIALBUILD", VS_FF_SPECIALBUILD);
 
     // clang-format off
-    PYWIN_BEGIN_LOAD_LIBRARY("secur32.dll")
+    HMODULE hmodule = PyWin_LibraryModule("secur32.dll");
+    if (hmodule != NULL) {
         pfnGetUserNameEx = (GetUserNameExfunc)GetProcAddress(hmodule, "GetUserNameExW");
         pfnGetComputerObjectName = (GetUserNameExfunc)GetProcAddress(hmodule, "GetComputerObjectNameW");
-    PYWIN_END_LOAD_LIBRARY
+    }
 
-    PYWIN_BEGIN_LOAD_LIBRARY("kernel32.dll")
+    hmodule = PyWin_LibraryModule("kernel32.dll");
+    if (hmodule != NULL) {
         pfnGetComputerNameEx = (GetComputerNameExfunc)GetProcAddress(hmodule, "GetComputerNameExW");
         pfnGetLongPathNameA = (GetLongPathNameAfunc)GetProcAddress(hmodule, "GetLongPathNameA");
         pfnGetLongPathNameW = (GetLongPathNameWfunc)GetProcAddress(hmodule, "GetLongPathNameW");
@@ -6279,10 +6281,10 @@ PYWIN_MODULE_INIT_FUNC(win32api)
         pfnSetDllDirectory = (SetDllDirectoryfunc)GetProcAddress(hmodule, "SetDllDirectoryW");
         pfnSetSystemPowerState = (SetSystemPowerStatefunc)GetProcAddress(hmodule, "SetSystemPowerState");
         pfnGetNativeSystemInfo = (GetNativeSystemInfofunc)GetProcAddress(hmodule, "GetNativeSystemInfo");
-    PYWIN_END_LOAD_LIBRARY
+    }
 
-
-    PYWIN_BEGIN_LOAD_LIBRARY("user32.dll")
+    hmodule = PyWin_LibraryModule("user32.dll");
+    if (hmodule != NULL) {
         pfnEnumDisplayMonitors = (EnumDisplayMonitorsfunc)GetProcAddress(hmodule, "EnumDisplayMonitors");
         pfnEnumDisplayDevices = (EnumDisplayDevicesfunc)GetProcAddress(hmodule, "EnumDisplayDevicesW");
         pfnChangeDisplaySettingsEx = (ChangeDisplaySettingsExfunc)GetProcAddress(hmodule, "ChangeDisplaySettingsExW");
@@ -6292,9 +6294,10 @@ PYWIN_MODULE_INIT_FUNC(win32api)
         pfnGetMonitorInfo = (GetMonitorInfofunc)GetProcAddress(hmodule, "GetMonitorInfoW");
         pfnEnumDisplaySettingsEx = (EnumDisplaySettingsExfunc)GetProcAddress(hmodule, "EnumDisplaySettingsExW");
         pfnGetLastInputInfo = (GetLastInputInfofunc)GetProcAddress(hmodule, "GetLastInputInfo");
-    PYWIN_END_LOAD_LIBRARY
+    }
 
-    PYWIN_BEGIN_LOAD_LIBRARY("Advapi32.dll")
+    hmodule = PyWin_LibraryModule("advapi32.dll");
+    if (hmodule != NULL) {
         pfnRegRestoreKey = (RegRestoreKeyfunc)GetProcAddress(hmodule, "RegRestoreKeyW");
         pfnRegSaveKeyEx = (RegSaveKeyExfunc)GetProcAddress(hmodule, "RegSaveKeyExW");
         pfnRegCreateKeyTransacted = (RegCreateKeyTransactedfunc)GetProcAddress(hmodule, "RegCreateKeyTransactedW");
@@ -6305,7 +6308,7 @@ PYWIN_MODULE_INIT_FUNC(win32api)
         pfnRegDeleteTree = (RegDeleteTreefunc)GetProcAddress(hmodule, "RegDeleteTreeW");
         pfnRegOpenCurrentUser = (RegOpenCurrentUserfunc)GetProcAddress(hmodule, "RegOpenCurrentUser");
         pfnRegOverridePredefKey = (RegOverridePredefKeyfunc)GetProcAddress(hmodule, "RegOverridePredefKey");
-    PYWIN_END_LOAD_LIBRARY
+    }
     // clang-format on
 
     PYWIN_MODULE_INIT_RETURN_SUCCESS;

--- a/win32/src/win32apimodule.cpp
+++ b/win32/src/win32apimodule.cpp
@@ -4778,10 +4778,7 @@ static PyObject *PySetSystemTime(PyObject *self, PyObject *args)
     {
         return ReturnAPIError("SetSystemTime");
     }
-    else
-    {
-        return Py_BuildValue("i", result);
-    }
+    else { return Py_BuildValue("i", result); }
 }
 
 // @pymethod |win32api|SetThreadLocale|Sets the current thread's locale.
@@ -6263,18 +6260,13 @@ PYWIN_MODULE_INIT_FUNC(win32api)
     PyModule_AddIntConstant(module, "VS_FF_PRIVATEBUILD", VS_FF_PRIVATEBUILD);
     PyModule_AddIntConstant(module, "VS_FF_SPECIALBUILD", VS_FF_SPECIALBUILD);
 
-    HMODULE hmodule = GetModuleHandle(TEXT("secur32.dll"));
-    if (hmodule == NULL)
-        hmodule = LoadLibrary(TEXT("secur32.dll"));
-    if (hmodule != NULL) {
+    // clang-format off
+    PYWIN_BEGIN_LOAD_LIBRARY("secur32.dll")
         pfnGetUserNameEx = (GetUserNameExfunc)GetProcAddress(hmodule, "GetUserNameExW");
         pfnGetComputerObjectName = (GetUserNameExfunc)GetProcAddress(hmodule, "GetComputerObjectNameW");
-    }
+    PYWIN_END_LOAD_LIBRARY
 
-    hmodule = GetModuleHandle(TEXT("kernel32.dll"));
-    if (hmodule == NULL)
-        hmodule = LoadLibrary(TEXT("kernel32.dll"));
-    if (hmodule != NULL) {
+    PYWIN_BEGIN_LOAD_LIBRARY("kernel32.dll")
         pfnGetComputerNameEx = (GetComputerNameExfunc)GetProcAddress(hmodule, "GetComputerNameExW");
         pfnGetLongPathNameA = (GetLongPathNameAfunc)GetProcAddress(hmodule, "GetLongPathNameA");
         pfnGetLongPathNameW = (GetLongPathNameWfunc)GetProcAddress(hmodule, "GetLongPathNameW");
@@ -6287,12 +6279,10 @@ PYWIN_MODULE_INIT_FUNC(win32api)
         pfnSetDllDirectory = (SetDllDirectoryfunc)GetProcAddress(hmodule, "SetDllDirectoryW");
         pfnSetSystemPowerState = (SetSystemPowerStatefunc)GetProcAddress(hmodule, "SetSystemPowerState");
         pfnGetNativeSystemInfo = (GetNativeSystemInfofunc)GetProcAddress(hmodule, "GetNativeSystemInfo");
-    }
+    PYWIN_END_LOAD_LIBRARY
 
-    hmodule = GetModuleHandle(TEXT("user32.dll"));
-    if (hmodule == NULL)
-        hmodule = LoadLibrary(TEXT("user32.dll"));
-    if (hmodule != NULL) {
+
+    PYWIN_BEGIN_LOAD_LIBRARY("user32.dll")
         pfnEnumDisplayMonitors = (EnumDisplayMonitorsfunc)GetProcAddress(hmodule, "EnumDisplayMonitors");
         pfnEnumDisplayDevices = (EnumDisplayDevicesfunc)GetProcAddress(hmodule, "EnumDisplayDevicesW");
         pfnChangeDisplaySettingsEx = (ChangeDisplaySettingsExfunc)GetProcAddress(hmodule, "ChangeDisplaySettingsExW");
@@ -6302,12 +6292,9 @@ PYWIN_MODULE_INIT_FUNC(win32api)
         pfnGetMonitorInfo = (GetMonitorInfofunc)GetProcAddress(hmodule, "GetMonitorInfoW");
         pfnEnumDisplaySettingsEx = (EnumDisplaySettingsExfunc)GetProcAddress(hmodule, "EnumDisplaySettingsExW");
         pfnGetLastInputInfo = (GetLastInputInfofunc)GetProcAddress(hmodule, "GetLastInputInfo");
-    }
+    PYWIN_END_LOAD_LIBRARY
 
-    hmodule = GetModuleHandle(TEXT("Advapi32.dll"));
-    if (hmodule == NULL)
-        hmodule = LoadLibrary(TEXT("Advapi32.dll"));
-    if (hmodule != NULL) {
+    PYWIN_BEGIN_LOAD_LIBRARY("Advapi32.dll")
         pfnRegRestoreKey = (RegRestoreKeyfunc)GetProcAddress(hmodule, "RegRestoreKeyW");
         pfnRegSaveKeyEx = (RegSaveKeyExfunc)GetProcAddress(hmodule, "RegSaveKeyExW");
         pfnRegCreateKeyTransacted = (RegCreateKeyTransactedfunc)GetProcAddress(hmodule, "RegCreateKeyTransactedW");
@@ -6318,7 +6305,8 @@ PYWIN_MODULE_INIT_FUNC(win32api)
         pfnRegDeleteTree = (RegDeleteTreefunc)GetProcAddress(hmodule, "RegDeleteTreeW");
         pfnRegOpenCurrentUser = (RegOpenCurrentUserfunc)GetProcAddress(hmodule, "RegOpenCurrentUser");
         pfnRegOverridePredefKey = (RegOverridePredefKeyfunc)GetProcAddress(hmodule, "RegOverridePredefKey");
-    }
+    PYWIN_END_LOAD_LIBRARY
+    // clang-format on
 
     PYWIN_MODULE_INIT_RETURN_SUCCESS;
 }

--- a/win32/src/win32apimodule.cpp
+++ b/win32/src/win32apimodule.cpp
@@ -4772,13 +4772,14 @@ static PyObject *PySetSystemTime(PyObject *self, PyObject *args)
                           ))
         return NULL;
     PyW32_BEGIN_ALLOW_THREADS result = ::SetSystemTime(&t);
-    PyW32_END_ALLOW_THREADS
+    PyW32_END_ALLOW_THREADS;
 
-        if (!result)
-    {
+    if (!result) {
         return ReturnAPIError("SetSystemTime");
     }
-    else { return Py_BuildValue("i", result); }
+    else {
+        return Py_BuildValue("i", result);
+    }
 }
 
 // @pymethod |win32api|SetThreadLocale|Sets the current thread's locale.

--- a/win32/src/win32consolemodule.cpp
+++ b/win32/src/win32consolemodule.cpp
@@ -2079,9 +2079,7 @@ PYWIN_MODULE_INIT_FUNC(win32console)
     PyDict_SetItemString(dict, "error", PyWinExc_ApiError);
 
     // load function pointers
-    kernel32_dll = GetModuleHandle(L"kernel32.dll");
-    if (kernel32_dll == NULL)
-        kernel32_dll = LoadLibrary(L"kernel32.dll");
+    kernel32_dll = PyWin_GetOrLoadLibraryHandle("kernel32.dll");
     if (kernel32_dll != NULL) {
         pfnGetConsoleProcessList = (GetConsoleProcessListfunc)GetProcAddress(kernel32_dll, "GetConsoleProcessList");
         pfnGetConsoleDisplayMode = (GetConsoleDisplayModefunc)GetProcAddress(kernel32_dll, "GetConsoleDisplayMode");

--- a/win32/src/win32file.i
+++ b/win32/src/win32file.i
@@ -5932,11 +5932,8 @@ PyCFunction pfnpy_OpenFileById=(PyCFunction)py_OpenFileById;
 			)
 			pmd->ml_flags = METH_VARARGS | METH_KEYWORDS;
 
-	HMODULE hmodule;
-	hmodule=GetModuleHandle(TEXT("AdvAPI32.dll"));
-	if (hmodule==NULL)
-		hmodule=LoadLibrary(TEXT("AdvAPI32.dll"));
-	if (hmodule){
+	HMODULE hmodule = PyWin_GetOrLoadLibraryHandle("advapi32.dll");
+	if (hmodule != NULL) {
 		pfnEncryptFile=(EncryptFilefunc)GetProcAddress(hmodule, "EncryptFileW");
 		pfnDecryptFile=(DecryptFilefunc)GetProcAddress(hmodule, "DecryptFileW");
 		pfnEncryptionDisable=(EncryptionDisablefunc)GetProcAddress(hmodule, "EncryptionDisable");
@@ -5952,12 +5949,10 @@ PyCFunction pfnpy_OpenFileById=(PyCFunction)py_OpenFileById;
 		pfnReadEncryptedFileRaw=(ReadEncryptedFileRawfunc)GetProcAddress(hmodule, "ReadEncryptedFileRaw");
 		pfnWriteEncryptedFileRaw=(WriteEncryptedFileRawfunc)GetProcAddress(hmodule, "WriteEncryptedFileRaw");
 		pfnCloseEncryptedFileRaw=(CloseEncryptedFileRawfunc)GetProcAddress(hmodule, "CloseEncryptedFileRaw");
-		}
+	}
 
-	hmodule=GetModuleHandle(TEXT("kernel32.dll"));
-	if (hmodule==NULL)
-		hmodule=LoadLibrary(TEXT("kernel32.dll"));
-	if (hmodule){
+	hmodule = PyWin_GetOrLoadLibraryHandle("kernel32.dll");
+	if (hmodule != NULL) {
 		pfnSetVolumeMountPoint=(SetVolumeMountPointfunc)GetProcAddress(hmodule, "SetVolumeMountPointW");
 		pfnDeleteVolumeMountPoint=(DeleteVolumeMountPointfunc)GetProcAddress(hmodule, "DeleteVolumeMountPointW");
 		pfnGetVolumeNameForVolumeMountPoint=(GetVolumeNameForVolumeMountPointfunc)GetProcAddress(hmodule, "GetVolumeNameForVolumeMountPointW");
@@ -6002,15 +5997,13 @@ PyCFunction pfnpy_OpenFileById=(PyCFunction)py_OpenFileById;
 		pfnWow64RevertWow64FsRedirection=(Wow64RevertWow64FsRedirectionfunc)GetProcAddress(hmodule, "Wow64RevertWow64FsRedirection");
 		pfnReOpenFile=(ReOpenFilefunc)GetProcAddress(hmodule, "ReOpenFile");
 		pfnOpenFileById=(OpenFileByIdfunc)GetProcAddress(hmodule, "OpenFileById");
-		}
+	}
 
-	hmodule=GetModuleHandle(TEXT("sfc.dll"));
-	if (hmodule==NULL)
-		hmodule=LoadLibrary(TEXT("sfc.dll"));
-	if (hmodule){
+	hmodule = PyWin_GetOrLoadLibraryHandle("sfc.dll");
+	if (hmodule != NULL) {
 		pfnSfcGetNextProtectedFile=(SfcGetNextProtectedFilefunc)GetProcAddress(hmodule, "SfcGetNextProtectedFile");
 		pfnSfcIsFileProtected=(SfcIsFileProtectedfunc)GetProcAddress(hmodule, "SfcIsFileProtected");
-		}
+	}
 
 %}
 

--- a/win32/src/win32gui.i
+++ b/win32/src/win32gui.i
@@ -266,7 +266,8 @@ for (PyMethodDef *pmd = win32guiMethods; pmd->ml_name; pmd++)
 		)
 		pmd->ml_flags = METH_VARARGS | METH_KEYWORDS;
 
-PYWIN_BEGIN_LOAD_LIBRARY("user32.dll")
+HMODULE hmodule = PyWin_LibraryModule("user32.dll");
+if (hmodule != NULL) {
     pfnSetLayeredWindowAttributes = (SetLayeredWindowAttributesfunc)GetProcAddress(hmodule,"SetLayeredWindowAttributes");
     pfnGetLayeredWindowAttributes = (GetLayeredWindowAttributesfunc)GetProcAddress(hmodule,"GetLayeredWindowAttributes");
     pfnUpdateLayeredWindow = (UpdateLayeredWindowfunc)GetProcAddress(hmodule,"UpdateLayeredWindow");
@@ -274,9 +275,10 @@ PYWIN_BEGIN_LOAD_LIBRARY("user32.dll")
     pfnGetMenuInfo = (GetMenuInfofunc)GetProcAddress(hmodule,"GetMenuInfo");
     pfnSetMenuInfo = (SetMenuInfofunc)GetProcAddress(hmodule,"SetMenuInfo");
     pfnDrawTextW = (DrawTextWfunc)GetProcAddress(hmodule, "DrawTextW");
-PYWIN_END_LOAD_LIBRARY
+}
 
-PYWIN_BEGIN_LOAD_LIBRARY("gdi32.dll")
+hmodule = PyWin_LibraryModule("gdi32.dll");
+if (hmodule != NULL) {
     pfnAngleArc = (AngleArcfunc)GetProcAddress(hmodule,"AngleArc");
     pfnPlgBlt = (PlgBltfunc)GetProcAddress(hmodule,"PlgBlt");
     pfnGetWorldTransform = (GetWorldTransformfunc)GetProcAddress(hmodule,"GetWorldTransform");
@@ -286,13 +288,14 @@ PYWIN_BEGIN_LOAD_LIBRARY("gdi32.dll")
     pfnMaskBlt = (MaskBltfunc)GetProcAddress(hmodule,"MaskBlt");
     pfnGetLayout = (GetLayoutfunc)GetProcAddress(hmodule,"GetLayout");
     pfnSetLayout = (SetLayoutfunc)GetProcAddress(hmodule,"SetLayout");
-PYWIN_END_LOAD_LIBRARY
+}
 
-PYWIN_BEGIN_LOAD_LIBRARY("msimg32.dll")
+hmodule = PyWin_LibraryModule("msimg32.dll");
+if (hmodule != NULL) {
     pfnGradientFill = (GradientFillfunc)GetProcAddress(hmodule,"GradientFill");
     pfnTransparentBlt = (TransparentBltfunc)GetProcAddress(hmodule,"TransparentBlt");
     pfnAlphaBlend = (AlphaBlendfunc)GetProcAddress(hmodule,"AlphaBlend");
-PYWIN_END_LOAD_LIBRARY
+}
 %}
 
 %{

--- a/win32/src/win32gui.i
+++ b/win32/src/win32gui.i
@@ -266,42 +266,33 @@ for (PyMethodDef *pmd = win32guiMethods; pmd->ml_name; pmd++)
 		)
 		pmd->ml_flags = METH_VARARGS | METH_KEYWORDS;
 
-HMODULE hmodule=GetModuleHandle(TEXT("user32.dll"));
-if (hmodule==NULL)
-	hmodule=LoadLibrary(TEXT("user32.dll"));
-if (hmodule){
-	pfnSetLayeredWindowAttributes=(SetLayeredWindowAttributesfunc)GetProcAddress(hmodule,"SetLayeredWindowAttributes");
-	pfnGetLayeredWindowAttributes=(GetLayeredWindowAttributesfunc)GetProcAddress(hmodule,"GetLayeredWindowAttributes");
-	pfnUpdateLayeredWindow=(UpdateLayeredWindowfunc)GetProcAddress(hmodule,"UpdateLayeredWindow");
-	pfnAnimateWindow=(AnimateWindowfunc)GetProcAddress(hmodule,"AnimateWindow");
-	pfnGetMenuInfo=(GetMenuInfofunc)GetProcAddress(hmodule,"GetMenuInfo");
-	pfnSetMenuInfo=(SetMenuInfofunc)GetProcAddress(hmodule,"SetMenuInfo");
-	pfnDrawTextW=(DrawTextWfunc)GetProcAddress(hmodule, "DrawTextW");
-	}
+PYWIN_BEGIN_LOAD_LIBRARY("user32.dll")
+    pfnSetLayeredWindowAttributes = (SetLayeredWindowAttributesfunc)GetProcAddress(hmodule,"SetLayeredWindowAttributes");
+    pfnGetLayeredWindowAttributes = (GetLayeredWindowAttributesfunc)GetProcAddress(hmodule,"GetLayeredWindowAttributes");
+    pfnUpdateLayeredWindow = (UpdateLayeredWindowfunc)GetProcAddress(hmodule,"UpdateLayeredWindow");
+    pfnAnimateWindow = (AnimateWindowfunc)GetProcAddress(hmodule,"AnimateWindow");
+    pfnGetMenuInfo = (GetMenuInfofunc)GetProcAddress(hmodule,"GetMenuInfo");
+    pfnSetMenuInfo = (SetMenuInfofunc)GetProcAddress(hmodule,"SetMenuInfo");
+    pfnDrawTextW = (DrawTextWfunc)GetProcAddress(hmodule, "DrawTextW");
+PYWIN_END_LOAD_LIBRARY
 
-hmodule=GetModuleHandle(TEXT("gdi32.dll"));
-if (hmodule==NULL)
-	hmodule=LoadLibrary(TEXT("gdi32.dll"));
-if (hmodule){
-	pfnAngleArc=(AngleArcfunc)GetProcAddress(hmodule,"AngleArc");
-	pfnPlgBlt=(PlgBltfunc)GetProcAddress(hmodule,"PlgBlt");
-	pfnGetWorldTransform=(GetWorldTransformfunc)GetProcAddress(hmodule,"GetWorldTransform");
-	pfnSetWorldTransform=(SetWorldTransformfunc)GetProcAddress(hmodule,"SetWorldTransform");
-	pfnModifyWorldTransform=(ModifyWorldTransformfunc)GetProcAddress(hmodule,"ModifyWorldTransform");
-	pfnCombineTransform=(CombineTransformfunc)GetProcAddress(hmodule,"CombineTransform");
-	pfnMaskBlt=(MaskBltfunc)GetProcAddress(hmodule,"MaskBlt");
-	pfnGetLayout=(GetLayoutfunc)GetProcAddress(hmodule,"GetLayout");
-	pfnSetLayout=(SetLayoutfunc)GetProcAddress(hmodule,"SetLayout");
-	}
+PYWIN_BEGIN_LOAD_LIBRARY("gdi32.dll")
+    pfnAngleArc = (AngleArcfunc)GetProcAddress(hmodule,"AngleArc");
+    pfnPlgBlt = (PlgBltfunc)GetProcAddress(hmodule,"PlgBlt");
+    pfnGetWorldTransform = (GetWorldTransformfunc)GetProcAddress(hmodule,"GetWorldTransform");
+    pfnSetWorldTransform = (SetWorldTransformfunc)GetProcAddress(hmodule,"SetWorldTransform");
+    pfnModifyWorldTransform = (ModifyWorldTransformfunc)GetProcAddress(hmodule,"ModifyWorldTransform");
+    pfnCombineTransform = (CombineTransformfunc)GetProcAddress(hmodule,"CombineTransform");
+    pfnMaskBlt = (MaskBltfunc)GetProcAddress(hmodule,"MaskBlt");
+    pfnGetLayout = (GetLayoutfunc)GetProcAddress(hmodule,"GetLayout");
+    pfnSetLayout = (SetLayoutfunc)GetProcAddress(hmodule,"SetLayout");
+PYWIN_END_LOAD_LIBRARY
 
-hmodule=GetModuleHandle(TEXT("msimg32.dll"));
-if (hmodule==NULL)
-	hmodule=LoadLibrary(TEXT("msimg32.dll"));
-if (hmodule){
-	pfnGradientFill=(GradientFillfunc)GetProcAddress(hmodule,"GradientFill");
-	pfnTransparentBlt=(TransparentBltfunc)GetProcAddress(hmodule,"TransparentBlt");
-	pfnAlphaBlend=(AlphaBlendfunc)GetProcAddress(hmodule,"AlphaBlend");
-	}
+PYWIN_BEGIN_LOAD_LIBRARY("msimg32.dll")
+    pfnGradientFill = (GradientFillfunc)GetProcAddress(hmodule,"GradientFill");
+    pfnTransparentBlt = (TransparentBltfunc)GetProcAddress(hmodule,"TransparentBlt");
+    pfnAlphaBlend = (AlphaBlendfunc)GetProcAddress(hmodule,"AlphaBlend");
+PYWIN_END_LOAD_LIBRARY
 %}
 
 %{

--- a/win32/src/win32gui.i
+++ b/win32/src/win32gui.i
@@ -266,7 +266,7 @@ for (PyMethodDef *pmd = win32guiMethods; pmd->ml_name; pmd++)
 		)
 		pmd->ml_flags = METH_VARARGS | METH_KEYWORDS;
 
-HMODULE hmodule = PyWin_LibraryModule("user32.dll");
+HMODULE hmodule = PyWin_GetOrLoadLibraryHandle("user32.dll");
 if (hmodule != NULL) {
     pfnSetLayeredWindowAttributes = (SetLayeredWindowAttributesfunc)GetProcAddress(hmodule,"SetLayeredWindowAttributes");
     pfnGetLayeredWindowAttributes = (GetLayeredWindowAttributesfunc)GetProcAddress(hmodule,"GetLayeredWindowAttributes");
@@ -277,7 +277,7 @@ if (hmodule != NULL) {
     pfnDrawTextW = (DrawTextWfunc)GetProcAddress(hmodule, "DrawTextW");
 }
 
-hmodule = PyWin_LibraryModule("gdi32.dll");
+hmodule = PyWin_GetOrLoadLibraryHandle("gdi32.dll");
 if (hmodule != NULL) {
     pfnAngleArc = (AngleArcfunc)GetProcAddress(hmodule,"AngleArc");
     pfnPlgBlt = (PlgBltfunc)GetProcAddress(hmodule,"PlgBlt");
@@ -290,7 +290,7 @@ if (hmodule != NULL) {
     pfnSetLayout = (SetLayoutfunc)GetProcAddress(hmodule,"SetLayout");
 }
 
-hmodule = PyWin_LibraryModule("msimg32.dll");
+hmodule = PyWin_GetOrLoadLibraryHandle("msimg32.dll");
 if (hmodule != NULL) {
     pfnGradientFill = (GradientFillfunc)GetProcAddress(hmodule,"GradientFill");
     pfnTransparentBlt = (TransparentBltfunc)GetProcAddress(hmodule,"TransparentBlt");

--- a/win32/src/win32inet.i
+++ b/win32/src/win32inet.i
@@ -1941,7 +1941,7 @@ extern PyObject *PyWinHttpOpen(PyObject *, PyObject *);
 
 %init %{
 	PyDict_SetItemString(d,	"error", PyWinExc_ApiError);
-	HMODULE	hmod = GetModuleHandle(TEXT("wininet.dll"));
+	HMODULE	hmod = PyWin_GetOrLoadLibraryHandle("wininet.dll");
 	assert(hmod);
 	PyWin_RegisterErrorMessageModule(INTERNET_ERROR_BASE,
 									 INTERNET_ERROR_LAST,

--- a/win32/src/win32job.i
+++ b/win32/src/win32job.i
@@ -20,12 +20,10 @@ static IsProcessInJobfunc pfnIsProcessInJob=NULL;
 
 
 %init %{
-HMODULE hmodule=GetModuleHandle(L"kernel32.dll");
-if (hmodule==NULL)
-	hmodule=LoadLibrary(L"kernel32.dll");
-if (hmodule){
-	pfnIsProcessInJob=(IsProcessInJobfunc)GetProcAddress(hmodule,"IsProcessInJob");
-	}
+HMODULE hmodule = PyWin_GetOrLoadLibraryHandle("kernel32.dll");
+if (hmodule != NULL) {
+	pfnIsProcessInJob = (IsProcessInJobfunc)GetProcAddress(hmodule, "IsProcessInJob");
+}
 
 %}
 

--- a/win32/src/win32net/win32netmodule.cpp
+++ b/win32/src/win32net/win32netmodule.cpp
@@ -1211,10 +1211,8 @@ PYWIN_MODULE_INIT_FUNC(win32net)
     AddConstant(dict, "USE_FORCE", USE_FORCE);
     AddConstant(dict, "USE_LOTS_OF_FORCE", USE_LOTS_OF_FORCE);
 
-    HMODULE hmodule = GetModuleHandle(_T("netapi32"));
+    HMODULE hmodule = PyWin_GetOrLoadLibraryHandle("netapi32.dll");
 #if WINVER >= 0x0500
-    if (hmodule == NULL)
-        hmodule = LoadLibrary(_T("netapi32"));
     if (hmodule != NULL) {
         pfnNetValidateName = (NetValidateNamefunc)GetProcAddress(hmodule, "NetValidateName");
         pfnNetGetJoinInformation = (NetGetJoinInformationfunc)GetProcAddress(hmodule, "NetGetJoinInformation");

--- a/win32/src/win32pipe.i
+++ b/win32/src/win32pipe.i
@@ -25,15 +25,13 @@ static GetNamedPipeClientProcessIdfunc pfnGetNamedPipeServerSessionId = NULL;
 	// All errors raised by this module are of this type.
 	PyDict_SetItemString(d, "error", PyWinExc_ApiError);
 
-	HMODULE hmod=GetModuleHandle(_T("Kernel32.dll"));
-	if (!hmod)
-		hmod=LoadLibrary(_T("Kernel32.dll"));
-	if (hmod){
+	HMODULE hmod = PyWin_GetOrLoadLibraryHandle("kernel32.dll");
+	if (hmod != NULL) {
 		pfnGetNamedPipeClientProcessId = (GetNamedPipeClientProcessIdfunc)GetProcAddress(hmod, "GetNamedPipeClientProcessId");
 		pfnGetNamedPipeServerProcessId = (GetNamedPipeClientProcessIdfunc)GetProcAddress(hmod, "GetNamedPipeServerProcessId");
 		pfnGetNamedPipeClientSessionId = (GetNamedPipeClientProcessIdfunc)GetProcAddress(hmod, "GetNamedPipeClientSessionId");
 		pfnGetNamedPipeServerSessionId = (GetNamedPipeClientProcessIdfunc)GetProcAddress(hmod, "GetNamedPipeServerSessionId");
-		}
+	}
 %}
 
 %{

--- a/win32/src/win32process.i
+++ b/win32/src/win32process.i
@@ -1686,23 +1686,18 @@ PyObject *PyWriteProcessMemory(PyObject *self, PyObject *args)
 	if (PyType_Ready(&PySTARTUPINFOType) == -1)
 		return NULL;
 
-	FARPROC fp=NULL;
-	HMODULE hmodule=NULL;
-	hmodule=GetModuleHandle(_T("Psapi.dll"));
-	if (hmodule==NULL)
-		hmodule=LoadLibrary(_T("Psapi.dll"));
-	if (hmodule!=NULL){
+	FARPROC fp = NULL;
+	HMODULE hmodule = PyWin_GetOrLoadLibraryHandle("psapi.dll");
+	if (hmodule != NULL) {
 		pfnEnumProcesses = (EnumProcessesfunc)GetProcAddress(hmodule, "EnumProcesses");
 		pfnEnumProcessModules = (EnumProcessModulesfunc)GetProcAddress(hmodule, "EnumProcessModules");
 		pfnEnumProcessModulesEx = (EnumProcessModulesExfunc)GetProcAddress(hmodule, "EnumProcessModulesEx");
 		pfnGetModuleFileNameEx = (GetModuleFileNameExfunc)GetProcAddress(hmodule, "GetModuleFileNameExW");
 		pfnGetProcessMemoryInfo = (GetProcessMemoryInfofunc)GetProcAddress(hmodule, "GetProcessMemoryInfo");
-		}
+	}
 
-	hmodule=GetModuleHandle(_T("Kernel32.dll"));
-	if (hmodule==NULL)
-		hmodule=LoadLibrary(_T("Kernel32.dll"));
-	if (hmodule!=NULL){
+	hmodule = PyWin_GetOrLoadLibraryHandle("kernel32.dll");
+	if (hmodule != NULL) {
 		pfnGetProcessTimes=(GetProcessTimesfunc)GetProcAddress(hmodule,"GetProcessTimes");
 		pfnGetProcessIoCounters=(GetProcessIoCountersfunc)GetProcAddress(hmodule,"GetProcessIoCounters");
 		pfnGetProcessShutdownParameters=(GetProcessShutdownParametersfunc)GetProcAddress(hmodule,"GetProcessShutdownParameters");
@@ -1720,15 +1715,13 @@ PyObject *PyWriteProcessMemory(PyObject *self, PyObject *args)
 		pfnSetProcessAffinityMask=(SetProcessAffinityMaskfunc)GetProcAddress(hmodule,"SetProcessAffinityMask");
 		pfnGetProcessId=(GetProcessIdfunc)GetProcAddress(hmodule, "GetProcessId");
 		pfnIsWow64Process=(IsWow64Processfunc)GetProcAddress(hmodule, "IsWow64Process");
-		}
+	}
 
-	hmodule=GetModuleHandle(_T("User32.dll"));
-	if (hmodule==NULL)
-		hmodule=LoadLibrary(_T("User32.dll"));
-	if (hmodule!=NULL){
+	hmodule = PyWin_GetOrLoadLibraryHandle("user32.dll");
+	if (hmodule != NULL) {
 		pfnGetProcessWindowStation=(GetProcessWindowStationfunc)GetProcAddress(hmodule,"GetProcessWindowStation");
 		pfnGetGuiResources=(GetGuiResourcesfunc)GetProcAddress(hmodule,"GetGuiResources");
-		}
+	}
 
 // *sob* - these symbols don't exist in the platform sdk needed to build
 // using Python 2.3

--- a/win32/src/win32profilemodule.cpp
+++ b/win32/src/win32profilemodule.cpp
@@ -489,10 +489,7 @@ PYWIN_MODULE_INIT_FUNC(win32profile)
     PyModule_AddIntConstant(module, "PT_ROAMING", PT_ROAMING);
     PyModule_AddIntConstant(module, "PT_TEMPORARY", PT_TEMPORARY);
 
-    HMODULE hmodule;
-    hmodule = GetModuleHandle(L"Userenv.dll");
-    if (hmodule == NULL)
-        hmodule = LoadLibrary(L"Userenv.dll");
+    HMODULE hmodule = PyWin_GetOrLoadLibraryHandle("userenv.dll");
     if (hmodule != NULL) {
         pfnDeleteProfile = (DeleteProfilefunc)GetProcAddress(hmodule, "DeleteProfileW");
         pfnExpandEnvironmentStringsForUser =

--- a/win32/src/win32service.i
+++ b/win32/src/win32service.i
@@ -36,12 +36,9 @@ EnumServicesStatusExfunc fpEnumServicesStatusEx=NULL;
 	PyDict_SetItemString(d, "error", PyWinExc_ApiError);
 	PyDict_SetItemString(d, "HWINSTAType", (PyObject *)&PyHWINSTAType);
 	PyDict_SetItemString(d, "HDESKType", (PyObject *)&PyHDESKType);
-	HMODULE hmod;
 	FARPROC fp;
-	hmod=GetModuleHandle(_T("Advapi32"));
-	if (hmod==NULL)
-		hmod=LoadLibrary(_T("Advapi32"));
-	if (hmod!=NULL){
+	HMODULE hmod = PyWin_GetOrLoadLibraryHandle("advapi32.dll");
+	if (hmod != NULL) {
 		fp=GetProcAddress(hmod,"QueryServiceStatusEx");
 		if (fp!=NULL)
 			fpQueryServiceStatusEx=(QueryServiceStatusExfunc)fp;
@@ -54,7 +51,7 @@ EnumServicesStatusExfunc fpEnumServicesStatusEx=NULL;
 		fp=GetProcAddress(hmod,"EnumServicesStatusExW");
 		if (fp!=NULL)
 			fpEnumServicesStatusEx=(EnumServicesStatusExfunc)fp;
-		}
+	}
 %}
 
 %{

--- a/win32/src/win32transactionmodule.cpp
+++ b/win32/src/win32transactionmodule.cpp
@@ -235,10 +235,8 @@ PYWIN_MODULE_INIT_FUNC(win32transaction)
                               " transacted NTFS and transacted registry functions.");
 
     // Load dll and function pointers to avoid dependency on newer libraries and headers
-    HMODULE hmodule = GetModuleHandle(L"Ktmw32.dll");
-    if (hmodule == NULL)
-        hmodule = LoadLibrary(L"Ktmw32.dll");
-    if (hmodule) {
+    HMODULE hmodule = PyWin_GetOrLoadLibraryHandle("ktmw32.dll");
+    if (hmodule != NULL) {
         pfnCreateTransaction = (CreateTransactionfunc)GetProcAddress(hmodule, "CreateTransaction");
         pfnRollbackTransaction = (RollbackTransactionfunc)GetProcAddress(hmodule, "RollbackTransaction");
         pfnRollbackTransactionAsync = (RollbackTransactionAsyncfunc)GetProcAddress(hmodule, "RollbackTransactionAsync");

--- a/win32/src/win32tsmodule.cpp
+++ b/win32/src/win32tsmodule.cpp
@@ -836,10 +836,8 @@ PYWIN_MODULE_INIT_FUNC(win32ts)
     PyModule_AddIntConstant(module, "NOTIFY_FOR_THIS_SESSION", NOTIFY_FOR_THIS_SESSION);
     PyModule_AddIntConstant(module, "NOTIFY_FOR_ALL_SESSIONS", NOTIFY_FOR_ALL_SESSIONS);
 
-    HMODULE h = GetModuleHandle(L"wtsapi32.dll");
-    if (h == NULL)
-        h = LoadLibrary(L"wtsapi32.dll");
-    if (h) {
+    HMODULE h = PyWin_GetOrLoadLibraryHandle("wtsapi32.dll");
+    if (h != NULL) {
         pfnWTSQueryUserToken = (WTSQueryUserTokenfunc)GetProcAddress(h, "WTSQueryUserToken");
         pfnWTSRegisterSessionNotification =
             (WTSRegisterSessionNotificationfunc)GetProcAddress(h, "WTSRegisterSessionNotification");
@@ -847,10 +845,8 @@ PYWIN_MODULE_INIT_FUNC(win32ts)
             (WTSUnRegisterSessionNotificationfunc)GetProcAddress(h, "WTSUnRegisterSessionNotification");
     }
 
-    h = GetModuleHandle(L"kernel32.dll");
-    if (h == NULL)
-        h = LoadLibrary(L"kernel32.dll");
-    if (h) {
+    h = PyWin_GetOrLoadLibraryHandle("kernel32.dll");
+    if (h != NULL) {
         pfnProcessIdToSessionId = (ProcessIdToSessionIdfunc)GetProcAddress(h, "ProcessIdToSessionId");
         pfnWTSGetActiveConsoleSessionId =
             (WTSGetActiveConsoleSessionIdfunc)GetProcAddress(h, "WTSGetActiveConsoleSessionId");


### PR DESCRIPTION
This is a proposed fix for #2301.

When searching for functions in libraries, *GetModuleHandle* is attempted 1<sup>st</sup> (most likely to avoid incrementing *RefCount*), and only if it fails *LoadLibrary* is used. Unfortunately, for libraries that aren't already loaded ("secur32* for *win32api* or *msimg32* for *win32gui*) *GetModuleHandle* sets last error flag to *126*: *ERROR\_MOD\_NOT\_FOUND*. Since the flag is not cleared, for *win32gui* my *EnumWindows* changes seem to have no effect.

The proposed fix is in a form of a macro that does the library loading (following *Py\_BEGIN\_ALLOW\_THREADS* model) and clears this particular error.

**Notes**:

- A simpler way would be to simply clear the error once (just before module initialization end), but that's lame, and may swallow other errors that could come and bite in the ass at a later time (just like this one did)

- I only fixed these 2 modules (as a POC). I will fix the others affected (a quick code search revealed them), once I have the green light, as this is basically monkey-work (that I don't want to do more than absolutely necessary)

- My *win32gui* tests were not affected by it since I'm manually clearing the error flag. I remember that I ran into this error at the time, and clearing the flag fixed the problem which was good enough (I didn't dig deeper). But tests are perfectly fine, as they should start from a known (and deterministic) state

- I don't know why this method with function pointers was chosen (instead of linking with the *.lib* files), as a vast majority of these functions are there since *Windows 2000* (and exposed by *VStudio*)

-  I wouldn't be surprised if there were more open issues caused by this
