### PR TITLE
Enable flake8-type-checking (TCH) to prevent regressions due to extra imports for type-checking purposes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,7 +119,7 @@ jobs:
       - uses: chartboost/ruff-action@v1
         with:
           version: "0.4.5"
-      - uses: psf/black@24.8.0 # stable/24.10.0 doesn't install, seemingly due to caching issue? Revert later
+      - uses: psf/black@stable
         with:
           options: "--fast --check --diff --verbose"
       - run: | # Too many files to fit in a single command, exclude vendored Scintilla and mapi_headers

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,7 +119,7 @@ jobs:
       - uses: chartboost/ruff-action@v1
         with:
           version: "0.4.5"
-      - uses: psf/black@stable
+      - uses: psf/black@24.8.0 # stable/24.10.0 doesn't install, seemingly due to caching issue? Revert later
         with:
           options: "--fast --check --diff --verbose"
       - run: | # Too many files to fit in a single command, exclude vendored Scintilla and mapi_headers

--- a/com/win32comext/axscript/client/error.py
+++ b/com/win32comext/axscript/client/error.py
@@ -19,7 +19,6 @@ from win32com.axscript import axscript
 from win32com.server.exception import COMException
 
 if TYPE_CHECKING:
-    # Prevent circular imports
     from win32comext.axscript.client.debug import DebugManager
     from win32comext.axscript.client.framework import AXScriptCodeBlock, COMScript
     from win32comext.axscript.server.axsite import AXSite

--- a/ruff.toml
+++ b/ruff.toml
@@ -31,6 +31,13 @@ select = [
   "UP007", # non-pep604-annotation
   "UP010", # unnecessary-future-import
   "UP037", # quoted-annotation
+
+  # Helps prevent circular imports and other unneeded imports
+  "TCH", # flake8-type-checking
+]
+extend-ignore = [
+  # No such concerns for stdlib
+  "TCH003", # typing-only-standard-library-import
 ]
 
 [lint.per-file-ignores]


### PR DESCRIPTION
Helps prevent regressions such as #2381 and #2387 . This rule contains autofixable suggestions too.

All 3 imports in `com/win32comext/axscript/client/error.py` are flagged by this if I remove `if TYPE_CHECKING:`.