### PR TITLE
adodbapi: Simplify dict iterations from Python 2 to 3 migration

### DIFF
--- a/adodbapi/adodbapi.py
+++ b/adodbapi/adodbapi.py
@@ -326,9 +326,7 @@ class Connection:
         an Error (or subclass) exception will be raised if any operation is attempted with the connection.
         The same applies to all cursor objects trying to use the connection.
         """
-        for crsr in list(self.cursors.values())[
-            :
-        ]:  # copy the list, then close each one
+        for crsr in self.cursors.values():
             crsr.close(dont_tell_me=True)  # close without back-link clearing
         self.messages = []
         try:

--- a/adodbapi/apibase.py
+++ b/adodbapi/apibase.py
@@ -564,7 +564,7 @@ class SQLrow:  # a single database row
             yield self._getValue(n)
 
     def __repr__(self):  # create a human readable representation
-        taglist = sorted(list(self.rows.columnNames.items()), key=lambda x: x[1])
+        taglist = sorted(self.rows.columnNames.items(), key=lambda x: x[1])
         s = "<SQLrow={"
         for name, i in taglist:
             s += f"{name}:{self._getValue(i)!r}, "

--- a/adodbapi/process_connect_string.py
+++ b/adodbapi/process_connect_string.py
@@ -124,7 +124,7 @@ def process(
             except KeyError:
                 raise TypeError("Must define 'connection_string' for ado connections")
     if expand_macros:
-        for kwarg in list(kwargs.keys()):
+        for kwarg in kwargs:
             if kwarg.startswith("macro_"):  # If a key defines a macro
                 macro_name = kwarg[6:]  # name without the "macro_"
                 macro_code = kwargs.pop(


### PR DESCRIPTION
- Python 2 to 3 automatic migration tooling added a bunch of unneeded `list` calls when the `dict_keys`/`dict_values`/`dict_items` object is immediately iterated upon.
- Similarly, removed redundant calls to `iter` on `dict_keys`/`dict_values`/`dict_items`
- Iterate over values only when the keys aren't used
- Iterate over keys only when the values aren't used
- Chain iterable instead of generating and concatenating multiple lists (only for lines affected by above changes)
- Use sets instead of dicts when the value isn't used (only for lines affected by above changes and only for non-public names)
- Uses comprehensions when relevant (only for lines affected by above changes)

Equivalent non-adodbapi PR: https://github.com/mhammond/pywin32/pull/2331