### PR TITLE
PythonService DoLogMessage raising fatal GIL lock error. 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -32,6 +32,7 @@ Coming in build 309, as yet unreleased
 * Improved handling of dict iterations and fallbacks (removes Python 2 support code, small general speed improvement) (#2332, #2330, @Avasam)
 * Fixed "Open GL Demo" (`Pythonwin/pywin/Demos/openGLDemo.py`) and restore "Font" demo in `Pythonwin/pywin/Demos/guidemo.py` (#2345, @Avasam)
 * Fixed accidentally trying to raise an undefined name instead of an `Exception` in `Pythonwin/pywin/debugger/debugger.py` (#2326, @Avasam)
+* Fixed PythonService DoLogMessage raising fatal GIL lock error (#2426, JacobNolan1)
 
 Build 308, released 2024-10-12
 ------------------------------

--- a/win32/src/PythonService.cpp
+++ b/win32/src/PythonService.cpp
@@ -173,9 +173,11 @@ static PyObject *DoLogMessage(WORD errorType, PyObject *obMsg)
     DWORD errorCode = errorType == EVENTLOG_ERROR_TYPE ? PYS_E_GENERIC_ERROR : PYS_E_GENERIC_WARNING;
     LPCTSTR inserts[] = {msg, NULL};
     BOOL ok;
-    Py_BEGIN_ALLOW_THREADS ok = ReportError(errorCode, inserts, errorType);
-    PyWinObject_FreeWCHAR(msg);
-    Py_END_ALLOW_THREADS if (!ok) return PyWin_SetAPIError("RegisterEventSource/ReportEvent");
+    Py_BEGIN_ALLOW_THREADS
+    ok = ReportError(errorCode, inserts, errorType);
+    Py_END_ALLOW_THREADS
+    PyWinObject_FreeWCHAR(msg); // free msg before potentially raising error 
+    if (!ok) return PyWin_SetAPIError("RegisterEventSource/ReportEvent");
     Py_INCREF(Py_None);
     return Py_None;
 }


### PR DESCRIPTION
Opening pull request for potential fix to #2155. @guentner suggested moving freeing of msg object in LogErrorMsg call out of PyBeginAllowThreads block. 

On Python 3.12 services were crashing from a call to servicemanager.LogErrorMsg().
Found error occurred when tested on 3.12.2 and 3.12.7 

By commenting out all calls to LogErrorMsg() the service crashes were fixed. 

@guentner found this was being raised here [PythonService.cpp](https://github.com/mhammond/pywin32/blob/14df8958df1c20bc4bdb7eb670b89262ae0bd23d/win32/src/PythonService.cpp#L176-L178)

> Fatal Python error: _PyMem_DebugFree: Python memory allocator called without holding the GIL


I've used the artifact build for Python3.12 and this has resolved my issue.