### PR TITLE
Fix bug introduced in 'genpy.py' by commit adf9cfb.

### DIFF
--- a/com/win32com/client/genpy.py
+++ b/com/win32com/client/genpy.py
@@ -1141,8 +1141,8 @@ class Generator:
 
         print("RecordMap = {", file=stream)
         for record in recordItems.values():
+            record_str = f"{record.doc[0]!r}: '{record.clsid}',"
             if record.clsid == pythoncom.IID_NULL:
-                record_str = f"{record.doc[0]!r}: '{record.clsid}',"
                 print(
                     f"\t###{record_str}",
                     "# Record disabled because it doesn't have a non-null GUID",


### PR DESCRIPTION
[Commit adf9cfb](https://github.com/geppi/pywin32/commit/adf9cfb89652050936c7f742179fe1cac48cc933#diff-3a5cf75a9dab9a2a6e2f5a6fa9f0ecb44430bac430161751cc9709fcc6381e96) introduced a bug into **genpy.py** that causes an exception when running **gencache.EnsureModule** on a TypeLibrary that defines COM Records:
```
File ".....\site-packages\win32com\client\genpy.py", line 1152, in do_generate
    print(f"\t{record_str}", file=stream)
UnboundLocalError: cannot access local variable 'record_str' where it is not associated with a value
```
I'm mildly surprised that this commit passed the tests.