### PR TITLE
Adding a test for nested COM Records

### DIFF
--- a/com/TestSources/PyCOMTest/PyCOMImpl.cpp
+++ b/com/TestSources/PyCOMTest/PyCOMImpl.cpp
@@ -657,6 +657,36 @@ HRESULT CPyCOMTest::VerifyArrayOfStructs(TestStruct2 *prec, VARIANT_BOOL *is_ok)
     return S_OK;
 }
 
+HRESULT CPyCOMTest::GetNestedStruct(TestStruct3 *ret)
+{
+    HRESULT hr;
+    double d_next;
+    double d = 1.0;
+    double last_d = 0.0;
+    SAFEARRAYBOUND rgsabound[1] = {7, 0};
+    TestStruct3 outer;
+    outer.id = 7.0;
+    outer.a_struct_field.int_value = 33;
+    outer.a_struct_field.str_value = SysAllocString(L"Fibonacci");
+
+    outer.array_of_double = SafeArrayCreate(VT_R8, 1, rgsabound);
+    if (outer.array_of_double == NULL)
+        return E_OUTOFMEMORY;
+    long i;
+    for (i = 0; i < 7; i++) {
+        if (S_OK != (hr = SafeArrayPutElement(outer.array_of_double, &i, &d))) {
+            SafeArrayDestroy(outer.array_of_double);
+            return hr;
+        }
+        d_next = d + last_d;
+        last_d = d;
+        d = d_next;
+    }
+
+    *ret = outer;
+    return S_OK;
+}
+
 HRESULT CPyCOMTest::ModifyArrayOfStructs(SAFEARRAY **array_of_structs)
 {
     HRESULT hr;

--- a/com/TestSources/PyCOMTest/PyCOMImpl.h
+++ b/com/TestSources/PyCOMTest/PyCOMImpl.h
@@ -131,6 +131,7 @@ class CPyCOMTest : public IDispatchImpl<IPyCOMTest, &IID_IPyCOMTest, &LIBID_PyCO
 
     STDMETHOD(ModifyStruct)(TestStruct1 *prec);
     STDMETHOD(VerifyArrayOfStructs)(TestStruct2 *prec, VARIANT_BOOL *is_ok);
+    STDMETHOD(GetNestedStruct)(TestStruct3 *ret);
     STDMETHOD(ModifyArrayOfStructs)(SAFEARRAY **array_of_structs);
 
     // info associated to each session

--- a/com/TestSources/PyCOMTest/PyCOMTest.idl
+++ b/com/TestSources/PyCOMTest/PyCOMTest.idl
@@ -319,6 +319,7 @@ library PyCOMTestLib
         // Test struct byref as [ in, out ] parameter.
         HRESULT ModifyStruct([ in, out ] TestStruct1 * prec);
         HRESULT VerifyArrayOfStructs([in] TestStruct2 * prec, [ out, retval ] VARIANT_BOOL * is_ok);
+        HRESULT GetNestedStruct([out, retval]TestStruct3 *ret);
         HRESULT ModifyArrayOfStructs([in, out] SAFEARRAY(TestStruct3) * array_of_structs);
 	};
 

--- a/com/win32com/test/testPyComTest.py
+++ b/com/win32com/test/testPyComTest.py
@@ -524,6 +524,40 @@ def TestArrayOfStructs(o, test_rec):
     assert o.VerifyArrayOfStructs(test_rec)
 
 
+def TestNestedStructs(o):
+    # Create an instance of a Record type with a nested Record field.
+    outer = TestStruct3()
+    # Initialize the Record fields including the fields of the nested Record.
+    outer.id = 7.0
+    outer.a_struct_field.int_value = 33
+    outer.a_struct_field.str_value = "Fibonacci"
+    outer.array_of_double = (1.0, 1.0, 2.0, 3.0, 5.0, 8.0, 13.0)
+    # We expect the representation to include the nested Record instance field values.
+    assert (
+        str(outer) == "com_struct(a_struct_field=com_struct(int_value=33, "
+        "str_value='Fibonacci'), array_of_double=(1.0, 1.0, "
+        "2.0, 3.0, 5.0, 8.0, 13.0), id=7.0)"
+    )
+    # Create a seperate instance of the nested Record type.
+    inner = TestStruct1()
+    # Initialize it with the same values as the nested instance above.
+    inner.int_value = 33
+    inner.str_value = "Fibonacci"
+    # We expect the types of this instace and the nested instance to be equal.
+    assert type(outer.a_struct_field) is TestStruct1
+    # We expect that their fields have the same values.
+    assert outer.a_struct_field == inner
+    # We expect that nevertheless they are different instance objects.
+    assert outer.a_struct_field is not inner
+    # Get a nested Record returned from a method.
+    nested = o.GetNestedStruct()
+    # We expect it to have the same field values as the 'outer' Record instance.
+    assert nested == outer
+    # Access the inner Record directly.
+    assert nested.a_struct_field.int_value == inner.int_value
+    assert nested.a_struct_field.str_value == inner.str_value
+
+
 def TestNestedArrays(o):
     # First we test the assignment of a nested sequence of Records
     # to a Record member attribute, followed by the retrieval of the
@@ -676,6 +710,8 @@ def TestGenerated():
     test_rec = ArrayOfStructsTestStruct()
     assert type(test_rec) is ArrayOfStructsTestStruct
     TestArrayOfStructs(o, test_rec)
+    progress("Testing nested Records.")
+    TestNestedStructs(o)
     progress("Testing multidimensional SAFEARRAYS of Records and double.")
     TestNestedArrays(o)
 


### PR DESCRIPTION
Motivated by Issue #2705 this PR adds a test for nested COM Records, i.e. Records with a field that contains another COM Record instance.