### PR TITLE
Don't run CI on push to every branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
This doesn't affect the main mhammond repo too much as I work in a fork anyway.

But on forked repos, any push, even without a PR, will lead to a build. Which unnecessarily queues up a lot of builds just waiting for each other.

A small example:
![image](https://github.com/user-attachments/assets/6c715999-286c-4452-8e7d-ce0a27b22a2b)