### PR TITLE
Fix memory leak in PyCom_VariantFromPyObject

### DIFF
--- a/com/win32com/src/oleargs.cpp
+++ b/com/win32com/src/oleargs.cpp
@@ -283,6 +283,7 @@ BOOL PyCom_VariantFromPyObject(PyObject *obj, VARIANT *var)
         if (PyObject_Length(obj) > 0) {
             PyObject *obItemCheck = PySequence_GetItem(obj, 0);
             is_record_item = PyRecord_Check(obItemCheck);
+            Py_XDECREF(obItemCheck);
         }
         // If the sequence elements are PyRecord objects we do NOT package
         // them as VARIANT elements but put them directly into the SAFEARRAY.

--- a/com/win32com/src/oleargs.cpp
+++ b/com/win32com/src/oleargs.cpp
@@ -787,6 +787,7 @@ static BOOL PyCom_SAFEARRAYFromPyObjectEx(PyObject *obj, SAFEARRAY **ppSA, bool 
             // SAFEARRAYS of UDTs need a special treatment.
             obItemCheck = PySequence_GetItem(obj, 0);
             PyRecord *pyrec = (PyRecord *)obItemCheck;
+            Py_XDECREF(obItemCheck);
             *ppSA = SafeArrayCreateEx(vt, cDims, pBounds, pyrec->pri);
         }
         else


### PR DESCRIPTION
#2317 introduced a memory leak. This PR fixes that.

PySequence_GetItem returns a new reference, so we need to free it again.

This bug doesn't just leak memory, but is likely to keep whole com objects (with their resources) alive.