### PR TITLE
Extract `/MANIFEST:NO` from `MSVCCompiler` hack and improve types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -373,7 +373,7 @@ class my_build_ext(build_ext):
         # The pywintypes library is created in the build_temp
         # directory, so we need to add this to library_dirs
         self.library_dirs.append(self.build_temp)
-        self.mingw32 = self.compiler == "mingw32"
+        self.mingw32 = self.compiler == "mingw32"  # type: ignore[comparison-overlap] # compiler is a string until `run` is run
         if self.mingw32:
             self.libraries.append("stdc++")
 


### PR DESCRIPTION
Getting really close to completely and cleanly removing the compiler hack entirely !

- Moved out `/MANIFEST:NO` from the compiler hack into a more reasonable location
- Solves a few more `LNK4075` that would still appear even with the previous version of the compiler hack (that's now handled by calls to `remove_manifest_flags`)
- Improved related types and checks

Just waiting for pypa/setuptools#4986 / pypa/distutils#370 next.