### PR TITLE
CI speedup: Run static checkers on Ubuntu

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 AutoDuck/*.fmt          text eol=crlf
 *.dsp                   text eol=crlf
 *.dsw                   text eol=crlf
+*.py                    text eol=crlf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,7 +127,7 @@ jobs:
           if-no-files-found: error
 
   merge:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     needs: [test, build_arm64]
     steps:
       - name: Merge Artifacts
@@ -142,7 +142,7 @@ jobs:
 
   # This job can be run locally by running `pre-commit run`
   checkers:
-    runs-on: windows-2022
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -167,14 +167,16 @@ jobs:
       - run: |
           clang-format --Werror --dry-run $(git ls-files '*.cpp' ':!:com/win32comext/mapi/src/MAPIStubLibrary/')
           if ($LastExitCode -ne 0) { exit $LastExitCode }
+        shell: pwsh
         if: ${{ !cancelled() }}
       - run: |
           clang-format --Werror --dry-run $(git ls-files '*.h' ':!:Pythonwin/Scintilla/' ':!:com/win32comext/mapi/src/MAPIStubLibrary/')
           if ($LastExitCode -ne 0) { exit $LastExitCode }
+        shell: pwsh
         if: ${{ !cancelled() }}
 
   type-checkers:
-    runs-on: windows-2022
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,7 @@
 [mypy]
 show_column_numbers = true
+; Needs to be set for non-Windows CI runners
+platform = win32
 ; Target the oldest supported version in editors and default CLI
 python_version = 3.8
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,5 +1,7 @@
 {
   "typeCheckingMode": "basic",
+  // Needs to be set for non-Windows CI runners
+  "pythonPlatform": "Windows",
   // Target the oldest supported version in editors and default CLI
   "pythonVersion": "3.9",
   // Keep it simple for now by allowing both mypy and pyright to use `type: ignore`
@@ -7,6 +9,7 @@
   // Exclude from scanning when running pyright
   "exclude": [
     ".git/", // Avoids scanning git branch names ending in ".py"
+    ".venv/",
     "build/",
     // Vendored
     "Pythonwin/Scintilla/",
@@ -16,6 +19,7 @@
     "**/Test/",
     "**/test/",
     "**/Demos/",
+    "**/demos/",
     "**/demo/",
   ],
   // Packages that will be accessible globally.


### PR DESCRIPTION
GitHub-hosted Windows runners are infamously extremely slow (https://github.com/actions/runner-images/issues/7320).
An easy win is to run other jobs that don't need windows on a Linux runner instead. (2.5-3x speedup)
I'll look into using a Dev Drive to speedup the actual build jobs.

