### PR TITLE
Set specific non-UTF8 encodings for 2 known files in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,7 @@
 AutoDuck/*.fmt          text eol=crlf
 *.dsp                   text eol=crlf
 *.dsw                   text eol=crlf
+
+# Files that can't be in UTF-8 encoding
+com/TestSources/PyCOMTest/PyCOMTest.idl working-tree-encoding=latin1
+Pythonwin/pywin/test/_dbgscript.py      working-tree-encoding=latin1

--- a/Pythonwin/pywin/test/_dbgscript.py
+++ b/Pythonwin/pywin/test/_dbgscript.py
@@ -2,7 +2,7 @@
 #
 # Script for testing pywin.debugger & interactive exec from test_pywin
 
-# Umlauts for encoding test: áéúäöü
+# Umlauts for encoding test: Ã¡Ã©ÃºÃ¤Ã¶Ã¼
 
 aa = 11
 aa = 22

--- a/com/TestSources/PyCOMTest/PyCOMTest.idl
+++ b/com/TestSources/PyCOMTest/PyCOMTest.idl
@@ -1,3 +1,5 @@
+// -*- coding: latin1 -*-
+
 // PyCOMTest.idl : IDL source for PyCOMTest.dll
 //
 // This is a test harness for Python
@@ -26,7 +28,7 @@ typedef enum // Missing EnumTestAttributes2
 	uuid(6bcdcb60-5605-11d0-ae5f-cadd4c000000),
 	version(1.1),
 	// an extended character in the help string should stress things...
-	helpstring("Python COM Test Harness 1.0 Type Library, � pywin32 contributors")
+	helpstring("Python COM Test Harness 1.0 Type Library, © pywin32 contributors")
 ]
 library PyCOMTestLib
 {
@@ -70,7 +72,7 @@ library PyCOMTestLib
 		const long LongTest2 = 0x7FFFFFFFL;
 		const unsigned char UCharTest = 255;
 		const char CharTest = -1;
-		const LPWSTR StringTest = L"Hello Wo�ld";
+		const LPWSTR StringTest = L"Hello Wo®ld";
 	};
 
 	enum TestAttributes3{ // Note missing the enum name.

--- a/com/win32com/demos/iebutton.py
+++ b/com/win32com/demos/iebutton.py
@@ -1,5 +1,3 @@
-# -*- coding: latin-1 -*-
-
 # PyWin32 Internet Explorer Button
 #
 # written by Leonard Ritter (paniq@gmx.net)

--- a/com/win32com/demos/ietoolbar.py
+++ b/com/win32com/demos/ietoolbar.py
@@ -1,5 +1,3 @@
-# -*- coding: latin-1 -*-
-
 # PyWin32 Internet Explorer Toolbar
 #
 # written by Leonard Ritter (paniq@gmx.net)


### PR DESCRIPTION
I added the entries to `.gitattributes`. I opened `com/TestSources/PyCOMTest/PyCOMTest.idl` as `ISO-8859-1`, fixed the "unknown characters", then saved under than encoding. Finally I ran `git add --renormalize .` (excluding adodbapi and other non-changed files)