### PR TITLE
Fix pywin32_bootstrap.py to handle early initialization environments

### DIFF
--- a/win32/Lib/pywin32_bootstrap.py
+++ b/win32/Lib/pywin32_bootstrap.py
@@ -8,7 +8,7 @@
 
 try:
     import pywin32_system32
-except ImportError:  # Python ≥3.6: replace ImportError with ModuleNotFoundError
+except ImportError:
     pass
 else:
     import os
@@ -17,5 +17,18 @@ else:
     # https://docs.python.org/3/reference/import.html#path-attributes-on-modules
     for path in pywin32_system32.__path__:
         if os.path.isdir(path):
-            os.add_dll_directory(path)
+            try:
+                # First try the preferred method
+                os.add_dll_directory(path)
+            except Exception:
+                # If anything fails, try to modify PATH if it exists
+                try:
+                    if "PATH" in os.environ:
+                        os.environ["PATH"] = path + os.pathsep + os.environ["PATH"]
+                    else:
+                        # If PATH doesn't exist, just create it
+                        os.environ["PATH"] = path
+                except Exception:
+                    # Last resort - if nothing works, just pass silently
+                    pass
             break

--- a/win32/Lib/pywin32_bootstrap.py
+++ b/win32/Lib/pywin32_bootstrap.py
@@ -17,18 +17,19 @@ else:
     # https://docs.python.org/3/reference/import.html#path-attributes-on-modules
     for path in pywin32_system32.__path__:
         if os.path.isdir(path):
-            try:
-                # First try the preferred method
+            # First try the preferred method
+            if hasattr(os, "add_dll_directory"):
                 os.add_dll_directory(path)
-            except Exception:
-                # If anything fails, try to modify PATH if it exists
-                try:
-                    if "PATH" in os.environ:
-                        os.environ["PATH"] = path + os.pathsep + os.environ["PATH"]
-                    else:
-                        # If PATH doesn't exist, just create it
-                        os.environ["PATH"] = path
-                except Exception:
-                    # Last resort - if nothing works, just pass silently
-                    pass
+            # If `add_dll_directory` is missing, which can happen in Pylance early initialization,
+            # try to modify PATH if it exists (just create it if it doesn't)
+            elif "PATH" not in os.environ:
+                os.environ["PATH"] = path
+            else:
+                # This is to ensure the pywin32 path is in the beginning to find the
+                # pywin32 DLLs first and prevent other PATH entries to shadow them
+                prepend_to_path = path + os.pathsep
+                if not os.environ["PATH"].startswith(prepend_to_path):
+                    os.environ["PATH"] = prepend_to_path + os.environ["PATH"].replace(
+                        os.pathsep + path, ""
+                    )
             break


### PR DESCRIPTION
Fix pywin32_bootstrap.py to handle early initialization environments

This patch adds robust error handling to pywin32_bootstrap.py to address
issues occurring during very early Python initialization, particularly
in VS Code's Python extension (Pylance/IntelliSense).

Problem:
During early initialization when .pth files are processed, neither
os.add_dll_directory() nor even os.environ['PATH'] may be fully available
yet, causing errors like:
- AttributeError: module 'os' has no attribute 'add_dll_directory'
- KeyError: 'PATH'

Solution:
- Wrap the os.add_dll_directory() call in a try/except block
- Add fallback to PATH environment manipulation with proper error handling
- Add final fallback that silently passes if all else fails

