### PR TITLE
Updated all old links (dead links, redirects and non-https)

### DIFF
--- a/AutoDuck/pyhtml.fmt
+++ b/AutoDuck/pyhtml.fmt
@@ -471,7 +471,7 @@ $(def1)$4$(par)
 
 .tag=pyseeapi, html, 1, 1
 .pre=$(rmh)Win32 API References$(rmhe)$(par)
-.format=$(term1)Search for <i>$1</i> at <a href="http://search.msdn.microsoft.com/search/results.aspx?view=msdn&query=$1" target="_blank">msdn</a>, <a href="http://www.google.com/search?q=$1" target="_blank">google</a> or <a href="http://groups.google.com/groups?q=$1" target="_blank">google groups</a>.$(par)
+.format=$(term1)Search for <i>$1</i> at <a href="https://learn.microsoft.com/en-ca/search/?terms=$1" target="_blank">msdn</a>, <a href="https://www.google.com/search?q=$1" target="_blank">google</a> or <a href="https://groups.google.com/groups?q=$1" target="_blank">google groups</a>.$(par)
 
 .tag=pyundocmfc, html, 2, 1
 .pre=$(rmh)Undocumented MFC References$(par)

--- a/AutoDuck/pywin32-document.xml
+++ b/AutoDuck/pywin32-document.xml
@@ -3,11 +3,11 @@
         <item name="View the change log" href="html/CHANGES.txt"/>
     </important>
     <links>
-        <item name="Python Web Site" href="http://www.python.org"/>
+        <item name="Python Web Site" href="https://www.python.org"/>
         <item name="Python for Win32 Extensions Site" href="https://github.com/mhammond/pywin32"/>
-        <item name="Python for Win32 mailing list" href="http://mail.python.org/mailman/listinfo/python-win32"/>
-        <item name="Tim Golden's Python pages" href="http://timgolden.me.uk/python/"/>
-        <item name="Paul Boddie's Python COM tutorial" href="http://thor.prohosting.com/~pboddie/Python/COM.html"/>
+        <item name="Python for Win32 mailing list" href="https://mail.python.org/mailman/listinfo/python-win32"/>
+        <item name="Tim Golden's Python pages" href="https://timgolden.me.uk/python/"/>
+        <item name="Paul Boddie's Python COM tutorial" href="https://web.archive.org/web/20090314180624/http://thor.prohosting.com:80/~pboddie/Python/COM.html"/>
     </links>
     <category id="win32" label="Win32 API">
         <overviews>

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,7 +9,7 @@ or
     https://github.com/mhammond/pywin32/compare/b3xx...main
 
 As of build 305, installation .exe files have been deprecated; see
-https://mhammond.github.io/pywin32_installers.html.
+https://mhammond.github.io/pywin32_installers.html .
 
 Coming in build 309, as yet unreleased
 --------------------------------------

--- a/Pythonwin/contents.d
+++ b/Pythonwin/contents.d
@@ -84,7 +84,7 @@ If the first fold in the file is collapsed, all top-level folds are opened.  Oth
 @flag Ctrl+Down|Recall the next command in the history list.
 
 @topic Source code folding in the editor|
-Thanks to Scintilla (http://www.scintilla.org), Pythonwin supports
+Thanks to Scintilla (https://www.scintilla.org), Pythonwin supports
 source code folding.  Folding is the ability to collapse sections of
 your source-code into a single line, making it easier to navigate
 around large files.  Any Python statement which introduces a new block

--- a/Pythonwin/doc/debugger/index.html
+++ b/Pythonwin/doc/debugger/index.html
@@ -9,7 +9,7 @@
 
 <H1><IMG SRC="pythonwin.gif" WIDTH=64 HEIGHT=64>Pythonwin Debugger Overview </H1>
 <B><P>News Flash:</P>
-</B><P>We take full advantage of Scintilla from Neil Hodgson (see <a HREF="http://www.scintilla.org">scintilla.org</a>)  This offers a much better interface, including Visual C++/VB type indicators for breakpoints in the left
+</B><P>We take full advantage of Scintilla from Neil Hodgson (see <a HREF="https://www.scintilla.org">scintilla.org</a>)  This offers a much better interface, including Visual C++/VB type indicators for breakpoints in the left
 column, etc</P>
 <P>This document gives a general overview of the Pythonwin Debugger package. </P>
 

--- a/Pythonwin/pywin/Demos/guidemo.py
+++ b/Pythonwin/pywin/Demos/guidemo.py
@@ -19,7 +19,7 @@ demos = [
     ("OCX Serial Port Demo", "from ocx import ocxserialtest; ocxserialtest.test()"),
     (
         "Internet Explorer Control Demo",
-        'from ocx import webbrowser; webbrowser.Demo("http://www.python.org")',
+        'from ocx import webbrowser; webbrowser.Demo("https://www.python.org")',
     ),
 ]
 

--- a/Pythonwin/pywin/Demos/ocx/flash.py
+++ b/Pythonwin/pywin/Demos/ocx/flash.py
@@ -2,7 +2,7 @@
 # simple flash/python application demonstrating bidirectional
 # communicaion between flash and python. Click the sphere to see
 # behavior. Uses Bounce.swf from FlashBounce.zip, available from
-# http://pages.cpsc.ucalgary.ca/~saul/vb_examples/tutorial12/
+# https://cspages.ucalgary.ca/~saul/vb_examples/tutorial12/
 
 # Update to the path of the .swf file (note it could be a true URL)
 flash_url = "c:\\bounce.swf"

--- a/Pythonwin/pywin/Demos/ocx/webbrowser.py
+++ b/Pythonwin/pywin/Demos/ocx/webbrowser.py
@@ -32,7 +32,7 @@ class BrowserFrame(window.MDIChildWnd):
         if url is None:
             self.url = regutil.GetRegisteredHelpFile("Main Python Documentation")
             if self.url is None:
-                self.url = "http://www.python.org"
+                self.url = "https://www.python.org"
         else:
             self.url = url
         pass  # Don't call base class doc/view version...

--- a/Pythonwin/pywin/framework/help.py
+++ b/Pythonwin/pywin/framework/help.py
@@ -44,7 +44,8 @@ def OpenHelpFile(fileName, helpCmd=None, helpArg=None):
         # XXX - using the htmlhelp API wreaks havoc with keyboard shortcuts
         # so we disable it, forcing ShellExecute, which works fine (but
         # doesn't close the help file when Pythonwin is closed.
-        # Tom Heller also points out http://www.microsoft.com/mind/0499/faq/faq0499.asp,
+        # Tom Heller also points out
+        # https://web.archive.org/web/20070519165457/http://www.microsoft.com:80/mind/0499/faq/faq0499.asp ,
         # which may or may not be related.
         elif 0 and ext == ".chm":
             import win32help

--- a/Pythonwin/readme.html
+++ b/Pythonwin/readme.html
@@ -55,7 +55,7 @@ like it has completely hung when infact it is just waiting for some code to
 finish.</P>
 <P>Support for Scintilla's indentation guides, that gives a nice indication of
 the block structure.</P>
-<P>New, improved color editor, using the Scintilla control by Neil Hodgson (see <A HREF="http://hare.net.au/~neilh/ScintillaTide.html">http://hare.net.au/~neilh/ScintillaTide.html</A>). The debugger now requires use of this editor.</P>
+<P>New, improved color editor, using the Scintilla control by Neil Hodgson (see <A HREF="https://www.scintilla.org/">https://www.scintilla.org/</A>). The debugger now requires use of this editor.</P>
 <P>Much better printing support from Roger Burnham. Pythonwin itself still can't print anything, but the framework can (meaning some kind soul could now add the support to Pythonwin :-)</P>
 <P>DDE support is complete.</P>
 <P>Reference helpfile is far more complete.</P>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ for all bugs or features are also welcome.
 However, please **do not open github issues for general support requests**, or
 for problems or questions using the modules in this package - they will be
 closed. For such issues, please email the
-[python-win32 mailing list](http://mail.python.org/mailman/listinfo/python-win32) -
+[python-win32 mailing list](https://mail.python.org/mailman/listinfo/python-win32) -
 note that you must be subscribed to the list before posting.
 
 ## Binaries

--- a/SWIG/pywin32_swig.patch
+++ b/SWIG/pywin32_swig.patch
@@ -6,7 +6,7 @@ The patch is against SWIG-1.1p5 which can be found at:
 
 or
 
-  http://starship.python.net/crew/mhammond/downloads/swig1.1p5.tar.gz
+  https://web.archive.org/web/20110527063221/http://starship.python.net/crew/mhammond/downloads/swig1.1p5.tar.gz
 
 To build the version of SWIG:
 

--- a/adodbapi/__init__.py
+++ b/adodbapi/__init__.py
@@ -2,7 +2,7 @@
 """adodbapi - A python DB API 2.0 (PEP 249) interface to Microsoft ADO
 
 Copyright (C) 2002 Henrik Ekelund, version 2.1 by Vernon Cole
-* http://sourceforge.net/projects/adodbapi
+* https://sourceforge.net/projects/adodbapi
 """
 
 import time

--- a/adodbapi/ado_consts.py
+++ b/adodbapi/ado_consts.py
@@ -1,5 +1,6 @@
 # ADO enumerated constants documented on MSDN:
-# http://msdn.microsoft.com/en-us/library/ms678353(VS.85).aspx
+# https://learn.microsoft.com/en-us/sql/ado/reference/ado-api/ado-enumerated-constants
+# TODO: Update to https://learn.microsoft.com/en-us/sql/ado/reference/ado-api/ado-enumerated-constants
 
 # IsolationLevelEnum
 adXactUnspecified = -1
@@ -79,6 +80,7 @@ ado_error_TIMEOUT = -2147217871
 
 # DataTypeEnum - ADO Data types documented at:
 # http://msdn2.microsoft.com/en-us/library/ms675318.aspx
+# TODO: Update to https://learn.microsoft.com/en-us/sql/ado/reference/ado-api/datatypeenum
 adArray = 0x2000
 adEmpty = 0x0
 adBSTR = 0x8

--- a/adodbapi/adodbapi.py
+++ b/adodbapi/adodbapi.py
@@ -1,9 +1,9 @@
 """adodbapi - A python DB API 2.0 (PEP 249) interface to Microsoft ADO
 
 Copyright (C) 2002 Henrik Ekelund, versions 2.1 and later by Vernon Cole
-* http://sourceforge.net/projects/pywin32
+* https://sourceforge.net/projects/pywin32
 * https://github.com/mhammond/pywin32
-* http://sourceforge.net/projects/adodbapi
+* https://sourceforge.net/projects/adodbapi
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public
@@ -21,7 +21,7 @@ Copyright (C) 2002 Henrik Ekelund, versions 2.1 and later by Vernon Cole
 
     django adaptations and refactoring by Adam Vandenberg
 
-DB-API 2.0 specification: http://www.python.org/dev/peps/pep-0249/
+DB-API 2.0 specification: https://peps.python.org/pep-0249/
 
 This module source should run correctly in CPython versions 2.7 and later,
 or CPython 3.4 or later.
@@ -79,8 +79,9 @@ def connect(*args, **kwargs):  # --> a db-api connection object
 
     call using:
     :connection_string -- An ADODB formatted connection string, see:
-         * http://www.connectionstrings.com
-         * http://www.asp101.com/articles/john/connstring/default.asp
+         * https://www.connectionstrings.com
+         * https://www.codeguru.com/dotnet/whats-in-an-ado-connection-string/
+         * https://learn.microsoft.com/en-us/dotnet/framework/data/adonet/connection-strings
     :timeout -- A command timeout value, in seconds (default 30 seconds)
     """
     co = Connection()  # make an empty connection object
@@ -474,7 +475,7 @@ class Connection:
         """Introspect the current ADO Errors and determine an appropriate error class.
 
         Error.SQLState is a SQL-defined error condition, per the SQL specification:
-        http://www.contrib.andrew.cmu.edu/~shadow/sql/sql1992.txt
+        https://www.contrib.andrew.cmu.edu/~shadow/sql/sql1992.txt
 
         The 23000 class of errors are integrity errors.
         Error 40002 is a transactional integrity error.

--- a/adodbapi/apibase.py
+++ b/adodbapi/apibase.py
@@ -1,8 +1,8 @@
 """adodbapi.apibase - A python DB API 2.0 (PEP 249) interface to Microsoft ADO
 
 Copyright (C) 2002 Henrik Ekelund, version 2.1 by Vernon Cole
-* http://sourceforge.net/projects/pywin32
-* http://sourceforge.net/projects/adodbapi
+* https://sourceforge.net/projects/pywin32
+* https://sourceforge.net/projects/adodbapi
 """
 
 from __future__ import annotations

--- a/adodbapi/quick_reference.md
+++ b/adodbapi/quick_reference.md
@@ -61,11 +61,7 @@ says that you must use 64 bit Python in this case. However, see the
 answer in
 <https://stackoverflow.com/questions/12270453/ms-access-db-engine-32-bit-with-office-64-bit>.
 If you decide to try hacking the installers, you may find
-<https://www.pantaray.com/msi_super_orca.html> to be a useful alternative
-to Orca. My experience is that such a [hacked installer (like this
-one)](http://shares.digvil.info/redis) (dead link) can also be used on machines
-where "click to buy" versions of Office have been removed, but are still
-blocking installation of the redistributable provider.
+<https://www.pantaray.com/msi_super_orca.html> to be a useful alternative to Orca.
 
 - To use any ODBC driver from 64 bit Python, you also need the MSDASQL
 provider, which is shipped with Windows.

--- a/adodbapi/quick_reference.md
+++ b/adodbapi/quick_reference.md
@@ -39,7 +39,7 @@ be able to process this information in either format. The resulting mass
 of confusion is called a "connection string". There is an entire web
 site dedicated to giving examples of connection strings in numerous
 combinations. See
-[http://www.connectionstrings.com](http://www.connectionstrings.com/)
+[https://www.connectionstrings.com](https://www.connectionstrings.com/)
 
 The software which connects ODBC to an engine is called a "Driver". One
 which talks in ADO is called a "Provider". Sometimes there will be a
@@ -47,11 +47,9 @@ Provider for a Driver.
 
 ### Driver (and Provider) download links
 
-The current (as of 2019) SQL Server OLE DB provider (which they call a
-"driver" here) is
-<https://www.microsoft.com/en-us/download/details.aspx?id=56730> which
-is linked from, and explained [here, in their
-document.](https://docs.microsoft.com/en-us/sql/connect/oledb/oledb-driver-for-sql-server?view=sql-server-2017)
+The current SQL Server OLE DB provider (which they call a
+"driver" here) is explained and can be downloaded from
+[their document](https://learn.microsoft.com/en-us/sql/connect/oledb/download-oledb-driver-for-sql-server#download).
 
 - Jet (ACCESS database) and other file datasets (like .xls and .csv) "ACE"
 Provider:
@@ -61,24 +59,24 @@ Windows. Note that you are not permitted load the 32 bit "ACE" provider
 if you have any 64-bit Office components installed. Conventional wisdom
 says that you must use 64 bit Python in this case. However, see the
 answer in
-<http://stackoverflow.com/questions/12270453/ms-access-db-engine-32-bit-with-office-64-bit>.
+<https://stackoverflow.com/questions/12270453/ms-access-db-engine-32-bit-with-office-64-bit>.
 If you decide to try hacking the installers, you may find
-<http://www.pantaray.com/msi_super_orca.html> to be a useful alternative
+<https://www.pantaray.com/msi_super_orca.html> to be a useful alternative
 to Orca. My experience is that such a [hacked installer (like this
-one)](http://shares.digvil.info/redis) can also be used on machines
+one)](http://shares.digvil.info/redis) (dead link) can also be used on machines
 where "click to buy" versions of Office have been removed, but are still
 blocking installation of the redistributable provider.
 
 - To use any ODBC driver from 64 bit Python, you also need the MSDASQL
 provider. It is shipped with Server 2008, and Vista and later. For
 Server 2003, You will have to [download
-it](http://www.microsoft.com/en-us/download/details.aspx?id=20065) [from
-Microsoft.]{lang="en-US"}
+it](https://web.archive.org/web/20140205114906/http://www.microsoft.com:80/en-us/download/details.aspx?id=20065) from
+Microsoft.
 
-- MySQL driver <http://dev.mysql.com/downloads/connector/odbc/>
-or MariaDB driver <https://downloads.mariadb.org/connector-odbc/>
+- MySQL driver <https://dev.mysql.com/downloads/connector/odbc/>
+or MariaDB driver <https://mariadb.org/connector-odbc/all-releases/>
 or `choco install mysql.odbc`
-- PostgreSQL driver <http://www.postgresql.org/ftp/odbc/versions/msi/>
+- PostgreSQL driver <https://www.postgresql.org/ftp/odbc/releases/>
 (scroll all the way to the bottom) or `choco install psqlodbc`.
 
 \-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\--
@@ -92,7 +90,7 @@ the PEP-249 api. I may write a book later. Here, I only intend to cover
 the extensions and special features of adodbapi. The PEP-249 database
 access api specification is found at:
 
-<http://www.python.org/dev/peps/pep-0249/>
+<https://peps.python.org/pep-0249/>
 
 ### Module level attributes
 

--- a/adodbapi/readme.txt
+++ b/adodbapi/readme.txt
@@ -5,7 +5,7 @@ adodbapi
 A Python DB-API 2.0 (PEP-249) module that makes it easy to use Microsoft ADO
 for connecting with databases and other data sources using CPython.
 
-Home page: <http://sourceforge.net/projects/adodbapi>
+Home page: <https://sourceforge.net/projects/adodbapi>
 
 Features:
 * 100% DB-API 2.0 (PEP-249) compliant (including most extensions and recommendations).
@@ -24,7 +24,7 @@ Prerequisites:
 
 Installation:
 * (C-Python on Windows): Install pywin32 (`python -m pip install pywin32`) which includes adodbapi.
-* (IronPython on Windows): Download adodbapi from http://sf.net/projects/adodbapi.  Unpack the zip.
+* (IronPython on Windows): Download adodbapi from https://sourceforge.net/projects/adodbapi/ .  Unpack the zip.
 
 NOTE: ...........
 If you do not like the new default operation of returning Numeric columns as decimal.Decimal,
@@ -69,15 +69,16 @@ what's new in version 2.5
 
 License
 -------
-LGPL, see http://www.opensource.org/licenses/lgpl-license.php
+LGPL, see https://opensource.org/license/lgpl-2-1
 
 Documentation
 -------------
 
-Look at adodbapi/quick_reference.md
-http://www.python.org/topics/database/DatabaseAPI-2.0.html
-read the examples in adodbapi/examples
-and look at the test cases in adodbapi/test directory.
+Look at:
+- `adodbapi/quick_reference.md`
+- https://wiki.python.org/moin/DatabaseProgramming#The_DB-API
+- read the examples in adodbapi/examples
+- and the test cases in `adodbapi/test directory`
 
 Mailing lists
 -------------

--- a/adodbapi/setup.py
+++ b/adodbapi/setup.py
@@ -9,7 +9,7 @@ MAINTAINER_EMAIL = "vernondcole@gmail.com"
 DESCRIPTION = (
     """A pure Python package implementing PEP 249 DB-API using Microsoft ADO."""
 )
-URL = "http://sourceforge.net/projects/adodbapi"
+URL = "https://sourceforge.net/projects/adodbapi"
 LICENSE = "LGPL"
 CLASSIFIERS = [
     "Development Status :: 5 - Production/Stable",

--- a/adodbapi/test/adodbapitestconfig.py
+++ b/adodbapi/test/adodbapitestconfig.py
@@ -166,7 +166,7 @@ if doPostgresTest:
         "Provider=MSDASQL;Driver={PostgreSQL Unicode(x64)}",
         "Driver=PostgreSQL Unicode",
     ]
-    # get driver from http://www.postgresql.org/ftp/odbc/versions/
+    # get driver from https://www.postgresql.org/ftp/odbc/releases/
     # test using positional and keyword arguments (bad example for real code)
     print("    ...Testing PostgreSQL login to {}...".format(_computername))
     doPostgresTest, connStrPostgres, dbPostgresConnect = tryconnection.try_connection(

--- a/build_env.md
+++ b/build_env.md
@@ -51,7 +51,8 @@ way to build pywin32 - it's build process should find these tools automatically.
 
 ## For Visual Studio 2019
 
-- Install the [Build Tools for Visual Studio 2019](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16#) (`vs_BuildTools.exe` ~ 1 MB)
+- Install the [Build Tools for Visual Studio 2019](https://my.visualstudio.com/Downloads?q=Build%20Tools%20for%20Visual%20Studio%202019) (Version 16.0)
+  Public landing page: <https://visualstudio.microsoft.com/vs/older-downloads/#2019-family>
 
 - Maybe stop your virus scanner
 - In `Visual Studio Installer`:

--- a/com/TestSources/PyCOMTest/PyCOMImpl.cpp
+++ b/com/TestSources/PyCOMTest/PyCOMImpl.cpp
@@ -437,7 +437,7 @@ HRESULT CPyCOMTest::Fire(long nID)
             if (FAILED(hr))
                 break;
             // call FireWithNamedParams a variety of ways.
-            // See http://msdn2.microsoft.com/en-us/library/ms221653.aspx
+            // See https://learn.microsoft.com/en-ca/previous-versions/windows/desktop/automat/passing-parameters
             // "Passing Parameters (Component Automation)" for details.
 
             OLECHAR *names2[] = {L"OnFireWithNamedParams"};

--- a/com/help/active_directory.html
+++ b/com/help/active_directory.html
@@ -276,7 +276,11 @@ So far we've only covered the basics of using Active Directory. Stay tuned for m
 <h1><a name="Further Info">Further Info</a></h1>
 <p>
 <ul>
-<li><a href="https://msdn.microsoft.com">Microsoft MSDN references</a>
+<li>
+  <a href="https://learn.microsoft.com/en-us/troubleshoot/windows-server/active-directory/active-directory-overview">
+    Windows Active Directory documentation
+  </a>
+</li>
 </ul>
 </p>
 <hr><h1><a name="Author">Author</a></h1>

--- a/com/help/adsi.html
+++ b/com/help/adsi.html
@@ -44,9 +44,9 @@
 <hr>
 <h1><a name="SUMMARY">SUMMARY</a></h1>
 <p>
-Python's adsi access works really well with Exchange (late or early binding since you can read microsoft's type library).
-To get started, you will need to download adsi from microsoft:
-<a href="https://www.microsoft.com/windows/server/Technical/directory/adsilinks.asp">Microsoft ADSI</a>.
+Python's ADSI access works really well with Exchange (late or early binding since you can read microsoft's type library).
+To get started, you will need to download ADSI from microsoft:
+<a href="https://learn.microsoft.com/en-us/windows/win32/adsi/setting-up-your-development-environment">Setting Up Your Development Environment</a>.
 Microsoft has documentation for using languages other than python in the sdk.
 </p>
 
@@ -89,9 +89,10 @@ Before doing anything else you need to go through the next two steps:
 </table>
 
 <br>
-<strong>Note</strong> -- the fourth argument to opendsobject has various options for how to authenticate.
+<strong>Note</strong> -- the fourth argument to OpenDSObject has various options for how to authenticate.
 For example, if you use 1 instead of zero, it should either use NTLM or Kerberos for authentication.
-For more information, check out: <a href="http://www.microsoft.com/windows/server/Technical/directory/adsilinks.asp">OpenDSObject</a>
+For more information, check out:
+ <a href="https://learn.microsoft.com/en-us/windows/win32/api/iads/nf-iads-iadsopendsobject-opendsobject">OpenDSObject</a>
 
 <p>
 The ex_path in the above example specifies the resource you are trying to access.  For example:
@@ -264,9 +265,11 @@ Python has no trouble accessing Microsoft's ADSI to help simplify user managemen
 <h1><a name="Further Info">Further Info</a></h1>
 <p>
 <ul>
-<li><a href="http://msdn.microsoft.com">Microsoft MSDN references</a>
-<li><a href="http://www.microsoft.com/windows/server/Technical/directory/adsilinks.asp">Microsoft ADSI</a>
-<li><a href="http://msdn.microsoft.com/library/default.asp?URL=/library/psdk/adsi/if_core_3uic.htm">Microsoft MSDN ADSI reference</a>
+<li>
+  <a href="https://learn.microsoft.com/en-us/windows/win32/ADSI">
+    Windows Active Directory Service Interfaces documentation
+  </a>
+</li>
 <li>Relevant Python libraries: win32com.client
 </ul>
 </p>

--- a/com/help/asp.d
+++ b/com/help/asp.d
@@ -40,8 +40,9 @@ block -- they don't extend past intervening html to the next block. For
 me that normally isn't an issue, since I do not like mixing code and
 html. Prefering a clean split of code and html, I generally
 generate webpages using templates all in python w/HTMLgen. Take a look
-at: http://www.python.org/topics/web/HTML.html for available resources
-w/HTML.  An very basic page would look like:
+at: https://wiki.python.org/moin/WebBrowserProgramming and
+https://wiki.python.org/moin/Asking%20for%20Help/How%20to%20run%20python%20from%20HTML
+for available resources w/HTML.  A very basic page would look like:
 
 @ex Basic Python ASP page: |
 

--- a/com/help/shell.d
+++ b/com/help/shell.d
@@ -20,10 +20,12 @@ Following is documentation for the PyIShellLink object.
 
 @ex This documentation class is based on:
 	http://msdn.microsoft.com/isapi/msdnlib.idc?theURL=/library/sdkdoc/shellcc/shell/ifaces/ishelllink/ishelllink.htm
+    (Updated docs at https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nn-shobjidl_core-ishelllinkw)
 	With only minor alterations and notations by Mike Fletcher.
 	Errors may be present, read at your own risk.
 See also:
 	http://msdn.microsoft.com/isapi/msdnlib.idc?theURL=/library/books/win95ui/chpt09-01.htm
+    (Archive found at https://library.thedatadungeon.com/msdn-2000-04/win95ui/html/chpt09-01.htm)
 	A tutorial-like introduction, includes brief discussion
 	of non-file linking, and a fairly simple C sample application
 	for file-based linking.

--- a/com/help/shell.d
+++ b/com/help/shell.d
@@ -20,15 +20,9 @@ Following is documentation for the PyIShellLink object.
 
 @ex This documentation class is based on:
 	http://msdn.microsoft.com/isapi/msdnlib.idc?theURL=/library/sdkdoc/shellcc/shell/ifaces/ishelllink/ishelllink.htm
-    (Updated docs at https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nn-shobjidl_core-ishelllinkw)
+    (TODO: Update to https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nn-shobjidl_core-ishelllinkw)
 	With only minor alterations and notations by Mike Fletcher.
 	Errors may be present, read at your own risk.
-See also:
-	http://msdn.microsoft.com/isapi/msdnlib.idc?theURL=/library/books/win95ui/chpt09-01.htm
-    (Archive found at https://library.thedatadungeon.com/msdn-2000-04/win95ui/html/chpt09-01.htm)
-	A tutorial-like introduction, includes brief discussion
-	of non-file linking, and a fairly simple C sample application
-	for file-based linking.
 |
 class PyIShellLink( IPersistFile ):
 	''' Following is not a functional class, intended solely for documentation '''

--- a/com/win32com/HTML/QuickStartClientCom.html
+++ b/com/win32com/HTML/QuickStartClientCom.html
@@ -10,8 +10,8 @@
 <H1>Quick Start to Client side COM and Python</H1>
 <H2>Introduction</H2>
 <P>This documents how to quickly start using COM from Python. It is not a thorough discussion of the COM system, or of the concepts introduced by COM.</P>
-<P>Other good information on COM can be found in various conference tutorials - please see <A HREF="http://starship.python.net/crew/mhammond/conferences">the collection of Mark's conference tutorials</A></P>
-<P>For information on implementing COM objects using Python, please see <A HREF="http://www.python.org/windows/win32com/QuickStartServerCom.html">a Quick Start to Server side COM and Python</A></P>
+<P>Other good information on COM can be found in various conference tutorials - please see <A HREF="https://web.archive.org/web/20130420121155/http://starship.python.net/crew/mhammond/conferences/">the collection of Mark's conference tutorials</A></P>
+<P>For information on implementing COM objects using Python, please see <A HREF="QuickStartServerCom.html">a Quick Start to Server side COM and Python</A></P>
 <P>In this document we discuss the following topics:</P>
 
 <UL>

--- a/com/win32com/HTML/QuickStartServerCom.html
+++ b/com/win32com/HTML/QuickStartServerCom.html
@@ -12,7 +12,7 @@
 <H1>Quick Start to Server side COM and Python</H1>
 <H2>Introduction</H2>
 <P>This documents how to quickly start implementing COM objects in Python. It is not a thorough discussion of the COM system, or of the concepts introduced by COM.</P>
-<P>For more details information on Python and COM, please see the <A HREF="http://www.python.org/windows/win32com/COMTutorial/index.htm">COM Tutorial given by Greg Stein and Mark Hammond at SPAM 6 (HTML format)</A> or download the same tutorial <A HREF="http://www.python.org/windows/win32com/COMTutorial.ppt">in PowerPoint format.</A></P>
+<P>For more details information on Python and COM, please see the COM Tutorial given by Greg Stein and Mark Hammond at SPAM 6 <A HREF="https://web.archive.org/web/20001117033400/http://www.python.org:80/windows/win32com/COMTutorial/index.htm">(in HTML format, lost to time)</A> or download the same tutorial <A HREF="https://web.archive.org/web/20060511064916/http://www.python.org/windows/win32com/COMTutorial.ppt">in PowerPoint format.</A></P>
 <P>For information on using external COM objects from Python, please see <A HREF="QuickStartClientCom.html">a Quick Start to Client side COM and Python</A>.</P>
 <P>In this document we discuss the <A HREF="#core">core functionality</A>, <A HREF="#Registering">registering the server</A>, <A HREF="#testing">testing the class</A>, <A HREF="#debugging">debugging the class</A>, <A HREF="#Exception">exception handling</A> and <A HREF="#Policies">server policies</A> (phew!)</P>
 <H2><A NAME="core">Implement the core functionality</A></H2>

--- a/com/win32com/client/selecttlb.py
+++ b/com/win32com/client/selecttlb.py
@@ -113,8 +113,8 @@ def EnumTlbs(excludeFlags=0):
             # The Resolve() method on the TypelibSpec does this.
             # For this reason, keep the version numbers as strings - that
             # way we can't be wrong!  Let code that really needs an int to work
-            # out what to do.  FWIW, http://support.microsoft.com/kb/816970 is
-            # pretty clear that they *should* be hex.
+            # out what to do.  FWIW, https://www.betaarchive.com/wiki/index.php?title=Microsoft_KB_Archive/816970
+            # is pretty clear that they *should* be hex.
             major = major_minor[0]
             minor = major_minor[1]
             key3 = win32api.RegOpenKey(key2, str(version))

--- a/com/win32com/demos/excelRTDServer.py
+++ b/com/win32com/demos/excelRTDServer.py
@@ -3,7 +3,7 @@
 This module is a functional example of how to implement the IRTDServer interface
 in python, using the pywin32 extensions. Further details, about this interface
 and it can be found at:
-     http://msdn.microsoft.com/library/default.asp?url=/library/en-us/dnexcl2k2/html/odc_xlrtdfaq.asp
+     https://learn.microsoft.com/en-us/previous-versions/office/developer/office-xp/aa140060(v=office.10)
 """
 
 # Copyright (c) 2003-2004 by Chris Nilsson <chris@slort.org>

--- a/com/win32com/demos/ietoolbar.py
+++ b/com/win32com/demos/ietoolbar.py
@@ -219,7 +219,7 @@ class IEToolbar:
 
     def on_first_button(self):
         print("first!")
-        self.webbrowser.Navigate2("http://starship.python.net/crew/mhammond/")
+        self.webbrowser.Navigate2("https://github.com/mhammond/pywin32")
 
     def on_second_button(self):
         print("second!")

--- a/com/win32com/readme.html
+++ b/com/win32com/readme.html
@@ -29,7 +29,7 @@ this object</a>
 In all builds prior to 204, a COM currency value was returned as a tuple of
 integers.  Working with 2 integers to represent a currency object was a poor
 choice, but the alternative was never clear.  Now Python ships with the
-<a href="http://www.python.org/dev/doc/devel/lib/module-decimal.html">decimal</a>
+<a href="https://docs.python.org/dev/library/decimal.html">decimal</a>
 module, the alternative has arrived!
 </p>
 <p>

--- a/com/win32com/src/Register.cpp
+++ b/com/win32com/src/Register.cpp
@@ -141,7 +141,7 @@ HRESULT PyCom_RegisterGatewayObject(REFIID iid, pfnPyGatewayConstructor ctor, co
 /* PyType_Ready assures that the type's tp_base is ready, but it does *not* call
     itself for entries in tp_bases, leading to a crash or indecipherable errors
     if one of multiple bases is not itself ready.
-    http://bugs.python.org:80/issue3453
+    https://github.com/python/cpython/issues/47703
     This code is also in win32uimodule.cpp, should move into pywintypes.
 */
 int PyWinType_Ready(PyTypeObject *pT)

--- a/com/win32comext/axcontrol/demos/container_ie.py
+++ b/com/win32comext/axcontrol/demos/container_ie.py
@@ -234,7 +234,7 @@ if __name__ == "__main__":
         h.browser2.Navigate2("about:blank")
         doc = h.browser2.Document
         doc.write(
-            'This is an IE page hosted by <a href="http://www.python.org">python</a>'
+            'This is an IE page hosted by <a href="https://www.python.org">python</a>'
         )
         doc.write("<br>(you can also specify a URL on the command-line...)")
     else:

--- a/com/win32comext/axscript/demos/client/ie/CHARTPY.HTM
+++ b/com/win32comext/axscript/demos/client/ie/CHARTPY.HTM
@@ -20,7 +20,7 @@ Edited:	3/19/96 - VBScript code edited so there is only one procedure for each p
 <BODY BGCOLOR=#FFFFCC TEXT=#000000>
 
 <B><FONT SIZE=6>Chart Example</FONT></B><BR>
-<FONT SIZE=2>You must be running Microsoft Internet Explorer 3.0 and have the <A HREF ="http://microsoft.saltmine.com/isapi/activexisv/prmgallery/gallery-activex-info.idc?ID=162">Microsoft ActiveX Chart control (dead link)</A> installed to view this page.</FONT><BR>
+<FONT SIZE=2>You must be running Microsoft Internet Explorer 3.0 and have the Microsoft ActiveX Chart Control installed to view this page.</FONT><BR>
 <P>
 The chart control enables you to draw charts. The chart's types and styles are properties of the control. The chart has one method, AboutBox. The chart generates no events.
 

--- a/com/win32comext/axscript/demos/client/ie/CHARTPY.HTM
+++ b/com/win32comext/axscript/demos/client/ie/CHARTPY.HTM
@@ -20,7 +20,7 @@ Edited:	3/19/96 - VBScript code edited so there is only one procedure for each p
 <BODY BGCOLOR=#FFFFCC TEXT=#000000>
 
 <B><FONT SIZE=6>Chart Example</FONT></B><BR>
-<FONT SIZE=2>You must be running Microsoft Internet Explorer 3.0 and have the <A HREF ="http://microsoft.saltmine.com/isapi/activexisv/prmgallery/gallery-activex-info.idc?ID=162">Microsoft ActiveX Chart control</A> installed to view this page.</FONT><BR>
+<FONT SIZE=2>You must be running Microsoft Internet Explorer 3.0 and have the <A HREF ="http://microsoft.saltmine.com/isapi/activexisv/prmgallery/gallery-activex-info.idc?ID=162">Microsoft ActiveX Chart control (dead link)</A> installed to view this page.</FONT><BR>
 <P>
 The chart control enables you to draw charts. The chart's types and styles are properties of the control. The chart has one method, AboutBox. The chart generates no events.
 
@@ -62,8 +62,7 @@ The chart control enables you to draw charts. The chart's types and styles are p
 
 
 <SCRIPT LANGUAGE="Python">
-<!-- ' This prevents script from being displayed in browsers that don't support the SCRIPT tag
-# OPTION EXPLICIT (?)
+
 
 # Calls the AboutBox Method. This displays the Chart Object About Box
 def DoChartAboutBox():
@@ -91,7 +90,7 @@ def DoVerticalGrid():
 			ax.Chart1.VGridStyle = 1
 		else:
 			ax.Chart1.VGridStyle = 0
--->
+
 </SCRIPT>
 
 

--- a/com/win32comext/axscript/demos/client/ie/MarqueeText1.htm
+++ b/com/win32comext/axscript/demos/client/ie/MarqueeText1.htm
@@ -17,7 +17,7 @@
 <P>For more information on Python as an ActiveX scripting language, see
 
 <P><B>Python</B>
-<BR><A HREF="http://www.python.org">http://www.python.org</A>
+<BR><A HREF="https://www.python.org">https://www.python.org</A>
 
 </FONT>
 </BODY>

--- a/com/win32comext/axscript/demos/client/ie/demo_check.htm
+++ b/com/win32comext/axscript/demos/client/ie/demo_check.htm
@@ -5,8 +5,8 @@
 
 <p>The Python ActiveX Scripting Engine is not currently registered.<p>
 
-<p>Due to a <a href="http://starship.python.net/crew/mhammond/win32/PrivacyProblem.html">privacy
-concern</a> discovered in the engine, the use of Python inside IE has been disabled.</p>
+<p>Due to a <a href="https://web.archive.org/web/20080305234321/http://starship.python.net:80/crew/mhammond/win32/PrivacyProblem.html">
+privacy concern</a> discovered in the engine, the use of Python inside IE has been disabled.</p>
 
 Before any of the supplied demos will work, the engine must be successfully registered.
 
@@ -15,8 +15,8 @@ Before any of the supplied demos will work, the engine must be successfully regi
 
 <H2>Register the engine now!</H2>
 
-<p>If you have read about the <a href="http://starship.python.net/crew/mhammond/win32/PrivacyProblem.html">privacy
-concern</a> and still wish to register the engine, just follow the process outlined below:</p>
+<p>If you have read about the <a href="https://web.archive.org/web/20080305234321/http://starship.python.net:80/crew/mhammond/win32/PrivacyProblem.html">
+privacy concern</a> and still wish to register the engine, just follow the process outlined below:</p>
 <OL>
   <LI>Click on the link below
   <LI><B>A dialog will be presented asking if the file should be opened or saved to disk.  Select "Open it".</B>

--- a/com/win32comext/axscript/demos/client/ie/demo_intro.htm
+++ b/com/win32comext/axscript/demos/client/ie/demo_intro.htm
@@ -9,8 +9,8 @@
 
 <p>Congratulations on installing the Python ActiveX Scripting Engine</p>
 
-<p>Be warned that there is a <a href="http://starship.python.net/crew/mhammond/win32/PrivacyProblem.html">privacy
-concern</a> with this engine.  Please read this information, including how to disable the feature.</p>
+<p>Be warned that there is a <a href="https://web.archive.org/web/20080305234321/http://starship.python.net:80/crew/mhammond/win32/PrivacyProblem.html">
+privacy concern</a> with this engine.  Please read this information, including how to disable the feature.</p>
 
 
 <H3>Object model</H3>

--- a/com/win32comext/axscript/demos/client/ie/mousetrack.htm
+++ b/com/win32comext/axscript/demos/client/ie/mousetrack.htm
@@ -47,7 +47,7 @@ rects =[rect(12,48,59,101,blows+"Visual Basic", ""),
 	rect(193,0,261,56,blows+"Microsoft Access", ""),
 	rect(332,43,392,93,blows+"Microsoft Word", ""),
 	rect(457,52,521,99,blows+"Microsoft Excel", ""),
-	rect(537,12,613,85,"Python blows them all away!", "http://www.python.org"),
+	rect(537,12,613,85,"Python blows them all away!", "https://www.python.org"),
 ]
 
 default = rect(0,0,0,0,"Click on an icon","")

--- a/com/win32comext/bits/test/test_bits.py
+++ b/com/win32comext/bits/test/test_bits.py
@@ -44,7 +44,7 @@ class BackgroundJobCallback:
         if f.GetRemoteName().endswith("missing-favicon.ico"):
             print("Changing to point to correct file")
             f2 = f.QueryInterface(bits.IID_IBackgroundCopyFile2)
-            favicon = "http://www.python.org/favicon.ico"
+            favicon = "https://www.python.org/favicon.ico"
             print("Changing RemoteName from", f2.GetRemoteName(), "to", favicon)
             f2.SetRemoteName(favicon)
             job.Resume()
@@ -93,11 +93,11 @@ job.SetNotifyFlags(
 # servers, an invalid hostname will *always* be resolved (they
 # redirect you to a search page), so be careful when testing.
 job.AddFile(
-    "http://www.python.org/favicon.ico",
+    "https://www.python.org/favicon.ico",
     os.path.join(tempfile.gettempdir(), "bits-favicon.ico"),
 )
 job.AddFile(
-    "http://www.python.org/missing-favicon.ico",
+    "https://www.python.org/missing-favicon.ico",
     os.path.join(tempfile.gettempdir(), "bits-missing-favicon.ico"),
 )
 

--- a/com/win32comext/ifilter/demo/filterDemo.py
+++ b/com/win32comext/ifilter/demo/filterDemo.py
@@ -239,7 +239,7 @@ def _usage():
     print("by default .htm, .txt, .doc, .dot, .xls, .xlt, .ppt are supported")
     print("you can filter .pdf's by downloading adobes ifilter component. ")
     print(
-        "(currently found at http://download.adobe.com/pub/adobe/acrobat/win/all/ifilter50.exe)."
+        "(currently found at https://download.adobe.com/pub/adobe/acrobat/win/all/ifilter50.exe)."
     )
     print("ifilters for other filetypes are also available.")
     print()

--- a/com/win32comext/ifilter/src/stdafx.h
+++ b/com/win32comext/ifilter/src/stdafx.h
@@ -17,8 +17,8 @@
 #ifdef MISSING_PROPSTG
 // Ack - NTQuery.h is failing with the Vista SDK - pull in what we need
 // Problem is missing propstg.h, and all the work-arounds are uglier than
-// just these 3 prototypes.
-// See http://forums.microsoft.com/MSDN/ShowPost.aspx?PostID=508254&SiteID=1
+// just these 3 prototypes. See
+// https://web.archive.org/web/20071215081009/http://forums.microsoft.com:80/MSDN/ShowPost.aspx?PostID=508254&SiteID=1
 
 STDAPI LoadIFilter(PCWSTR pwcsPath, __in IUnknown *pUnkOuter, __deref_out void **ppIUnk);
 STDAPI BindIFilterFromStorage(__in IStorage *pStg, __in IUnknown *pUnkOuter, __deref_out void **ppIUnk);

--- a/com/win32comext/mapi/demos/mapisend.py
+++ b/com/win32comext/mapi/demos/mapisend.py
@@ -2,7 +2,7 @@
 
 """module to send mail with Extended MAPI using the pywin32 mapi wrappers..."""
 
-# this was based on Jason Hattingh's C++ code at http://www.codeproject.com/internet/mapadmin.asp
+# this was based on Jason Hattingh's C++ code at http://www.codeproject.com/internet/mapadmin.asp (dead link)
 # written by David Fraser <davidf at sjsoft.com> and Stephen Emslie <stephene at sjsoft.com>
 # you can test this by changing the variables at the bottom and running from the command line
 

--- a/com/win32comext/mapi/src/IConverterSession.h
+++ b/com/win32comext/mapi/src/IConverterSession.h
@@ -8,7 +8,10 @@ DEFINE_GUID(CLSID_IConverterSession, 0x4e3a7680, 0xb77a, 0x11d0, 0x9d, 0xa5, 0x0
 // {4b401570-b77b-11d0-9da5-00c04fd65685}
 DEFINE_GUID(IID_IConverterSession, 0x4b401570, 0xb77b, 0x11d0, 0x9d, 0xa5, 0x0, 0xc0, 0x4f, 0xd6, 0x56, 0x85);
 
-// Constants
+// Constants - http://msdn2.microsoft.com/en-us/library/bb905201.aspx
+// TODO: Update to
+// https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb905201(v=office.12)
+// https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2010/hh204509(v=office.14)#mapi-mime-conversion-api
 #define CCSF_SMTP 0x0002              // the converter is being passed an SMTP message
 #define CCSF_NOHEADERS 0x0004         // the converter should ignore the headers on the outside message
 #define CCSF_USE_TNEF 0x0010          // the converter should embed TNEF in the MIME message
@@ -21,6 +24,9 @@ DEFINE_GUID(IID_IConverterSession, 0x4b401570, 0xb77b, 0x11d0, 0x9d, 0xa5, 0x0, 
 #define CCSF_PRESERVE_SOURCE 0x40000  // don't modify the source message
 
 // http://msdn2.microsoft.com/en-us/library/bb905202.aspx
+// TODO: Update to
+// https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb905202(v=office.12)
+// https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2010/ff960231(v=office.14)
 interface IConverterSession : public IUnknown
 {
    public:

--- a/com/win32comext/mapi/src/PyIExchangeManageStoreEx.i
+++ b/com/win32comext/mapi/src/PyIExchangeManageStoreEx.i
@@ -52,7 +52,7 @@ PyIExchangeManageStoreEx::~PyIExchangeManageStoreEx() {}
 %}
 
 /*
-** See http://blogs.msdn.com/b/dvespa/archive/2014/01/15/new-mapi-interface-ignore-home-server.aspx
+** See https://learn.microsoft.com/en-ca/archive/blogs/dvespa/a-new-mapi-interface-is-available-to-let-you-force-connections-to-go-to-a-specific-exchange-server
 */
 
 %native(CreateStoreEntryID2) CreateStoreEntryID2;

--- a/com/win32comext/mapi/src/extraMAPIDefs.h
+++ b/com/win32comext/mapi/src/extraMAPIDefs.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// https://blogs.msdn.microsoft.com/stephen_griffin/2011/10/13/the-elusive-0x81002746-error/
+// https://learn.microsoft.com/en-ca/archive/blogs/stephen_griffin/the-elusive-0x81002746-error
 // https://github.com/microsoft/mfcmapi/blob/main/core/interpret/errorArray.h
 #define MAIL_E_NAMENOTFOUND MAKE_SCODE(SEVERITY_ERROR, 0x0100, 10054)
 #define MAPI_E_STORE_FULL MAKE_MAPI_E(0x60C)

--- a/com/win32comext/mapi/src/extraMAPIGuids.h
+++ b/com/win32comext/mapi/src/extraMAPIGuids.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// https://support.microsoft.com/en-ca/help/171907/info-save-message-to-msg-compound-file
+// https://learn.microsoft.com/en-us/outlook/troubleshoot/development/save-message-to-msg-file
 // CLSID_MailMessage{00020D0B-0000-0000-C000-000000000046}
 DEFINE_GUID(CLSID_MailMessage, 0x00020D0B, 0x0000, 0x0000, 0xC0, 0x00, 0x0, 0x00, 0x0, 0x00, 0x00, 0x46);
 

--- a/com/win32comext/mapi/src/mapi.i
+++ b/com/win32comext/mapi/src/mapi.i
@@ -555,6 +555,9 @@ static PyObject *PyMAPIUninitialize(PyObject *self, PyObject *args)
 #define FLUSH_ASYNC_OK FLUSH_ASYNC_OK
 
 // IConverterSession Constants - http://msdn2.microsoft.com/en-us/library/bb905201.aspx
+// TODO: Update to
+// https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb905201(v=office.12)
+// https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2010/hh204509(v=office.14)#mapi-mime-conversion-api
 #define CCSF_SMTP             CCSF_SMTP // the converter is being passed an SMTP message
 #define CCSF_NOHEADERS        CCSF_NOHEADERS // the converter should ignore the headers on the outside message
 #define CCSF_USE_TNEF         CCSF_USE_TNEF // the converter should embed TNEF in the MIME message
@@ -870,7 +873,7 @@ done:
 
 %{
 // Code for converting RTF to HTML.
-// Found at http://www.wischik.com/lu/programmer/mapi_utils.html
+// Found at https://www.wischik.com/lu/programmer/mapi_utils.html
 // MarkH converted it to Python, but was too slow.  Moving to a regex
 // based parser was too much work.
 

--- a/com/win32comext/propsys/src/PyPROPVARIANT.cpp
+++ b/com/win32comext/propsys/src/PyPROPVARIANT.cpp
@@ -532,7 +532,7 @@ BOOL PyWin_NewPROPVARIANT(PyObject *ob, VARTYPE vt, PROPVARIANT *ppv)
             break;
         }
             // Docs are contradictory as to whether VT_VARIANT can be used with VT_ARRAY
-            // http://msdn.microsoft.com/en-us/library/aa380072%28VS.85%29.aspx
+            // https://learn.microsoft.com/en-ca/windows/win32/api/propidlbase/ns-propidlbase-propvariant
             // In the section on VT_ARRAY, it says it can be or'ed with VT_VARIANT.  However,
             // under VT_VARIANT it says it can only be used with VT_VECTOR or VT_BYREF
 

--- a/com/win32comext/shell/demos/servers/empty_volume_cache.py
+++ b/com/win32comext/shell/demos/servers/empty_volume_cache.py
@@ -1,5 +1,5 @@
 # A sample implementation of IEmptyVolumeCache - see
-# http://msdn2.microsoft.com/en-us/library/aa969271.aspx for an overview.
+# https://learn.microsoft.com/en-ca/windows/win32/lwef/disk-cleanup for an overview.
 #
 # * Execute this script to register the handler
 # * Start the "disk cleanup" tool - look for "pywin32 compiled files"

--- a/com/win32comext/shell/demos/servers/folder_view.py
+++ b/com/win32comext/shell/demos/servers/folder_view.py
@@ -1,5 +1,5 @@
 # This is a port of the Vista SDK "FolderView" sample, and associated
-# notes at http://shellrevealed.com/blogs/shellblog/archive/2007/03/15/Shell-Namespace-Extension_3A00_-Creating-and-Using-the-System-Folder-View-Object.aspx
+# notes at https://web.archive.org/web/20081225011615/http://shellrevealed.com/blogs/shellblog/archive/2007/03/15/Shell-Namespace-Extension_3A00_-Creating-and-Using-the-System-Folder-View-Object.aspx
 # A key difference to shell_view.py is that this version uses the default
 # IShellView provided by the shell (via SHCreateShellFolderView) rather
 # than our own.

--- a/com/win32comext/shell/src/shell.cpp
+++ b/com/win32comext/shell/src/shell.cpp
@@ -408,8 +408,9 @@ PyObject *PyObject_FromPIDLArray(UINT cidl, LPCITEMIDLIST *pidl)
 }
 
 // See MSDN
-// http://msdn.microsoft.com/library/default.asp?url=/library/en-us/shellcc/platform/shell/programmersguide/shell_basics/shell_basics_programming/transferring/clipboard.asp
-// (or search MSDN for "CFSTR_SHELLIDLIST"
+// https://learn.microsoft.com/en-us/windows/win32/shell/dragdrop
+// https://learn.microsoft.com/en-us/windows/win32/shell/clipboard#cfstr_shellidlist
+// (or search for "CFSTR_SHELLIDLIST")
 #define GetPIDLFolder(pida) (LPCITEMIDLIST)(((LPBYTE)pida) + (pida)->aoffset[0])
 #define GetPIDLItem(pida, i) (LPCITEMIDLIST)(((LPBYTE)pida) + (pida)->aoffset[i + 1])
 PyObject *PyObject_FromCIDA(CIDA *pida)

--- a/isapi/samples/redirector.py
+++ b/isapi/samples/redirector.py
@@ -29,7 +29,7 @@ if hasattr(sys, "isapidllhandle"):
     import win32traceutil
 
 # The site we are proxying.
-proxy = "http://www.python.org"
+proxy = "https://www.python.org"
 
 # Urls we exclude (ie, allow IIS to handle itself) - all are lowered,
 # and these entries exist by default on Vista...

--- a/isapi/samples/redirector_asynch.py
+++ b/isapi/samples/redirector_asynch.py
@@ -17,7 +17,7 @@ if hasattr(sys, "isapidllhandle"):
     import win32traceutil
 
 # The site we are proxying.
-proxy = "http://www.python.org"
+proxy = "https://www.python.org"
 
 # We synchronously read chunks of this size then asynchronously write them.
 CHUNK_SIZE = 8192

--- a/isapi/samples/redirector_with_filter.py
+++ b/isapi/samples/redirector_with_filter.py
@@ -46,7 +46,7 @@ if hasattr(sys, "isapidllhandle"):
     import win32traceutil
 
 # The site we are proxying.
-proxy = "http://www.python.org"
+proxy = "https://www.python.org"
 # The name of the virtual directory we install in, and redirect from.
 virtualdir = "/python"
 

--- a/isapi/src/pyISAPI.cpp
+++ b/isapi/src/pyISAPI.cpp
@@ -221,7 +221,7 @@ DWORD WINAPI HttpFilterProc(HTTP_FILTER_CONTEXT *phfc, DWORD NotificationType, V
 }
 
 // Hmm - this appears to never be called!?!?
-// http://sf.net/support/tracker.php?aid=1173795
+// https://sourceforge.net/p/pywin32/bugs/206/
 BOOL WINAPI TerminateFilter(DWORD status)
 {
     BOOL bRetStatus;

--- a/win32/Demos/security/localized_names.py
+++ b/win32/Demos/security/localized_names.py
@@ -1,6 +1,6 @@
 # A Python port of the MS knowledge base article Q157234
 # "How to deal with localized and renamed user and group names"
-# http://support.microsoft.com/default.aspx?kbid=157234
+# https://www.betaarchive.com/wiki/index.php?title=Microsoft_KB_Archive/157234
 
 import sys
 

--- a/win32/Demos/win32gui_menu.py
+++ b/win32/Demos/win32gui_menu.py
@@ -177,9 +177,9 @@ class MainWindow:
         InsertMenuItem(menu, 0, 1, item)
 
         # Owner-draw menus mainly from:
-        # http://windowssdk.msdn.microsoft.com/en-us/library/ms647558.aspx
+        # https://learn.microsoft.com/en-ca/windows/win32/menurc/using-menus
         # and:
-        # http://www.codeguru.com/cpp/controls/menu/bitmappedmenus/article.php/c165
+        # https://www.codeguru.com/cplusplus/owner-drawn-menu-with-icons/
 
         # Create one with an icon - this is *lots* more work - we do it
         # owner-draw!  The primary reason is to handle transparency better -

--- a/win32/Demos/win32gui_taskbar.py
+++ b/win32/Demos/win32gui_taskbar.py
@@ -104,7 +104,7 @@ class MainWindow:
             win32gui.AppendMenu(menu, win32con.MF_STRING, 1024, "Say Hello")
             win32gui.AppendMenu(menu, win32con.MF_STRING, 1025, "Exit program")
             pos = win32gui.GetCursorPos()
-            # See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/winui/menus_0hdi.asp
+            # See https://learn.microsoft.com/en-us/windows/win32/api/_menurc/
             win32gui.SetForegroundWindow(self.hwnd)
             win32gui.TrackPopupMenu(
                 menu, win32con.TPM_LEFTALIGN, pos[0], pos[1], 0, self.hwnd, None

--- a/win32/Lib/pywin32_bootstrap.py
+++ b/win32/Lib/pywin32_bootstrap.py
@@ -14,7 +14,7 @@ else:
     import os
 
     # We're guaranteed only that __path__: Iterable[str]
-    # https://docs.python.org/3/reference/import.html#__path__
+    # https://docs.python.org/3/reference/import.html#path-attributes-on-modules
     for path in pywin32_system32.__path__:
         if os.path.isdir(path):
             os.add_dll_directory(path)

--- a/win32/Lib/sspi.py
+++ b/win32/Lib/sspi.py
@@ -100,7 +100,7 @@ class _BaseAuth:
     def unwrap(self, token):
         """
         GSSAPI's unwrap with SSPI.
-        https://docs.microsoft.com/en-us/windows/win32/secauthn/sspi-kerberos-interoperability-with-gssapi
+        https://learn.microsoft.com/en-us/windows/win32/secauthn/sspi-kerberos-interoperability-with-gssapi
 
         Usable mainly with Kerberos SSPI package, but this is not enforced.
 
@@ -125,7 +125,7 @@ class _BaseAuth:
     def wrap(self, msg, encrypt=False):
         """
         GSSAPI's wrap with SSPI.
-        https://docs.microsoft.com/en-us/windows/win32/secauthn/sspi-kerberos-interoperability-with-gssapi
+        https://learn.microsoft.com/en-us/windows/win32/secauthn/sspi-kerberos-interoperability-with-gssapi
 
         Usable mainly with Kerberos SSPI package, but this is not enforced.
 

--- a/win32/Lib/win32gui_struct.py
+++ b/win32/Lib/win32gui_struct.py
@@ -91,7 +91,7 @@ def UnpackNMITEMACTIVATE(lparam):
 
 
 # MENUITEMINFO struct
-# http://msdn.microsoft.com/library/default.asp?url=/library/en-us/winui/WinUI/WindowsUserInterface/Resources/Menus/MenuReference/MenuStructures/MENUITEMINFO.asp
+# https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-menuiteminfow
 # We use the struct module to pack and unpack strings as MENUITEMINFO
 # structures.  We also have special handling for the 'fMask' item in that
 # structure to avoid the caller needing to explicitly check validity

--- a/win32/Lib/win32pdhquery.py
+++ b/win32/Lib/win32pdhquery.py
@@ -88,10 +88,10 @@ number of common one-off tasks.
 If you can access the MS Developers Network Library, you can find
 information about the PDH API as MS describes it.  For a background article,
 try:
-http://msdn.microsoft.com/library/en-us/dnperfmo/html/msdn_pdhlib.asp
+https://web.archive.org/web/20040926110045/http://msdn.microsoft.com:80/library/en-us/dnperfmo/html/msdn_pdhlib.asp
 
 The reference guide for the PDH API was last spotted at:
-http://msdn.microsoft.com/library/en-us/perfmon/base/using_the_pdh_interface.asp
+https://learn.microsoft.com/en-us/windows/win32/perfctrs/using-the-pdh-functions-to-consume-counter-data
 
 
 In general the Python version of the API is just a wrapper around the
@@ -108,7 +108,7 @@ in this plan.  There should be an article describing the creation of
 a simple logger there, but the example above is 90% of the work of
 that project, so don't sweat it if you don't find anything there.
 (currently the account hasn't been set up).
-http://starship.skyport.net/crew/mcfletch/
+https://web.archive.org/web/19980422204546/http://starship.skyport.net/crew/mcfletch/
 
 If you need to contact me immediately, (why I can't imagine), you can
 email me at mcfletch@golden.net, or just post your question to the

--- a/win32/Lib/win32pdhutil.py
+++ b/win32/Lib/win32pdhutil.py
@@ -27,7 +27,7 @@ import win32pdh
 error = win32pdh.error  # Re-exported alias
 
 # Handle some localization issues.
-# see http://support.microsoft.com/default.aspx?scid=http://support.microsoft.com:80/support/kb/articles/Q287/1/59.asp&NoWebContent=1
+# see https://www.betaarchive.com/wiki/index.php?title=Microsoft_KB_Archive/287159
 # Build a map of english_counter_name: counter_id
 counter_english_map: dict[str, int] = {}
 
@@ -60,8 +60,8 @@ def GetPerformanceAttributes(
     # thread's CPU usage is either 0 or 100).  To read counters like this,
     # you should copy this function, but keep the counter open, and call
     # CollectQueryData() each time you need to know.
-    # See http://support.microsoft.com/default.aspx?scid=kb;EN-US;q262938
-    # and http://msdn.microsoft.com/library/en-us/dnperfmo/html/perfmonpt2.asp
+    # See https://www.betaarchive.com/wiki/index.php?title=Microsoft_KB_Archive/262938
+    # and https://web.archive.org/web/20040926105842/http://msdn.microsoft.com:80/library/en-us/dnperfmo/html/perfmonpt2.asp
     # My older explanation for this was that the "AddCounter" process forced
     # the CPU to 100%, but the above makes more sense :)
     path = win32pdh.MakeCounterPath((machine, object, instance, None, inum, counter))
@@ -145,8 +145,8 @@ def ShowAllProcesses():
                 )
                 hcs.append(win32pdh.AddCounter(hq, path))
             win32pdh.CollectQueryData(hq)
-            # as per http://support.microsoft.com/default.aspx?scid=kb;EN-US;q262938, some "%" based
-            # counters need two collections
+            # as per https://www.betaarchive.com/wiki/index.php?title=Microsoft_KB_Archive/262938
+            # some "%" based  counters need two collections
             time.sleep(0.01)
             win32pdh.CollectQueryData(hq)
             print("%-15s\t" % (instance[:15]), end=" ")

--- a/win32/Lib/win32timezone.py
+++ b/win32/Lib/win32timezone.py
@@ -101,7 +101,7 @@ True
 '2007-06-13 01:00:00'
 
 Microsoft now has a patch for handling time zones in 2007 (see
-http://support.microsoft.com/gp/cp_dst)
+https://learn.microsoft.com/en-us/troubleshoot/windows-client/system-management-components/daylight-saving-time-help-support)
 
 As a result, patched systems will give an incorrect result for
 dates prior to the designated year except for Vista and its
@@ -901,7 +901,7 @@ class TimeZoneInfo(datetime.tzinfo):
         key must be a function that takes a TimeZoneInfo object and returns
         a value suitable for sorting on.
         The key defaults to the bias (descending), as is done in Windows
-        (see http://blogs.msdn.com/michkap/archive/2006/12/22/1350684.aspx)
+        (see https://web.archive.org/web/20130723075340/http://blogs.msdn.com/b/michkap/archive/2006/12/22/1350684.aspx)
         """
         key = key or (lambda tzi: -tzi.staticInfo.bias)
         zones = TimeZoneInfo.get_all_time_zones()
@@ -1023,7 +1023,8 @@ def resolveMUITimeZone(spec: str) -> str | None:
     """Resolve a multilingual user interface resource for the time zone name
 
     spec should be of the format @path,-stringID[;comment]
-    see http://msdn2.microsoft.com/en-us/library/ms725481.aspx for details
+    see https://learn.microsoft.com/en-ca/windows/win32/api/timezoneapi/ns-timezoneapi-time_zone_information
+    for details
 
     >>> import sys
     >>> result = resolveMUITimeZone('@tzres.dll,-110')

--- a/win32/help/process_info.html
+++ b/win32/help/process_info.html
@@ -840,8 +840,10 @@ into the details.
 <H1><A NAME="Further Info">Further Info</A></H1>
 <p>
 <ul>
-<li>Pdh stuff found at ftp://ftp.microsoft.com in something similar to /developr/platformsdk/april2000/x86/redist/pdh</li>
-<li>Mirosoft MSDN references at http://msdn.microsoft.com</li>
+<li>
+    Microsoft documentation on using PDH
+    https://learn.microsoft.com/en-us/windows/win32/perfctrs/using-the-pdh-functions-to-consume-counter-data
+</li>
 <li>Relevant Pdh Python libraries: win32pdh.py, win32pdhutil.py</li>
 </ul>
 </p>

--- a/win32/help/security_directories.html
+++ b/win32/help/security_directories.html
@@ -70,8 +70,8 @@ a filesystem.
 <H2><A NAME="Extend">Extending Python</A></H3>
 <p>
 There are several ways one can extend python. You can take a raw wrapping
-approach, <a href="http://www.swig.org">SWIG</a> or
-<a href="http://www.boost.org/libs/python/doc/index.html">BPL (Boost Python Libraries) </a>.
+approach, <a href="https://www.swig.org">SWIG</a> or
+<a href="https://www.boost.org/libs/python/doc/">BPL (Boost Python Libraries) </a>.
 
 This extension is simple enough that we're going to wrap the C++ w/out the
 help of SWIG of BPL. This won't be an extensive discussion about extending
@@ -143,16 +143,14 @@ through</li>
 </ol>
 
 The following code goes through those 4 steps in greater detail.
-Refer to <a href="http://msdn.microsoft.com">Microsoft MSDN references</a>
+Refer to <a href="https://learn.microsoft.com/en-us/windows/win32/">Build desktop Windows apps using the Win32 API</a>
 for info about the various win32 calls made.
 
 
 
 <HR>
 <H2><A NAME="Extend_get">Extending Python for Directory Permissions</A></H2>
-To setup Visual Studio correctly for building an extension, it is easiest to
-use a program called <A HREF="http://starship.python.net/crew/da/compile">compile.py</A>
-which builds the project for you. The Extension creates a dictionary of
+The following Extension creates a dictionary of
 user or group plus the access mask. To Python it will look like:
 <pre>
 import fileperm
@@ -515,7 +513,7 @@ else:
 Extending python isn't as simple as writing python, but it greatly expands
 python's capabilities. There are many details not covered here like
 reference counting, threading, and error handeling. The python website has documentation about
-<A HREF="http://www.python.org/doc/current/ext/ext.html">Extending Python</A>.
+<A HREF="https://docs.python.org/3/extending/index.html">Extending and Embedding the Python Interpreter</A>.
 
 
 </p>
@@ -525,11 +523,14 @@ reference counting, threading, and error handeling. The python website has docum
 <H1><A NAME="Further Info">Further Info</A></H1>
 <p>
 <ul>
-<li><a href="http://msdn.microsoft.com">Microsoft MSDN references</a></li>
-<li><A HREF="http://www.python.org/doc/current/ext/ext.html">Extending Python</A></li>
-<li><A HREF="http://starship.python.net/crew/da/compile">compile.py</A></li>
-<li><a href="http://www.swig.org">SWIG</a> </li>
-<li><a href="http://www.boost.org/libs/python/doc/index.html">BPL (Boost Python Libraries) </a></li>
+<li>
+    <a href="https://learn.microsoft.com/en-us/windows/win32/api/_security/">
+        Windows Security and Identity documentation
+    </a>
+</li>
+<li><A HREF="https://docs.python.org/3/extending/index.html">Extending and Embedding the Python Interpreter</A></li>
+<li><a href="https://www.swig.org">SWIG</a> </li>
+<li><a href="https://www.boost.org/libs/python/doc/">BPL (Boost Python Libraries) </a></li>
 </ul>
 </p>
 <HR><H1><A NAME="Author">Author</A></H1>

--- a/win32/help/win32net.html
+++ b/win32/help/win32net.html
@@ -65,7 +65,8 @@ There are several examples of this:
 
 The python api for the win32net module closely mirrors the C++
 functions documented in the msdn.  This makes it convenient to look at
-the <a href="http://msdn.microsoft.com">Microsoft MSDN </a>
+the <a href="https://learn.microsoft.com/en-us/windows/win32/api/_netmgmt/">
+Windows Network Management documentation</a>
 for further information if necessary. There is a sister module to
 win32net called win32netcon that houses all of the constants needed by
 the win32net modules.
@@ -319,7 +320,7 @@ are many levels. One of the most useful one is USER_INFO_3 this
 structure lets you change just about anything you want for a
 user.Also, not all levels are available for both NetUserSetInfo and
 NetUserGetInfo. NetUserGetInfo has about 7 available to it. (btw, <a
-href="http://msdn.microsoft.com">Microsoft MSDN </a> would have more
+href="https://learn.microsoft.com/en-us/windows/win32/api/lmaccess/">lmaccess.h header documentation</a> would have more
 information about this). I'll show an example with NetUserSetInfo
 using USER_INFO_1008 that has no corresponding NetUserGetInfo.
 
@@ -445,7 +446,7 @@ the simple access python gives one to the underlying api.
 <H1><A NAME="Further Info">Further Info</A></H1>
 <p>
 <ul>
-<li><a href="http://msdn.microsoft.com">Microsoft MSDN references</a>
+<li><a href="https://learn.microsoft.com/en-us/windows/win32/api/_netmgmt/">Windows Network Management documentation</a>
 <li>Relevant Python libraries: win32net and win32netcon
 </ul>
 </p>

--- a/win32/src/PyWinTypesmodule.cpp
+++ b/win32/src/PyWinTypesmodule.cpp
@@ -512,7 +512,7 @@ PyLong_AsVoidPtr is unsuitable for use in many places due to the following issue
     that function and can be converted back to a usable address.
 
 From the response to this bug report:
-http://sourceforge.net/tracker/?func=detail&atid=105470&aid=1630863&group_id=5470
+https://github.com/python/cpython/issues/44430
 apparently if you want any reasonable or consistent behaviour from this function
 you're expected to perform the type checking yourself first.
 And if you have to do all that, why use the damn function at all ?

--- a/win32/src/PythonService.cpp
+++ b/win32/src/PythonService.cpp
@@ -147,7 +147,7 @@ SERVICE_STATUS stoppedErrorStatus = {SERVICE_WIN32_OWN_PROCESS,
                                      0,                             // dwCheckPoint
                                      0};
 // The Service Control Manager/Event Log seems to interpret dwServiceSpecificExitCode as a Win32 Error code
-// (https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes)
+// (https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes)
 // So stoppedErrorStatus has dwServiceSpecificExitCode with bit 29 set to indicate an application-defined error code.
 
 ///////////////////////////////////////////////////////////////////////

--- a/win32/src/win32credmodule.cpp
+++ b/win32/src/win32credmodule.cpp
@@ -62,7 +62,7 @@ BOOL PyWinObject_AsCREDENTIAL_ATTRIBUTE(PyObject *obattr, PCREDENTIAL_ATTRIBUTE 
         goto done;
     }
     // Handle `Value`: the docs
-    // https://docs.microsoft.com/en-us/windows/win32/api/wincred/ns-wincred-credential_attributew say it's an LPBYTE
+    // https://learn.microsoft.com/en-us/windows/win32/api/wincred/ns-wincred-credential_attributew say it's an LPBYTE
     // Value (meaning it's just bytes) but then the description says "Data associated with the attribute. By convention,
     // if Value is a text string, then Value should not include the trailing zero character and should be in UNICODE."
     if (PyUnicode_Check(obValue)) {

--- a/win32/src/win32file.i
+++ b/win32/src/win32file.i
@@ -2924,12 +2924,6 @@ static Wow64DisableWow64FsRedirectionfunc pfnWow64DisableWow64FsRedirection = NU
 typedef BOOL (WINAPI *Wow64RevertWow64FsRedirectionfunc)(PVOID);
 static Wow64RevertWow64FsRedirectionfunc pfnWow64RevertWow64FsRedirection = NULL;
 
-/* GetFileInformationByHandleEx and supporting structs are defined in SDK for Vista and later,
-	but can also be used on XP with a separate header and lib:
-	https://web.archive.org/web/20121118034013/http://www.microsoft.com:80/en-us/download/details.aspx?id=22599
-    or https://web.archive.org/web/20130718200015/http://www.microsoft.com/en-us/download/confirmation.aspx?id=22599
-	However, the filextd.lib included is static, so this module would have to be compiled for XP only.
-*/
 typedef BOOL (WINAPI *GetFileInformationByHandleExfunc)(HANDLE,FILE_INFO_BY_HANDLE_CLASS,LPVOID,DWORD);
 static GetFileInformationByHandleExfunc pfnGetFileInformationByHandleEx = NULL;
 typedef BOOL (WINAPI *SetFileInformationByHandlefunc)(HANDLE,FILE_INFO_BY_HANDLE_CLASS,LPVOID,DWORD);

--- a/win32/src/win32file.i
+++ b/win32/src/win32file.i
@@ -2926,7 +2926,8 @@ static Wow64RevertWow64FsRedirectionfunc pfnWow64RevertWow64FsRedirection = NULL
 
 /* GetFileInformationByHandleEx and supporting structs are defined in SDK for Vista and later,
 	but can also be used on XP with a separate header and lib:
-	http://www.microsoft.com/en-us/download/details.aspx?id=22599
+	https://web.archive.org/web/20121118034013/http://www.microsoft.com:80/en-us/download/details.aspx?id=22599
+    or https://web.archive.org/web/20130718200015/http://www.microsoft.com/en-us/download/confirmation.aspx?id=22599
 	However, the filextd.lib included is static, so this module would have to be compiled for XP only.
 */
 typedef BOOL (WINAPI *GetFileInformationByHandleExfunc)(HANDLE,FILE_INFO_BY_HANDLE_CLASS,LPVOID,DWORD);

--- a/win32/src/win32gui.i
+++ b/win32/src/win32gui.i
@@ -6453,7 +6453,7 @@ PyCFunction pfnPyGetOpenFileNameW=(PyCFunction)PyGetOpenFileNameW;
 BOOL PyObject_AsUINT(PyObject *ob, UINT *puint)
 {
 	// PyLong_AsUnsignedLong throws a bogus error in 2.3 if passed an int, and there is no PyInt_AsUnsignedLong
-	// ref: http://mail.python.org/pipermail/patches/2004-September/016060.html
+	// ref: https://mail.python.org/pipermail/patches/2004-September/016060.html
 	// And for some reason none of the Unsigned*Mask functions check for overflow ???
 
 	__int64 UINT_candidate=PyLong_AsLongLong(ob);

--- a/win32/test/test_sspi.py
+++ b/win32/test/test_sspi.py
@@ -84,7 +84,7 @@ class TestSSPI(unittest.TestCase):
 
     def _doTestEncryptStream(self, pkg_name):
         # Test out the SSPI/GSSAPI interop wrapping examples at
-        # https://docs.microsoft.com/en-us/windows/win32/secauthn/sspi-kerberos-interoperability-with-gssapi
+        # https://learn.microsoft.com/en-us/windows/win32/secauthn/sspi-kerberos-interoperability-with-gssapi
 
         sspiclient, sspiserver = self._doAuth(pkg_name)
 

--- a/win32/test/test_win32crypt.py
+++ b/win32/test/test_win32crypt.py
@@ -2,7 +2,8 @@
 
 import contextlib
 import unittest
-from typing import Any, Iterator
+from collections.abc import Iterator
+from typing import Any
 
 import win32crypt
 from pywin32_testutil import find_test_fixture, testmain

--- a/win32/test/test_win32inet.py
+++ b/win32/test/test_win32inet.py
@@ -26,15 +26,15 @@ from win32inetcon import (
 class CookieTests(unittest.TestCase):
     def testCookies(self):
         data = "TestData=Test"
-        InternetSetCookie("http://www.python.org", None, data)
-        got = InternetGetCookie("http://www.python.org", None)
+        InternetSetCookie("https://www.python.org", None, data)
+        got = InternetGetCookie("https://www.python.org", None)
         # handle that there might already be cookies for the domain.
         bits = (x.strip() for x in got.split(";"))
         self.assertTrue(data in bits)
 
     def testCookiesEmpty(self):
         try:
-            InternetGetCookie("http://site-with-no-cookie.python.org", None)
+            InternetGetCookie("https://site-with-no-cookie.python.org", None)
             self.fail("expected win32 exception")
         except error as exc:
             self.assertEqual(exc.winerror, winerror.ERROR_NO_MORE_ITEMS)
@@ -61,7 +61,7 @@ class TestNetwork(unittest.TestCase):
 
     def testPythonDotOrg(self):
         hdl = InternetOpenUrl(
-            self.hi, "http://www.python.org", None, INTERNET_FLAG_EXISTING_CONNECT
+            self.hi, "https://www.python.org", None, INTERNET_FLAG_EXISTING_CONNECT
         )
         chunks = []
         while 1:


### PR DESCRIPTION
Closes https://github.com/mhammond/pywin32/issues/2398

- Replaced all `http://` with `https://` for links that exists
- Followed existing link redirects 
- Checked through The Internet Archive's Wayback Machine for more links that could lead to a now-valid redirect.
- Fallback to https://www.betaarchive.com/wiki/index.php?title=Microsoft_KB_Archive for KB items and https://web.archive.org/web for other pages where I could not find a modern equivalent.
  - I got a bit lazy with `Microsoft_KB_Archive`, some of those links *may* have a modern equivalent if you search hard enough.
  - It looks like most of http://starship.python.net/crew/mhammond has been archived, conference files included. Such documentation could be restored in GitHub if still relevant.