### PR TITLE
Bump actions/upload-artifact to v4 and automatically merge artefacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Delete standalone Artifacts
         uses: geekyeggo/delete-artifact@v5
         with:
-          name: artifact-*
+          name: artifacts-*
 
   # This job can be run locally by running `pre-commit run`
   checkers:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,11 +65,11 @@ jobs:
       - name: Build wheels
         run: pip wheel . -v --wheel-dir=dist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         # Upload artifacts even if tests fail
         if: ${{ always() }}
         with:
-          name: artifacts
+          name: artifacts-${{ matrix.python-version }}-${{ matrix.architecture }}
           path: dist/*.whl
           if-no-files-found: error
 
@@ -107,11 +107,25 @@ jobs:
       - name: Build wheels
         run: python -m build --wheel --config-setting=--build-option=build_ext --config-setting=--build-option=-L.\arm64libs --config-setting=--build-option=--plat-name=win-arm64 --config-setting=--build-option=build --config-setting=--build-option=--plat-name=win-arm64 --config-setting=--build-option=bdist_wheel --config-setting=--build-option=--plat-name=win-arm64
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: artifacts-${{ matrix.python-version }}-arm64
           path: dist/*.whl
           if-no-files-found: error
+
+  merge:
+    runs-on: windows-latest
+    needs: [test, build_arm64]
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: artifacts
+          pattern: artifacts-*
+      - name: Delete standalone Artifacts
+        uses: geekyeggo/delete-artifact@v5
+        with:
+          name: artifact-*
 
   # This job can be run locally by running `pre-commit run`
   checkers:


### PR DESCRIPTION
Follow-up to https://github.com/mhammond/pywin32/pull/2376

@mhammond This update is now mandatory for workflows to keep working.
> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

I think you prefer having a single zip file with all artefacts to make publishing easier. So I updated to workflow to still produce a *single* merged artifact with v4.