### PR TITLE
Release GIL around blocking Win32 API calls in native functions

### DIFF
--- a/win32/src/win32credmodule.cpp
+++ b/win32/src/win32credmodule.cpp
@@ -723,10 +723,12 @@ PyObject *PyCredWrite(PyObject *self, PyObject *args, PyObject *kwargs)
     if (!PyWinObject_AsCREDENTIAL(obcred, &cred))
         return NULL;
     BOOL ok;
-    Py_BEGIN_ALLOW_THREADS ok = CredWrite(&cred, flags);
-    Py_END_ALLOW_THREADS if (!ok) PyWin_SetAPIError("CredWrite");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS;
+    ok = CredWrite(&cred, flags);
+    Py_END_ALLOW_THREADS;
+    if (!ok)
+        PyWin_SetAPIError("CredWrite");
+    else {
         Py_INCREF(Py_None);
         ret = Py_None;
     }
@@ -941,8 +943,10 @@ PyObject *PyCredUIPromptForCredentials(PyObject *self, PyObject *args, PyObject 
     if (!PyWinObject_AsCREDUI_INFO(obuiinfo, &uiinfo))
         goto done;
 
+    Py_BEGIN_ALLOW_THREADS;
     reterr = CredUIPromptForCredentials(uiinfo, targetname, reserved, autherror, username_io, maxusername, password_io,
                                         maxpassword, &save, flags);
+    Py_END_ALLOW_THREADS;
     if (reterr == NO_ERROR)
         ret = Py_BuildValue("uuN", username_io, password_io, PyBool_FromLong(save));
     else

--- a/win32/src/win32credmodule.cpp
+++ b/win32/src/win32credmodule.cpp
@@ -723,11 +723,16 @@ PyObject *PyCredWrite(PyObject *self, PyObject *args, PyObject *kwargs)
     if (!PyWinObject_AsCREDENTIAL(obcred, &cred))
         return NULL;
     BOOL ok;
+    DWORD err;
     Py_BEGIN_ALLOW_THREADS;
     ok = CredWrite(&cred, flags);
+    // Capture error before Py_END_ALLOW_THREADS reacquires the GIL,
+    // which may call Win32 functions that overwrite GetLastError().
+    if (!ok)
+        err = GetLastError();
     Py_END_ALLOW_THREADS;
     if (!ok)
-        PyWin_SetAPIError("CredWrite");
+        PyWin_SetAPIError("CredWrite", err);
     else {
         Py_INCREF(Py_None);
         ret = Py_None;

--- a/win32/src/win32credmodule.cpp
+++ b/win32/src/win32credmodule.cpp
@@ -722,9 +722,11 @@ PyObject *PyCredWrite(PyObject *self, PyObject *args, PyObject *kwargs)
         return NULL;
     if (!PyWinObject_AsCREDENTIAL(obcred, &cred))
         return NULL;
-    if (!CredWrite(&cred, flags))
-        PyWin_SetAPIError("CredWrite");
-    else {
+    BOOL ok;
+    Py_BEGIN_ALLOW_THREADS ok = CredWrite(&cred, flags);
+    Py_END_ALLOW_THREADS if (!ok) PyWin_SetAPIError("CredWrite");
+    else
+    {
         Py_INCREF(Py_None);
         ret = Py_None;
     }

--- a/win32/src/win32net/win32netuser.cpp
+++ b/win32/src/win32net/win32netuser.cpp
@@ -373,10 +373,10 @@ PyObject *PyNetUserEnum(PyObject *self, PyObject *args)
     if (!FindNET_STRUCT(level, user_infos, &pInfo))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS err =
-        NetUserEnum(szServer, level, filter, &buf, dwPrefLen, &numRead, &totalEntries, &resumeHandle);
-    Py_END_ALLOW_THREADS if (err != 0 && err != ERROR_MORE_DATA)
-    {
+    Py_BEGIN_ALLOW_THREADS;
+    err = NetUserEnum(szServer, level, filter, &buf, dwPrefLen, &numRead, &totalEntries, &resumeHandle);
+    Py_END_ALLOW_THREADS;
+    if (err != 0 && err != ERROR_MORE_DATA) {
         ReturnNetError("NetUserEnum", err);  // @pyseeapi NetUserEnum
         goto done;
     }

--- a/win32/src/win32net/win32netuser.cpp
+++ b/win32/src/win32net/win32netuser.cpp
@@ -373,8 +373,10 @@ PyObject *PyNetUserEnum(PyObject *self, PyObject *args)
     if (!FindNET_STRUCT(level, user_infos, &pInfo))
         goto done;
 
-    err = NetUserEnum(szServer, level, filter, &buf, dwPrefLen, &numRead, &totalEntries, &resumeHandle);
-    if (err != 0 && err != ERROR_MORE_DATA) {
+    Py_BEGIN_ALLOW_THREADS err =
+        NetUserEnum(szServer, level, filter, &buf, dwPrefLen, &numRead, &totalEntries, &resumeHandle);
+    Py_END_ALLOW_THREADS if (err != 0 && err != ERROR_MORE_DATA)
+    {
         ReturnNetError("NetUserEnum", err);  // @pyseeapi NetUserEnum
         goto done;
     }

--- a/win32/src/win32profilemodule.cpp
+++ b/win32/src/win32profilemodule.cpp
@@ -134,9 +134,13 @@ PyObject *PyLoadUserProfile(PyObject *self, PyObject *args, PyObject *kwargs)
     if (!PyWinObject_AsPROFILEINFO(obPROFILEINFO, &profileinfo))
         return NULL;
     BOOL ok;
-    Py_BEGIN_ALLOW_THREADS ok = LoadUserProfile(hToken, &profileinfo);
-    Py_END_ALLOW_THREADS if (!ok) PyWin_SetAPIError("LoadUserProfile");
-    else ret = new PyHKEY(profileinfo.hProfile);
+    Py_BEGIN_ALLOW_THREADS;
+    ok = LoadUserProfile(hToken, &profileinfo);
+    Py_END_ALLOW_THREADS;
+    if (!ok)
+        PyWin_SetAPIError("LoadUserProfile");
+    else
+        ret = new PyHKEY(profileinfo.hProfile);
     PyWinObject_FreePROFILEINFO(&profileinfo);
     return ret;
 }
@@ -160,9 +164,10 @@ PyObject *PyUnloadUserProfile(PyObject *self, PyObject *args, PyObject *kwargs)
     if (!PyWinObject_AsHANDLE(obhProfile, &hProfile))
         return NULL;
     BOOL ok;
-    Py_BEGIN_ALLOW_THREADS ok = UnloadUserProfile(hToken, hProfile);
-    Py_END_ALLOW_THREADS if (!ok)
-    {
+    Py_BEGIN_ALLOW_THREADS;
+    ok = UnloadUserProfile(hToken, hProfile);
+    Py_END_ALLOW_THREADS;
+    if (!ok) {
         PyWin_SetAPIError("UnloadUserProfile");
         return NULL;
     }
@@ -339,10 +344,12 @@ PyObject *PyCreateEnvironmentBlock(PyObject *self, PyObject *args, PyObject *kwa
     if (!PyWinObject_AsHANDLE(obhToken, &hToken))
         return NULL;
     BOOL ok;
-    Py_BEGIN_ALLOW_THREADS ok = CreateEnvironmentBlock(&env, hToken, inherit);
-    Py_END_ALLOW_THREADS if (!ok) PyWin_SetAPIError("CreateEnvironmentBlock");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS;
+    ok = CreateEnvironmentBlock(&env, hToken, inherit);
+    Py_END_ALLOW_THREADS;
+    if (!ok)
+        PyWin_SetAPIError("CreateEnvironmentBlock");
+    else {
         ret = PyWinObject_FromEnvironmentBlock((WCHAR *)env);
         DestroyEnvironmentBlock(env);
     }

--- a/win32/src/win32profilemodule.cpp
+++ b/win32/src/win32profilemodule.cpp
@@ -134,11 +134,16 @@ PyObject *PyLoadUserProfile(PyObject *self, PyObject *args, PyObject *kwargs)
     if (!PyWinObject_AsPROFILEINFO(obPROFILEINFO, &profileinfo))
         return NULL;
     BOOL ok;
+    DWORD err;
     Py_BEGIN_ALLOW_THREADS;
     ok = LoadUserProfile(hToken, &profileinfo);
+    // Capture error before Py_END_ALLOW_THREADS reacquires the GIL,
+    // which may call Win32 functions that overwrite GetLastError().
+    if (!ok)
+        err = GetLastError();
     Py_END_ALLOW_THREADS;
     if (!ok)
-        PyWin_SetAPIError("LoadUserProfile");
+        PyWin_SetAPIError("LoadUserProfile", err);
     else
         ret = new PyHKEY(profileinfo.hProfile);
     PyWinObject_FreePROFILEINFO(&profileinfo);
@@ -164,11 +169,14 @@ PyObject *PyUnloadUserProfile(PyObject *self, PyObject *args, PyObject *kwargs)
     if (!PyWinObject_AsHANDLE(obhProfile, &hProfile))
         return NULL;
     BOOL ok;
+    DWORD err;
     Py_BEGIN_ALLOW_THREADS;
     ok = UnloadUserProfile(hToken, hProfile);
+    if (!ok)
+        err = GetLastError();
     Py_END_ALLOW_THREADS;
     if (!ok) {
-        PyWin_SetAPIError("UnloadUserProfile");
+        PyWin_SetAPIError("UnloadUserProfile", err);
         return NULL;
     }
     Py_INCREF(Py_None);
@@ -344,11 +352,14 @@ PyObject *PyCreateEnvironmentBlock(PyObject *self, PyObject *args, PyObject *kwa
     if (!PyWinObject_AsHANDLE(obhToken, &hToken))
         return NULL;
     BOOL ok;
+    DWORD err;
     Py_BEGIN_ALLOW_THREADS;
     ok = CreateEnvironmentBlock(&env, hToken, inherit);
+    if (!ok)
+        err = GetLastError();
     Py_END_ALLOW_THREADS;
     if (!ok)
-        PyWin_SetAPIError("CreateEnvironmentBlock");
+        PyWin_SetAPIError("CreateEnvironmentBlock", err);
     else {
         ret = PyWinObject_FromEnvironmentBlock((WCHAR *)env);
         DestroyEnvironmentBlock(env);

--- a/win32/src/win32profilemodule.cpp
+++ b/win32/src/win32profilemodule.cpp
@@ -133,10 +133,10 @@ PyObject *PyLoadUserProfile(PyObject *self, PyObject *args, PyObject *kwargs)
         return NULL;
     if (!PyWinObject_AsPROFILEINFO(obPROFILEINFO, &profileinfo))
         return NULL;
-    if (!LoadUserProfile(hToken, &profileinfo))
-        PyWin_SetAPIError("LoadUserProfile");
-    else
-        ret = new PyHKEY(profileinfo.hProfile);
+    BOOL ok;
+    Py_BEGIN_ALLOW_THREADS ok = LoadUserProfile(hToken, &profileinfo);
+    Py_END_ALLOW_THREADS if (!ok) PyWin_SetAPIError("LoadUserProfile");
+    else ret = new PyHKEY(profileinfo.hProfile);
     PyWinObject_FreePROFILEINFO(&profileinfo);
     return ret;
 }
@@ -159,7 +159,10 @@ PyObject *PyUnloadUserProfile(PyObject *self, PyObject *args, PyObject *kwargs)
         return NULL;
     if (!PyWinObject_AsHANDLE(obhProfile, &hProfile))
         return NULL;
-    if (!UnloadUserProfile(hToken, hProfile)) {
+    BOOL ok;
+    Py_BEGIN_ALLOW_THREADS ok = UnloadUserProfile(hToken, hProfile);
+    Py_END_ALLOW_THREADS if (!ok)
+    {
         PyWin_SetAPIError("UnloadUserProfile");
         return NULL;
     }
@@ -335,9 +338,11 @@ PyObject *PyCreateEnvironmentBlock(PyObject *self, PyObject *args, PyObject *kwa
         return NULL;
     if (!PyWinObject_AsHANDLE(obhToken, &hToken))
         return NULL;
-    if (!CreateEnvironmentBlock(&env, hToken, inherit))
-        PyWin_SetAPIError("CreateEnvironmentBlock");
-    else {
+    BOOL ok;
+    Py_BEGIN_ALLOW_THREADS ok = CreateEnvironmentBlock(&env, hToken, inherit);
+    Py_END_ALLOW_THREADS if (!ok) PyWin_SetAPIError("CreateEnvironmentBlock");
+    else
+    {
         ret = PyWinObject_FromEnvironmentBlock((WCHAR *)env);
         DestroyEnvironmentBlock(env);
     }

--- a/win32/src/win32security.i
+++ b/win32/src/win32security.i
@@ -850,7 +850,11 @@ PyObject *PyLogonUser(PyObject *self, PyObject *args, PyObject *kwargs)
 	if (PyWinObject_AsWCHAR(obusername, &username, FALSE)
 		&&PyWinObject_AsWCHAR(obdomain, &domain, TRUE)
 		&&PyWinObject_AsWCHAR(obpassword, &password, FALSE)){
-		if (!LogonUser(username, domain, password, logontype, logonprovider, &htoken))
+		BOOL ok;
+		Py_BEGIN_ALLOW_THREADS
+		ok = LogonUser(username, domain, password, logontype, logonprovider, &htoken);
+		Py_END_ALLOW_THREADS
+		if (!ok)
 			PyWin_SetAPIError("LogonUser");
 		else
 			ret=PyWinObject_FromHANDLE(htoken);
@@ -981,7 +985,11 @@ PyObject *LookupAccountName(PyObject *self, PyObject *args)
 
 	pSid = (PSID)malloc(sidSize);
 
-	if (!LookupAccountName(szSystemName, szAcctName, pSid, &sidSize, refDomain, &refDomainSize, &sidType)) {
+	BOOL bLookup;
+	Py_BEGIN_ALLOW_THREADS
+	bLookup = LookupAccountName(szSystemName, szAcctName, pSid, &sidSize, refDomain, &refDomainSize, &sidType);
+	Py_END_ALLOW_THREADS
+	if (!bLookup) {
 		PyWin_SetAPIError("LookupAccountName");
 		goto done;
 	}
@@ -1322,7 +1330,9 @@ PyObject *SetNamedSecurityInfo(PyObject *self, PyObject *args)
 	if (!PyWinObject_AsWCHAR(obObjectName, &ObjectName, FALSE ))
 		return NULL;
 
+	Py_BEGIN_ALLOW_THREADS
 	err=SetNamedSecurityInfo(ObjectName, ObjectType, info, pSidOwner, pSidGroup, pDacl, pSacl);
+	Py_END_ALLOW_THREADS
 	if (err==ERROR_SUCCESS){
 		Py_INCREF(Py_None);
 		ret=Py_None;
@@ -1356,7 +1366,9 @@ static PyObject *PyGetNamedSecurityInfo(PyObject *self, PyObject *args)
 	if (!PyWinObject_AsWCHAR(obObjectName, &ObjectName, FALSE))
 		return NULL;
 
+	Py_BEGIN_ALLOW_THREADS
 	err=GetNamedSecurityInfoW(ObjectName, object_type, required_info, NULL, NULL, NULL, NULL, &pSD);
+	Py_END_ALLOW_THREADS
 	if (err==ERROR_SUCCESS){
 		// When retrieving security for an administrative share (C$, D$, etc) the returned security descriptor
 		//	may be NULL even though the return code indicates success.
@@ -2234,7 +2246,9 @@ static PyObject *PyLsaOpenPolicy(PyObject *self, PyObject *args)
 	if (!PyWinObject_AsLSA_UNICODE_STRING(obsystem_name, &system_name, TRUE))
 		return NULL;
 
+	Py_BEGIN_ALLOW_THREADS
 	ntsResult = LsaOpenPolicy(&system_name, &ObjectAttributes, access_mask, &lsahPolicyHandle);
+	Py_END_ALLOW_THREADS
 	if (ntsResult != STATUS_SUCCESS)
 		PyWin_SetAPIError("LsaOpenPolicy",LsaNtStatusToWinError(ntsResult));
 	else
@@ -2495,7 +2509,9 @@ static PyObject *PyLsaAddAccountRights(PyObject *self, PyObject *args, PyObject 
 			goto done;
 		plsau++;
 		}
+	Py_BEGIN_ALLOW_THREADS
 	err=LsaAddAccountRights(hpolicy, psid, plsau_start, priv_cnt);
+	Py_END_ALLOW_THREADS
 	if (err != STATUS_SUCCESS){
 		PyWin_SetAPIError("LsaAddAccountRights",LsaNtStatusToWinError(err));
 		goto done;
@@ -2700,7 +2716,11 @@ static PyObject *PyConvertSidToStringSid(PyObject *self, PyObject *args)
         return NULL;
     if (!PyWinObject_AsSID(obsid, &psid))
         return NULL;
-    if (!ConvertSidToStringSid(psid,&stringsid))
+    BOOL bConvert;
+    Py_BEGIN_ALLOW_THREADS
+    bConvert = ConvertSidToStringSid(psid,&stringsid);
+    Py_END_ALLOW_THREADS
+    if (!bConvert)
         PyWin_SetAPIError("ConvertSidToStringSid");
     else
         ret=PyWinObject_FromWCHAR(stringsid);

--- a/win32/src/win32security.i
+++ b/win32/src/win32security.i
@@ -851,11 +851,16 @@ PyObject *PyLogonUser(PyObject *self, PyObject *args, PyObject *kwargs)
 		&&PyWinObject_AsWCHAR(obdomain, &domain, TRUE)
 		&&PyWinObject_AsWCHAR(obpassword, &password, FALSE)){
 		BOOL ok;
+		DWORD err;
 		Py_BEGIN_ALLOW_THREADS
 		ok = LogonUser(username, domain, password, logontype, logonprovider, &htoken);
+		// Capture error before Py_END_ALLOW_THREADS reacquires the GIL,
+		// which may call Win32 functions that overwrite GetLastError().
+		if (!ok)
+			err = GetLastError();
 		Py_END_ALLOW_THREADS
 		if (!ok)
-			PyWin_SetAPIError("LogonUser");
+			PyWin_SetAPIError("LogonUser", err);
 		else
 			ret=PyWinObject_FromHANDLE(htoken);
 		}
@@ -986,11 +991,14 @@ PyObject *LookupAccountName(PyObject *self, PyObject *args)
 	pSid = (PSID)malloc(sidSize);
 
 	BOOL bLookup;
+	DWORD err;
 	Py_BEGIN_ALLOW_THREADS
 	bLookup = LookupAccountName(szSystemName, szAcctName, pSid, &sidSize, refDomain, &refDomainSize, &sidType);
+	if (!bLookup)
+		err = GetLastError();
 	Py_END_ALLOW_THREADS
 	if (!bLookup) {
-		PyWin_SetAPIError("LookupAccountName");
+		PyWin_SetAPIError("LookupAccountName", err);
 		goto done;
 	}
 	obDomain = PyWinObject_FromTCHAR(refDomain);
@@ -2717,11 +2725,14 @@ static PyObject *PyConvertSidToStringSid(PyObject *self, PyObject *args)
     if (!PyWinObject_AsSID(obsid, &psid))
         return NULL;
     BOOL bConvert;
+    DWORD err;
     Py_BEGIN_ALLOW_THREADS
     bConvert = ConvertSidToStringSid(psid,&stringsid);
+    if (!bConvert)
+        err = GetLastError();
     Py_END_ALLOW_THREADS
     if (!bConvert)
-        PyWin_SetAPIError("ConvertSidToStringSid");
+        PyWin_SetAPIError("ConvertSidToStringSid", err);
     else
         ret=PyWinObject_FromWCHAR(stringsid);
     if (stringsid!=NULL)


### PR DESCRIPTION
We noticed in our project that several Win32 API calls were blocking the main thread for 100ms–2s+ each, preventing our asyncio event loop from making progress. After investigation, we found that a number of hand-written native functions call Win32 APIs without releasing the GIL. None of these functions access Python objects during the syscall, so holding the GIL is probably unnecessary.