### PR TITLE
Fix broken assignment in pyscript.ScriptItem.Register

### DIFF
--- a/com/win32comext/axscript/client/pyscript.py
+++ b/com/win32comext/axscript/client/pyscript.py
@@ -158,7 +158,7 @@ class ScriptItem(framework.ScriptItem):
         self.attributeObject = NamedScriptAttribute(self)
         if self.dispatch:
             # Need to avoid the new Python "lazy" dispatch behaviour.
-            olerepr, clsid = None
+            olerepr = clsid = None
             try:
                 engine = self.GetEngine()
                 typeinfo = self.dispatch.GetTypeInfo()


### PR DESCRIPTION
Recent change #2330 introduced a comma instead of an assignment when refactoring the Register method of the ScriptItem class. This change corrects that typo.