### PR TITLE
Fix deprecation warnings found by tests

### DIFF
--- a/com/win32com/client/combrowse.py
+++ b/com/win32com/client/combrowse.py
@@ -26,6 +26,7 @@ Details
 import sys
 
 import pythoncom
+import pywintypes
 import win32api
 import win32con
 import win32ui
@@ -61,7 +62,7 @@ class HLICOM(browser.HLIPythonObject):
 class HLICLSID(HLICOM):
     def __init__(self, myobject, name=None):
         if isinstance(myobject, str):
-            myobject = pythoncom.MakeIID(myobject)
+            myobject = pywintypes.IID(myobject)
         if name is None:
             try:
                 name = pythoncom.ProgIDFromCLSID(myobject)

--- a/com/win32com/demos/connect.py
+++ b/com/win32com/demos/connect.py
@@ -6,11 +6,12 @@
 # is cheated on - so this is still working as a fully-fledged server.
 
 import pythoncom
+import pywintypes
 import win32com.server.connect
 import win32com.server.util
 
 # This is the IID of the Events interface both Client and Server support.
-IID_IConnectDemoEvents = pythoncom.MakeIID("{A4988850-49C3-11d0-AE5D-52342E000000}")
+IID_IConnectDemoEvents = pywintypes.IID("{A4988850-49C3-11d0-AE5D-52342E000000}")
 
 # The server which implements
 # Create a connectable class, that has a single public method

--- a/com/win32com/server/policy.py
+++ b/com/win32com/server/policy.py
@@ -257,7 +257,7 @@ class BasicWrapPolicy:
                     if i[0] != "{":
                         i = pythoncom.InterfaceNames[i]
                     else:
-                        i = pythoncom.MakeIID(i)
+                        i = pywintypes.IID(i)
                 self._com_interfaces_.append(i)
         else:
             self._com_interfaces_ = []

--- a/com/win32com/test/testDynamic.py
+++ b/com/win32com/test/testDynamic.py
@@ -1,10 +1,11 @@
 # Test dynamic policy, and running object table.
 
 import pythoncom
+import pywintypes
 import winerror
 from win32com.server.exception import COMException
 
-iid = pythoncom.MakeIID("{b48969a0-784b-11d0-ae71-d23f56000000}")
+iid = pywintypes.IID("{b48969a0-784b-11d0-ae71-d23f56000000}")
 
 
 class VeryPermissive:

--- a/com/win32com/test/testShell.py
+++ b/com/win32com/test/testShell.py
@@ -151,7 +151,7 @@ class FILEGROUPDESCRIPTORTester(win32com.test.util.TestCase):
         self._testSimple(True)
 
     def testComplex(self):
-        clsid = pythoncom.MakeIID("{CD637886-DB8B-4b04-98B5-25731E1495BE}")
+        clsid = pywintypes.IID("{CD637886-DB8B-4b04-98B5-25731E1495BE}")
         ctime, atime, wtime = self._getTestTimes()
         d = {
             "cFileName": "foo.txt",

--- a/com/win32comext/axscript/test/leakTest.py
+++ b/com/win32comext/axscript/test/leakTest.py
@@ -1,6 +1,7 @@
 import sys
 
 import pythoncom
+import pywintypes
 from win32com.axscript import axscript
 from win32com.axscript.server import axsite
 from win32com.server import connect, util
@@ -53,7 +54,7 @@ class Test:
 #### Connections currently won't work, as there is no way for the engine to
 #### know what events we support.  We need typeinfo support.
 
-IID_ITestEvents = pythoncom.MakeIID("{8EB72F90-0D44-11d1-9C4B-00AA00125A98}")
+IID_ITestEvents = pywintypes.IID("{8EB72F90-0D44-11d1-9C4B-00AA00125A98}")
 
 
 class TestConnectServer(connect.ConnectableServer):

--- a/com/win32comext/axscript/test/testHost.py
+++ b/com/win32comext/axscript/test/testHost.py
@@ -2,6 +2,7 @@ import sys
 import unittest
 
 import pythoncom
+import pywintypes
 import win32com.server.policy
 import win32com.test.util
 from win32com.axscript import axscript
@@ -72,7 +73,7 @@ class Test:
 #### Connections currently won't work, as there is no way for the engine to
 #### know what events we support.  We need typeinfo support.
 
-IID_ITestEvents = pythoncom.MakeIID("{8EB72F90-0D44-11d1-9C4B-00AA00125A98}")
+IID_ITestEvents = pywintypes.IID("{8EB72F90-0D44-11d1-9C4B-00AA00125A98}")
 
 
 class TestConnectServer(connect.ConnectableServer):


### PR DESCRIPTION
Replacing `pythoncom.MakeIID` with `pywintypes.IID` to solve a handful of deprecation warnings end users have no control over.