### PR TITLE
Remove dead code for too old compiler versions

### DIFF
--- a/com/win32com/src/oleargs.cpp
+++ b/com/win32com/src/oleargs.cpp
@@ -1462,23 +1462,15 @@ BOOL PythonOleArgHelper::MakeObjToVariant(PyObject *obj, VARIANT *var, PyObject 
             break;
         case VT_BOOL | VT_BYREF:
             if (bCreateBuffers)
-#if _MSC_VER <= 1010
-                // use this macro for MSVC4.1 or before
-                V_BOOLREF(var) = &m_boolBuf;
-#define MYBOOLREF V_BOOLREF(var)
-#else
                 // this is used in MSVC4.2 and after
                 var->pboolVal = &m_boolBuf;
-#define MYBOOLREF (var->pboolVal)
-#endif
-
             if (!VALID_BYREF_MISSING(obj)) {
                 if ((obUse = PyNumber_Long(obj)) == NULL)
                     BREAK_FALSE
-                *MYBOOLREF = PyLong_AsLong(obj) ? VARIANT_TRUE : VARIANT_FALSE;
+                *(var->pboolVal) = PyLong_AsLong(obj) ? VARIANT_TRUE : VARIANT_FALSE;
             }
             else
-                *MYBOOLREF = 0;
+                *(var->pboolVal) = 0;
             break;
         case VT_R8:
             if ((obUse = PyNumber_Float(obj)) == NULL)

--- a/win32/src/win32file.i
+++ b/win32/src/win32file.i
@@ -53,10 +53,6 @@
 #	undef socklen_t
 #endif
 #include "Ws2tcpip.h"
-// *sob* - msvc6 can't handle the _WSPIAPI_COUNTOF in later SDKs...
-#if _MSC_VER < 1300
-#define _WSPIAPI_COUNTOF(_Array) (sizeof(_Array) / sizeof(_Array[0]))
-#endif
 #include "Wspiapi.h" // for WspiapiGetAddrInfo/WspiapiFreeAddrInfo
 
 #define NEED_PYWINOBJECTS_H

--- a/win32/src/win32helpmodule.cpp
+++ b/win32/src/win32helpmodule.cpp
@@ -18,14 +18,6 @@ generates Windows .hlp files.
 #include "htmlhelp.h"
 
 #define DllExport _declspec(dllexport)
-
-#if _MSC_VER == 1500
-// This uses htmlhelp.lib, which causes an unresolved external for
-// __report_rangecheckfailure with vs2008 (which is what we used for Python 2)
-// No idea why, but we define it here and cause it to kill the process if it is ever hit.
-extern "C" __declspec(noreturn, dllexport) void __cdecl __report_rangecheckfailure(void) { ::ExitProcess(1); }
-#endif
-
 #define PyW32_BEGIN_ALLOW_THREADS PyThreadState *_save = PyEval_SaveThread()
 #define PyW32_END_ALLOW_THREADS PyEval_RestoreThread(_save)
 


### PR DESCRIPTION
Visual Studio 2015 (VC++14) is now the minimal supported by non-EOL python version, so this is no longer necessary
- https://learn.microsoft.com/en-us/cpp/overview/compiler-versions?view=msvc-170#version-macros
- https://wiki.python.org/moin/WindowsCompilers#Which_Microsoft_Visual_C.2B-.2B-_compiler_to_use_with_a_specific_Python_version_.3F