### PR TITLE
Fix setuptools 76.1 issue (and bump to >=77.0.3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [build-system]
-# As of setuptools==74, we no longer need to
-# be concerned about distutils calling win32api
-# setuptools==76.1 breaks building of .mc files
-# win32/src/PythonService.cpp(49): fatal error C1083: Cannot open include file: 'PythonServiceMessages.h': No such file or directory
-requires = ["setuptools>=74,<76.1"]
+# setuptools==77.0.3 made PEP-639 license deprecations introduced by 77.0.0 into warnings rather than errors
+# setuptools==75.4 dropped support for Python 3.8
+requires = [
+  "setuptools >=77.0.3; python_version >='3.9'",
+  "setuptools <76.1; python_version <'3.9'",
+]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Can't use v77.0.0 - v77.0.2 because of new license-related errors.

`setuptools>=77` opens the door to solving https://github.com/mhammond/pywin32/issues/1127#issuecomment-2836482696 thanks to [PEP 639 – Improving License Clarity with Better Package Metadata](https://peps.python.org/pep-0639/), namely [License-File (multiple use)](https://packaging.python.org/en/latest/specifications/core-metadata/#license-file-multiple-use)

Thanks to having already solved https://github.com/mhammond/pywin32/issues/2208, we can stay on the latest versions, which are removing support for the long deprecated `easy_install` and `develop` commands.