### PR TITLE
Fix potential default mutable issue introduced in #2274

### DIFF
--- a/com/win32com/server/register.py
+++ b/com/win32com/server/register.py
@@ -304,7 +304,7 @@ def RegisterServer(
     if addPyComCat is None:
         addPyComCat = pythoncom.frozen == 0
     if addPyComCat:
-        catids.append(CATID_PythonCOMServer)
+        catids = catids + [CATID_PythonCOMServer]
 
     # Set up the implemented categories
     if catids:


### PR DESCRIPTION
Introduced in #2274 . I manually re-reviewed and didn't find any other similar regression.

Simplified demonstration of the issue:
```py
>>> def RegisterServer(catids=[]):
...     catids.append("hi")
...     return catids
...
>>> RegisterServer()
['hi']
>>> RegisterServer()
['hi', 'hi']
>>> RegisterServer()
['hi', 'hi', 'hi']
```

There are linting rules to avoid using mutable defaults for such reasons. But we don't use them yet.

I'm just reverting this one line as an easy fix