### PR TITLE
Add an upper bound pin to setuptools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,12 +33,6 @@ jobs:
           cache-dependency-path: .github/workflows/main.yml
           check-latest: true
 
-      - name: Setup environment
-        run: |
-          python --version
-          pip --version
-          pip install --upgrade setuptools>=74 wheel
-
       - name: Fix user Scripts missing from PATH
         if: matrix.architecture == 'x86'
         run: |
@@ -102,11 +96,8 @@ jobs:
           cache-dependency-path: .github/workflows/main.yml
           check-latest: true
 
-      - name: Setup Environment
-        run: |
-          python --version
-          pip --version
-          pip install --upgrade setuptools>=74 wheel build
+      - name: Install build module
+        run: pip install --upgrade  build
 
       - name: Obtain ARM64 library files
         run: python .github\workflows\download-arm64-libs.py .\arm64libs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+# As of setuptools==74, we no longer need to
+# be concerned about distutils calling win32api
+# setuptools==76.1 breaks building of .mc files
+# win32/src/PythonService.cpp(49): fatal error C1083: Cannot open include file: 'PythonServiceMessages.h': No such file or directory
+requires = ["setuptools>=74,<76.1"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
I'm guessing the CI might be failing because of setuptools==76.1. The timing checks out.

Temporary upper bound pin on setuptools until the breaking change is figured out.

Specifying the version of setuptools in `main.yml` actually did nothing with build isolation, so I moved it to where it belongs as an explicit build backend definition in `pyproject.toml`.
`wheel` is vendored by setuptool since v70.1.0, no need to ask for it anymore.
