### PR TITLE
EnsureDispatch: Check for the class attribute 'CLSID' instead of the instance attribute

### DIFF
--- a/com/win32com/client/gencache.py
+++ b/com/win32com/client/gencache.py
@@ -626,7 +626,7 @@ def EnsureDispatch(
 ):  # New fn, so we default the new demand feature to on!
     """Given a COM prog_id, return an object that is using makepy support, building if necessary"""
     disp = win32com.client.Dispatch(prog_id)
-    if not disp.__dict__.get("CLSID"):  # Eeek - no makepy support - try and build it.
+    if not hasattr(disp, "CLSID"):  # Eeek - no makepy support - try and build it.
         try:
             ti = disp._oleobj_.GetTypeInfo()
             disp_clsid = ti.GetTypeAttr()[0]


### PR DESCRIPTION
to decide if building makepy support is required.

The current code is checking for the `CLSID` atttribute of the instance created by `win32com.client.Dispatch()`.
This attribute is never set on the instance and therefore the condition is always `True` and the code to build the makepy support is always executed.

The changed code does instead check for the `CLSID` class attribute which is set by the code that builds the makepy support and therefore avoids executing this code again if the makepy support already exists.

This pull request resolves https://github.com/mhammond/pywin32/issues/2354.