### PR TITLE
adodbapi: simplify onWindows checks

### DIFF
--- a/adodbapi/test/adodbapitestconfig.py
+++ b/adodbapi/test/adodbapitestconfig.py
@@ -42,10 +42,6 @@ if "--help" in sys.argv:
     """
     )
     exit()
-try:
-    onWindows = bool(sys.getwindowsversion())  # seems to work on all versions of Python
-except:
-    onWindows = False
 
 # create a random name for temporary table names
 _alphabet = (
@@ -89,7 +85,7 @@ doAccessTest = not ("--nojet" in sys.argv)
 doSqlServerTest = "--mssql" in sys.argv or doAllTests
 doMySqlTest = "--mysql" in sys.argv or doAllTests
 doPostgresTest = "--pg" in sys.argv or doAllTests
-doTimeTest = ("--time" in sys.argv or doAllTests) and onWindows
+doTimeTest = ("--time" in sys.argv or doAllTests) and sys.platform == "win32"
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # # start your environment setup here v v v

--- a/adodbapi/test/test_adodbapi_dbapi20.py
+++ b/adodbapi/test/test_adodbapi_dbapi20.py
@@ -29,11 +29,6 @@ if "--verbose" in sys.argv:
 print(adodbapi.version)
 print("Tested with dbapi20 %s" % dbapi20.__version__)
 
-try:
-    onWindows = bool(sys.getwindowsversion())  # seems to work on all versions of Python
-except:
-    onWindows = False
-
 node = platform.node()
 
 conn_kws = {}
@@ -56,7 +51,7 @@ conn_kws["provider"] = (
 )
 connStr = "%(provider)s; %(security)s; Initial Catalog=%(name)s;Data Source=%(host)s"
 
-if onWindows and node != "z-PC":
+if sys.platform == "win32" and node != "z-PC":
     pass  # default should make a local SQL Server connection
 elif node == "xxx":  # try Postgres database
     _computername = "25.223.161.222"


### PR DESCRIPTION
Slight push towards Windows version agnostic Python code. Along with https://github.com/mhammond/pywin32/pull/2667 there will be no more usages of `sys.getwindowsversion`. Instead using a more canonical way of checking if, for example, code is running under cygwin.
<img width="521" height="87" alt="image" src="https://github.com/user-attachments/assets/5383dd79-0faf-47ef-ac0f-61e13f039783" />
