### PR TITLE
Fix DispatchWithEvents and WithEvents throw on 2nd call

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,8 +14,8 @@ https://mhammond.github.io/pywin32_installers.html .
 Coming in build 310, as yet unreleased
 --------------------------------------
 * Fixed a regression where `win32com.client.DispatchWithEvents` and win32com.client.WithEvents` would throw a `TypeError` on the second call (#2491, @Avasam)
-* Drop support for Vista, set Windows 7 as the minimal Windows version. (#2487, @Avasam)
-  * Restores many IIDs in `win32com(ext).shell.shell`. See #2486 for details.
+* Dropped support for Vista, set Windows 7 as the minimal Windows version. (#2487, @Avasam)
+* Restored many IIDs in `win32com(ext).shell.shell`. See #2486 for details. (#2487, @Avasam)
 
 Build 309, released 2025/03/09
 ------------------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,7 +13,8 @@ https://mhammond.github.io/pywin32_installers.html .
 
 Coming in build 310, as yet unreleased
 --------------------------------------
-* Drop support for Vista, set Windows 7 as the minimal Windows version. (#, @Avasam)
+* Fixed a regression where `win32com.client.DispatchWithEvents` and win32com.client.WithEvents` would throw a `TypeError` on the second call (#2489, @Avasam)
+* Drop support for Vista, set Windows 7 as the minimal Windows version. (#2487, @Avasam)
   * Restores many IIDs in `win32com(ext).shell.shell`. See #2486 for details.
 
 Build 309, released 2025/03/09

--- a/com/win32com/client/__init__.py
+++ b/com/win32com/client/__init__.py
@@ -270,22 +270,22 @@ def __get_disp_and_event_classes(dispatch):
 
     if disp.__class__.__dict__.get("CLSID"):
         disp_class = disp.__class__
+    else:
+        # Eeek - no makepy support - try and build it.
+        try:
+            ti = disp._oleobj_.GetTypeInfo()
+            disp_clsid = ti.GetTypeAttr()[0]
+            tlb, index = ti.GetContainingTypeLib()
+            tla = tlb.GetLibAttr()
+            gencache.EnsureModule(tla[0], tla[1], tla[3], tla[4], bValidateFile=0)
+            # Get the class from the module.
+            disp_class = gencache.GetClassForProgID(str(disp_clsid))
+        except pythoncom.com_error as error:
+            disp_class = None
 
-    # Eeek - no makepy support - try and build it.
-    error_msg = "This COM object can not automate the makepy process - please run makepy manually for this object"
-    try:
-        ti = disp._oleobj_.GetTypeInfo()
-        disp_clsid = ti.GetTypeAttr()[0]
-        tlb, index = ti.GetContainingTypeLib()
-        tla = tlb.GetLibAttr()
-        gencache.EnsureModule(tla[0], tla[1], tla[3], tla[4], bValidateFile=0)
-        # Get the class from the module.
-        disp_class = gencache.GetClassForProgID(str(disp_clsid))
-    except pythoncom.com_error as error:
-        raise TypeError(error_msg) from error
+        if disp_class is None:
+            raise TypeError("This COM object can not automate the makepy process - please run makepy manually for this object")
 
-    if disp_class is None:
-        raise TypeError(error_msg)
     # Get the clsid
     clsid = disp_class.CLSID
     # Create a new class that derives from 2 classes:

--- a/com/win32com/client/__init__.py
+++ b/com/win32com/client/__init__.py
@@ -269,7 +269,7 @@ def __get_disp_and_event_classes(dispatch):
     disp = Dispatch(dispatch)
 
     if disp.__class__.__dict__.get("CLSID"):
-        return disp.__class__
+        disp_class = disp.__class__
 
     # Eeek - no makepy support - try and build it.
     error_msg = "This COM object can not automate the makepy process - please run makepy manually for this object"
@@ -333,7 +333,6 @@ def DispatchWithEvents(clsid, user_event_class) -> EventsProxy:
     >>> ie = DispatchWithEvents("InternetExplorer.Application", IEEvents)
     >>> ie.Visible = 1
     Visible changed: 1
-    >>>
     """
     disp, disp_class, events_class = __get_disp_and_event_classes(clsid)
     result_class = type(

--- a/com/win32com/client/__init__.py
+++ b/com/win32com/client/__init__.py
@@ -272,6 +272,7 @@ def __get_disp_and_event_classes(dispatch):
         disp_class = disp.__class__
     else:
         # Eeek - no makepy support - try and build it.
+        error_msg = "This COM object can not automate the makepy process - please run makepy manually for this object"
         try:
             ti = disp._oleobj_.GetTypeInfo()
             disp_clsid = ti.GetTypeAttr()[0]
@@ -281,10 +282,11 @@ def __get_disp_and_event_classes(dispatch):
             # Get the class from the module.
             disp_class = gencache.GetClassForProgID(str(disp_clsid))
         except pythoncom.com_error as error:
-            disp_class = None
+            raise TypeError(error_msg) from error
+
 
         if disp_class is None:
-            raise TypeError("This COM object can not automate the makepy process - please run makepy manually for this object")
+            raise TypeError(error_msg)
 
     # Get the clsid
     clsid = disp_class.CLSID

--- a/com/win32com/client/__init__.py
+++ b/com/win32com/client/__init__.py
@@ -284,7 +284,6 @@ def __get_disp_and_event_classes(dispatch):
         except pythoncom.com_error as error:
             raise TypeError(error_msg) from error
 
-
         if disp_class is None:
             raise TypeError(error_msg)
 

--- a/com/win32com/test/testPyComTest.py
+++ b/com/win32com/test/testPyComTest.py
@@ -628,6 +628,13 @@ def TestGenerated():
     # and a plain "WithEvents".
     handler = win32com.client.WithEvents(o, RandomEventHandler)
     TestEvents(o, handler)
+
+    # Ensure that if it has already been dispatched, the base classes are the same.
+    o2_again = win32com.client.DispatchWithEvents(o, RandomEventHandler)
+    assert o2._obj_.__class__.__bases__ == o2_again._obj_.__class__.__bases__
+    handler_again = win32com.client.WithEvents(o, RandomEventHandler)
+    assert handler.__class__.__bases__ == handler_again.__class__.__bases__
+
     progress("Finished generated .py test.")
 
 


### PR DESCRIPTION
Fixes #2489

Obligatory "this would've been caught by pyright `reportGeneralTypeIssues`" (but there's still like a thousand of those, so I'm far from enabling it)

Easier to review by hiding whitespaces.

---

~~Added tests to cover the case where it's already been dispatched.~~

But as we found out in https://github.com/mhammond/pywin32/pull/2467 , these tests aren't run on the CI, and I'm unable to run it locally either:
```
python .\com\win32com\test\testPyComTest.py
Traceback (most recent call last):
  File "E:\Users\Avasam\Documents\Git\pywin32\com\win32com\test\testPyComTest.py", line 12, in <module>
    import pythoncom
ModuleNotFoundError: No module named 'pythoncom'
```