### PR TITLE
Use booleans directly instead of generating by literal comparisons

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -153,7 +153,7 @@ Coming in build 307, as yet unreleased
   * Removed redundant and obsolete references to older python unicode compatibility (#2085, @Avasam)
   * Use byte-string (`b""`) for constant bytes values instead of superfluous `.encode` calls (#2046, @Avasam)
   * Cleaned up unused imports (#1986, #2051, #1990, #2124, #2126, @Avasam)
-  * Removed duplicated declarations, constants and definitions (#2050, #1950, #1990, #2328, @Avasam)
+  * Removed duplicated declarations, constants and definitions (#2050, #1950, #1990, @Avasam)
 * Small generalized optimization by using augmented assignements (in-place operators) where possible (#2274, @Avasam)
 * General speed and size improvements due to all the removed code. (#2046, #1986, #2050, #1950, #2085, #2087, #2051, #1990, #2106, #2127, #2124, #2126, #2177, #2218, #2202, #2205, #2217)
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -153,7 +153,7 @@ Coming in build 307, as yet unreleased
   * Removed redundant and obsolete references to older python unicode compatibility (#2085, @Avasam)
   * Use byte-string (`b""`) for constant bytes values instead of superfluous `.encode` calls (#2046, @Avasam)
   * Cleaned up unused imports (#1986, #2051, #1990, #2124, #2126, @Avasam)
-  * Removed duplicated declarations, constants and definitions (#2050 , #1950, #1990, @Avasam)
+  * Removed duplicated declarations, constants and definitions (#2050, #1950, #1990, #2328, @Avasam)
 * Small generalized optimization by using augmented assignements (in-place operators) where possible (#2274, @Avasam)
 * General speed and size improvements due to all the removed code. (#2046, #1986, #2050, #1950, #2085, #2087, #2051, #1990, #2106, #2127, #2124, #2126, #2177, #2218, #2202, #2205, #2217)
 

--- a/com/win32com/test/testPyComTest.py
+++ b/com/win32com/test/testPyComTest.py
@@ -250,9 +250,9 @@ def TestCommon(o, is_generated):
     ), f"Property value wrong - got {o.ULongProp} (expected {check})"
     TestApplyResult(o.Test, ("Unused", 99), 1)  # A bool function
     TestApplyResult(o.Test, ("Unused", -1), 1)  # A bool function
-    TestApplyResult(o.Test, ("Unused", 1 == 1), 1)  # A bool function
+    TestApplyResult(o.Test, ("Unused", True), 1)  # A bool function
     TestApplyResult(o.Test, ("Unused", 0), 0)
-    TestApplyResult(o.Test, ("Unused", 1 == 0), 0)
+    TestApplyResult(o.Test, ("Unused", False), 0)
 
     assert o.DoubleString("foo") == "foofoo"
 

--- a/com/win32comext/mapi/mapiutil.py
+++ b/com/win32comext/mapi/mapiutil.py
@@ -156,7 +156,7 @@ def SetPropertyValue(obj, prop, val):
     if not isinstance(prop, int):
         props = ((mapi.PS_PUBLIC_STRINGS, prop),)
         propIds = obj.GetIDsFromNames(props, mapi.MAPI_CREATE)
-        if val == (1 == 1) or val == (1 == 0):
+        if val == True or val == False:
             type_tag = mapitags.PT_BOOLEAN
         else:
             type_tag = _MapiTypeMap.get(type(val))


### PR DESCRIPTION
I assume this was Python 2 and/or IronPython compat. Resolves a few pyright `reportUnnecessaryComparison` and mypy `comparison-overlap`