### PR TITLE
Set timeout-minutes in GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
   test:
     name: Build and test
     runs-on: windows-2019
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -64,6 +65,7 @@ jobs:
   build_arm64:
     name: Cross-compile ARM
     runs-on: windows-2019
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -103,6 +105,7 @@ jobs:
   # This job can be run locally by running `pre-commit run`
   checkers:
     runs-on: windows-2019
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -126,6 +129,7 @@ jobs:
 
   mypy:
     runs-on: windows-2019
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -145,6 +149,7 @@ jobs:
 
   pyright:
     runs-on: windows-2019
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Sometimes, build tests fail but don't raise an error. They get stuck in limbo and timeout after GitHub's limit of 6 hours. See https://github.com/mhammond/pywin32/actions/runs/11188366703/job/31107020384?pr=2321 for the latest example.

Jobs take up to 8m 30s to run. So I doubled that time and nicely rounded it up to 20 minutes.

A shorter timeout allows much quicker feedback on failing jobs. Especially when there's no error to track the breaking change. Of course it'd be nicer if we figured out why it gets stuck, but this is a nice bandaid patch.

Static checkers jobs don't have that issue, but just applied the timeout indiscriminately. See https://github.com/orgs/community/discussions/10690 for a feature request to be configurable at a workflow level (please take the time to upvote if you'd find this valuable)