### PR TITLE
Remove obsolete Windows Server 2012 doc comment

### DIFF
--- a/win32/src/win32tsmodule.cpp
+++ b/win32/src/win32tsmodule.cpp
@@ -415,10 +415,8 @@ static PyObject *PyWTSQuerySessionInformation(PyObject *self, PyObject *args, Py
                                 "VerticalResolution", wcd->VerticalResolution, "ColorDepth", wcd->ColorDepth);
             break;
         }
-        case WTSClientAddress: {  // @flag WTSClientAddress|Dict containing type and value of client's IP address (None
-                                  // if console session) IPV6 addresses may not be returned correctly on Windows
-                                  // versions earlier than Windows Server 2012 (see
-                                  // http://sourceforge.net/p/pywin32/bugs/664/ for details)
+        case WTSClientAddress: {  // @flag WTSClientAddress|Dict containing type and value of client's IP address
+                                  // (None if console session)
             PyObject *obaddress;
             size_t address_cnt, address_ind;
             WTS_CLIENT_ADDRESS *wca = (WTS_CLIENT_ADDRESS *)buf;


### PR DESCRIPTION
Windows Server 2012's extended support has ended October 10, 2023. It doesn't need to be mentioned in documentation anymore. Sources:
- https://learn.microsoft.com/en-us/lifecycle/announcements/windows-server-2012-r2-end-of-support
- https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2012
- https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2012-r2