### PR TITLE
Fix new 3.14 C API deprecation for `_PyLong_Sign`

### DIFF
--- a/com/win32com/src/oleargs.cpp
+++ b/com/win32com/src/oleargs.cpp
@@ -138,7 +138,14 @@ BOOL PyCom_VariantFromPyObject(PyObject *obj, VARIANT *var)
         V_BOOL(var) = VARIANT_FALSE;
     }
     else if (PyLong_Check(obj)) {
+#if PY_VERSION_HEX >= 0x03140000
+        int sign;
+        if (!PyLong_GetSign(obj, sign)) {
+            return NULL
+        }
+#else
         int sign = _PyLong_Sign(obj);
+#endif
         size_t nbits = _PyLong_NumBits(obj);
         if (nbits == (size_t)-1 && PyErr_Occurred())
             return FALSE;


### PR DESCRIPTION
Addresses a Python C API Deprecation listed in https://github.com/mhammond/pywin32/issues/2588