### PR TITLE
Fixed unbound globals in `Pythonwin/pywin/dialogs/ideoptions.py`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,8 @@ https://mhammond.github.io/pywin32_installers.html.
 Coming in build 308, as yet unreleased
 --------------------------------------
 
+* Fixed unbound globals in `Pythonwin/pywin/dialogs/ideoptions.py` (#2325, @Avasam)
+
 Build 307, released 2024-10-04
 ------------------------------
 ### Release process changes

--- a/Pythonwin/pywin/dialogs/ideoptions.py
+++ b/Pythonwin/pywin/dialogs/ideoptions.py
@@ -11,6 +11,11 @@ buttonControlMap = {
     win32ui.IDC_BUTTON3: win32ui.IDC_EDIT3,
 }
 
+formatTitle = interact.formatTitle
+formatInput = interact.formatInput
+formatOutput = interact.formatOutput
+formatOutputError = interact.formatOutputError
+
 
 class OptionsPropPage(dialog.PropertyPage):
     def __init__(self):
@@ -111,8 +116,9 @@ class OptionsPropPage(dialog.PropertyPage):
             return None
         return dlg.GetCharFormat()
 
-    def OnFormatTitle(self, command, code):
-        fmt = self.GetFormat(interact.formatTitle)
+    def OnFormatTitle(self, command, code) -> None:
+        global formatTitle
+        fmt = self.GetFormat(formatTitle)
         if fmt:
             formatTitle = fmt
             interact.SaveFontPreferences()


### PR DESCRIPTION
This was caught by pyright's `reportUnboundVariable` which can be enabled when this and #2324 are merged.