### PR TITLE
Improve `argType` membership check in `InteractivePythonApp`

### DIFF
--- a/Pythonwin/pywin/framework/intpyapp.py
+++ b/Pythonwin/pywin/framework/intpyapp.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import traceback
+from typing import Sequence
 
 import __main__
 import commctrl
@@ -266,7 +267,7 @@ class InteractivePythonApp(app.CApp):
         if frame.GetWindowPlacement()[1] == win32con.SW_SHOWMINIMIZED:
             frame.ShowWindow(win32con.SW_RESTORE)
 
-    def ProcessArgs(self, args, dde=None):
+    def ProcessArgs(self, args: Sequence[str], dde=None):
         # If we are going to talk to a remote app via DDE, then
         # activate it!
         if (
@@ -288,7 +289,7 @@ class InteractivePythonApp(app.CApp):
                 ).lower()
                 i -= 1  #  arg is /edit's parameter
             par = i < len(args) and args[i] or "MISSING"
-            if argType in ("/nodde", "/new", "-nodde", "-new"):
+            if argType in {"/nodde", "/new"}:
                 # Already handled
                 pass
             elif argType.startswith("/goto:"):


### PR DESCRIPTION
Split from https://github.com/mhammond/pywin32/pull/2413/files#r2600482337

1. Python optimizes `set` membership tests. (https://docs.python.org/3/whatsnew/3.2.html#optimizations)
2. No args can start with `-` at this point because they were already transformed into the `/` form by
```py
            if argType.startswith("-"):
                # Support dash options. Slash options are misinterpreted by python init
                # as path and not finding usually 'C:\\' ends up in sys.path[0]
                argType = "/" + argType[1:]
```