### PR TITLE
Remove obsolete `_AFX_NO_*` macro checks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,7 +30,7 @@ Coming in build 312, as yet unreleased
   * `win32con.FILE_ATTRIBUTE_XACTION_WRITE`
 * Bugfix for COM Record instance creation (mhammond#2641, [@geppi][geppi])
 * Fix regression introduced by mhammond#2506 (mhammond#2640, [@geppi][geppi])
-* Removed considerations for MFC < 9 (VS 2008) (mhammond#2669, [@Avasam][Avasam])
+* Removed considerations for MFC < 9 (VS 2008) (mhammond#2669, mhammond#2716, [@Avasam][Avasam])
   * This removes the unusable `PyCSliderCtrl.VerifyPos` method
 * Dropped support for Python 3.8 (mhammond#2413, [@Avasam][Avasam])
   * Note that whilst pywin32 hasn't explicitly dropped support for Windows 7 / Windows Server 2008,

--- a/Pythonwin/Win32app.h
+++ b/Pythonwin/Win32app.h
@@ -53,10 +53,7 @@ class PYW_EXPORT CProtectedWinApp : public CWinApp {
     CDocument *FindOpenDocument(const TCHAR *lpszFileName);
 // warning C4996: 'xxx' was declared deprecated
 #pragma warning(disable : 4996)
-#ifndef _AFX_NO_CTL3D_SUPPORT
-    // Not available on early SDK _Win64 builds.
     BOOL Enable3dControls() { return CWinApp::Enable3dControls(); }
-#endif
     void SetDialogBkColor(COLORREF clrCtlBk, COLORREF clrCtlText) { CWinApp::SetDialogBkColor(clrCtlBk, clrCtlText); }
 #pragma warning(default : 4996)
     BOOL HaveLoadStdProfileSettings() { return m_pRecentFileList != NULL; }

--- a/Pythonwin/win32cmdui.cpp
+++ b/Pythonwin/win32cmdui.cpp
@@ -48,7 +48,6 @@ BOOL Python_OnCmdMsg(CCmdTarget *obj, UINT nID, int nCode, void *pExtra, AFX_CMD
     if (nCode == CN_UPDATE_COMMAND_UI && nID == ID_FILE_MRU_FILE1)
         return FALSE;
 
-#ifndef _AFX_NO_OCC_SUPPORT
     // OLE control events are a special case
     if (nCode == CN_EVENT) {
         AFX_EVENT *pEvent = (AFX_EVENT *)pExtra;
@@ -91,7 +90,6 @@ BOOL Python_OnCmdMsg(CCmdTarget *obj, UINT nID, int nCode, void *pExtra, AFX_CMD
             Py_XDECREF(pObj);
         }
     }
-#endif  // !_AFX_NO_OCC_SUPPORT
 
     CEnterLeavePython _celp;
     PyCCmdTarget *pObj = (PyCCmdTarget *)ui_assoc_CObject::GetAssocObject(obj);

--- a/Pythonwin/win32uimodule.cpp
+++ b/Pythonwin/win32uimodule.cpp
@@ -916,12 +916,7 @@ static PyObject *ui_enable_3d_controls(PyObject *self, PyObject *args)
     if (!pApp)
         return NULL;
     GUI_BGN_SAVE;
-#ifdef _AFX_NO_CTL3D_SUPPORT
-    // This is defined for _WIN64 in earlier SDKs.
-    int rc = 0;
-#else
     int rc = pApp->Enable3dControls();
-#endif
     GUI_END_SAVE;
 
     return Py_BuildValue("i", rc);


### PR DESCRIPTION
- Follow-up to https://github.com/mhammond/pywin32/pull/2669
- Found during https://github.com/mhammond/pywin32/pull/2711