### PR TITLE
Remove unbuildable `exchange` methods

### DIFF
--- a/com/win32comext/mapi/src/exchange.i
+++ b/com/win32comext/mapi/src/exchange.i
@@ -1,4 +1,4 @@
-/* File : exchdapi.i */
+/* File : exchange.i */
 
 /*
    This is designed to be an interface to the Exchange specific
@@ -38,30 +38,6 @@
 
 %}
 
-/*
-   Only include Ex2KSdk.lib functions for 32-bit builds.
-*/
-#ifdef SWIG_PY32BIT
-%{
-#include "EDKMAPI.H"
-#include "EDKCFG.H"
-#include "EDKUTILS.H"
-
-// What is the correct story here??  The Exchange SDK story sucks - it seems
-// certain functions in the stand-alone version are simply commented out.
-#if defined(EXCHANGE_RE)
-#	define DONT_HAVE_MBLOGON
-#	define DONT_HAVE_ADDRLKUP
-#endif
-
-#if !defined(DONT_HAVE_ADDRLKUP)
-#	include "ADDRLKUP.H"
-#endif
-#if !defined(DONT_HAVE_MBLOGON)
-#	include "MBLOGON.H"
-#endif
-%}
-#endif
 
 %{
 static int AddIID(PyObject *dict, const char *key, REFGUID guid)
@@ -98,6 +74,12 @@ static int AddIID(PyObject *dict, const char *key, REFGUID guid)
    Only include Ex2KSdk.lib functions for 32-bit builds.
 */
 #ifdef SWIG_PY32BIT
+%{
+#include "EDKMAPI.H"
+#include "EDKCFG.H"
+#include "EDKUTILS.H"
+%}
+
 // @pyswig int, int|HrGetExchangeStatus|Obtains the current state of the server on a computer.
 // @rdesc The result is a tuple of serviceState, serverState
 HRESULT HrGetExchangeStatus(
@@ -407,55 +389,6 @@ done:
 %}
 
 
-%native (HrFindExchangeGlobalAddressList) PyHrFindExchangeGlobalAddressList;
-%{
-// @pyswig string|HrFindExchangeGlobalAddressList|Retrieves the entry identifier of the global address list (GAL) container in the address book.
-static PyObject *PyHrFindExchangeGlobalAddressList(PyObject *self, PyObject *args)
-{
-#ifdef DONT_HAVE_ADDRLKUP
-	return PyErr_Format(PyExc_NotImplementedError, "Not available with this version of the Exchange SDK");
-#else
-	PyObject *obAddrBook;
-	// @pyparm <o PyIAddrBook>|addrBook||The interface containing the address book
-	if (!PyArg_ParseTuple(args, "O:HrFindExchangeGlobalAddressList", &obAddrBook))
-		return NULL;
-
-	IAddrBook *pAB;
-	ULONG cb;
-	LPENTRYID peid;
-	if (!PyCom_InterfaceFromPyInstanceOrObject(obAddrBook, IID_IAddrBook, (void **)&pAB, 0))
-		return NULL;
-	HRESULT _result = HrFindExchangeGlobalAddressList(pAB, &cb, &peid);
-    if (FAILED(_result)) {
-           return OleSetOleError(_result);
-     }
-
-	PyObject *rc = PyBytes_FromStringAndSize((char *)peid, cb);
-	MAPIFreeBuffer(peid);
-	return rc;
-#endif
-}
-%}
-
-%{
-HRESULT MyHrMailboxLogon(
-    IN  LPMAPISESSION   lplhSession,                // ptr to MAPI session handle
-    IN  LPMDB           lpMDB,                      // ptr to message store
-    IN  LPSTR           lpszMsgStoreDN,             // ptr to message store DN
-    IN  LPSTR           lpszMailboxDN,              // ptr to mailbox DN
-    OUT LPMDB           *lppMailboxMDB)            // ptr to mailbox message store ptr
-{
-#if defined(DONT_HAVE_MBLOGON)
-	PyGILState_STATE gstate = PyGILState_Ensure();
-	PyErr_Warn(PyExc_RuntimeWarning, "Not available with this version of the Exchange SDK");
-	PyGILState_Release(gstate);
-	return E_NOTIMPL;
-#else
-	return HrMailboxLogon(lplhSession, lpMDB, lpszMsgStoreDN, lpszMailboxDN, lppMailboxMDB);
-#endif
-}
-%}
-
 // @pyswig <o PyIMsgStore>|HrMailboxLogon|Logs on a server and mailbox.
 %name(HrMailboxLogon) HRESULT MyHrMailboxLogon(
 	IMAPISession *INPUT, // @pyparm <o PyIMAPISession>|session||The session object
@@ -464,20 +397,6 @@ HRESULT MyHrMailboxLogon(
 	char *INPUT, // @pyparm string/<o PyUnicode>|mailboxDN||
 	IMsgStore **OUTPUT
 );
-
-%{
-HRESULT MyHrMailboxLogoff(IMsgStore **pp)
-{
-#if defined(DONT_HAVE_MBLOGON)
-	PyGILState_STATE gstate = PyGILState_Ensure();
-	PyErr_Warn(PyExc_RuntimeWarning, "Not available with this version of the Exchange SDK");
-	PyGILState_Release(gstate);
-	return E_NOTIMPL;
-#else
-	return HrMailboxLogoff(pp);
-#endif
-}
-%}
 
 // @pyswig |HrMailboxLogoff|Logs off a server and mailbox.
 %name(HrMailboxLogoff) HRESULT MyHrMailboxLogoff(


### PR DESCRIPTION
Similar to https://github.com/mhammond/pywin32/pull/2374 Read that for details.

From what I can tell, these API are no longer provided in any obtainable SDK. These methods also haven't been built for post- MSVC6 compilers since 2004 (pywin32 v218.5 in https://github.com/mhammond/pywin32/commit/38f329e7b5042f46b3dace5ac6db00fda9672c77) which isn't even supported for Python anymore: https://wiki.python.org/moin/WindowsCompilers#Which_Microsoft_Visual_C.2B-.2B-_compiler_to_use_with_a_specific_Python_version_.3F