### PR TITLE
Direct users to typeshed for type hint stuff

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Typeshed type stubs and annotations
+    url: https://github.com/python/typeshed/issues?q=state%3Aopen+pywin32
+    about: For static type-checking and IntelliSense
   - name: python-win32 mailing list
     url: http://mail.python.org/mailman/listinfo/python-win32
     about: For support requests, problems or questions

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -4,7 +4,10 @@ about: Do not open github issues for general support requests
 ---
 
 <!--
-Note that issues in this repository are only for bugs or feature requests in the pywin32.
+Note that issues in this repository are only for bugs or feature requests in the pywin32 repository.
+
+Type stubs currently live in [typeshed](<https://github.com/python/typeshed/tree/main/stubs/pywin32>).
+Any issue or request related to static type-checking and IntelliSense should be raised there.
 
 **If you need support or help using this package, please follow [these instructions](https://github.com/mhammond/pywin32/blob/master/README.md#support)** - support or help requests will be closed without comment.
 -->

--- a/README.md
+++ b/README.md
@@ -18,13 +18,18 @@ The docs are a long and sad story, but [there's now an online version](https://m
 of the `PyWin32.chm` helpfile (thanks [@ofek](https://github.com/mhammond/pywin32/pull/1774)!).
 Lots of that is very old, but some is auto-generated and current. Would love help untangling the docs!
 
+You can get type hints, signatures and annotations from [`types-pywin32`](https://pypi.org/project/types-pywin32/).
+
 ## Support
 
 Feel free to [open issues](https://github.com/mhammond/pywin32/issues) for
 all bugs (or suspected bugs) in pywin32. [pull-requests](https://github.com/mhammond/pywin32/pulls)
 for all bugs or features are also welcome.
 
-However, please **do not open github issues for general support requests**, or
+Type stubs currently live in [typeshed](<https://github.com/python/typeshed/tree/main/stubs/pywin32>).
+Any issue or request related to static type-checking and IntelliSense should be raised there.
+
+However, please **do not open GitHub issues for general support requests**, or
 for problems or questions using the modules in this package - they will be
 closed. For such issues, please email the
 [python-win32 mailing list](https://mail.python.org/mailman/listinfo/python-win32) -


### PR DESCRIPTION
Closes #2468
Help with #1535

Whilst work has been under way to add first-party type-annotations to pywin32's pure-python public API. The typeshed stubs still prevail at the moment. Direct users there if they have any issue with static typing, like #1989, #1913, #2006, #2065, #2411