### PR TITLE
Print Python Warnings in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  # We can't yet run tests with PYTHONDEVMODE=1, let's at least show warnings
+  PYTHONWARNINGS: always
+
 jobs:
   test:
     name: Build and test


### PR DESCRIPTION
We can't yet run tests with `PYTHONDEVMODE=1` (see https://github.com/mhammond/pywin32/pull/2502), let's at least show warnings in CI tests.

See all the warnings in this run's logs (once all fixed, Python warnings can be turned to errors)