### PR TITLE
Remove mentions of Windows (Server and Platform SDK) 2003

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@ win32/src/win32service_messages.h
 win32/src/win32evtlog_messages.h
 isapi/src/pyISAPI_messages.h
 
-# VC2003 and up project files
+# Visual Studio project files
 *.sln
 *.suo
 *.vcproj

--- a/adodbapi/quick_reference.md
+++ b/adodbapi/quick_reference.md
@@ -70,10 +70,7 @@ where "click to buy" versions of Office have been removed, but are still
 blocking installation of the redistributable provider.
 
 - To use any ODBC driver from 64 bit Python, you also need the MSDASQL
-provider. It is shipped with Server 2008, and Vista and later. For
-Server 2003, You will have to [download
-it](http://www.microsoft.com/en-us/download/details.aspx?id=20065) [from
-Microsoft.]{lang="en-US"}
+provider. It is shipped with Server 2008, and Vista and later.
 
 - MySQL driver <http://dev.mysql.com/downloads/connector/odbc/>
 or MariaDB driver <https://downloads.mariadb.org/connector-odbc/>

--- a/com/win32com/src/PyGatewayBase.cpp
+++ b/com/win32com/src/PyGatewayBase.cpp
@@ -14,13 +14,6 @@ extern const GUID IID_IInternalUnwrapPythonObject = {
 extern PyObject *g_obMissing;
 
 #include <malloc.h>
-// When building with the 2003 Platform SDK 64-bit compiloer, _MSC_VER is 1400,
-// but _malloca is not defined
-// #if _MSC_VER < 1400
-#ifndef _malloca
-// _malloca is the new 'safe' one
-#define _malloca _alloca
-#endif
 
 // Internal ErrorUtil helpers we reach in for.
 // Free the strings from an excep-info.


### PR DESCRIPTION
I left in https://github.com/mhammond/pywin32/blob/0aadef03667056e2b657f6e43d2e5b8a04b0a3c9/win32/Lib/winioctlcon.py#L1056-L1059 since that would be tackled in a `winioctlcon.py` regeneration.