### PR TITLE
Implement record pointers as [in, out] method parameters of a Dispatch Interface

### DIFF
--- a/com/TestSources/PyCOMTest/PyCOMImpl.cpp
+++ b/com/TestSources/PyCOMTest/PyCOMImpl.cpp
@@ -618,6 +618,14 @@ HRESULT CPyCOMTest::GetStruct(TestStruct1 *ret)
     *ret = r;
     return S_OK;
 }
+
+HRESULT CPyCOMTest::ModifyStruct(TestStruct1 *prec)
+{
+    prec->int_value = 100;
+    prec->str_value = SysAllocString(L"Nothing is as constant as change");
+    return S_OK;
+}
+
 HRESULT CPyCOMTest::DoubleString(BSTR in, BSTR *out)
 {
     *out = SysAllocStringLen(NULL, SysStringLen(in) * 2);

--- a/com/TestSources/PyCOMTest/PyCOMImpl.h
+++ b/com/TestSources/PyCOMTest/PyCOMImpl.h
@@ -119,6 +119,8 @@ class CPyCOMTest : public IDispatchImpl<IPyCOMTest, &IID_IPyCOMTest, &LIBID_PyCO
     STDMETHOD(None)();
     STDMETHOD(def)();
 
+    STDMETHOD(ModifyStruct)(TestStruct1 *prec);
+
     // info associated to each session
     struct PyCOMTestSessionData {
         IStream *pStream;  // Stream for marshalling the data to the new thread.

--- a/com/TestSources/PyCOMTest/PyCOMTest.idl
+++ b/com/TestSources/PyCOMTest/PyCOMTest.idl
@@ -293,6 +293,8 @@ library PyCOMTestLib
 		// reserved words etc
 		HRESULT None();
 		HRESULT def();
+        // Test struct byref as [ in, out ] parameter.
+        HRESULT ModifyStruct([ in, out ] TestStruct1 * prec);
 	};
 
 	// Define a new class to test how Python handles derived interfaces!

--- a/com/win32com/client/build.py
+++ b/com/win32com/client/build.py
@@ -545,7 +545,6 @@ def _ResolveType(typerepr, itypeinfo):
             if was_user and subrepr in [
                 pythoncom.VT_DISPATCH,
                 pythoncom.VT_UNKNOWN,
-                pythoncom.VT_RECORD,
             ]:
                 # Drop the VT_PTR indirection
                 return subrepr, sub_clsid, sub_doc

--- a/com/win32com/src/oleargs.cpp
+++ b/com/win32com/src/oleargs.cpp
@@ -1572,6 +1572,7 @@ BOOL PythonOleArgHelper::MakeObjToVariant(PyObject *obj, VARIANT *var, PyObject 
             // Nothing else to do - the code below sets the VT up correctly.
             break;
         case VT_RECORD:
+		case VT_RECORD | VT_BYREF:
             rc = PyObject_AsVARIANTRecordInfo(obj, var);
             break;
         case VT_CY:

--- a/com/win32com/test/testPyComTest.py
+++ b/com/win32com/test/testPyComTest.py
@@ -198,6 +198,18 @@ def TestCommon(o, is_generated):
     progress("Checking structs")
     r = o.GetStruct()
     assert r.int_value == 99 and str(r.str_value) == "Hello from C++"
+    # Dynamic does not support struct byref as [ in, out ] parameters
+    if hasattr(o, "CLSID"):
+        progress("Checking struct byref as [ in, out ] parameter")
+        mod_r = o.ModifyStruct(r)
+        # We expect the input value to stay unchanged
+        assert r.int_value == 99 and str(r.str_value) == "Hello from C++"
+        # and the return value to reflect the modifications performed on the COM server side
+        assert (
+            mod_r.int_value == 100
+            and str(mod_r.str_value) == "Nothing is as constant as change"
+        )
+
     assert o.DoubleString("foo") == "foofoo"
 
     progress("Checking var args")


### PR DESCRIPTION
to get server side modifications of a record marshaled back to the client.

COM interfaces with an [in, out] method parameter of type pointer to record can get
server side changes to record fields marshaled back to the client.

The current implementation of win32com does not support this and drops
an indirection level on pointer to records, i.e. the VT_BYREF attribute from a VT_RECORD.

This pull request changes the handling of record pointers and enables server side modifications of record fields to be visible on the client side. The standard type library marshaler does marshal those server side modifications back to the COM client when the VARIANT type of a parameter in the DISPPARAMS structure is (VT_BYREF | VT_RECORD).

This pull request resolves #2304.