### PR TITLE
Update some `repr` to produce a string representation valid for `eval`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,6 +16,11 @@ Coming in build 311, as yet unreleased
 * Fixed a regression that broke special __dunder__ methods with CoClass. (#1870, #2493, @Avasam, @geppi)
 * Fixed a memory leak when SafeArrays are used as out parameters (@the-snork)
 * Fixed dispatch handling for properties (@the-snork)
+* The following classes now produce a valid `eval` string representation when calling `repr`: (#2573, @Avasam)
+  * `pywin.tools.browser.HLIPythonObject`
+  * `win32com.server.exception.COMException`
+  * `win32comext.axscript.client.error.AXScriptException`
+  * `win32comext.axscript.client.pyscript.NamedScriptAttribute`
 
 Build 310, released 2025/03/16
 ------------------------------

--- a/Pythonwin/pywin/tools/browser.py
+++ b/Pythonwin/pywin/tools/browser.py
@@ -45,11 +45,9 @@ class HLIPythonObject(hierlist.HierListItem):
         return self.name == other.name
 
     def __repr__(self):
-        try:
-            type = self.GetHLIType()
-        except:
-            type = "Generic"
-        return f"HLIPythonObject({type}) - name: {self.name} object: {self.myobject!r}"
+        return (
+            f"{self.__class__.__name__}(name={self.name!r}, object={self.myobject!r})"
+        )
 
     def GetText(self):
         try:

--- a/com/win32com/server/exception.py
+++ b/com/win32com/server/exception.py
@@ -78,7 +78,7 @@ class COMException(pythoncom.com_error):  # type: ignore[name-defined] # Dynamic
         pythoncom.com_error.__init__(self, scode, self.description, None, -1)
 
     def __repr__(self):
-        return f"<COM Exception - scode={self.scode}, desc={self.description}>"
+        return f"{self.__class__.__name__}(scode={self.scode!r}, desc={self.description!r})"
 
 
 def IsCOMException(t=None):

--- a/com/win32comext/axscript/client/error.py
+++ b/com/win32comext/axscript/client/error.py
@@ -218,9 +218,6 @@ class AXScriptException(COMException):
             line = None
         return filename, lineno, name, line
 
-    def __repr__(self):
-        return "AXScriptException Object with description:" + self.description
-
 
 def ProcessAXScriptException(
     scriptingSite: AXSite,

--- a/com/win32comext/axscript/client/pyscript.py
+++ b/com/win32comext/axscript/client/pyscript.py
@@ -109,7 +109,7 @@ class NamedScriptAttribute:
         self.__dict__["_scriptItem_"] = scriptItem
 
     def __repr__(self):
-        return f"<NamedItemAttribute{self._scriptItem_!r}>"
+        return f"{self.__class__.__name__}({self._scriptItem_!r})"
 
     def __getattr__(self, attr):
         # If a known subitem, return it.


### PR DESCRIPTION
Extracted from #2555