### PR TITLE
Stop using deprecated glob1 on Python 3.10+

### DIFF
--- a/Pythonwin/pywin/framework/bitmap.py
+++ b/Pythonwin/pywin/framework/bitmap.py
@@ -1,11 +1,10 @@
 import os
+import sys
 
 import win32api
 import win32con
 import win32ui
 from pywin.mfc import docview, window
-
-from . import app
 
 bStretch = 1
 
@@ -160,5 +159,10 @@ def demo():
     import glob
 
     winDir = win32api.GetWindowsDirectory()
-    for fileName in glob.glob1(winDir, "*.bmp")[:2]:
+    if sys.version_info >= (3, 10):
+        fileNames = glob.glob("*.bmp", root_dir=winDir)[:2]
+    else:
+        fileNames = glob.glob1(winDir, "*.bmp")[:2]
+
+    for fileName in fileNames:
         bitmapTemplate.OpenDocumentFile(os.path.join(winDir, fileName))


### PR DESCRIPTION
Deprecated in Python 3.13, alternative using `root_dir` is available since Python 3.10.

Closes https://github.com/mhammond/pywin32/issues/2357