### PR TITLE
Fix dispatch handling for properties

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,7 @@ https://mhammond.github.io/pywin32_installers.html .
 Coming in build 311, as yet unreleased
 --------------------------------------
 * Fixed a regression that broke special __dunder__ methods with CoClass. (#1870, #2493, @Avasam, @geppi)
+* Fixed dispatch handling for properties (@the-snork)
 
 Build 310, released 2025/03/16
 ------------------------------

--- a/com/win32com/client/__init__.py
+++ b/com/win32com/client/__init__.py
@@ -538,6 +538,20 @@ class DispatchBaseClass:
                 if details.hresult != winerror.E_NOINTERFACE:
                     raise
                 oobj = oobj._oleobj_
+        elif isinstance(oobj, _PyIDispatchType):
+            try:
+                oobj = oobj.QueryInterface(
+                    self.CLSID, pythoncom.IID_IDispatch
+                )  # Must be a valid COM instance
+            except pythoncom.com_error as details:
+                import winerror
+
+                # Some stupid objects fail here, even tho it is _already_ IDispatch!!??
+                # Eg, Lotus notes.
+                # So just let it use the existing object if E_NOINTERFACE
+                if details.hresult != winerror.E_NOINTERFACE:
+                    raise
+                
         self.__dict__["_oleobj_"] = oobj  # so we don't call __setattr__
 
     def __dir__(self):

--- a/com/win32com/client/__init__.py
+++ b/com/win32com/client/__init__.py
@@ -524,25 +524,10 @@ class DispatchBaseClass:
     def __init__(self, oobj=None):
         if oobj is None:
             oobj = pythoncom.new(self.CLSID)
-        elif isinstance(oobj, DispatchBaseClass):
+        elif isinstance(oobj, (DispatchBaseClass, _PyIDispatchType)):
             try:
-                oobj = oobj._oleobj_.QueryInterface(
-                    self.CLSID, pythoncom.IID_IDispatch
-                )  # Must be a valid COM instance
-            except pythoncom.com_error as details:
-                import winerror
-
-                # Some stupid objects fail here, even tho it is _already_ IDispatch!!??
-                # Eg, Lotus notes.
-                # So just let it use the existing object if E_NOINTERFACE
-                if details.hresult != winerror.E_NOINTERFACE:
-                    raise
-                oobj = oobj._oleobj_
-        elif isinstance(oobj, _PyIDispatchType):
-            try:
-                oobj = oobj.QueryInterface(
-                    self.CLSID, pythoncom.IID_IDispatch
-                )  # Must be a valid COM instance
+                oobj = oobj._oleobj_ if isinstance(oobj, DispatchBaseClass) else oobj
+                oobj = oobj.QueryInterface(self.CLSID, pythoncom.IID_IDispatch)
             except pythoncom.com_error as details:
                 import winerror
 

--- a/com/win32com/client/__init__.py
+++ b/com/win32com/client/__init__.py
@@ -551,7 +551,7 @@ class DispatchBaseClass:
                 # So just let it use the existing object if E_NOINTERFACE
                 if details.hresult != winerror.E_NOINTERFACE:
                     raise
-                
+
         self.__dict__["_oleobj_"] = oobj  # so we don't call __setattr__
 
     def __dir__(self):


### PR DESCRIPTION
See the following pseudo code (IDL):

```
[...]
interface IFoo : IDispatch
{
    HRESULT Bar();
}

interface IHolder
{
    [propget]HRESULT Foo
    {
        [out, retval]IFoo **foo
    };
}
```

When importing above with makepy, the following fails in Python

```
foo = holder.Foo
foo.Bar()
```

due to member not found, while this works:

```
foo = holder.Foo
fooWrapped = IFoo(foo)
fooWrapped.Bar()
```

This pull request is for enabling the first variant, too.


The problem is the intermediate dynamic wrapper.