### PR TITLE
Remove obsolete `is_platform_unicode` marked for removal 16 years ago

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,7 @@ Coming in build 307, as yet unreleased
 --------------------------------------
 
 ### pywin32
+* Remove obsolete and unused `pywin.is_platform_unicode` (#2343, @Avasam)
 * Add RealGetWindowClass (#2299, @CristiFati)
 * Make it compile on Python 3.13 (#2260, @clin1234)
 * Fixed accidentally trying to raise a `str` instead of an `Exception` in (#2270, @Avasam)

--- a/Pythonwin/pywin/__init__.py
+++ b/Pythonwin/pywin/__init__.py
@@ -1,7 +1,3 @@
-# is_platform_unicode is an old variable that was never correctly used and
-# is no longer referenced in pywin32.  It is staying for a few releases incase
-# others are looking at it, but it will go away soon!
-is_platform_unicode = 0
-
-# This one *is* real and used - but in practice can't be changed.
-default_scintilla_encoding = "utf-8"  # Scintilla _only_ supports this ATM
+# Referenced and used variable - but in practice can't be changed.
+# Scintilla _only_ supports "utf-8" ATM
+default_scintilla_encoding = "utf-8"


### PR DESCRIPTION
`is_platform_unicode` has been marked for removal 16 years ago
This goes well with the following cleanups:
- https://github.com/mhammond/pywin32/pull/2085
- https://github.com/mhammond/pywin32/pull/2200

(and already deployed):
- https://github.com/mhammond/pywin32/pull/1860
- https://github.com/mhammond/pywin32/pull/1874
- https://github.com/mhammond/pywin32/pull/1886