### PR TITLE
Migrate to new issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: python-win32 mailing list
+    url: http://mail.python.org/mailman/listinfo/python-win32
+    about: For support requests, problems or questions

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,3 +1,8 @@
+---
+name: New issue
+about: Do not open github issues for general support requests
+---
+
 <!--
 Note that issues in this repository are only for bugs or feature requests in the pywin32.
 


### PR DESCRIPTION
The current issue template is deprecated and no longer works with GitHub's new issue template system.
This is the new flows (I added an entry for support requests):
![image](https://github.com/user-attachments/assets/eff82930-1291-47c0-817d-186aa82341ba)
And restored template:
![image](https://github.com/user-attachments/assets/f0f8e9d5-58d2-448e-8290-82c59105f5d2)

I could transform the existing issue template into [an issue form](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) to force writing down some of the necessary info (like pywin32 and Python version) but my immediate concern is just restoring having a template in the first place.