### PR TITLE
Remove `lib2to3`

### DIFF
--- a/adodbapi/quick_reference.md
+++ b/adodbapi/quick_reference.md
@@ -816,7 +816,7 @@ Running the tests
 The test folder contains a set of unittest programs. Setting them up can
 be a bit complex, because you need several database servers to do a
 complete test, and each one has a different configuration. Scripts in
-this folder try to work in Python 2.7 or Python 3.5(+)
+this folder try to work in Python 3.7(+)
 
 - dbapi20.py
 

--- a/adodbapi/quick_reference.md
+++ b/adodbapi/quick_reference.md
@@ -846,9 +846,8 @@ the database servers are distant, this can take a while.
 It does some lightweight command line processing (actually the config
 does it).
 
-"\--package" tries to build a proper Python package in a temporary
-location and adds it to sys.path so it can import a test version of the
-code. It will run 2to3 when it does this, if needed.
+"\--package" tries to build a proper Python package in a temporary location
+and adds it to sys.path so it can import a test version of the code.
 
 "\--all" run as many of the 12 passes as possible.
 

--- a/adodbapi/test/adodbapitestconfig.py
+++ b/adodbapi/test/adodbapitestconfig.py
@@ -32,7 +32,7 @@ except:
 if "--help" in sys.argv:
     print(
         """Valid command-line switches are:
-    --package - create a temporary test package, run 2to3 if needed.
+    --package - create a temporary test package
     --all - run all possible tests
     --time - do time format test
     --nojet - do not test against an ACCESS database file
@@ -56,7 +56,7 @@ mdb_name = "xx_" + tmp + ".mdb"  # generate a non-colliding name for the tempora
 testfolder = setuptestframework.maketemp()
 
 if "--package" in sys.argv:
-    #  create a new adodbapi module -- running 2to3 if needed.
+    #  create a new adodbapi module
     pth = setuptestframework.makeadopackage(testfolder)
 else:
     #  use the adodbapi module in which this file appears

--- a/adodbapi/test/adodbapitestconfig.py
+++ b/adodbapi/test/adodbapitestconfig.py
@@ -67,17 +67,10 @@ if pth not in sys.path:
 
 # function to clean up the temporary folder -- calling program must run this function before exit.
 cleanup = setuptestframework.getcleanupfunction()
-try:
-    import adodbapi  # will (hopefully) be imported using the "pth" discovered above
-except SyntaxError:
-    print(
-        '\n* * * Are you trying to run Python2 code using Python3? Re-run this test using the "--package" switch.'
-    )
-    sys.exit(11)
-try:
-    print(adodbapi.version)  # show version
-except:
-    print('"adodbapi.version" not present or not working.')
+
+import adodbapi  # will (hopefully) be imported using the "pth" discovered above
+
+print(adodbapi.version)  # show version
 print(__doc__)
 
 verbose = False
@@ -183,7 +176,7 @@ if doPostgresTest:
         _password,
         _computername,
         _databasename,
-        **kws
+        **kws,
     )
 
 assert (

--- a/adodbapi/test/setuptestframework.py
+++ b/adodbapi/test/setuptestframework.py
@@ -3,7 +3,6 @@
 "setuptestframework.py v 2.6.0.8"
 import os
 import shutil
-import sys
 import tempfile
 
 
@@ -46,7 +45,7 @@ def makeadopackage(testfolder):
     if os.path.exists(adoName):
         newpackage = os.path.join(testfolder, "adodbapi")
         try:
-            os.mkdir(newpackage)
+            os.makedirs(newpackage)
         except OSError:
             print(
                 "*Note: temporary adodbapi package already exists: may be two versions running?"
@@ -54,13 +53,6 @@ def makeadopackage(testfolder):
         for f in os.listdir(adoPath):
             if f.endswith(".py"):
                 shutil.copy(os.path.join(adoPath, f), newpackage)
-        if sys.version_info >= (3, 0):  # only when running Py3.n
-            save = sys.stdout
-            sys.stdout = None
-            from lib2to3.main import main  # use 2to3 to make test package
-
-            main("lib2to3.fixes", args=["-n", "-w", newpackage])
-            sys.stdout = save
         return testfolder
     else:
         raise OSError("Connot find source of adodbapi to test.")


### PR DESCRIPTION
`lib2to3` is no longer provided with Python 3.13: https://peps.python.org/pep-0594/#deprecated-modules But it's also redundant here.

See the following test:
`python -c "from setuptestframework import makeadopackage; makeadopackage('test_folder')"`:
Before: [with_2_to_3.zip](https://github.com/user-attachments/files/16339685/with_2_to_3.zip)
This PR: [plain.zip](https://github.com/user-attachments/files/16339682/plain.zip)

The only changes are:
- Naive addition of extra parentheses around `print` arguments
- `lib2to3` actually *breaks* annotations by removing `from __future__ import annotations`
- `dict.items()` is redundantly wrapped in a `list` (probably to avoid issues with single-use iterators)
- Redundant type tuple in `isinstance` is simplified (good catch `lib2to3`, I've added this source code cleanup to https://github.com/mhammond/pywin32/pull/2094 )

Additionally, I changed `os.mkdir` to `os.makedirs` (which creates folders recursively) so that you don't have to manually create the test folder first (it would still fail if it already exists)