### PR TITLE
Added more URLs in project metadata (appears on PyPI sidebar)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2020,7 +2020,16 @@ dist = setup(
     long_description_content_type="text/markdown",
     author="Mark Hammond (et al)",
     author_email="mhammond@skippinet.com.au",
-    url="https://github.com/mhammond/pywin32",
+    project_urls={
+        # https://docs.pypi.org/project_metadata/#general-url
+        "Homepage": "https://github.com/mhammond/pywin32",
+        "Changes": "https://github.com/mhammond/pywin32/blob/main/CHANGES.txt",
+        "Docs": "https://mhammond.github.io/pywin32/",
+        "Bugs": "https://github.com/mhammond/pywin32/issues",
+        # Arbitrary URLs (icons still recognized)
+        "Support Requests": "https://github.com/mhammond/pywin32/discussions",
+        "Mailing List": "https://mail.python.org/mailman/listinfo/python-win32",
+    },
     license="PSF",
     classifiers=classifiers,
     cmdclass=cmdclass,


### PR DESCRIPTION
To see all keywords (and their aliases) associated to specific icons: https://docs.pypi.org/project_metadata/#icons

I used the same terminology as pywin32 already does where possible.
I kept "Homepage" rather that something like "Source", but either would be fine.
"Support Requests" will show the GitHub icon.
"Mailing List" will show the Python ecosystem icon.

Current look:
![image](https://github.com/user-attachments/assets/8758b719-e5a7-4cfa-ade9-d6d1332851cc)

What it would now look like (I edited the HTML on PyPI to produce this image):
![image](https://github.com/user-attachments/assets/ec32e993-b514-4368-997f-0163e451294c)
