### PR TITLE
Fix struct handling in makepy generated code

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,7 @@ Coming in build 311, as yet unreleased
 --------------------------------------
 * Fixed a regression that broke special __dunder__ methods with CoClass. (#1870, #2493, @Avasam, @geppi)
 * Fixed dispatch handling for properties (@the-snork)
+* Fixed struct handling in makepy generated code (@the-snork)
 
 Build 310, released 2025/03/16
 ------------------------------

--- a/com/TestSources/PyCOMTest/PyCOMImpl.cpp
+++ b/com/TestSources/PyCOMTest/PyCOMImpl.cpp
@@ -619,6 +619,16 @@ HRESULT CPyCOMTest::GetStruct(TestStruct1 *ret)
     return S_OK;
 }
 
+HRESULT CPyCOMTest::GetOutStruct(TestStruct1 *ret)
+{
+    if (ret == NULL) {
+        return E_POINTER;
+    }
+    ret->int_value = 99;
+    ret->str_value = SysAllocString(L"Hello from C++");
+    return S_OK;
+}
+
 HRESULT CPyCOMTest::ModifyStruct(TestStruct1 *prec)
 {
     prec->int_value = 100;

--- a/com/TestSources/PyCOMTest/PyCOMImpl.h
+++ b/com/TestSources/PyCOMTest/PyCOMImpl.h
@@ -98,6 +98,7 @@ class CPyCOMTest : public IDispatchImpl<IPyCOMTest, &IID_IPyCOMTest, &LIBID_PyCO
     STDMETHOD(TestOptionals2)(double dval, BSTR strval, short sval, SAFEARRAY **pRet);
     STDMETHOD(TestOptionals3)(double dval, short sval, IPyCOMTest **outinterface2);
     STDMETHOD(GetStruct)(TestStruct1 *ret);
+    STDMETHOD(GetOutStruct)(TestStruct1 *ret);
     STDMETHOD(DoubleString)(BSTR inStr, BSTR *outStr);
     STDMETHOD(DoubleInOutString)(BSTR *str);
     STDMETHOD(TestMyInterface)(IUnknown *t);

--- a/com/TestSources/PyCOMTest/PyCOMTest.idl
+++ b/com/TestSources/PyCOMTest/PyCOMTest.idl
@@ -260,7 +260,8 @@ library PyCOMTestLib
 							   [in, defaultvalue(1)] short sval,
 							   [out, retval] IPyCOMTest **ppout );
 		HRESULT GetStruct([out, retval]TestStruct1 *ret);
-		HRESULT DoubleString([in] BSTR inStr, [out, retval] BSTR *outStr);
+        HRESULT GetOutStruct([ out ] TestStruct1 * ret);
+        HRESULT DoubleString([in] BSTR inStr, [ out, retval ] BSTR * outStr);
 		HRESULT DoubleInOutString([in,out] BSTR *str);
 		[restricted] HRESULT NotScriptable([in,out] int *val);
 

--- a/com/win32com/client/genpy.py
+++ b/com/win32com/client/genpy.py
@@ -1153,6 +1153,17 @@ class Generator:
         print("}", file=stream)
         print(file=stream)
 
+        # create classes for records
+        for record in recordItems.values():
+            if record.clsid != pythoncom.IID_NULL:
+                print(f"class {record.doc[0]}:", file=stream)
+                print("\tdef __new__(cls, *args, **kwargs):", file=stream)
+                print(
+                    f"\t\treturn pythoncom.GetRecordFromGuids(CLSID, MajorVersion, MinorVersion, LCID, '{record.clsid}')",
+                    file=stream,
+                )
+        print(file=stream)
+
         # Write out _all_ my generated CLSID's in the map
         if self.generate_type == GEN_FULL:
             print("CLSIDToClassMap = {", file=stream)

--- a/com/win32com/client/makepy.py
+++ b/com/win32com/client/makepy.py
@@ -319,6 +319,8 @@ def GenerateFromTypeLibSpec(
                 outputName = full_name + ".py"
             fileUse = gen.open_writer(outputName)
             progress.LogBeginGenerate(outputName)
+        elif isinstance(file, str):
+            fileUse = gen.open_writer(file)
         else:
             fileUse = file
 
@@ -330,6 +332,8 @@ def GenerateFromTypeLibSpec(
             if file is None:
                 with gencache.ModuleMutex(this_name):
                     gen.finish_writer(outputName, fileUse, worked)
+            elif isinstance(file, str):
+                gen.finish_writer(file, fileUse, worked)
         importlib.invalidate_caches()
         if bToGenDir:
             progress.SetDescription("Importing module")


### PR DESCRIPTION
In code generated by makepy, there was no chance to create struct instances, as using Record failed. Convenience constructors are generated now.

```
class TestStruct1:
	def __new__(cls, *args, **kwargs):
		return pythoncom.GetRecordFromGuids(CLSID, MajorVersion, MinorVersion, LCID, '{7A4CE6A7-7959-4E85-A3C0-B41442FF0F67}')
class TestStruct2:
	def __new__(cls, *args, **kwargs):
		return pythoncom.GetRecordFromGuids(CLSID, MajorVersion, MinorVersion, LCID, '{78F0EA07-B7CF-42EA-A251-A4C6269F76AF}')
```

In addition, functions using structs as out values could not be called, as the default (missing) value could not be converted to a struct instance. The change creates struct instances automatically in such cases.

```
	def GetOutStruct(self, ret=pythoncom.Missing):
		if ret == pythoncom.Missing:
			ret = pythoncom.GetRecordFromGuids(CLSID, MajorVersion, MinorVersion, LCID, IID('{7A4CE6A7-7959-4E85-A3C0-B41442FF0F67}'))
		return self._ApplyTypes_(1610743852, 1, (24, 0), ((16420, 2),), 'GetOutStruct', None,ret
			)
```