### PR TITLE
Dropping support for Python 3.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13-dev"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         architecture: ["x64", "x86"]
 
     steps:
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13-dev"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           # This job only needs to target the oldest supported version
-          python-version: "3.8"
+          python-version: "3.9"
           cache: pip
           cache-dependency-path: .github/workflows/main.yml
       - run: pip install clang-format pycln
@@ -133,8 +133,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # mypy won't understand "3.13-dev", keeping the CI simple by just omitting it
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -152,7 +151,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13-dev"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run tests
         # Run the tests directly from the source dir so support files (eg, .wav files etc)
         # can be found - they aren't installed into the Python tree.
-        run: python pywin32_testall.py -v -skip-adodbapi
+        run: python -X dev pywin32_testall.py -v -skip-adodbapi
 
       - name: Build wheels
         run: |

--- a/Pythonwin/pywin/framework/app.py
+++ b/Pythonwin/pywin/framework/app.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import os
 import sys
 import traceback
-from typing import TYPE_CHECKING
+from typing import Literal
 
 import regutil
 import win32api
@@ -19,9 +19,6 @@ from pywin.mfc import afxres, dialog, window
 from pywin.mfc.thread import WinApp
 
 from . import scriptutils
-
-if TYPE_CHECKING:
-    from typing_extensions import Literal
 
 
 # Helper for writing a Window position by name, and later loading it.

--- a/Pythonwin/pywin/framework/intpyapp.py
+++ b/Pythonwin/pywin/framework/intpyapp.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import traceback
+from collections.abc import Iterable, Sequence
 
 import __main__
 import commctrl
@@ -268,7 +269,7 @@ class InteractivePythonApp(app.CApp):
         if frame.GetWindowPlacement()[1] == win32con.SW_SHOWMINIMIZED:
             frame.ShowWindow(win32con.SW_RESTORE)
 
-    def ProcessArgs(self, args, dde=None):
+    def ProcessArgs(self, args: Sequence[str], dde=None):
         # If we are going to talk to a remote app via DDE, then
         # activate it!
         if (
@@ -290,7 +291,7 @@ class InteractivePythonApp(app.CApp):
                 ).lower()
                 i -= 1  #  arg is /edit's parameter
             par = i < len(args) and args[i] or "MISSING"
-            if argType in ("/nodde", "/new", "-nodde", "-new"):
+            if argType in ("/nodde", "/new"):
                 # Already handled
                 pass
             elif argType.startswith("/goto:"):

--- a/Pythonwin/pywin/idle/CallTips.py
+++ b/Pythonwin/pywin/idle/CallTips.py
@@ -94,10 +94,8 @@ class CallTips:
             # How is this for a hack!
             import __main__
 
-            namespace = sys.modules.copy()
-            namespace.update(__main__.__dict__)
             try:
-                return eval(word, namespace)
+                return eval(word, sys.modules | __main__.__dict__)
             except:
                 pass
         return None  # Can't find an object.

--- a/Pythonwin/pywin/scintilla/view.py
+++ b/Pythonwin/pywin/scintilla/view.py
@@ -480,7 +480,7 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
                 # extra attributes of win32ui objects
                 if hasattr(ob, "_obj_"):
                     try:
-                        items_dict.update(list2dict(dir(ob._obj_)))
+                        items_dict = list2dict(dir(ob._obj_))
                     except AttributeError:
                         pass  # object has no __dict__
 
@@ -650,8 +650,7 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
         left, right = self._GetWordSplit(pos, bAllowCalls)
         if left:  # It is an attribute lookup
             # How is this for a hack!
-            namespace = sys.modules.copy()
-            namespace.update(__main__.__dict__)
+            namespace = sys.modules | __main__.__dict__
             # Get the debugger's context.
             try:
                 from pywin.framework import interact

--- a/Pythonwin/pywin/test/test_pywin.py
+++ b/Pythonwin/pywin/test/test_pywin.py
@@ -139,9 +139,13 @@ class T(unittest.TestCase):
         if __name__ != "__main__":
             # make T findable by browser in __main__ namespace
             setattr(__main__, __class__.__qualname__, __class__)
-        with mock.patch(
-            "pywin.mfc.dialog.GetSimpleInput", (lambda *args: __class__.__qualname__)
-        ), mock.patch("pywin.tools.browser.Browse", t_Browse):
+        with (
+            mock.patch(
+                "pywin.mfc.dialog.GetSimpleInput",
+                (lambda *args: __class__.__qualname__),
+            ),
+            mock.patch("pywin.tools.browser.Browse", t_Browse),
+        ):
             self.app.OnViewBrowse(0, 0)
         hl = o.dlg.hier_list
         self.assertGreater(len(hl.itemHandleMap), 10)
@@ -443,8 +447,9 @@ class T(unittest.TestCase):
             GUIAboutToBreak()
 
         dmod = types.ModuleType("__main__", "debugger test main")
-        with mock.patch("pywin.framework.scriptutils.__main__", dmod), mock.patch(
-            "pywin.debugger.debugger.Debugger.GUIAboutToBreak", t_brk
+        with (
+            mock.patch("pywin.framework.scriptutils.__main__", dmod),
+            mock.patch("pywin.debugger.debugger.Debugger.GUIAboutToBreak", t_brk),
         ):
             mf.SendMessage(wc.WM_COMMAND, cmGo)  # debh.OnGo(0, 0)
         self.assertFalse(cmds_brk_next, "break commands remaining")

--- a/Pythonwin/win32cmdui.cpp
+++ b/Pythonwin/win32cmdui.cpp
@@ -27,19 +27,6 @@ inline void *GetPythonOleProcAddress(const char *procName)
 #endif
     hMod = GetModuleHandle(buf);
 
-    // XXX It is unclear why the code previously tried to identify a loaded PythonCOM DLL of
-    // any Python version 1.5 .. 3.9. If some InprocServer would load the DLL of a different
-    // Python version that would likely cause a crash. Thus deactivated.
-    //
-    //     for (int i = 0; hMod == NULL && i < 40; i++) {
-    // #ifdef _DEBUG
-    //         wsprintf(buf, _T("PythonCOM3%d_d.dll"), i);
-    // #else
-    //         wsprintf(buf, _T("PythonCOM3%d.dll"), i);
-    // #endif
-    //         hMod = GetModuleHandle(buf);
-    //     }
-
     if (hMod) {
         void *rc = GetProcAddress(hMod, procName);
         if (rc == NULL)

--- a/Pythonwin/win32uimodule.cpp
+++ b/Pythonwin/win32uimodule.cpp
@@ -2559,9 +2559,9 @@ extern "C" PYW_EXPORT BOOL Win32uiApplicationInit(Win32uiHostGlue *pGlue, const 
     PyObject *argv = PySys_GetObject("argv");
     PyInit_win32ui();
     // Decide if we render sys.argv from command line.
-    // PY3.6- Py_Initialize sets sys.argv=NULL .
-    // PY3.7 Py_Initialize or intentional script triggers set sys.argv=[] .
-    // PY3.8+ Py_Initialize sets sys.argv=[''] - cannot be distinguished
+    // Python 3.6- Py_Initialize sets sys.argv=NULL .
+    // Python 3.7 Py_Initialize or intentional script triggers set sys.argv=[] .
+    // Python 3.8+ Py_Initialize sets sys.argv=[''] - cannot be distinguished
     //   from a pre-existing command line setup anymore. So we need to check
     //   another flag regarding the intended type of invokation, e.g. `cmd`
     //   (or untangle all that crossover startup + module + app init here)

--- a/adodbapi/apibase.py
+++ b/adodbapi/apibase.py
@@ -13,7 +13,6 @@ import numbers
 import sys
 import time
 from collections.abc import Callable, Iterable, Mapping
-from typing import Dict
 
 # noinspection PyUnresolvedReferences
 from . import ado_consts as adc
@@ -465,7 +464,7 @@ def convert_to_python(variant, func):  # convert DB value into Python value
     return func(variant)  # call the appropriate conversion function
 
 
-class MultiMap(Dict[int, Callable[[object], object]]):
+class MultiMap(dict[int, Callable[[object], object]]):
     # builds a dictionary from {(iterable,of,keys) : function}
     """A dictionary of ado.type : function
     -- but you can set multiple items by passing an iterable of keys"""

--- a/adodbapi/test/adodbapitest.py
+++ b/adodbapi/test/adodbapitest.py
@@ -1093,7 +1093,7 @@ class TestADOwithSQLServer(CommonDBTests):
         return self.conn
 
     def getAnotherConnection(self, addkeys=None):
-        keys = dict(config.connStrSQLServer[1])
+        keys = config.connStrSQLServer[1].copy()
         if addkeys:
             keys.update(addkeys)
         return config.dbSqlServerconnect(*config.connStrSQLServer[0], **keys)
@@ -1273,7 +1273,7 @@ class TestADOwithMySql(CommonDBTests):
         return self.conn
 
     def getAnotherConnection(self, addkeys=None):
-        keys = dict(config.connStrMySql[1])
+        keys = config.connStrMySql[1].copy()
         if addkeys:
             keys.update(addkeys)
         return config.dbMySqlconnect(*config.connStrMySql[0], **keys)
@@ -1339,7 +1339,7 @@ class TestADOwithPostgres(CommonDBTests):
         return self.conn
 
     def getAnotherConnection(self, addkeys=None):
-        keys = dict(config.connStrPostgres[1])
+        keys = config.connStrPostgres[1].copy()
         if addkeys:
             keys.update(addkeys)
         return config.dbPostgresConnect(*config.connStrPostgres[0], **keys)

--- a/adodbapi/test/adodbapitest.py
+++ b/adodbapi/test/adodbapitest.py
@@ -188,49 +188,6 @@ class CommonDBTests(unittest.TestCase):
                 pass
             self.helpRollbackTblTemp()
 
-    def testUserDefinedConversionForExactNumericTypes(self):
-        # variantConversions is a dictionary of conversion functions
-        # held internally in adodbapi.apibase
-        #
-        # !!! this test intentionally alters the value of what should be constant in the module
-        # !!! no new code should use this example, to is only a test to see that the
-        # !!! deprecated way of doing this still works.  (use connection.variantConversions)
-        #
-        if sys.version_info < (3, 0):  ### Py3 need different test
-            oldconverter = adodbapi.variantConversions[
-                ado_consts.adNumeric
-            ]  # keep old function to restore later
-            # By default decimal and "numbers" are returned as decimals.
-            # Instead, make numbers return as  floats
-            try:
-                adodbapi.variantConversions[ado_consts.adNumeric] = adodbapi.cvtFloat
-                self.helpTestDataType(
-                    "decimal(18,2)", "NUMBER", 3.45, compareAlmostEqual=1
-                )
-                self.helpTestDataType(
-                    "numeric(18,2)", "NUMBER", 3.45, compareAlmostEqual=1
-                )
-                # now return strings
-                adodbapi.variantConversions[ado_consts.adNumeric] = adodbapi.cvtString
-                self.helpTestDataType("numeric(18,2)", "NUMBER", "3.45")
-                # now a completly weird user defined convertion
-                adodbapi.variantConversions[ado_consts.adNumeric] = (
-                    lambda x: "!!This function returns a funny unicode string %s!!" % x
-                )
-                self.helpTestDataType(
-                    "numeric(18,2)",
-                    "NUMBER",
-                    "3.45",
-                    allowedReturnValues=[
-                        "!!This function returns a funny unicode string 3.45!!"
-                    ],
-                )
-            finally:
-                # now reset the converter to its original function
-                adodbapi.variantConversions[ado_consts.adNumeric] = (
-                    oldconverter  # Restore the original convertion function
-                )
-
     def helpTestDataType(
         self,
         sqlDataTypeString,
@@ -432,7 +389,7 @@ class CommonDBTests(unittest.TestCase):
                 "bigint",
                 "NUMBER",
                 3000000000,
-                allowedReturnValues=[3000000000, int(3000000000)],
+                allowedReturnValues=[3000000000, 3000000000],
             )
         self.helpTestDataType("int", "NUMBER", 2147483647)
 

--- a/adodbapi/test/dbapi20.py
+++ b/adodbapi/test/dbapi20.py
@@ -197,14 +197,9 @@ class DatabaseAPI20Test(unittest.TestCase):
             self.fail("Driver doesn't define paramstyle")
 
     def test_Exceptions(self):
-        # Make sure required exceptions exist, and are in the
-        # defined heirarchy.
-        if sys.version[0] == "3":  # under Python 3 StardardError no longer exists
-            self.assertTrue(issubclass(self.driver.Warning, Exception))
-            self.assertTrue(issubclass(self.driver.Error, Exception))
-        else:
-            self.failUnless(issubclass(self.driver.Warning, Exception))
-            self.failUnless(issubclass(self.driver.Error, Exception))
+        # Make sure required exceptions exist, and are in the defined hierarchy.
+        self.assertTrue(issubclass(self.driver.Warning, Exception))
+        self.assertTrue(issubclass(self.driver.Error, Exception))
 
         self.assertTrue(issubclass(self.driver.InterfaceError, self.driver.Error))
         self.assertTrue(issubclass(self.driver.DatabaseError, self.driver.Error))

--- a/build_all.bat
+++ b/build_all.bat
@@ -1,7 +1,3 @@
-py -3.8-32 setup.py -q build
-@if errorlevel 1 goto failed
-py -3.8 setup.py -q build
-@if errorlevel 1 goto failed
 py -3.9-32 setup.py -q build
 @if errorlevel 1 goto failed
 py -3.9 setup.py -q build

--- a/build_env.md
+++ b/build_env.md
@@ -5,7 +5,7 @@ This describes how to setup the build environment for pywin32.
 Double check the compiler version you need in the [Python wiki](https://wiki.python.org/moin/WindowsCompilers)
 but note that Python 3.5 -> 3.13 all use version 14.X of the compiler, which,
 confusingly, report themselves as V.19XX (eg, note in Python's banner,
-3.5's "MSC v.1900", even 3.9b4's "MSC v.1924")
+3.5's "MSC v.1900", even 3.13's "MSC v.1941")
 
 This compiler first shipped with Visual Studio 2015, although Visual Studio
 2017, 2019 and 2022 all have this compiler available, just not installed

--- a/com/win32com/client/gencache.py
+++ b/com/win32com/client/gencache.py
@@ -97,6 +97,7 @@ def _LoadDicts():
         arc_path = loader.archive
         dicts_path = os.path.join(win32com.__gen_path__, "dicts.dat")
         if dicts_path.startswith(arc_path):
+            # Remove the leading slash as well
             dicts_path = dicts_path[len(arc_path) + 1 :]
         else:
             # Hm. See below.

--- a/isapi/install.py
+++ b/isapi/install.py
@@ -760,8 +760,7 @@ def HandleCommandLine(
 
     # build a usage string if we don't have one.
     if not parser.get_usage():
-        all_handlers = standard_arguments.copy()
-        all_handlers.update(custom_arg_handlers)
+        all_handlers = standard_arguments | custom_arg_handlers
         parser.set_usage(build_usage(all_handlers))
 
     # allow the user to use uninstall as a synonym for remove if it wasn't

--- a/isapi/install.py
+++ b/isapi/install.py
@@ -626,7 +626,7 @@ def _PatchParamsModule(params, dll_name, file_must_exist=True):
                 sm.Module = dll_name
 
 
-def GetLoaderModuleName(mod_name, check_module=None):
+def GetLoaderModuleName(mod_name: str, check_module=None):
     # find the name of the DLL hosting us.
     # By default, this is "_{module_base_name}.dll"
     if hasattr(sys, "frozen"):
@@ -635,8 +635,7 @@ def GetLoaderModuleName(mod_name, check_module=None):
         base, ext = os.path.splitext(mod_name)
         path, base = os.path.split(base)
         # handle the common case of 'foo.exe'/'foow.exe'
-        if base.endswith("w"):
-            base = base[:-1]
+        base.removesuffix("w")
         # For py2exe, we have '_foo.dll' as the standard pyisapi loader - but
         # 'foo.dll' is what we use (it just delegates).
         # So no leading '_' on the installed name.

--- a/make_all.bat
+++ b/make_all.bat
@@ -13,11 +13,6 @@ rem Now the binaries.
 rem Check /build_env.md#build-environment to make sure you have all the required components installed
 
 rem (bdist_wininst needs --target-version to name the installers correctly!)
-py -3.8-32 setup.py -q bdist_wininst --skip-build --target-version=3.8
-py -3.8-32 setup.py -q bdist_wheel --skip-build
-py -3.8 setup.py -q bdist_wininst --skip-build --target-version=3.8
-py -3.8 setup.py -q bdist_wheel --skip-build
-
 py -3.9-32 setup.py -q bdist_wininst --skip-build --target-version=3.9
 py -3.9-32 setup.py -q bdist_wheel --skip-build
 py -3.9 setup.py -q bdist_wininst --skip-build --target-version=3.9

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 show_column_numbers = true
 ; Target the oldest supported version in editors and default CLI
-python_version = 3.8
+python_version = 3.9
 
 strict = true
 implicit_reexport = true

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,11 +1,12 @@
 {
   "typeCheckingMode": "basic",
   // Target the oldest supported version in editors and default CLI
-  "pythonVersion": "3.8",
+  "pythonVersion": "3.9",
   // Keep it simple for now by allowing both mypy and pyright to use `type: ignore`
   "enableTypeIgnoreComments": true,
   // Exclude from scanning when running pyright
   "exclude": [
+    ".git/", // Avoids scanning git branch names ending in ".py"
     "build/",
     // Vendored
     "Pythonwin/Scintilla/",
@@ -37,7 +38,7 @@
   "reportOptionalIterable": "warning",
   "reportOptionalMemberAccess": "warning",
   "reportOptionalSubscript": "warning",
-  // Needs fixes in types-pywin32 and requires Python 3.8 to annotate ambiguous global variables
+  // Needs fixes in types-pywin32 to annotate ambiguous global variables
   "reportUnnecessaryComparison": "warning",
   // TODO: Leave Unbound its own PR(s)
   "reportUnboundVariable": "warning",

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-target-version = "py38" # Target the oldest supported version in editors and default CLI
+target-version = "py39" # Target the oldest supported version in editors and default CLI
 # This file is not UTF-8
 extend-exclude = ["Pythonwin/pywin/test/_dbgscript.py"]
 
@@ -16,12 +16,7 @@ select = [
   # String formatting, concatenating, interpolation, ...
   "FLY", # static-join-to-f-string
   "G", # flake8-logging-format
-  # Note, we still want to allow multiline ISC
-  "UP025", # Remove unicode literals from strings
-  "UP030", # Use implicit references for positional format fields
-  # TODO: Still lots of manual fixes needed
-  # "UP031", # Use format specifiers instead of percent format
-  # "UP032", # Use f-string instead of format call
+  "UP", # pyupgrade
 
   # Ensure modern type annotation syntax and best practices
   # Not including those covered by type-checkers
@@ -31,21 +26,27 @@ select = [
   "UP006", # non-pep585-annotation
   "UP007", # non-pep604-annotation
   "UP010", # unnecessary-future-import
+  "UP035", # deprecated-import
   "UP037", # quoted-annotation
 
   # Helps prevent circular imports and other unneeded imports
   "TCH", # flake8-type-checking
 ]
 extend-ignore = [
+  # We prefer explicit open mode parameter
+  "UP015", # redundant-open-modes
   # No such concerns for stdlib
   "TCH003", # typing-only-standard-library-import
+  # TODO: Still lots of manual fixes needed
+  "UP031", # Use format specifiers instead of percent format
+  "UP032", # Use f-string instead of format call
 ]
 
 [lint.per-file-ignores]
 # Explicit re-exports is fine in __init__.py, still a code smell elsewhere.
 "__init__.py" = ["PLC0414"]
 # TODO: Make adodbapi changes in their own PRs
-"adodbapi/*" = ["C4", "YTT301", "UP031", "UP032", "ISC002"]
+"adodbapi/*" = ["C4", "YTT301", "UP031", "UP032"]
 
 [lint.isort]
 combine-as-imports = true

--- a/setup.py
+++ b/setup.py
@@ -2024,9 +2024,7 @@ def convert_data_files(files: Iterable[str]):
                 raise RuntimeError("No file '%s'" % file)
             files_use = (file,)
         for fname in files_use:
-            path_use = os.path.dirname(fname)
-            if path_use.startswith("com\\"):
-                path_use = path_use[4:]
+            path_use = os.path.dirname(fname).removeprefix("com\\")
             ret.append((path_use, (fname,)))
     return ret
 

--- a/win32/Demos/win32netdemo.py
+++ b/win32/Demos/win32netdemo.py
@@ -194,8 +194,7 @@ def SetInfo(userName=None):
         userName = win32api.GetUserName()
     oldData = win32net.NetUserGetInfo(server, userName, 3)
     try:
-        d = oldData.copy()
-        d["usr_comment"] = "Test comment"
+        d = oldData | {"usr_comment": "Test comment"}
         win32net.NetUserSetInfo(server, userName, 3, d)
         new = win32net.NetUserGetInfo(server, userName, 3)["usr_comment"]
         if str(new) != "Test comment":

--- a/win32/Lib/_win32verstamp_pywin32ctypes.py
+++ b/win32/Lib/_win32verstamp_pywin32ctypes.py
@@ -30,13 +30,12 @@ from ctypes.wintypes import (
     LPVOID,
     WORD,
 )
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, SupportsBytes, SupportsIndex
 
 if TYPE_CHECKING:
     from ctypes import _NamedFuncPointer
 
     from _typeshed import ReadableBuffer
-    from typing_extensions import Literal, SupportsBytes, SupportsIndex
 
 kernel32 = WinDLL("kernel32", use_last_error=True)
 

--- a/win32/Lib/win32timezone.py
+++ b/win32/Lib/win32timezone.py
@@ -246,7 +246,6 @@ import re
 import struct
 import winreg
 from itertools import count
-from typing import Dict
 
 import win32api
 
@@ -855,7 +854,7 @@ class TimeZoneInfo(datetime.tzinfo):
         return zones
 
 
-class _RegKeyDict(Dict[str, int]):
+class _RegKeyDict(dict[str, int]):
     def __init__(self, key: winreg.HKEYType):
         dict.__init__(self)
         self.key = key

--- a/win32/scripts/VersionStamp/bulkstamp.py
+++ b/win32/scripts/VersionStamp/bulkstamp.py
@@ -33,7 +33,7 @@
 import fnmatch
 import os
 import sys
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from optparse import Values
 
 try:
@@ -51,7 +51,9 @@ g_patterns = [
 ]
 
 
-def walk(vars: Mapping[str, str], debug, descriptions, dirname, names) -> int:
+def walk(
+    vars: Mapping[str, str], debug, descriptions, dirname, names: Iterable[str]
+) -> int:
     """Returns the number of stamped files."""
     numStamped = 0
     for name in names:
@@ -60,8 +62,7 @@ def walk(vars: Mapping[str, str], debug, descriptions, dirname, names) -> int:
                 # Handle the "_d" thing.
                 pathname = os.path.join(dirname, name)
                 base, ext = os.path.splitext(name)
-                if base.endswith("_d"):
-                    name = base[:-2] + ext
+                name = base.removesuffix("_d") + ext
                 is_dll = ext.lower() != ".exe"
                 if os.path.normcase(name) in descriptions:
                     description = descriptions[os.path.normcase(name)]

--- a/win32/test/test_win32cred.py
+++ b/win32/test/test_win32cred.py
@@ -14,12 +14,10 @@ class TestCredFunctions(unittest.TestCase):
         }
 
     def create_dummy_cred(self):
-        cred = copy.deepcopy(self.dummy_cred)
-        cred.update(
-            {
-                "Persist": win32cred.CRED_PERSIST_SESSION,
-            }
-        )
+        cred = copy.deepcopy(self.dummy_cred) | {
+            "Persist": win32cred.CRED_PERSIST_SESSION,
+        }
+
         try:
             win32cred.CredWrite(cred, self.flags)
         except Exception as e:

--- a/win32/test/test_win32crypt.py
+++ b/win32/test/test_win32crypt.py
@@ -2,7 +2,8 @@
 
 import contextlib
 import unittest
-from typing import Any, Iterator
+from collections.abc import Iterator
+from typing import Any
 
 import win32crypt
 from pywin32_testutil import find_test_fixture, testmain

--- a/win32/test/test_win32file.py
+++ b/win32/test/test_win32file.py
@@ -556,8 +556,7 @@ class TestFindFiles(unittest.TestCase):
     def testIter(self):
         dir = os.path.join(os.getcwd(), "*")
         files = win32file.FindFilesW(dir)
-        set1 = set()
-        set1.update(files)
+        set1 = set(files)
         set2 = set()
         for file in win32file.FindFilesIterator(dir):
             set2.add(file)


### PR DESCRIPTION
CPython 3.8 is EOL as of October 7 2024 (last week).
Anaconda is dropping support at the end of the month

Highlights represented by these changes:
- [PEP 584](https://peps.python.org/pep-0584/), union operators added to dict;
- [PEP 585](https://peps.python.org/pep-0585/), type hinting generics in standard collections;
- [PEP 616](https://peps.python.org/pep-0616/), string methods to remove prefixes and suffixes.
- [PEP 593](https://peps.python.org/pep-0593/), flexible function and variable annotations;

Testing in dev mode as per:
> [You should check for DeprecationWarning in your code](https://docs.python.org/3/whatsnew/3.9.html#you-should-check-for-deprecationwarning-in-your-code)
> [...]
> More generally, try to run your tests in the [Python Development Mode](https://docs.python.org/3/library/devmode.html#devmode) which helps to prepare your code to make it compatible with the next Python version.

Also of interests, we now have unconditional access to the [zoneinfo](https://docs.python.org/3/library/zoneinfo.html#module-zoneinfo) module: https://docs.python.org/3/whatsnew/3.9.html#zoneinfo, which may or may not be usable as part of `win32/Lib/win32timezone.py`.