### PR TITLE
Explicitly mention COM support, adodbapi and isapi in readme

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -6,7 +6,7 @@ about: Do not open github issues for general support requests
 <!--
 Note that issues in this repository are only for bugs or feature requests in the pywin32.
 
-**If you need support or help using this package, please follow [these instructions](https://github.com/mhammond/pywin32/blob/master/README.md#support)** - support or help requests will be closed without comment.
+**If you need support or help using this package, please follow [these instructions](https://github.com/mhammond/pywin32/blob/main/README.md#support)** - support or help requests will be closed without comment.
 -->
 
 For all bugs, please provide the following information:

--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@
 
 -----
 
-This is the readme for the Python for Win32 (pywin32) extensions, which provides access to many of the Windows APIs from Python.
+This is the readme for the Python for Win32 (pywin32) extensions, which provides access to many of the Windows APIs from Python, including COM support.
 
-See [CHANGES.txt](https://github.com/mhammond/pywin32/blob/master/CHANGES.txt) for recent notable changes.
+See [CHANGES.txt](https://github.com/mhammond/pywin32/blob/main/CHANGES.txt) for recent notable changes.
+
+adodbapi's documentation can be found in: [adodbapi/readme.txt](https://github.com/mhammond/pywin32/blob/main/adodbapi/readme.txt)
+
+isapi's documentation can be found in: [isapi/README.txt](https://github.com/mhammond/pywin32/blob/main/isapi/README.txt)
 
 ## Docs
 

--- a/adodbapi/quick_reference.md
+++ b/adodbapi/quick_reference.md
@@ -6,7 +6,7 @@ Adodbapi is a Python DB-API 2.0 module that makes it easy to use Microsoft ADO
 for connecting with databases and other data sources using CPython.
 
 Source home page:
-<https://github.com/mhammond/pywin32/tree/master/adodbapi>
+<https://github.com/mhammond/pywin32/tree/main/adodbapi>
 
 For complete installation instructions, see the README.txt file, which you may
 also find at

--- a/adodbapi/readme.txt
+++ b/adodbapi/readme.txt
@@ -37,7 +37,7 @@ or:
         adodbapi.apibase.variantConversions[adodbapi.ado_consts.adNumeric] = write_your_own_conversion_function
 		............
 notes for 2.6.2:
-    The definitive source has been moved to https://github.com/mhammond/pywin32/tree/master/adodbapi.
+    The definitive source has been moved to https://github.com/mhammond/pywin32/tree/main/adodbapi.
     Remote has proven too hard to configure and test with Pyro4. I am moving it to unsupported status
     until I can change to a different connection method.
 what's new in version 2.6


### PR DESCRIPTION
Closes #867

pywin32 includes quite a few features, tools and packages that are not obvious at all from a first read. it's:
- A C-extension (more like multiple c-extension packages) to bridge Windows API
- A generator of modules to use COM objects
- The home of adodbapi
- The home of isapi
- An IDE (Pythonwin, not mentioned because of this comment: https://github.com/mhammond/pywin32/pull/2450#pullrequestreview-2535648895)
- An ActiveX Python scripting engine (not mentioned ActiveX because it's pretty much obsolete)