### PR TITLE
Fix new 3.14 C API deprecation for `_Py_HashPointer`

### DIFF
--- a/win32/src/PyHANDLE.cpp
+++ b/win32/src/PyHANDLE.cpp
@@ -288,7 +288,11 @@ Py_hash_t PyHANDLE::hashFunc(PyObject *ob) { return ((PyHANDLE *)ob)->hash(); }
 Py_hash_t PyHANDLE::hash(void)
 {
     // Just use the address.
+#if PY_VERSION_HEX >= 0x03130000
+    return Py_HashPointer(this);
+#else
     return _Py_HashPointer(this);
+#endif
 }
 
 int PyHANDLE::print(FILE *fp, int flags)

--- a/win32/src/PyOVERLAPPED.cpp
+++ b/win32/src/PyOVERLAPPED.cpp
@@ -110,7 +110,7 @@ PYWINTYPES_EXPORT PyTypeObject PyOVERLAPPEDType = {
     {"Offset", T_ULONG,
      OFF(m_overlapped.Offset)},  // @prop integer|Offset|Specifies a file position at which to start the transfer. The
                                  // file position is a byte offset from the start of the file. The calling process sets
-                                 // this member before calling the ReadFile or WriteFile function. This member is
+                                 // this member before calling the ReadFile or WriteFile function. This member is
                                  // ignored when reading from or writing to named pipes and communications devices.
     {"OffsetHigh", T_ULONG, OFF(m_overlapped.OffsetHigh)},  // @prop integer|OffsetHigh|Specifies the high word of the
                                                             // byte offset at which to start the transfer.
@@ -123,7 +123,7 @@ PYWINTYPES_EXPORT PyTypeObject PyOVERLAPPEDType = {
     {"hEvent", T_OBJECT, OFF(obDummy)},  // @prop <o PyHANDLE>|hEvent|Identifies an event set to the signaled state when
                                          // the transfer has been completed. The calling process sets this member before
                                          // calling the <om win32file.ReadFile>, <om win32file.WriteFile>, <om
-                                         // win32pipe.ConnectNamedPipe>, or <om win32pipe.TransactNamedPipe> function.
+                                         // win32pipe.ConnectNamedPipe>, or <om win32pipe.TransactNamedPipe> function.
     {"Internal", T_OBJECT,
      OFF(obDummy)},  // @prop integer|Internal|Reserved for operating system use. (pointer-sized value)
     {"InternalHigh", T_OBJECT,
@@ -251,7 +251,11 @@ int PyOVERLAPPED::setattro(PyObject *self, PyObject *obname, PyObject *v)
 /*static*/ Py_hash_t PyOVERLAPPED::hashFunc(PyObject *ob)
 {
     // Just use the address.
+#if PY_VERSION_HEX >= 0x03130000
+    return Py_HashPointer(ob);
+#else
     return _Py_HashPointer(ob);
+#endif
 }
 
 /*static*/ void PyOVERLAPPED::deallocFunc(PyObject *ob) { delete (PyOVERLAPPED *)ob; }


### PR DESCRIPTION
Addresses a Python C API Deprecation listed in https://github.com/mhammond/pywin32/issues/2588

`_Py_HashPointer` is currently an alias for `Py_HashPointer` kept temporarily for backwards compatibility. So this should be safe.

```h
// Kept for backward compatibility
#define _Py_HashPointer Py_HashPointer
```