### PR TITLE
AutoDuck: include link to documentation, examples and source

### DIFF
--- a/AutoDuck/README.md
+++ b/AutoDuck/README.md
@@ -5,3 +5,13 @@ provides the best documentation solution.  We don't even
 build a .hlp file anymore.
 
 pywin32-document.xml provides the front-page for the docs.
+
+---
+
+# [AutoDuck 2.0](http://helpmaster.info/hlp-developmentaids-autoduck.htm)
+
+Autoduck is a command-line utility that extracts specially tagged comment blocks from programming source files and generates rich text files containing the contents of those comment blocks. Autoduck has traditionally been used to document programming APIs. Placing API documentation within the source files helps programmers disseminate information about a developing codebase. Autoduck can generate online Help files containing full hypertext coding with links and keyword lists. Typically, Autoduck is integrated into the build process, so a new Help database can be automatically generated each build.
+
+_Freeware by Eric Artzt_
+
+- [Download (includes documentation, examples and source)](https://web.archive.org/web/20070326125446/http://www.appletmaster.de/zip/autoduck.zip)


### PR DESCRIPTION
https://peps.python.org/pep-0256/ links to http://www.helpmaster.com/hlp-developmentaids-autoduck.htm, but that's dead. (last Wayback machine archive with images: https://web.archive.org/web/20060210082651/http://www.helpmaster.com:80/hlp-developmentaids-autoduck.htm)

But http://helpmaster.info/hlp-developmentaids-autoduck.htm (updated URL that still works) still uses the old dead download link, so I used a Wayback machine link for that as well.