### PR TITLE
`list2dict` is the same as `dict.fromkeys`

### DIFF
--- a/Pythonwin/pywin/scintilla/view.py
+++ b/Pythonwin/pywin/scintilla/view.py
@@ -462,12 +462,6 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
         return 1
 
     def _AutoComplete(self):
-        def list2dict(l):
-            ret = {}
-            for i in l:
-                ret[i] = None
-            return ret
-
         self.SCIAutoCCancel()  # Cancel old auto-complete lists.
         # First try and get an object without evaluating calls
         ob = self._GetObjectAtPos(bAllowCalls=0)
@@ -480,17 +474,19 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
                 # extra attributes of win32ui objects
                 if hasattr(ob, "_obj_"):
                     try:
-                        items_dict.update(list2dict(dir(ob._obj_)))
+                        items_dict.update(dict.fromkeys(dir(ob._obj_)))
                     except AttributeError:
                         pass  # object has no __dict__
 
                 # normal attributes
                 try:
-                    items_dict.update(list2dict(dir(ob)))
+                    items_dict.update(dict.fromkeys(dir(ob)))
                 except AttributeError:
                     pass  # object has no __dict__
                 if hasattr(ob, "__class__"):
-                    items_dict.update(list2dict(_get_class_attributes(ob.__class__)))
+                    items_dict.update(
+                        dict.fromkeys(_get_class_attributes(ob.__class__))
+                    )
                 # The object may be a COM object with typelib support - let's see if we can get its props.
                 # (contributed by Stefan Migowsky)
                 try:


### PR DESCRIPTION
A little something I noticed a while ago and forgot to push
The implementation of `list2dict` is the same as just doing `dict.fromkeys`. Probably wasn't available back then.