### PR TITLE
Declare dev dependencies using PEP 735 – Dependency Groups in pyproject.toml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,20 +149,21 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           # This job only needs to target the oldest supported version
-          python-version: "3.8"
+          python-version: "3.9"
           cache: pip
           cache-dependency-path: .github/workflows/main.yml
-      - run: pip install clang-format==18.1.* pycln
+      - run: pip install --group=checkers
+
       # !cancelled(): Show issues even if the previous steps failed. But still fail the job
       - run: pycln . --config=pycln.toml --check
+
       - name: Run Ruff linter
         uses: astral-sh/ruff-action@v3
-        with:
-          version: "0.11.0"
         if: ${{ !cancelled() }}
       - name: Run Ruff formatter
         run: ruff format --check
         if: ${{ !cancelled() }}
+
       # Too many files to fit in a single command, also exclude vendored Scintilla and MAPIStubLibrary
       - run: |
           clang-format --Werror --dry-run $(git ls-files '*.cpp' ':!:com/win32comext/mapi/src/MAPIStubLibrary/')
@@ -189,13 +190,13 @@ jobs:
           cache-dependency-path: .github/workflows/main.yml
           check-latest: true
           allow-prereleases: true
-      - run: pip install types-setuptools PyOpenGL mypy==1.16.*
+      - run: pip install --group=type-checkers
 
       - run: mypy . --python-version=${{ matrix.python-version }}
 
       - uses: jakebailey/pyright-action@v2
         with:
           python-version: ${{ matrix.python-version }}
-          version: "1.1.401"
+          version: PATH
           annotate: errors
         if: ${{ !cancelled() }} # Show issues even if the previous steps failed. But still fail the job

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,21 @@ requires = [
   "setuptools <76.1; python_version <'3.9'",
 ]
 build-backend = "setuptools.build_meta"
+
+[dependency-groups]
+checkers = [ # Keep these in sync with .pre-commit-config.yaml
+  "clang-format ==18.1.8",
+  "pycln ==2.4.0",
+  "ruff ==0.11.0",
+]
+type-checkers = [
+  "types-setuptools",
+  "PyOpenGL",
+  "mypy ==1.16.*; python_version >='3.9'",
+  "pyright ==1.1.401",
+]
+dev = [
+  "pre-commit",
+  { include-group = "checkers" },
+  { include-group = "type-checkers" },
+]


### PR DESCRIPTION
Unlike using `[extras]`, [PEP 735 – Dependency Groups in pyproject.toml](https://www.python.org/dev/peps/pep-0735/) allows declaratively configuring Project dependencies that won't end up exposed in the published package.

Here I have set a `dev` dependency group, which is the canonical group name to specify dev-dependencies for which certain package managers can take shortcuts (for example `uv sync`, `uv pip install --dev`, `poetry sync`, `poetry install --dev`, `pipenv install --dev`, etc. will install dev dependencies by default).

I have added 2 subgroups (`checkers` and `type-checkers`) for minimal dependency install on the CI. These group names match the CI job names.

This requires pip >=25.1 to use with pip: `pip install --group=dev`. Pip 25.1 dropped support for Python 3.8, but luckily since this is only used for checkers in CI, I don't need to wait for https://github.com/mhammond/pywin32/pull/2413 .