### PR TITLE
Fixed a circular import between `win32comext.axscript.client.framework` and `win32comext.axscript.client.error`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,8 @@ https://mhammond.github.io/pywin32_installers.html.
 Coming in build 308, as yet unreleased
 --------------------------------------
 
+* Fixed a circular import between `win32comext.axscript.client.framework` and `win32comext.axscript.client.error` (#2381, @Avasam)
+
 Build 307, released 2024-10-04
 ------------------------------
 ### Release process changes

--- a/com/win32comext/axscript/client/error.py
+++ b/com/win32comext/axscript/client/error.py
@@ -10,15 +10,19 @@ import re
 import traceback
 import warnings
 from types import TracebackType
+from typing import TYPE_CHECKING
 
 import pythoncom
 import win32com.server.util
 import winerror
 from win32com.axscript import axscript
 from win32com.server.exception import COMException
-from win32comext.axscript.client.debug import DebugManager
-from win32comext.axscript.client.framework import AXScriptCodeBlock, COMScript
-from win32comext.axscript.server.axsite import AXSite
+
+if TYPE_CHECKING:
+    # Prevent circular imports
+    from win32comext.axscript.client.debug import DebugManager
+    from win32comext.axscript.client.framework import AXScriptCodeBlock, COMScript
+    from win32comext.axscript.server.axsite import AXSite
 
 debugging = 0
 

--- a/com/win32comext/axscript/client/framework.py
+++ b/com/win32comext/axscript/client/framework.py
@@ -19,6 +19,9 @@ import win32com.client.connect
 import win32com.server.util
 import winerror
 from win32com.axscript import axscript
+from win32com.server.exception import COMException, IsCOMServerException
+
+from . import error  # axscript.client.error
 
 
 def RemoveCR(text):
@@ -32,9 +35,6 @@ SCRIPTTEXT_FORCEEXECUTION = -2147483648  # 0x80000000
 SCRIPTTEXT_ISEXPRESSION = 0x00000020
 SCRIPTTEXT_ISPERSISTENT = 0x00000040
 
-from win32com.server.exception import COMException, IsCOMServerException
-
-from . import error  # ax.client.error
 
 state_map = {
     axscript.SCRIPTSTATE_UNINITIALIZED: "SCRIPTSTATE_UNINITIALIZED",


### PR DESCRIPTION
Fixes a regression in 307 found whilst updating typeshed's pywin32 stubs

Whilst this area of code isn't automatically tested, there are ways we can automatically safeguard against this kind of issue by detecting imports that are only used for annotations: https://docs.astral.sh/ruff/rules/#flake8-type-checking-tch