### PR TITLE
Enable more of Python dev mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-env:
-  # We can't yet run tests with PYTHONDEVMODE=1, let's at least show warnings
-  PYTHONWARNINGS: always
-
 jobs:
   test:
     name: Build and test
@@ -26,6 +22,13 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         architecture: [x64, x86]
+    env:
+      # TODO: We can't yet run tests with PYTHONDEVMODE=1, let's emulated it as much as we can
+      # https://docs.python.org/3/library/devmode.html#effects-of-the-python-development-mode
+      PYTHONMALLOC: debug
+      PYTHONASYNCIODEBUG: 1
+      PYTHONWARNINGS: always
+      # PYTHONFAULTHANDLER: 1 # This causes our tests to fail
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
A subset of https://github.com/mhammond/pywin32/pull/2502

- Moved the env vars to only the job that runs the tests. This avoids potentially unnecessary warnings that could be caused by upstream tooling (pip, setuptools, mypy, etc.) outside of the job where we actually test pywin32's own code.
- Get closer to what `PYTHONDEVMODE=1` would do, but without https://docs.python.org/3/using/cmdline.html#envvar-PYTHONFAULTHANDLER which causes pywin32's tests to fail.