### PR TITLE
Remove `cgi` | Fix `isapi.ThreadPoolExtension`'s printing of exception traceback

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,7 @@ Coming in build 307, as yet unreleased
 --------------------------------------
 
 ### pywin32
+* Fix `isapi.ThreadPoolExtension`'s printing of exception traceback broken on Python 3.8+ (#2312, @Avasam)
 * Add RealGetWindowClass (#2299, @CristiFati)
 * Make it compile on Python 3.13 (#2260, @clin1234)
 * Fixed accidentally trying to raise a `str` instead of an `Exception` in (#2270, @Avasam)

--- a/isapi/threaded_extension.py
+++ b/isapi/threaded_extension.py
@@ -156,7 +156,7 @@ class ThreadPoolExtension(isapi.simple.SimpleExtension):
         limit = None
         try:
             try:
-                import cgi
+                import html
 
                 ecb.SendResponseHeaders(
                     "200 OK", "Content-type: text/html\r\n\r\n", False
@@ -169,8 +169,8 @@ class ThreadPoolExtension(isapi.simple.SimpleExtension):
                 bold = list.pop()
                 print(
                     "<PRE>{}<B>{}</B></PRE>".format(
-                        cgi.escape("".join(list)),
-                        cgi.escape(bold),
+                        html.escape("".join(list)),
+                        html.escape(bold),
                     ),
                     file=ecb,
                 )


### PR DESCRIPTION
`cgi.escape` is deprecated since Python 3.2 and removed in Python 3.8 https://docs.python.org/3.7/library/cgi.html#cgi.escape
The entire `cgi` module is removed in Python 3.13: https://peps.python.org/pep-0594/#deprecated-modules

This would be caught by mypy with `attr-defined` turned back on, or by pyright with `reportAttributeAccessIssue` back on.