### PR TITLE
Fix missing version stamp on built `.dll` and `.exe` files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ As of build 305, installation .exe files have been deprecated; see
 Coming in build 312, as yet unreleased
 --------------------------------------
 
+* Fixed missing version stamp on built `.dll` and `.exe` files (mhammond#2647, [@Avasam][Avasam])
 * Removed considerations for Windows 95/98/ME (mhammond#2400, [@Avasam][Avasam])
   This removes the following constants:
   * `win32con.FILE_ATTRIBUTE_ATOMIC_WRITE`


### PR DESCRIPTION
Fixes #2647

- exes weren't verstamped because their sources was targetted, not the final exe
- dlls weren't verstamped because the old pre-move location was targetted