### PR TITLE
Include StackOverflow's link about MREs in issue_template.md

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -10,8 +10,7 @@ For all bugs, please provide the following information:
 
 ## Steps to reproduce the problem
 <!--
-Prefer using code snippets rather than a screenshot. Please include a full minimal reproduction if possible.
-See https://stackoverflow.com/help/minimal-reproducible-example
+Prefer using code snippets rather than a screenshot. Please include a (full minimal reproduction)[https://stackoverflow.com/help/minimal-reproducible-example] if possible.
 -->
 
 1. ...

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -9,7 +9,10 @@ For all bugs, please provide the following information:
 ## Expected behavior and actual behavior
 
 ## Steps to reproduce the problem
-<!-- Prefer using code snippets rather than a screenshot. Please include a full minimal reproduction if possible. -->
+<!--
+Prefer using code snippets rather than a screenshot. Please include a full minimal reproduction if possible.
+See https://stackoverflow.com/help/minimal-reproducible-example
+-->
 
 1. ...
 2. ...

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -9,9 +9,7 @@ For all bugs, please provide the following information:
 ## Expected behavior and actual behavior
 
 ## Steps to reproduce the problem
-<!--
-Prefer using code snippets rather than a screenshot. Please include a (full minimal reproduction)[https://stackoverflow.com/help/minimal-reproducible-example] if possible.
--->
+<!-- Prefer using code snippets rather than a screenshot. Please include a (full minimal reproduction)[https://stackoverflow.com/help/minimal-reproducible-example] if possible. -->
 
 1. ...
 2. ...

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -9,7 +9,7 @@ For all bugs, please provide the following information:
 ## Expected behavior and actual behavior
 
 ## Steps to reproduce the problem
-<!-- Prefer using code snippets rather than a screenshot. Please include a (full minimal reproduction)[https://stackoverflow.com/help/minimal-reproducible-example] if possible. -->
+<!-- Prefer using code snippets rather than a screenshot. Please include a [full minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) if possible. -->
 
 1. ...
 2. ...


### PR DESCRIPTION
This is mainly for myself to make it easier to find it if I'm on a device where it's not bookmarked. But I figured it couldn't hurt to include it directly in the template.