### PR TITLE
Assume MFC >=9 (VS 2008)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@ Coming in build 312, as yet unreleased
   This removes the following constants:
   * `win32con.FILE_ATTRIBUTE_ATOMIC_WRITE`
   * `win32con.FILE_ATTRIBUTE_XACTION_WRITE`
+* Removed considerations for MFC < 9 (VS 2008) (mhammond#2669, [@Avasam][Avasam])
+  * This removes the unusable `PyCSliderCtrl.VerifyPos` method
 
 Build 311, released 2025/07/14
 ------------------------------

--- a/Pythonwin/win32control.cpp
+++ b/Pythonwin/win32control.cpp
@@ -1855,25 +1855,6 @@ static PyObject *PyCSliderCtrl_clear_sel(PyObject *self, PyObject *args)
     RETURN_NONE;
 }
 
-// @pymethod int|PyCSliderCtrl|VerifyPos|Verify the position is between configured min and max
-static PyObject *PyCSliderCtrl_verify_pos(PyObject *self, PyObject *args)
-{
-    CHECK_NO_ARGS(args);
-    CSliderCtrl *pSC = GetSliderCtrl(self);
-    if (!pSC)
-        return NULL;
-#if _MFC_VER >= 0x0710
-    // This just vanished in VS7
-    PyErr_SetString(PyExc_NotImplementedError, "VerifyPos does not appear in this version of MFC");
-    return NULL;
-#else
-    GUI_BGN_SAVE;
-    pSC->VerifyPos();
-    GUI_END_SAVE;
-#endif
-    RETURN_NONE;
-}
-
 // @pymethod int|PyCSliderCtrl|ClearTics|Clear the control's tic marks
 static PyObject *PyCSliderCtrl_clear_tics(PyObject *self, PyObject *args)
 {
@@ -1919,7 +1900,6 @@ static struct PyMethodDef PyCSliderCtrl_methods[] = {
     {"SetTic", PyCSliderCtrl_set_tic, 1},           // @pymeth SetTic|Set a tick at the position
     {"SetTicFreq", PyCSliderCtrl_set_tic_freq, 1},  // @pymeth SetTicFreq|Set the tic mark frequency
     {"ClearSel", PyCSliderCtrl_clear_sel, 1},       // @pymeth ClearSel|Clear any control selection
-    {"VerifyPos", PyCSliderCtrl_verify_pos, 1},     // @pymeth VerifyPos|Verify the positon between min and max
     {"ClearTics", PyCSliderCtrl_clear_tics, 1},     // @pymeth ClearTics|Clear any tic marks from the control
     {NULL, NULL}};
 

--- a/Pythonwin/win32prop.cpp
+++ b/Pythonwin/win32prop.cpp
@@ -440,15 +440,9 @@ PyObject *ui_propsheet_press_button(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "i", &button))
         return NULL;
     GUI_BGN_SAVE;
-    BOOL ok = TRUE;
-#if _MFC_VER < 0x0710
-    ok =
-#endif
-        pPS->PressButton(button);
-
+    pPS->PressButton(button);
     GUI_END_SAVE;
-    if (!ok)
-        RETURN_ERR("PressButton failed");
+
     RETURN_NONE;
 }
 

--- a/Pythonwin/win32thread.cpp
+++ b/Pythonwin/win32thread.cpp
@@ -108,12 +108,8 @@ void CProtectedWinThread::PumpMessages()
     // for tracking the idle time state
     BOOL bIdle = TRUE;
     LONG lIdleCount = 0;
-#if _MFC_VER >= 0x0710
     _AFX_THREAD_STATE *pState = AfxGetThreadState();
     MSG &msgCur = pState->m_msgCur;
-#else
-    MSG &msgCur = m_msgCur;
-#endif /* _MFC_VER_ */
 
     // acquire and dispatch messages until a WM_QUIT message is received.
     for (;;) {
@@ -128,11 +124,7 @@ void CProtectedWinThread::PumpMessages()
             // pump message, but quit on WM_QUIT
             if (!PumpMessage()) {
 #if defined(_DEBUG)
-#if _MFC_VER < 0x0710
-                m_nDisablePumpCount--;  // application must NOT die
-#else
                 pState->m_nDisablePumpCount--;  // application must NOT die
-#endif
 #endif
                 return;
             }

--- a/Pythonwin/win32uiExt.h
+++ b/Pythonwin/win32uiExt.h
@@ -410,14 +410,7 @@ class CPythonWndFramework : public T {
 
    protected:
     static AFX_DATA const AFX_MSGMAP messageMap;
-    static const AFX_MSGMAP *PASCAL _GetBaseMessageMap()
-    {
-#if _MFC_VER >= 0x0700
-        return T::GetThisMessageMap();
-#else
-        return &T::messageMap;
-#endif /* _MFC_VER */
-    }
+    static const AFX_MSGMAP *PASCAL _GetBaseMessageMap() { return T::GetThisMessageMap(); }
     virtual const AFX_MSGMAP *GetMessageMap() const { return &messageMap; }
 };
 
@@ -425,8 +418,8 @@ template <class T>
 AFX_DATADEF const AFX_MSGMAP CPythonWndFramework<T>::messageMap = {&CPythonWndFramework<T>::_GetBaseMessageMap,
                                                                    &CPythonWndFramework<T>::_messageEntries[0]};
 
-// ack - compile error in MFC9 (and not x64), and only for ON_WM_NCHITTEST!
-#if _MFC_VER >= 0x0900 && !defined(_WIN64)
+// ack - compile error on not x64, and only for ON_WM_NCHITTEST!
+#if !defined(_WIN64)
 #undef ON_WM_NCHITTEST
 // from afxmsg_.h - the UINT was originally LRESULT
 #define ON_WM_NCHITTEST() \
@@ -1073,14 +1066,7 @@ class CPythonPrtDlgFramework : public CPythonDlgFramework<T> {
    protected:
     static AFX_DATA const AFX_MSGMAP messageMap;
 
-    static const AFX_MSGMAP *PASCAL _GetBaseMessageMap()
-    {
-#if _MFC_VER >= 0x0700
-        return T::GetThisMessageMap();
-#else
-        return &T::messageMap;
-#endif
-    }
+    static const AFX_MSGMAP *PASCAL _GetBaseMessageMap() { return T::GetThisMessageMap(); }
     virtual const AFX_MSGMAP *GetMessageMap() const { return &messageMap; }
 };
 

--- a/Pythonwin/win32uiole.cpp
+++ b/Pythonwin/win32uiole.cpp
@@ -14,18 +14,11 @@
 #include "afxdao.h"
 #endif
 
-#if _MFC_VER >= 0x0700
 #include "afxocc.h"
 // Sorry about this - OLE support needs MFC private header.
 // You MUST install MFC with source-code to build this extension.
 // (and this source must be in "../src" relative to the MFC
 // includes, which it is by default)
-#else
-#ifndef MFC_OCC_IMPL_H
-#error(MFC_OCC_IMPL_H must be set to the location of the MFC source code)
-#endif
-#include MFC_OCC_IMPL_H
-#endif /* _MFC_VER */
 
 extern PyObject *PyCOleClientItem_Create(PyObject *self, PyObject *args);
 

--- a/Pythonwin/win32win.cpp
+++ b/Pythonwin/win32win.cpp
@@ -889,14 +889,9 @@ static PyObject *ui_window_dlg_dir_select(PyObject *self, PyObject *args)
     // @pyparm int|idListbox||The Id of the listbox.
     if (!PyArg_ParseTuple(args, "i:DlgDirSelect", &nIDListBox))
         return NULL;
-    int rc;
     TCHAR buf[MAX_PATH];
     GUI_BGN_SAVE;
-#if _MFC_VER >= 0x0800
-    rc = pWnd->DlgDirSelect(buf, sizeof(buf) / sizeof(TCHAR), nIDListBox);
-#else
-    rc = pWnd->DlgDirSelect(buf, nIDListBox);
-#endif
+    int rc = pWnd->DlgDirSelect(buf, sizeof(buf) / sizeof(TCHAR), nIDListBox);
     // @pyseemfc CWnd|DlgDirSelect
     GUI_END_SAVE;
     if (!rc)
@@ -916,15 +911,10 @@ static PyObject *ui_window_dlg_dir_select_combo(PyObject *self, PyObject *args)
     // @pyparm int|idListbox||The Id of the combobox.
     if (!PyArg_ParseTuple(args, "i:DlgDirSelectComboBox", &nIDListBox))
         return NULL;
-    int rc;
     TCHAR buf[MAX_PATH];
     GUI_BGN_SAVE;
     // @pyseemfc CWnd|DlgDirSelectComboBox
-#if _MFC_VER >= 0x0800
-    rc = pWnd->DlgDirSelectComboBox(buf, sizeof(buf) / sizeof(TCHAR), nIDListBox);
-#else
-    rc = pWnd->DlgDirSelectComboBox(buf, nIDListBox);
-#endif
+    int rc = pWnd->DlgDirSelectComboBox(buf, sizeof(buf) / sizeof(TCHAR), nIDListBox);
     GUI_END_SAVE;
     if (!rc)
         RETURN_ERR("DlgDirSelectComboBox failed");


### PR DESCRIPTION
I think it's safe to say no one's gonna try to build with a MFC version older than 9 nowadays (which would mean older than MSVC 9 / VS 2008).

This removes all `_MFC_VER` checks.

`CSliderCtrl::VerifyPos` is also long gone, I just removed the unusable method (anyone calling it would've been getting an error for years anyway)

Fun fact: There was a single stray mention of `VerifyPos` in Microsoft's official docs: https://github.com/MicrosoftDocs/cpp-docs/pull/5832