### PR TITLE
Resolve Python 3.10 threading deprecation warnings

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,6 +17,7 @@ Coming in build 311, as yet unreleased
 * Fixed `TypeError: cannot unpack non-iterable NoneType object` when registering an axscript client ScriptItem (#2513, @Avasam)
 * Fixed a memory leak when SafeArrays are used as out parameters (@the-snork)
 * Fixed dispatch handling for properties (@the-snork)
+* Resolved a handful of deprecation warnings (#2567, #2576, @Avasam)
 
 Build 310, released 2025/03/16
 ------------------------------

--- a/Pythonwin/pywin/dialogs/status.py
+++ b/Pythonwin/pywin/dialogs/status.py
@@ -202,7 +202,7 @@ def ThreadedStatusProgressDialog(title, msg="", maxticks=100):
     # event - so use a dumb strategy
     end_time = time.time() + 10
     while time.time() < end_time:
-        if t.createdEvent.isSet():
+        if t.createdEvent.is_set():
             break
         win32ui.PumpWaitingMessages()
         time.sleep(0.1)

--- a/com/win32com/demos/excelRTDServer.py
+++ b/com/win32com/demos/excelRTDServer.py
@@ -346,7 +346,7 @@ class TimeServer(ExcelRTDServer):
         self.ticker.start()
 
     def OnServerTerminate(self):
-        if not self.ticker.finished.isSet():
+        if not self.ticker.finished.is_set():
             self.ticker.cancel()  # Cancel our wake-up thread. Excel has killed us.
 
     def Update(self):

--- a/com/win32com/test/testMSOfficeEvents.py
+++ b/com/win32com/test/testMSOfficeEvents.py
@@ -99,7 +99,7 @@ def _WaitForFinish(ob, timeout):
             break
         pythoncom.PumpWaitingMessages()
         stopEvent.wait(0.2)
-        if stopEvent.isSet():
+        if stopEvent.is_set():
             stopEvent.clear()
             break
         try:

--- a/com/win32com/test/testMarshal.py
+++ b/com/win32com/test/testMarshal.py
@@ -72,9 +72,10 @@ class ThreadInterpCase(InterpCase):
                 pythoncom.IID_IDispatch, interp._oleobj_
             )
             t = threading.Thread(
-                target=self._testInterpInThread, args=(hEvent, interpStream)
+                target=self._testInterpInThread,
+                args=(hEvent, interpStream),
+                daemon=True,  # so errors don't cause shutdown hang
             )
-            t.setDaemon(1)  # so errors don't cause shutdown hang
             t.start()
             threads.append(t)
         interp = None
@@ -100,8 +101,11 @@ class ThreadInterpCase(InterpCase):
         threads = []
         for i in range(numThreads):
             hEvent = win32event.CreateEvent(None, 0, 0, None)
-            t = threading.Thread(target=self._testInterpInThread, args=(hEvent, interp))
-            t.setDaemon(1)  # so errors don't cause shutdown hang
+            t = threading.Thread(
+                target=self._testInterpInThread,
+                args=(hEvent, interp),
+                daemon=True,  # so errors don't cause shutdown hang
+            )
             t.start()
             events.append(hEvent)
             threads.append(t)

--- a/isapi/threaded_extension.py
+++ b/isapi/threaded_extension.py
@@ -29,10 +29,12 @@ class WorkerThread(threading.Thread):
         self.running = False
         self.io_req_port = io_req_port
         self.extension = extension
-        threading.Thread.__init__(self)
-        # We wait 15 seconds for a thread to terminate, but if it fails to,
-        # we don't want the process to hang at exit waiting for it...
-        self.setDaemon(True)
+        threading.Thread.__init__(
+            self,
+            # We wait 15 seconds for a thread to terminate, but if it fails to,
+            # we don't want the process to hang at exit waiting for it...
+            daemon=True,
+        )
 
     def run(self):
         self.running = True

--- a/win32/test/test_win32file.py
+++ b/win32/test/test_win32file.py
@@ -436,9 +436,10 @@ class TestOverlapped(unittest.TestCase):
         win32file.CreateIoCompletionPort(handle, port, 1, 0)
 
         t = threading.Thread(
-            target=self._IOCPServerThread, args=(handle, port, test_overlapped_death)
+            target=self._IOCPServerThread,
+            args=(handle, port, test_overlapped_death),
+            daemon=True,  # avoid hanging entire test suite on failure.
         )
-        t.setDaemon(True)  # avoid hanging entire test suite on failure.
         t.start()
         try:
             time.sleep(0.1)  # let thread do its thing.
@@ -530,7 +531,7 @@ class TestSocketExtensions(unittest.TestCase):
         t = threading.Thread(target=self.acceptWorker, args=(port, running, stopped))
         t.start()
         running.wait(2)
-        if not running.isSet():
+        if not running.is_set():
             self.fail("AcceptEx Worker thread failed to start")
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.connect(("127.0.0.1", port))
@@ -548,7 +549,7 @@ class TestSocketExtensions(unittest.TestCase):
         self.assertEqual(got, b"hello")
         # thread should have stopped
         stopped.wait(2)
-        if not stopped.isSet():
+        if not stopped.is_set():
             self.fail("AcceptEx Worker thread failed to successfully stop")
 
 

--- a/win32/test/test_win32pipe.py
+++ b/win32/test/test_win32pipe.py
@@ -57,7 +57,7 @@ class PipeTests(unittest.TestCase):
         )
         self.assertEqual(got, b"bar\0foo")
         event.wait(5)
-        self.assertTrue(event.isSet(), "Pipe server thread didn't terminate")
+        self.assertTrue(event.is_set(), "Pipe server thread didn't terminate")
 
     def testTransactNamedPipeBlocking(self):
         event = threading.Event()
@@ -82,7 +82,7 @@ class PipeTests(unittest.TestCase):
         hr, got = win32pipe.TransactNamedPipe(hpipe, b"foo\0bar", 1024, None)
         self.assertEqual(got, b"bar\0foo")
         event.wait(5)
-        self.assertTrue(event.isSet(), "Pipe server thread didn't terminate")
+        self.assertTrue(event.is_set(), "Pipe server thread didn't terminate")
 
     def testTransactNamedPipeBlockingBuffer(self):
         # Like testTransactNamedPipeBlocking, but a pre-allocated buffer is
@@ -110,7 +110,7 @@ class PipeTests(unittest.TestCase):
         hr, got = win32pipe.TransactNamedPipe(hpipe, b"foo\0bar", buffer, None)
         self.assertEqual(got, b"bar\0foo")
         event.wait(5)
-        self.assertTrue(event.isSet(), "Pipe server thread didn't terminate")
+        self.assertTrue(event.is_set(), "Pipe server thread didn't terminate")
 
     def testTransactNamedPipeAsync(self):
         event = threading.Event()
@@ -141,7 +141,7 @@ class PipeTests(unittest.TestCase):
         got = buffer[:nbytes]
         self.assertEqual(got, b"bar\0foo")
         event.wait(5)
-        self.assertTrue(event.isSet(), "Pipe server thread didn't terminate")
+        self.assertTrue(event.is_set(), "Pipe server thread didn't terminate")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Warnings in tests revealed that pywin32 was using a few deprecated methods from the `threading` module.

This PR resolves those warnings that are out of the control of pywin32 users.