### PR TITLE
Reduce loop repetition in `win32/test/test_win32gui.py`'s `TestEnumWindowsFamily`

### DIFF
--- a/win32/test/test_win32gui.py
+++ b/win32/test/test_win32gui.py
@@ -80,9 +80,9 @@ class TestEnumWindowsFamily(unittest.TestCase):
     def setUp(self):
         self.default_data_set = (None, -1, 0, 1, True, False)
         if sys.version_info >= (3, 10):
-            self.type_data_set = ("", (), {})
-        else:
             self.type_data_set = ("", (), {}, 2.718282)
+        else:
+            self.type_data_set = ("", (), {})
 
     def test_enumwindows(self):
         win32api.SetLastError(0)

--- a/win32/test/test_win32gui.py
+++ b/win32/test/test_win32gui.py
@@ -79,7 +79,10 @@ class TestEnumWindowsFamily(unittest.TestCase):
 
     def setUp(self):
         self.default_data_set = (None, -1, 0, 1, True, False)
-        self.type_data_set = ("", (), {})
+        if sys.version_info >= (3, 10):
+            self.type_data_set = ("", (), {})
+        else:
+            self.type_data_set = ("", (), {}, 2.718282)
 
     def test_enumwindows(self):
         win32api.SetLastError(0)
@@ -99,10 +102,6 @@ class TestEnumWindowsFamily(unittest.TestCase):
         for func in (self.enum_callback, self.enum_callback_sle):
             for data in self.type_data_set:
                 self.assertRaises(TypeError, win32gui.EnumWindows, func, data)
-            if sys.version_info >= (3, 10):
-                self.assertRaises(
-                    TypeError, win32gui.EnumWindows, func, self.enum_callback, 2.718282
-                )
 
     def test_enumchildwindows(self):
         win32api.SetLastError(0)
@@ -125,15 +124,6 @@ class TestEnumWindowsFamily(unittest.TestCase):
             for data in self.type_data_set:
                 self.assertRaises(
                     TypeError, win32gui.EnumChildWindows, None, func, data
-                )
-            if sys.version_info >= (3, 10):
-                self.assertRaises(
-                    TypeError,
-                    win32gui.EnumChildWindows,
-                    None,
-                    func,
-                    self.enum_callback,
-                    2.718282,
                 )
 
     def test_enumdesktopwindows(self):
@@ -177,10 +167,6 @@ class TestEnumWindowsFamily(unittest.TestCase):
         for func in (self.enum_callback, self.enum_callback_sle):
             for data in self.type_data_set:
                 self.assertRaises(TypeError, win32gui.EnumDesktopWindows, 0, func, data)
-            if sys.version_info >= (3, 10):
-                self.assertRaises(
-                    TypeError, win32gui.EnumDesktopWindows, 0, func, 2.718282
-                )
 
 
 class TestWindowProperties(unittest.TestCase):

--- a/win32/test/test_win32gui.py
+++ b/win32/test/test_win32gui.py
@@ -96,17 +96,10 @@ class TestEnumWindowsFamily(unittest.TestCase):
             self.assertRaises(
                 ValueError, win32gui.EnumWindows, self.enum_callback_exc, data
             )
-        for func in (
-            self.enum_callback,
-            self.enum_callback_sle,
-        ):
+        for func in (self.enum_callback, self.enum_callback_sle):
             for data in self.type_data_set:
                 self.assertRaises(TypeError, win32gui.EnumWindows, func, data)
-        if sys.version_info >= (3, 10):
-            for func in (
-                self.enum_callback,
-                self.enum_callback_sle,
-            ):
+            if sys.version_info >= (3, 10):
                 self.assertRaises(
                     TypeError, win32gui.EnumWindows, func, self.enum_callback, 2.718282
                 )
@@ -128,19 +121,12 @@ class TestEnumWindowsFamily(unittest.TestCase):
                 self.enum_callback_exc,
                 data,
             )
-        for data in self.type_data_set:
-            for func in (
-                self.enum_callback,
-                self.enum_callback_sle,
-            ):
+        for func in (self.enum_callback, self.enum_callback_sle):
+            for data in self.type_data_set:
                 self.assertRaises(
                     TypeError, win32gui.EnumChildWindows, None, func, data
                 )
-        if sys.version_info >= (3, 10):
-            for func in (
-                self.enum_callback,
-                self.enum_callback_sle,
-            ):
+            if sys.version_info >= (3, 10):
                 self.assertRaises(
                     TypeError,
                     win32gui.EnumChildWindows,
@@ -188,24 +174,13 @@ class TestEnumWindowsFamily(unittest.TestCase):
                     self.enum_callback_exc,
                     data,
                 )
-        for func in (
-            self.enum_callback,
-            self.enum_callback_sle,
-        ):
-            for desktop in desktops:
-                for data in self.type_data_set:
-                    self.assertRaises(
-                        TypeError, win32gui.EnumDesktopWindows, 0, func, data
-                    )
-        if sys.version_info >= (3, 10):
-            for func in (
-                self.enum_callback,
-                self.enum_callback_sle,
-            ):
-                for desktop in desktops:
-                    self.assertRaises(
-                        TypeError, win32gui.EnumDesktopWindows, 0, func, 2.718282
-                    )
+        for func in (self.enum_callback, self.enum_callback_sle):
+            for data in self.type_data_set:
+                self.assertRaises(TypeError, win32gui.EnumDesktopWindows, 0, func, data)
+            if sys.version_info >= (3, 10):
+                self.assertRaises(
+                    TypeError, win32gui.EnumDesktopWindows, 0, func, 2.718282
+                )
 
 
 class TestWindowProperties(unittest.TestCase):


### PR DESCRIPTION
@CristiFati unless you tell me there was a specific reason for the extra loops I dont see, it looks like maybe some copy-paste error? (test added in https://github.com/mhammond/pywin32/pull/2219/files#diff-03b2dff96aca5e6460f7c82bbffacaa1f2d55cc6878d484784bd835ef02d650a)

Originally spotted in https://github.com/mhammond/pywin32/pull/2413/files#diff-03b2dff96aca5e6460f7c82bbffacaa1f2d55cc6878d484784bd835ef02d650a