### PR TITLE
Remove actions/setup-python#1005 workaround

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,14 +40,6 @@ jobs:
           check-latest: true
           allow-prereleases: true
 
-      - name: Fix user Scripts missing from PATH
-        if: matrix.architecture == 'x86'
-        run: |
-          # Work around https://github.com/actions/setup-python/issues/1005
-          $ScriptsPath = python -c "import sysconfig,os; print(sysconfig.get_path('scripts', f'{os.name}_user'))"
-          echo $ScriptsPath
-          Add-Content $env:GITHUB_PATH $ScriptsPath
-
       - name: Build and install
         run: pip install . -v --user
 


### PR DESCRIPTION
actions/setup-python#1005 has been closed by https://github.com/actions/setup-python/pull/1122

So we should be able to remove this workaround.