### PR TITLE
Update CoClassBaseClass repr to not always include None as a submodule

### DIFF
--- a/com/win32com/client/__init__.py
+++ b/com/win32com/client/__init__.py
@@ -630,7 +630,7 @@ class CoClassBaseClass:
         self.__dict__["_dispobj_"] = self.default_interface(oobj)
 
     def __repr__(self):
-        return f"<win32com.gen_py.{__doc__}.{self.__class__.__name__}>"
+        return f"<{self.__class__.__module__}.{self.__class__.__name__}>"
 
     def __getattr__(self, attr):
         d = self.__dict__["_dispobj_"]


### PR DESCRIPTION
Extracted from https://github.com/mhammond/pywin32/pull/2555

`__doc__` will always be `None` because it references `com/win32com/client/__init__.py`'s docstring (I believe this class was part of the gen_py generation a long time ago).


Before:
```py
>>> from win32com.client import gencache
>>> repr(gencache.EnsureModule("{6BCDCB60-5605-11D0-AE5F-CADD4C000000}", 0, 1, 1).ArrayTest())
'<win32com.gen_py.None.ArrayTest>'
```

After:
```py
>>> from win32com.client import gencache
>>> repr(gencache.EnsureModule("{6BCDCB60-5605-11D0-AE5F-CADD4C000000}", 0, 1, 1).ArrayTest())
'<win32com.gen_py.6BCDCB60-5605-11D0-AE5F-CADD4C000000x0x1x1.ArrayTest>'
```
