### PR TITLE
Change `PendingDeprecationWarning` to `DeprecationWarning`

### DIFF
--- a/com/win32com/src/PythonCOM.cpp
+++ b/com/win32com/src/PythonCOM.cpp
@@ -777,14 +777,14 @@ static PyObject *pythoncom_WrapObject(PyObject *self, PyObject *args)
 
 static PyObject *pythoncom_MakeIID(PyObject *self, PyObject *args)
 {
-    PyErr_Warn(PyExc_PendingDeprecationWarning, "MakeIID is deprecated - please use pywintypes.IID() instead.");
+    PyErr_Warn(PyExc_DeprecationWarning, "MakeIID is deprecated - please use pywintypes.IID() instead.");
     return PyWinMethod_NewIID(self, args);
 }
 
 // no autoduck - this is deprecated.
 static PyObject *pythoncom_MakeTime(PyObject *self, PyObject *args)
 {
-    PyErr_Warn(PyExc_PendingDeprecationWarning, "MakeTime is deprecated - please use pywintypes.Time() instead.");
+    PyErr_Warn(PyExc_DeprecationWarning, "MakeTime is deprecated - please use pywintypes.Time() instead.");
     return PyWinMethod_NewTime(self, args);
 }
 

--- a/win32/Lib/regcheck.py
+++ b/win32/Lib/regcheck.py
@@ -4,8 +4,8 @@
 import warnings
 
 warnings.warn(
-    "The regcheck module has been pending deprecation since build 210",
-    category=PendingDeprecationWarning,
+    "The regcheck module has been deprecated and pending removal since build 210",
+    category=DeprecationWarning,
 )
 
 import os

--- a/win32/src/PyLARGE_INTEGER.cpp
+++ b/win32/src/PyLARGE_INTEGER.cpp
@@ -25,7 +25,7 @@ BOOL PyWinObject_AsLARGE_INTEGER(PyObject *ob, LARGE_INTEGER *pResult)
         return !(pResult->QuadPart == -1 && PyErr_Occurred());
     }
     else {
-        PyErr_Warn(PyExc_PendingDeprecationWarning,
+        PyErr_Warn(PyExc_DeprecationWarning,
                    "Support for passing 2 integers to create a 64bit value is deprecated - pass a long instead");
         long hiVal, loVal;
         if (!PyArg_ParseTuple(ob, "ll", &hiVal, &loVal)) {
@@ -50,7 +50,7 @@ BOOL PyWinObject_AsULARGE_INTEGER(PyObject *ob, ULARGE_INTEGER *pResult)
         PyErr_SetString(PyExc_TypeError, "ULARGE_INTEGER must be 'int', or '(int, int)'");
         return FALSE;
     }
-    PyErr_Warn(PyExc_PendingDeprecationWarning,
+    PyErr_Warn(PyExc_DeprecationWarning,
                "Support for passing 2 integers to create a 64bit value is deprecated - pass a long instead");
     pResult->QuadPart = (((__int64)hiVal) << 32) | loVal;
     return TRUE;

--- a/win32/src/win32crypt/PyCERTSTORE.cpp
+++ b/win32/src/win32crypt/PyCERTSTORE.cpp
@@ -144,7 +144,7 @@ PyObject *PyCERTSTORE::PyCertCloseStore(PyObject *self, PyObject *args, PyObject
         return NULL;
     }
     if (dwFlags != (DWORD)-1) {
-        PyErr_Warn(PyExc_PendingDeprecationWarning,
+        PyErr_Warn(PyExc_DeprecationWarning,
                    "The Flags param to CertCloseStore is deprecated; a non-zero value is likely to crash");
     }
     BOOL bsuccess;

--- a/win32/src/win32gui.i
+++ b/win32/src/win32gui.i
@@ -1499,7 +1499,7 @@ static PyObject *PyGetObjectType(PyObject *self, PyObject *args)
 
 static PyObject *PyMakeBuffer(PyObject *self, PyObject *args)
 {
-	PyErr_Warn(PyExc_PendingDeprecationWarning, "PyMakeBuffer is deprecated; use PyGetMemory instead");
+	PyErr_Warn(PyExc_DeprecationWarning, "PyMakeBuffer is deprecated; use PyGetMemory instead");
 	size_t len;
 	void *addr=NULL;
 #ifdef _WIN64


### PR DESCRIPTION
Because these were technically `PendingDeprecationWarning`. I'd give them at least another release before updating codepaths.