### PR TITLE
Remove obsolete `GetVersion(Ex)` platform check and fix build deprecation warnings

### DIFF
--- a/Pythonwin/Win32uiHostGlue.h
+++ b/Pythonwin/Win32uiHostGlue.h
@@ -91,14 +91,7 @@ inline Win32uiHostGlue::Win32uiHostGlue()
 }
 inline Win32uiHostGlue::~Win32uiHostGlue() {}
 
-inline HKEY Win32uiHostGlue::GetRegistryRootKey()
-{
-    // different for win32s.
-    OSVERSIONINFO ver;
-    ver.dwOSVersionInfoSize = sizeof(ver);
-    GetVersionEx(&ver);
-    return ver.dwPlatformId == VER_PLATFORM_WIN32s ? HKEY_CLASSES_ROOT : HKEY_LOCAL_MACHINE;
-}
+inline HKEY Win32uiHostGlue::GetRegistryRootKey() { return HKEY_LOCAL_MACHINE; }
 
 #ifndef LINK_WITH_WIN32UI
 

--- a/Pythonwin/pythonwin.cpp
+++ b/Pythonwin/pythonwin.cpp
@@ -109,27 +109,7 @@ BOOL CPythonWinApp::OnIdle(LONG lCount)
     return glue.OnIdle(lCount);
 }
 
-CDocument *CPythonWinApp::OpenDocumentFile(LPCTSTR lpszFileName)
-{
-#if 0  // win32s no longer supported
-	ver.dwOSVersionInfoSize = sizeof(ver);
-	GetVersionEx(&ver);
-	ver.dwOSVersionInfoSize = sizeof(ver);
-	GetVersionEx(&ver);
-	if (ver.dwPlatformId == VER_PLATFORM_WIN32s) {
-		OutputDebugString("Win32s - Searching templates!\n");
-		POSITION posTempl = m_pDocManager->GetFirstDocTemplatePosition();
-		CDocTemplate* pTemplate = m_pDocManager->GetNextDocTemplate(posTempl);
-		if (pTemplate)
-			return pTemplate->OpenDocumentFile(lpszFileName);
-		else {
-			AfxMessageBox("win32s error - There is no template to use");
-			return NULL;
-		}
-	} else
-#endif
-    return CWinApp::OpenDocumentFile(lpszFileName);
-}
+CDocument *CPythonWinApp::OpenDocumentFile(LPCTSTR lpszFileName) { return CWinApp::OpenDocumentFile(lpszFileName); }
 
 int CPythonWinApp::Run()
 {

--- a/Pythonwin/pywin/framework/app.py
+++ b/Pythonwin/pywin/framework/app.py
@@ -128,13 +128,10 @@ class CApp(WinApp):
         HookInput()
         numMRU = win32ui.GetProfileVal("Settings", "Recent File List Size", 10)
         win32ui.LoadStdProfileSettings(numMRU)
-        # 		self._obj_.InitMDIInstance()
-        if win32api.GetVersionEx()[0] < 4:
-            win32ui.SetDialogBkColor()
-            win32ui.Enable3dControls()
+        # self._obj_.InitMDIInstance()
 
         # install a "callback caller" - a manager for the callbacks
-        # 		self.oldCallbackCaller = win32ui.InstallCallbackCaller(self.CallbackManager)
+        # self.oldCallbackCaller = win32ui.InstallCallbackCaller(self.CallbackManager)
         self.LoadMainFrame()
         self.SetApplicationPaths()
 

--- a/win32/Demos/eventLogDemo.py
+++ b/win32/Demos/eventLogDemo.py
@@ -72,11 +72,6 @@ def usage():
 
 
 def test():
-    # check if running on Windows NT, if not, display notice and terminate
-    if win32api.GetVersion() & 0x80000000:
-        print("This sample only runs on NT")
-        return
-
     import getopt
     import sys
 

--- a/win32/src/PerfMon/perfmondata.cpp
+++ b/win32/src/PerfMon/perfmondata.cpp
@@ -150,13 +150,8 @@ DWORD APIENTRY OpenPerformanceData(LPWSTR lpDeviceNames)
     TCHAR registryKeyName[MAX_PATH];
     TCHAR szFileMapping[MAX_PATH + 10] = _T("");
 
-    // Use a TerminalServices friendly "Global\\" prefix if supported.
-    OSVERSIONINFO info;
-    info.dwOSVersionInfoSize = sizeof(info);
-    GetVersionEx(&info);
-    if (info.dwMajorVersion > 4)
-        // 2000 or later - "Global\\" prefix OK.
-        _tcscpy(szFileMapping, _T("Global\\"));
+    // Use a TerminalServices friendly "Global\\" prefix.
+    _tcscpy(szFileMapping, _T("Global\\"));
     _tcscat(szFileMapping, szModuleName);
 
     //


### PR DESCRIPTION
Some even more obscure platform (version) checks I didn't catch previously.
Fixes a handful of:
- `warning C4996: 'GetVersion': was declared deprecated`
- `warning C4996: 'GetVersionExW': was declared deprecated`