### PR TITLE
Replace `writeln` by `write` in tests

### DIFF
--- a/com/win32com/test/testall.py
+++ b/com/win32com/test/testall.py
@@ -300,14 +300,14 @@ if __name__ == "__main__":
     testRunner = TestRunner(verbosity=verbosity)
     testResult = testRunner.run(suite)
     if import_failures:
-        testResult.stream.writeln(
+        testResult.stream.write(
             "*** The following test modules could not be imported ***"
         )
         for mod_name, (exc_type, exc_val) in import_failures:
             desc = "\n".join(traceback.format_exception_only(exc_type, exc_val))
             testResult.stream.write(f"{mod_name}: {desc}")
-        testResult.stream.writeln(
-            "*** %d test(s) could not be run ***" % len(import_failures)
+        testResult.stream.write(
+            f"*** {len(import_failures)} test(s) could not be run ***"
         )
 
     # re-print unit-test error here so it is noticed

--- a/win32/Lib/pywin32_testutil.py
+++ b/win32/Lib/pywin32_testutil.py
@@ -254,7 +254,7 @@ class TestResult(unittest.TextTestResult):
             self.skips.setdefault(reason, 0)
             self.skips[reason] += 1
             if self.showAll:
-                self.stream.writeln(f"SKIP ({reason})")
+                self.stream.write(f"SKIP ({reason})")
             elif self.dots:
                 self.stream.write("S")
                 self.stream.flush()
@@ -264,7 +264,7 @@ class TestResult(unittest.TextTestResult):
     def printErrors(self):
         super().printErrors()
         for reason, num_skipped in self.skips.items():
-            self.stream.writeln("SKIPPED: %d tests - %s" % (num_skipped, reason))
+            self.stream.write(f"SKIPPED: {num_skipped} tests - {reason}")
 
 
 # TestRunner subclass necessary just to get our TestResult hooked up.


### PR DESCRIPTION
`writeln` is hard to know statically whether it's available or not (see https://github.com/python/typeshed/pull/12407 ).
We don't even make use of it since the strings we pass are never empty.

Solves a few `reportAttributeAccessIssue`