### PR TITLE
Fix for issue #2415: Python 3.12.7 interpreter crashes

### DIFF
--- a/com/win32com/src/PyRecord.cpp
+++ b/com/win32com/src/PyRecord.cpp
@@ -478,8 +478,8 @@ PyObject *PyRecord::getattro(PyObject *self, PyObject *obname)
 
     PY_INTERFACE_PRECALL;
     HRESULT hr = pyrec->pri->GetFieldNoCopy(pyrec->pdata, wname, &vret, &sub_data);
-    PyWinObject_FreeWCHAR(wname);
     PY_INTERFACE_POSTCALL;
+    PyWinObject_FreeWCHAR(wname);
 
     if (FAILED(hr)) {
         if (hr == TYPE_E_FIELDNOTFOUND) {


### PR DESCRIPTION
when accessing a COM Record field.

It looks like the culprit is calling `PyWinObject_FreeWCHAR()` while not holding the GIL.

The fix is moving the call to `PyWinObject_FreeWCHAR()` outside of the `PY_INTERFACE_PRECALL` / `PY_INTERFACE_POSTCALL` block to reacquire the GIL before the call.

This pull request resolves issue #2415 