### PR TITLE
clang-format: Use `MacroBlock` for `Py_*_ALLOW_THREADS` formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -18,3 +18,7 @@ SpaceBeforeParens: ControlStatements
 SpacesInParentheses: false
 TabWidth: 4
 UseTab: Never
+
+# https://clang.llvm.org/docs/ClangFormatStyleOptions.html#macroblockbegin
+MacroBlockBegin: Py_BEGIN_ALLOW_THREADS
+MacroBlockEnd: Py_END_ALLOW_THREADS

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -20,3 +20,6 @@ b74bfdca97238735adbd1b20d7245cca7070900f
 
 # 2025-11-25 renormalized line endings in adodbapi
 d8f97a8c8f72263d336fc4050f83e007ac6e770d
+
+# 2026-04-20 reformatted Py_*_ALLOW_THREADS with clang-format MacroBlock
+81ea73b0c3227536cb1bf54e37e78dc849977c99

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -21,5 +21,8 @@ b74bfdca97238735adbd1b20d7245cca7070900f
 # 2025-11-25 renormalized line endings in adodbapi
 d8f97a8c8f72263d336fc4050f83e007ac6e770d
 
-# 3036-04-27 renamed Pythonwin folder to pythonwin
+# 2026-04-27 renamed Pythonwin folder to pythonwin
 5ed60c439db929d82acc09c9a85a417e406d6429
+
+# 2026-05-04 reformatted Py_*_ALLOW_THREADS with clang-format MacroBlock
+a44059e33471b9b6958e2667b9140aeec01b4dd9

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -21,5 +21,8 @@ b74bfdca97238735adbd1b20d7245cca7070900f
 # 2025-11-25 renormalized line endings in adodbapi
 d8f97a8c8f72263d336fc4050f83e007ac6e770d
 
-# 3036-04-27 renamed Pythonwin folder to pythonwin
+# 2026-04-27 renamed Pythonwin folder to pythonwin
 5ed60c439db929d82acc09c9a85a417e406d6429
+
+# 2026-05-04 reformatted Py_*_ALLOW_THREADS with clang-format MacroBlock
+dd12a27fb6ef43a6b3df1237f28dbf5e68f0e1c6

--- a/com/win32com/src/ErrorUtils.cpp
+++ b/com/win32com/src/ErrorUtils.cpp
@@ -252,9 +252,10 @@ BOOL PyCom_SetCOMErrorFromExcepInfo(const EXCEPINFO *pexcepinfo, REFIID riid)
             pICEI->SetSource(pexcepinfo->bstrSource);
 
         IErrorInfo *pIEI;
-        Py_BEGIN_ALLOW_THREADS hr = pICEI->QueryInterface(IID_IErrorInfo, (LPVOID *)&pIEI);
-        Py_END_ALLOW_THREADS if (SUCCEEDED(hr))
-        {
+        Py_BEGIN_ALLOW_THREADS
+            hr = pICEI->QueryInterface(IID_IErrorInfo, (LPVOID *)&pIEI);
+        Py_END_ALLOW_THREADS
+        if (SUCCEEDED(hr)) {
             SetErrorInfo(0, pIEI);
             pIEI->Release();
         }
@@ -546,17 +547,19 @@ PyObject *PyCom_BuildPyException(HRESULT errorhr, IUnknown *pUnk /* = NULL */, R
         // See if it supports error info.
         ISupportErrorInfo *pSEI;
         HRESULT hr;
-        Py_BEGIN_ALLOW_THREADS hr = pUnk->QueryInterface(IID_ISupportErrorInfo, (void **)&pSEI);
+        Py_BEGIN_ALLOW_THREADS
+            hr = pUnk->QueryInterface(IID_ISupportErrorInfo, (void **)&pSEI);
+            if (SUCCEEDED(hr)) {
+                hr = pSEI->InterfaceSupportsErrorInfo(iid);
+                pSEI->Release();  // Finished with this object
+            }
+        Py_END_ALLOW_THREADS
         if (SUCCEEDED(hr)) {
-            hr = pSEI->InterfaceSupportsErrorInfo(iid);
-            pSEI->Release();  // Finished with this object
-        }
-        Py_END_ALLOW_THREADS if (SUCCEEDED(hr))
-        {
             IErrorInfo *pEI;
-            Py_BEGIN_ALLOW_THREADS hr = GetErrorInfo(0, &pEI);
-            Py_END_ALLOW_THREADS if (hr == S_OK)
-            {
+            Py_BEGIN_ALLOW_THREADS
+                hr = GetErrorInfo(0, &pEI);
+            Py_END_ALLOW_THREADS
+            if (hr == S_OK) {
                 obEI = PyCom_PyObjectFromIErrorInfo(pEI, errorhr);
                 PYCOM_RELEASE(pEI);
             }
@@ -655,37 +658,37 @@ static PyObject *PyCom_PyObjectFromIErrorInfo(IErrorInfo *pEI, HRESULT errorhr)
 
     HRESULT hr;
 
-    Py_BEGIN_ALLOW_THREADS hr = pEI->GetDescription(&desc);
-    Py_END_ALLOW_THREADS if (hr != S_OK)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hr = pEI->GetDescription(&desc);
+    Py_END_ALLOW_THREADS
+    if (hr != S_OK) {
         obDesc = Py_None;
         Py_INCREF(obDesc);
     }
-    else
-    {
+    else {
         obDesc = MakeBstrToObj(desc);
         SysFreeString(desc);
     }
 
-    Py_BEGIN_ALLOW_THREADS hr = pEI->GetSource(&source);
-    Py_END_ALLOW_THREADS if (hr != S_OK)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hr = pEI->GetSource(&source);
+    Py_END_ALLOW_THREADS
+    if (hr != S_OK) {
         obSource = Py_None;
         Py_INCREF(obSource);
     }
-    else
-    {
+    else {
         obSource = MakeBstrToObj(source);
         SysFreeString(source);
     }
-    Py_BEGIN_ALLOW_THREADS hr = pEI->GetHelpFile(&helpfile);
-    Py_END_ALLOW_THREADS if (hr != S_OK)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hr = pEI->GetHelpFile(&helpfile);
+    Py_END_ALLOW_THREADS
+    if (hr != S_OK) {
         obHelpFile = Py_None;
         Py_INCREF(obHelpFile);
     }
-    else
-    {
+    else {
         obHelpFile = MakeBstrToObj(helpfile);
         SysFreeString(helpfile);
     }

--- a/com/win32com/src/PyComHelpers.cpp
+++ b/com/win32com/src/PyComHelpers.cpp
@@ -356,9 +356,10 @@ BOOL PyCom_InterfaceFromPyObject(PyObject *ob, REFIID iid, LPVOID *ppv, BOOL bNo
         return FALSE; /* exception was set by GetI() */
     /* note: we don't explicitly hold a reference to punk */
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = punk->QueryInterface(iid, ppv);
-    Py_END_ALLOW_THREADS if (FAILED(hr))
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hr = punk->QueryInterface(iid, ppv);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
         return FALSE;
     }

--- a/com/win32com/src/PyIDispatch.cpp
+++ b/com/win32com/src/PyIDispatch.cpp
@@ -13,26 +13,26 @@ static BOOL ExcepInfoFromIErrorInfo(EXCEPINFO *einfo, IDispatch *pDisp, HRESULT 
     }
     ISupportErrorInfo *pSEI;
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = pDisp->QueryInterface(IID_ISupportErrorInfo, (void **)&pSEI);
-    if (SUCCEEDED(hr)) {
-        hr = pSEI->InterfaceSupportsErrorInfo(IID_IDispatch);
-        pSEI->Release();  // Finished with this object
-    }
+    Py_BEGIN_ALLOW_THREADS
+        hr = pDisp->QueryInterface(IID_ISupportErrorInfo, (void **)&pSEI);
+        if (SUCCEEDED(hr)) {
+            hr = pSEI->InterfaceSupportsErrorInfo(IID_IDispatch);
+            pSEI->Release();  // Finished with this object
+        }
     Py_END_ALLOW_THREADS
 
-        // InterfaceSupportsErrorInfo returning S_FALSE means we should ignore it.
-        if (FAILED(hr) || hr == S_FALSE)
-    {
+    // InterfaceSupportsErrorInfo returning S_FALSE means we should ignore it.
+    if (FAILED(hr) || hr == S_FALSE) {
         return FALSE;
     }
 
     // ErrorInfo via IErrorInfo hence transform to EXCEPINFO
     IErrorInfo *pEI;
-    Py_BEGIN_ALLOW_THREADS hr = GetErrorInfo(0, &pEI);
+    Py_BEGIN_ALLOW_THREADS
+        hr = GetErrorInfo(0, &pEI);
     Py_END_ALLOW_THREADS
 
-        if (hr != S_OK)
-    {
+    if (hr != S_OK) {
         return FALSE;
     }
     // These strings will be freed when PyCom_CleanupExcepInfo is called
@@ -41,26 +41,28 @@ static BOOL ExcepInfoFromIErrorInfo(EXCEPINFO *einfo, IDispatch *pDisp, HRESULT 
     BSTR source = NULL;
     BSTR helpfile = NULL;
 
-    Py_BEGIN_ALLOW_THREADS hr = pEI->GetDescription(&desc);
-    if (hr == S_OK) {
-        einfo->bstrDescription = desc;
-    }
-    hr = pEI->GetSource(&source);
-    if (hr == S_OK) {
-        einfo->bstrSource = source;
-    }
-    hr = pEI->GetHelpFile(&helpfile);
-    if (hr == S_OK) {
-        einfo->bstrHelpFile = helpfile;
-    }
-    DWORD helpContext = 0;
-    hr = pEI->GetHelpContext(&helpContext);
-    if (hr == S_OK) {
-        einfo->dwHelpContext = helpContext;
-    }
-    einfo->wCode = 0;
-    einfo->scode = scode;
-    Py_END_ALLOW_THREADS PYCOM_RELEASE(pEI);
+    Py_BEGIN_ALLOW_THREADS
+        hr = pEI->GetDescription(&desc);
+        if (hr == S_OK) {
+            einfo->bstrDescription = desc;
+        }
+        hr = pEI->GetSource(&source);
+        if (hr == S_OK) {
+            einfo->bstrSource = source;
+        }
+        hr = pEI->GetHelpFile(&helpfile);
+        if (hr == S_OK) {
+            einfo->bstrHelpFile = helpfile;
+        }
+        DWORD helpContext = 0;
+        hr = pEI->GetHelpContext(&helpContext);
+        if (hr == S_OK) {
+            einfo->dwHelpContext = helpContext;
+        }
+        einfo->wCode = 0;
+        einfo->scode = scode;
+    Py_END_ALLOW_THREADS
+    PYCOM_RELEASE(pEI);
     return TRUE;
 }
 

--- a/com/win32com/src/PythonCOM.cpp
+++ b/com/win32com/src/PythonCOM.cpp
@@ -1428,17 +1428,18 @@ static PyObject *pythoncom_PumpWaitingMessages(PyObject *self, PyObject *args)
     long result = 0;
     // Read all of the messages in this next loop,
     // removing each message as we read it.
-    Py_BEGIN_ALLOW_THREADS while (PeekMessage(&msg, NULL, firstMsg, lastMsg, PM_REMOVE))
-    {
-        // If it's a quit message, we're out of here.
-        if (msg.message == WM_QUIT) {
-            result = 1;
-            break;
-        }
-        // Otherwise, dispatch the message.
-        DispatchMessage(&msg);
-    }  // End of PeekMessage while loop
-    Py_END_ALLOW_THREADS return PyLong_FromLong(result);
+    Py_BEGIN_ALLOW_THREADS
+        while (PeekMessage(&msg, NULL, firstMsg, lastMsg, PM_REMOVE)) {
+            // If it's a quit message, we're out of here.
+            if (msg.message == WM_QUIT) {
+                result = 1;
+                break;
+            }
+            // Otherwise, dispatch the message.
+            DispatchMessage(&msg);
+        }  // End of PeekMessage while loop
+    Py_END_ALLOW_THREADS
+    return PyLong_FromLong(result);
 }
 
 // @pymethod |pythoncom|PumpMessages|Pumps all messages for the current thread until a WM_QUIT message.
@@ -1446,12 +1447,14 @@ static PyObject *pythoncom_PumpMessages(PyObject *self, PyObject *args)
 {
     MSG msg;
     int rc;
-    Py_BEGIN_ALLOW_THREADS while ((rc = GetMessage(&msg, 0, 0, 0)) == 1)
-    {
-        TranslateMessage(&msg);  // needed?
-        DispatchMessage(&msg);
-    }
-    Py_END_ALLOW_THREADS if (rc == -1) return PyWin_SetAPIError("GetMessage");
+    Py_BEGIN_ALLOW_THREADS
+        while ((rc = GetMessage(&msg, 0, 0, 0)) == 1) {
+            TranslateMessage(&msg);  // needed?
+            DispatchMessage(&msg);
+        }
+    Py_END_ALLOW_THREADS
+    if (rc == -1)
+        return PyWin_SetAPIError("GetMessage");
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -1520,9 +1523,14 @@ static PyObject *pythoncom_CoWaitForMultipleHandles(PyObject *self, PyObject *ar
     DWORD index;
     PyObject *rc = NULL;
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = CoWaitForMultipleHandles(flags, timeout, numItems, pItems, &index);
-    Py_END_ALLOW_THREADS if (FAILED(hr)) { PyCom_BuildPyException(hr); }
-    else rc = PyLong_FromLong(index);
+    Py_BEGIN_ALLOW_THREADS
+        hr = CoWaitForMultipleHandles(flags, timeout, numItems, pItems, &index);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr)) {
+        PyCom_BuildPyException(hr);
+    }
+    else
+        rc = PyLong_FromLong(index);
     free(pItems);
     return rc;
 }
@@ -1535,9 +1543,10 @@ static PyObject *pythoncom_OleGetClipboard(PyObject *, PyObject *args)
         return NULL;
     IDataObject *pd = NULL;
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = ::OleGetClipboard(&pd);
-    Py_END_ALLOW_THREADS if (FAILED(hr))
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::OleGetClipboard(&pd);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
         return NULL;
     }
@@ -1557,8 +1566,11 @@ static PyObject *pythoncom_OleSetClipboard(PyObject *, PyObject *args)
     if (!PyCom_InterfaceFromPyObject(obd, IID_IDataObject, (void **)&pd, TRUE))
         return NULL;
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = ::OleSetClipboard(pd);
-    Py_END_ALLOW_THREADS if (pd) pd->Release();
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::OleSetClipboard(pd);
+    Py_END_ALLOW_THREADS
+    if (pd)
+        pd->Release();
     if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
         return NULL;
@@ -1579,8 +1591,10 @@ static PyObject *pythoncom_OleIsCurrentClipboard(PyObject *, PyObject *args)
     if (!PyCom_InterfaceFromPyObject(obd, IID_IDataObject, (void **)&pd, FALSE))
         return NULL;
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = ::OleIsCurrentClipboard(pd);
-    Py_END_ALLOW_THREADS pd->Release();
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::OleIsCurrentClipboard(pd);
+    Py_END_ALLOW_THREADS
+    pd->Release();
     if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
         return NULL;
@@ -1598,9 +1612,10 @@ static PyObject *pythoncom_OleFlushClipboard(PyObject *, PyObject *args)
         return NULL;
 
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = ::OleFlushClipboard();
-    Py_END_ALLOW_THREADS if (FAILED(hr))
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::OleFlushClipboard();
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
         return NULL;
     }
@@ -1626,8 +1641,10 @@ static PyObject *pythoncom_RegisterDragDrop(PyObject *, PyObject *args)
     if (!PyCom_InterfaceFromPyObject(obd, IID_IDropTarget, (void **)&dt, FALSE))
         return NULL;
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = ::RegisterDragDrop(hwnd, dt);
-    Py_END_ALLOW_THREADS dt->Release();
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::RegisterDragDrop(hwnd, dt);
+    Py_END_ALLOW_THREADS
+    dt->Release();
     if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
         return NULL;
@@ -1649,9 +1666,10 @@ static PyObject *pythoncom_RevokeDragDrop(PyObject *, PyObject *args)
     if (!PyWinObject_AsHANDLE(obhwnd, (HANDLE *)&hwnd))
         return NULL;
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = ::RevokeDragDrop(hwnd);
-    Py_END_ALLOW_THREADS if (FAILED(hr))
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::RevokeDragDrop(hwnd);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
         return NULL;
     }
@@ -1676,8 +1694,10 @@ static PyObject *pythoncom_DoDragDrop(PyObject *, PyObject *args)
     }
     HRESULT hr;
     DWORD retEffect = 0;
-    Py_BEGIN_ALLOW_THREADS hr = ::DoDragDrop(dob, ds, effects, &retEffect);
-    Py_END_ALLOW_THREADS ds->Release();
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::DoDragDrop(dob, ds, effects, &retEffect);
+    Py_END_ALLOW_THREADS
+    ds->Release();
     dob->Release();
     if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
@@ -1694,9 +1714,10 @@ static PyObject *pythoncom_OleInitialize(PyObject *, PyObject *args)
     if (!PyArg_ParseTuple(args, ":OleInitialize"))
         return NULL;
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = ::OleInitialize(NULL);
-    Py_END_ALLOW_THREADS if (FAILED(hr))
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::OleInitialize(NULL);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
         return NULL;
     }
@@ -1728,9 +1749,10 @@ static PyObject *pythoncom_ObjectFromLresult(PyObject *self, PyObject *args)
 
     HRESULT hr;
     void *ret = 0;
-    Py_BEGIN_ALLOW_THREADS hr = ObjectFromLresult(lresult, iid, wparam, &ret);
-    Py_END_ALLOW_THREADS if (FAILED(hr))
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hr = ObjectFromLresult(lresult, iid, wparam, &ret);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
         return NULL;
     }
@@ -1796,8 +1818,11 @@ static PyObject *pythoncom_CoGetCallContext(PyObject *self, PyObject *args)
         return NULL;
 
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = CoGetCallContext(riid, &ret);
-    Py_END_ALLOW_THREADS if (FAILED(hr)) return PyCom_BuildPyException(hr);
+    Py_BEGIN_ALLOW_THREADS
+        hr = CoGetCallContext(riid, &ret);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr))
+        return PyCom_BuildPyException(hr);
     return PyCom_PyObjectFromIUnknown((IUnknown *)ret, riid, FALSE);
 }
 
@@ -1813,8 +1838,11 @@ static PyObject *pythoncom_CoGetObjectContext(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "|O&:CoGetObjectContext", PyWinObject_AsIID, &riid))
         return NULL;
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = CoGetObjectContext(riid, &ret);
-    Py_END_ALLOW_THREADS if (FAILED(hr)) return PyCom_BuildPyException(hr);
+    Py_BEGIN_ALLOW_THREADS
+        hr = CoGetObjectContext(riid, &ret);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr))
+        return PyCom_BuildPyException(hr);
     return PyCom_PyObjectFromIUnknown((IUnknown *)ret, riid, FALSE);
 }
 
@@ -1829,8 +1857,11 @@ static PyObject *pythoncom_CoGetCancelObject(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "|kO&:CoGetCancelObject", &tid, PyWinObject_AsIID, &riid))
         return NULL;
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = CoGetCancelObject(tid, riid, &ret);
-    Py_END_ALLOW_THREADS if (FAILED(hr)) return PyCom_BuildPyException(hr);
+    Py_BEGIN_ALLOW_THREADS
+        hr = CoGetCancelObject(tid, riid, &ret);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr))
+        return PyCom_BuildPyException(hr);
     return PyCom_PyObjectFromIUnknown((IUnknown *)ret, riid, FALSE);
 }
 
@@ -1848,8 +1879,11 @@ static PyObject *pythoncom_CoSetCancelObject(PyObject *self, PyObject *args)
         return NULL;
 
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = CoSetCancelObject(pUnk);
-    Py_END_ALLOW_THREADS if (FAILED(hr)) return PyCom_BuildPyException(hr);
+    Py_BEGIN_ALLOW_THREADS
+        hr = CoSetCancelObject(pUnk);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr))
+        return PyCom_BuildPyException(hr);
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -1859,8 +1893,11 @@ static PyObject *pythoncom_CoEnableCallCancellation(PyObject *self, PyObject *ar
 {
     // Only param is reserved
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = CoEnableCallCancellation(NULL);
-    Py_END_ALLOW_THREADS if (FAILED(hr)) return PyCom_BuildPyException(hr);
+    Py_BEGIN_ALLOW_THREADS
+        hr = CoEnableCallCancellation(NULL);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr))
+        return PyCom_BuildPyException(hr);
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -1870,8 +1907,11 @@ static PyObject *pythoncom_CoDisableCallCancellation(PyObject *self, PyObject *a
 {
     // Only param is reserved
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = CoDisableCallCancellation(NULL);
-    Py_END_ALLOW_THREADS if (FAILED(hr)) return PyCom_BuildPyException(hr);
+    Py_BEGIN_ALLOW_THREADS
+        hr = CoDisableCallCancellation(NULL);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr))
+        return PyCom_BuildPyException(hr);
     Py_INCREF(Py_None);
     return Py_None;
 }

--- a/com/win32com/src/PythonCOM.cpp
+++ b/com/win32com/src/PythonCOM.cpp
@@ -1428,17 +1428,18 @@ static PyObject *pythoncom_PumpWaitingMessages(PyObject *self, PyObject *args)
     long result = 0;
     // Read all of the messages in this next loop,
     // removing each message as we read it.
-    Py_BEGIN_ALLOW_THREADS while (PeekMessage(&msg, NULL, firstMsg, lastMsg, PM_REMOVE))
-    {
-        // If it's a quit message, we're out of here.
-        if (msg.message == WM_QUIT) {
-            result = 1;
-            break;
-        }
-        // Otherwise, dispatch the message.
-        DispatchMessage(&msg);
-    }  // End of PeekMessage while loop
-    Py_END_ALLOW_THREADS return PyLong_FromLong(result);
+    Py_BEGIN_ALLOW_THREADS
+        while (PeekMessage(&msg, NULL, firstMsg, lastMsg, PM_REMOVE)) {
+            // If it's a quit message, we're out of here.
+            if (msg.message == WM_QUIT) {
+                result = 1;
+                break;
+            }
+            // Otherwise, dispatch the message.
+            DispatchMessage(&msg);
+        }  // End of PeekMessage while loop
+    Py_END_ALLOW_THREADS
+    return PyLong_FromLong(result);
 }
 
 // @pymethod |pythoncom|PumpMessages|Pumps all messages for the current thread until a WM_QUIT message.
@@ -1446,12 +1447,14 @@ static PyObject *pythoncom_PumpMessages(PyObject *self, PyObject *args)
 {
     MSG msg;
     int rc;
-    Py_BEGIN_ALLOW_THREADS while ((rc = GetMessage(&msg, 0, 0, 0)) == 1)
-    {
-        TranslateMessage(&msg);  // needed?
-        DispatchMessage(&msg);
-    }
-    Py_END_ALLOW_THREADS if (rc == -1) return PyWin_SetAPIError("GetMessage");
+    Py_BEGIN_ALLOW_THREADS
+        while ((rc = GetMessage(&msg, 0, 0, 0)) == 1) {
+            TranslateMessage(&msg);  // needed?
+            DispatchMessage(&msg);
+        }
+    Py_END_ALLOW_THREADS
+    if (rc == -1)
+        return PyWin_SetAPIError("GetMessage");
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -1520,9 +1523,14 @@ static PyObject *pythoncom_CoWaitForMultipleHandles(PyObject *self, PyObject *ar
     DWORD index;
     PyObject *rc = NULL;
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = CoWaitForMultipleHandles(flags, timeout, numItems, pItems, &index);
-    Py_END_ALLOW_THREADS if (FAILED(hr)) { PyCom_BuildPyException(hr); }
-    else rc = PyLong_FromLong(index);
+    Py_BEGIN_ALLOW_THREADS
+        hr = CoWaitForMultipleHandles(flags, timeout, numItems, pItems, &index);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr)) {
+        PyCom_BuildPyException(hr);
+    }
+    else
+        rc = PyLong_FromLong(index);
     free(pItems);
     return rc;
 }
@@ -1535,9 +1543,10 @@ static PyObject *pythoncom_OleGetClipboard(PyObject *, PyObject *args)
         return NULL;
     IDataObject *pd = NULL;
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = ::OleGetClipboard(&pd);
-    Py_END_ALLOW_THREADS if (FAILED(hr))
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::OleGetClipboard(&pd);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
         return NULL;
     }
@@ -1557,8 +1566,11 @@ static PyObject *pythoncom_OleSetClipboard(PyObject *, PyObject *args)
     if (!PyCom_InterfaceFromPyObject(obd, IID_IDataObject, (void **)&pd, TRUE))
         return NULL;
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = ::OleSetClipboard(pd);
-    Py_END_ALLOW_THREADS if (pd) pd->Release();
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::OleSetClipboard(pd);
+    Py_END_ALLOW_THREADS
+    if (pd)
+        pd->Release();
     if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
         return NULL;
@@ -1579,8 +1591,10 @@ static PyObject *pythoncom_OleIsCurrentClipboard(PyObject *, PyObject *args)
     if (!PyCom_InterfaceFromPyObject(obd, IID_IDataObject, (void **)&pd, FALSE))
         return NULL;
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = ::OleIsCurrentClipboard(pd);
-    Py_END_ALLOW_THREADS pd->Release();
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::OleIsCurrentClipboard(pd);
+    Py_END_ALLOW_THREADS
+    pd->Release();
     if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
         return NULL;
@@ -1598,9 +1612,10 @@ static PyObject *pythoncom_OleFlushClipboard(PyObject *, PyObject *args)
         return NULL;
 
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = ::OleFlushClipboard();
-    Py_END_ALLOW_THREADS if (FAILED(hr))
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::OleFlushClipboard();
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
         return NULL;
     }
@@ -1626,8 +1641,10 @@ static PyObject *pythoncom_RegisterDragDrop(PyObject *, PyObject *args)
     if (!PyCom_InterfaceFromPyObject(obd, IID_IDropTarget, (void **)&dt, FALSE))
         return NULL;
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = ::RegisterDragDrop(hwnd, dt);
-    Py_END_ALLOW_THREADS dt->Release();
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::RegisterDragDrop(hwnd, dt);
+    Py_END_ALLOW_THREADS
+    dt->Release();
     if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
         return NULL;
@@ -1649,9 +1666,10 @@ static PyObject *pythoncom_RevokeDragDrop(PyObject *, PyObject *args)
     if (!PyWinObject_AsHANDLE(obhwnd, (HANDLE *)&hwnd))
         return NULL;
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = ::RevokeDragDrop(hwnd);
-    Py_END_ALLOW_THREADS if (FAILED(hr))
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::RevokeDragDrop(hwnd);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
         return NULL;
     }
@@ -1676,8 +1694,10 @@ static PyObject *pythoncom_DoDragDrop(PyObject *, PyObject *args)
     }
     HRESULT hr;
     DWORD retEffect = 0;
-    Py_BEGIN_ALLOW_THREADS hr = ::DoDragDrop(dob, ds, effects, &retEffect);
-    Py_END_ALLOW_THREADS ds->Release();
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::DoDragDrop(dob, ds, effects, &retEffect);
+    Py_END_ALLOW_THREADS
+    ds->Release();
     dob->Release();
     if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
@@ -1694,9 +1714,10 @@ static PyObject *pythoncom_OleInitialize(PyObject *, PyObject *args)
     if (!PyArg_ParseTuple(args, ":OleInitialize"))
         return NULL;
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = ::OleInitialize(NULL);
-    Py_END_ALLOW_THREADS if (FAILED(hr))
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::OleInitialize(NULL);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
         return NULL;
     }
@@ -1728,9 +1749,10 @@ static PyObject *pythoncom_ObjectFromLresult(PyObject *self, PyObject *args)
 
     HRESULT hr;
     void *ret = 0;
-    Py_BEGIN_ALLOW_THREADS hr = ObjectFromLresult(lresult, iid, wparam, &ret);
-    Py_END_ALLOW_THREADS if (FAILED(hr))
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hr = ObjectFromLresult(lresult, iid, wparam, &ret);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
         return NULL;
     }
@@ -1794,8 +1816,11 @@ static PyObject *pythoncom_CoGetCallContext(PyObject *self, PyObject *args)
         return NULL;
 
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = CoGetCallContext(riid, &ret);
-    Py_END_ALLOW_THREADS if (FAILED(hr)) return PyCom_BuildPyException(hr);
+    Py_BEGIN_ALLOW_THREADS
+        hr = CoGetCallContext(riid, &ret);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr))
+        return PyCom_BuildPyException(hr);
     return PyCom_PyObjectFromIUnknown((IUnknown *)ret, riid, FALSE);
 }
 
@@ -1811,8 +1836,11 @@ static PyObject *pythoncom_CoGetObjectContext(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "|O&:CoGetObjectContext", PyWinObject_AsIID, &riid))
         return NULL;
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = CoGetObjectContext(riid, &ret);
-    Py_END_ALLOW_THREADS if (FAILED(hr)) return PyCom_BuildPyException(hr);
+    Py_BEGIN_ALLOW_THREADS
+        hr = CoGetObjectContext(riid, &ret);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr))
+        return PyCom_BuildPyException(hr);
     return PyCom_PyObjectFromIUnknown((IUnknown *)ret, riid, FALSE);
 }
 
@@ -1827,8 +1855,11 @@ static PyObject *pythoncom_CoGetCancelObject(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "|kO&:CoGetCancelObject", &tid, PyWinObject_AsIID, &riid))
         return NULL;
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = CoGetCancelObject(tid, riid, &ret);
-    Py_END_ALLOW_THREADS if (FAILED(hr)) return PyCom_BuildPyException(hr);
+    Py_BEGIN_ALLOW_THREADS
+        hr = CoGetCancelObject(tid, riid, &ret);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr))
+        return PyCom_BuildPyException(hr);
     return PyCom_PyObjectFromIUnknown((IUnknown *)ret, riid, FALSE);
 }
 
@@ -1846,8 +1877,11 @@ static PyObject *pythoncom_CoSetCancelObject(PyObject *self, PyObject *args)
         return NULL;
 
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = CoSetCancelObject(pUnk);
-    Py_END_ALLOW_THREADS if (FAILED(hr)) return PyCom_BuildPyException(hr);
+    Py_BEGIN_ALLOW_THREADS
+        hr = CoSetCancelObject(pUnk);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr))
+        return PyCom_BuildPyException(hr);
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -1857,8 +1891,11 @@ static PyObject *pythoncom_CoEnableCallCancellation(PyObject *self, PyObject *ar
 {
     // Only param is reserved
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = CoEnableCallCancellation(NULL);
-    Py_END_ALLOW_THREADS if (FAILED(hr)) return PyCom_BuildPyException(hr);
+    Py_BEGIN_ALLOW_THREADS
+        hr = CoEnableCallCancellation(NULL);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr))
+        return PyCom_BuildPyException(hr);
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -1868,8 +1905,11 @@ static PyObject *pythoncom_CoDisableCallCancellation(PyObject *self, PyObject *a
 {
     // Only param is reserved
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = CoDisableCallCancellation(NULL);
-    Py_END_ALLOW_THREADS if (FAILED(hr)) return PyCom_BuildPyException(hr);
+    Py_BEGIN_ALLOW_THREADS
+        hr = CoDisableCallCancellation(NULL);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr))
+        return PyCom_BuildPyException(hr);
     Py_INCREF(Py_None);
     return Py_None;
 }

--- a/com/win32com/src/extensions/PyGEnumVariant.cpp
+++ b/com/win32com/src/extensions/PyGEnumVariant.cpp
@@ -96,11 +96,12 @@ STDMETHODIMP PyGEnumVARIANT::Clone(
     ** Get the interface we want. note it is returned with a refcount.
     ** This QI is actually going to instantiate a PyGEnumVARIANT.
     */
-    Py_BEGIN_ALLOW_THREADS hr = punk->QueryInterface(IID_IEnumVARIANT, (LPVOID *)ppEnum);
+    Py_BEGIN_ALLOW_THREADS
+        hr = punk->QueryInterface(IID_IEnumVARIANT, (LPVOID *)ppEnum);
     Py_END_ALLOW_THREADS
 
-        /* done with the result; this DECREF is also for <punk> */
-        Py_DECREF(result);
+    /* done with the result; this DECREF is also for <punk> */
+    Py_DECREF(result);
 
     return PyCom_SetCOMErrorFromSimple(hr, IID_IEnumVARIANT);
 }

--- a/com/win32com/src/extensions/PyIEnumConnectionPoints.cpp
+++ b/com/win32com/src/extensions/PyIEnumConnectionPoints.cpp
@@ -241,11 +241,12 @@ STDMETHODIMP PyGEnumConnectionPoints::Clone(
     ** Get the interface we want. note it is returned with a refcount.
     ** This QI is actually going to instantiate a PyGEnumConnections.
     */
-    Py_BEGIN_ALLOW_THREADS hr = punk->QueryInterface(IID_IEnumConnectionPoints, (LPVOID *)ppEnum);
+    Py_BEGIN_ALLOW_THREADS
+        hr = punk->QueryInterface(IID_IEnumConnectionPoints, (LPVOID *)ppEnum);
     Py_END_ALLOW_THREADS
 
-        /* done with the result; this DECREF is also for <punk> */
-        Py_DECREF(result);
+    /* done with the result; this DECREF is also for <punk> */
+    Py_DECREF(result);
 
     return PyCom_SetCOMErrorFromSimple(hr, IID_IEnumConnectionPoints);
 }

--- a/com/win32com/src/extensions/PyIEnumConnections.cpp
+++ b/com/win32com/src/extensions/PyIEnumConnections.cpp
@@ -237,11 +237,12 @@ STDMETHODIMP PyGEnumConnections::Clone(
     ** Get the interface we want. note it is returned with a refcount.
     ** This QI is actually going to instantiate a PyGEnumConnections.
     */
-    Py_BEGIN_ALLOW_THREADS hr = punk->QueryInterface(IID_IEnumConnections, (LPVOID *)ppEnum);
+    Py_BEGIN_ALLOW_THREADS
+        hr = punk->QueryInterface(IID_IEnumConnections, (LPVOID *)ppEnum);
     Py_END_ALLOW_THREADS
 
-        /* done with the result; this DECREF is also for <punk> */
-        Py_DECREF(result);
+    /* done with the result; this DECREF is also for <punk> */
+    Py_DECREF(result);
 
     return PyCom_SetCOMErrorFromSimple(hr, IID_IEnumConnections);
 }

--- a/com/win32com/src/extensions/PyIEnumFORMATETC.cpp
+++ b/com/win32com/src/extensions/PyIEnumFORMATETC.cpp
@@ -237,11 +237,12 @@ STDMETHODIMP PyGEnumFORMATETC::Clone(
     ** Get the interface we want. note it is returned with a refcount.
     ** This QI is actually going to instantiate a PyGEnumFORMATETC.
     */
-    Py_BEGIN_ALLOW_THREADS hr = punk->QueryInterface(IID_IEnumFORMATETC, (LPVOID *)ppEnum);
+    Py_BEGIN_ALLOW_THREADS
+        hr = punk->QueryInterface(IID_IEnumFORMATETC, (LPVOID *)ppEnum);
     Py_END_ALLOW_THREADS
 
-        /* done with the result; this DECREF is also for <punk> */
-        Py_DECREF(result);
+    /* done with the result; this DECREF is also for <punk> */
+    Py_DECREF(result);
 
     return PyCom_CheckIEnumNextResult(hr, IID_IEnumFORMATETC);
 }

--- a/com/win32com/src/extensions/PyIEnumGUID.cpp
+++ b/com/win32com/src/extensions/PyIEnumGUID.cpp
@@ -200,11 +200,12 @@ STDMETHODIMP PyGEnumGUID::Clone(IEnumGUID __RPC_FAR *__RPC_FAR *ppEnum)
         return PyCom_SetCOMErrorFromSimple(E_FAIL, IID_IEnumGUID);
     }
 
-    Py_BEGIN_ALLOW_THREADS hr = punk->QueryInterface(IID_IEnumGUID, (LPVOID *)ppEnum);
+    Py_BEGIN_ALLOW_THREADS
+        hr = punk->QueryInterface(IID_IEnumGUID, (LPVOID *)ppEnum);
     Py_END_ALLOW_THREADS
 
-        // done with the result; this DECREF is also for <punk>
-        Py_DECREF(result);
+    // done with the result; this DECREF is also for <punk>
+    Py_DECREF(result);
 
     return PyCom_SetCOMErrorFromSimple(hr, IID_IEnumGUID);
 }

--- a/com/win32com/src/extensions/PyIEnumSTATSTG.cpp
+++ b/com/win32com/src/extensions/PyIEnumSTATSTG.cpp
@@ -239,11 +239,12 @@ STDMETHODIMP PyGEnumSTATSTG::Clone(
     ** Get the interface we want. note it is returned with a refcount.
     ** This QI is actually going to instantiate a PyGEnumSTATSTG.
     */
-    Py_BEGIN_ALLOW_THREADS hr = punk->QueryInterface(IID_IEnumSTATSTG, (LPVOID *)ppEnum);
+    Py_BEGIN_ALLOW_THREADS
+        hr = punk->QueryInterface(IID_IEnumSTATSTG, (LPVOID *)ppEnum);
     Py_END_ALLOW_THREADS
 
-        /* done with the result; this DECREF is also for <punk> */
-        Py_DECREF(result);
+    /* done with the result; this DECREF is also for <punk> */
+    Py_DECREF(result);
 
     return PyCom_SetCOMErrorFromSimple(hr, IID_IEnumSTATSTG);
 }

--- a/com/win32com/src/extensions/PyIEnumString.cpp
+++ b/com/win32com/src/extensions/PyIEnumString.cpp
@@ -216,11 +216,12 @@ STDMETHODIMP PyGEnumString::Clone(IEnumString __RPC_FAR *__RPC_FAR *ppEnum)
         return PyCom_SetCOMErrorFromSimple(E_FAIL, IID_IEnumString);
     }
 
-    Py_BEGIN_ALLOW_THREADS hr = punk->QueryInterface(IID_IEnumString, (LPVOID *)ppEnum);
+    Py_BEGIN_ALLOW_THREADS
+        hr = punk->QueryInterface(IID_IEnumString, (LPVOID *)ppEnum);
     Py_END_ALLOW_THREADS
 
-        // done with the result; this DECREF is also for <punk>
-        Py_DECREF(result);
+    // done with the result; this DECREF is also for <punk>
+    Py_DECREF(result);
 
     return PyCom_SetCOMErrorFromSimple(hr, IID_IEnumString);
 }

--- a/com/win32com/src/univgw.cpp
+++ b/com/win32com/src/univgw.cpp
@@ -56,9 +56,10 @@ static void set_error(REFIID riid, LPCOLESTR desc)
         pICEI->SetDescription(b);
 
         IErrorInfo *pIEI;
-        Py_BEGIN_ALLOW_THREADS hr = pICEI->QueryInterface(IID_IErrorInfo, (LPVOID *)&pIEI);
-        Py_END_ALLOW_THREADS if (SUCCEEDED(hr))
-        {
+        Py_BEGIN_ALLOW_THREADS
+            hr = pICEI->QueryInterface(IID_IErrorInfo, (LPVOID *)&pIEI);
+        Py_END_ALLOW_THREADS
+        if (SUCCEEDED(hr)) {
             SetErrorInfo(0, pIEI);
             pIEI->Release();
         }

--- a/com/win32comext/adsi/src/PyIADs.cpp
+++ b/com/win32comext/adsi/src/PyIADs.cpp
@@ -262,19 +262,28 @@ PyObject *PyIADs_getattro(PyObject *ob, PyObject *obname)
         // allow both
         // @prop <o PyUnicode>|ADsPath|
         // @prop <o PyUnicode>|AdsPath|Synonym for ADsPath
-        if (strcmp(name, "AdsPath") == 0 || strcmp(name, "ADsPath") == 0) hr = p->get_ADsPath(&ret);
-    // @prop <o PyUnicode>|Class|
-    else if (strcmp(name, "Class") == 0) hr = p->get_Class(&ret);
-    // @prop <o PyUnicode>|GUID|Like the IADs method, this returns a string rather than a GUID object.
-    else if (strcmp(name, "GUID") == 0) hr = p->get_GUID(&ret);
-    // @prop <o PyUnicode>|Name|
-    else if (strcmp(name, "Name") == 0) hr = p->get_Name(&ret);
-    // @prop <o PyUnicode>|Parent|
-    else if (strcmp(name, "Parent") == 0) hr = p->get_Parent(&ret);
-    // @prop <o PyUnicode>|Schema|
-    else if (strcmp(name, "Schema") == 0) hr = p->get_Schema(&ret);
-    else bad = TRUE;
-    Py_END_ALLOW_THREADS if (bad) return PyIBase::getattro(ob, obname);
+        if (strcmp(name, "AdsPath") == 0 || strcmp(name, "ADsPath") == 0)
+            hr = p->get_ADsPath(&ret);
+        // @prop <o PyUnicode>|Class|
+        else if (strcmp(name, "Class") == 0)
+            hr = p->get_Class(&ret);
+        // @prop <o PyUnicode>|GUID|Like the IADs method, this returns a string rather than a GUID object.
+        else if (strcmp(name, "GUID") == 0)
+            hr = p->get_GUID(&ret);
+        // @prop <o PyUnicode>|Name|
+        else if (strcmp(name, "Name") == 0)
+            hr = p->get_Name(&ret);
+        // @prop <o PyUnicode>|Parent|
+        else if (strcmp(name, "Parent") == 0)
+            hr = p->get_Parent(&ret);
+        // @prop <o PyUnicode>|Schema|
+        else if (strcmp(name, "Schema") == 0)
+            hr = p->get_Schema(&ret);
+        else
+            bad = TRUE;
+    Py_END_ALLOW_THREADS
+    if (bad)
+        return PyIBase::getattro(ob, obname);
     if (FAILED(hr))
         return PyCom_BuildPyException(hr, p, IID_IADs);
     PyObject *rc = MakeBstrToObj(ret);

--- a/com/win32comext/adsi/src/adsi.i
+++ b/com/win32comext/adsi/src/adsi.i
@@ -75,9 +75,9 @@ static PyObject *PyADsOpenObject(PyObject *self, PyObject *args)
 		goto done;
 	if (!PyWinObject_AsWCHAR(obPassword, &password, TRUE))
 		goto done;
-	Py_BEGIN_ALLOW_THREADS;
+	Py_BEGIN_ALLOW_THREADS
 	hr = ADsOpenObject(path, userName, password, (DWORD)lres, iid, (void **)&pOb);
-	Py_END_ALLOW_THREADS;
+	Py_END_ALLOW_THREADS
 	if (FAILED(hr))
 		ret = OleSetADSIError(hr, NULL, IID_NULL);
 	else
@@ -109,9 +109,9 @@ static PyObject *PyADsGetObject(PyObject *self, PyObject *args)
 		goto done;
 	if (!PyWinObject_AsWCHAR(obPath, &path, FALSE))
 		goto done;
-	Py_BEGIN_ALLOW_THREADS;
+	Py_BEGIN_ALLOW_THREADS
 	hr = ADsGetObject(path, iid, (void **)&pOb);
-	Py_END_ALLOW_THREADS;
+	Py_END_ALLOW_THREADS
 	if (FAILED(hr))
 		ret = OleSetADSIError(hr, NULL, IID_NULL);
 	else
@@ -149,10 +149,10 @@ static PyObject *PyADsBuildEnumerator(PyObject *self, PyObject *args)
 	if (!PyCom_InterfaceFromPyInstanceOrObject(obCont, IID_IADsContainer, (void **)&pC, FALSE))
 		return NULL;
 	IEnumVARIANT *pev;
-	Py_BEGIN_ALLOW_THREADS;
+	Py_BEGIN_ALLOW_THREADS
 	hr = ADsBuildEnumerator(pC, &pev);
 	pC->Release();
-	Py_END_ALLOW_THREADS;
+	Py_END_ALLOW_THREADS
 	if (FAILED(hr))
 		ret = OleSetADSIError(hr, NULL, IID_NULL);
 	else

--- a/com/win32comext/authorization/src/authorization.cpp
+++ b/com/win32comext/authorization/src/authorization.cpp
@@ -23,8 +23,9 @@ static PyObject *PyEditSecurity(PyObject *self, PyObject *args, PyObject *kwargs
     if (!PyCom_InterfaceFromPyObject(obisi, IID_ISecurityInformation, (void **)&isi, FALSE))
         return NULL;
 
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = EditSecurity(hwnd, isi);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        bsuccess = EditSecurity(hwnd, isi);
     Py_END_ALLOW_THREADS;
     if (!bsuccess)
         ret = PyWin_SetAPIError("EditSecurity");

--- a/com/win32comext/authorization/src/authorization.cpp
+++ b/com/win32comext/authorization/src/authorization.cpp
@@ -23,9 +23,9 @@ static PyObject *PyEditSecurity(PyObject *self, PyObject *args, PyObject *kwargs
     if (!PyCom_InterfaceFromPyObject(obisi, IID_ISecurityInformation, (void **)&isi, FALSE))
         return NULL;
 
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = EditSecurity(hwnd, isi);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = EditSecurity(hwnd, isi);
+    Py_END_ALLOW_THREADS
     if (!bsuccess)
         ret = PyWin_SetAPIError("EditSecurity");
     else {

--- a/com/win32comext/axcontrol/src/AXControl.cpp
+++ b/com/win32comext/axcontrol/src/AXControl.cpp
@@ -251,9 +251,10 @@ static PyObject *axcontrol_OleLoadPicture(PyObject *, PyObject *args)
         if (!PyWinObject_AsIID(obIIDRet, &iidRet))
             goto done;
     }
-    Py_BEGIN_ALLOW_THREADS hr = ::OleLoadPicture(pStream, size, runMode, iidAPI, (LPVOID *)&pUnk);
-    Py_END_ALLOW_THREADS if (FAILED(hr))
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::OleLoadPicture(pStream, size, runMode, iidAPI, (LPVOID *)&pUnk);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
         goto done;
     }
@@ -302,10 +303,10 @@ static PyObject *axcontrol_OleLoadPicturePath(PyObject *, PyObject *args)
         if (!PyWinObject_AsIID(obIIDRet, &iidRet))
             goto done;
     }
-    Py_BEGIN_ALLOW_THREADS hr =
-        ::OleLoadPicturePath(szPath, pUnkIn, (DWORD)reserved, (OLE_COLOR)clr, iidAPI, (LPVOID *)&pUnkRet);
-    Py_END_ALLOW_THREADS if (FAILED(hr))
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::OleLoadPicturePath(szPath, pUnkIn, (DWORD)reserved, (OLE_COLOR)clr, iidAPI, (LPVOID *)&pUnkRet);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
         goto done;
     }
@@ -335,9 +336,10 @@ static PyObject *axcontrol_OleSetContainedObject(PyObject *, PyObject *args)
     if (!PyCom_InterfaceFromPyInstanceOrObject(obunk, IID_IUnknown, (void **)&punk, FALSE))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS hr = ::OleSetContainedObject(punk, fContained);
-    Py_END_ALLOW_THREADS if (FAILED(hr))
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::OleSetContainedObject(punk, fContained);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
         goto done;
     }
@@ -371,9 +373,10 @@ static PyObject *axcontrol_OleTranslateAccelerator(PyObject *, PyObject *args)
     MSG msg;
     if (!PyWinObject_AsMSG(obmsg, &msg))
         goto done;
-    Py_BEGIN_ALLOW_THREADS hr = ::OleTranslateAccelerator(pframe, &info, &msg);
-    Py_END_ALLOW_THREADS if (FAILED(hr))
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::OleTranslateAccelerator(pframe, &info, &msg);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
         goto done;
     }

--- a/com/win32comext/axdebug/src/PyIEnumDebugApplicationNodes.cpp
+++ b/com/win32comext/axdebug/src/PyIEnumDebugApplicationNodes.cpp
@@ -247,11 +247,12 @@ STDMETHODIMP PyGEnumDebugApplicationNodes::Clone(
     ** Get the interface we want. note it is returned with a refcount.
     ** This QI is actually going to instantiate a PyGEnumDebugApplicationNodes.
     */
-    Py_BEGIN_ALLOW_THREADS hr = punk->QueryInterface(IID_IEnumDebugApplicationNodes, (LPVOID *)ppEnum);
+    Py_BEGIN_ALLOW_THREADS
+        hr = punk->QueryInterface(IID_IEnumDebugApplicationNodes, (LPVOID *)ppEnum);
     Py_END_ALLOW_THREADS
 
-        /* done with the result; this DECREF is also for <punk> */
-        Py_DECREF(result);
+    /* done with the result; this DECREF is also for <punk> */
+    Py_DECREF(result);
 
     return PyCom_SetCOMErrorFromSimple(hr, IID_IEnumDebugApplicationNodes);
 }

--- a/com/win32comext/axdebug/src/PyIEnumDebugCodeContexts.cpp
+++ b/com/win32comext/axdebug/src/PyIEnumDebugCodeContexts.cpp
@@ -245,11 +245,12 @@ STDMETHODIMP PyGEnumDebugCodeContexts::Clone(
     ** Get the interface we want. note it is returned with a refcount.
     ** This QI is actually going to instantiate a PyGEnumDebugCodeContexts.
     */
-    Py_BEGIN_ALLOW_THREADS hr = punk->QueryInterface(IID_IEnumDebugCodeContexts, (LPVOID *)ppEnum);
+    Py_BEGIN_ALLOW_THREADS
+        hr = punk->QueryInterface(IID_IEnumDebugCodeContexts, (LPVOID *)ppEnum);
     Py_END_ALLOW_THREADS
 
-        /* done with the result; this DECREF is also for <punk> */
-        Py_DECREF(result);
+    /* done with the result; this DECREF is also for <punk> */
+    Py_DECREF(result);
 
     return PyCom_SetCOMErrorFromSimple(hr, IID_IEnumDebugCodeContexts);
 }

--- a/com/win32comext/axdebug/src/PyIEnumDebugExpressionContexts.cpp
+++ b/com/win32comext/axdebug/src/PyIEnumDebugExpressionContexts.cpp
@@ -244,11 +244,12 @@ STDMETHODIMP PyGEnumDebugExpressionContexts::Clone(
     ** Get the interface we want. note it is returned with a refcount.
     ** This QI is actually going to instantiate a PyGEnumDebugExpressionContexts.
     */
-    Py_BEGIN_ALLOW_THREADS hr = punk->QueryInterface(IID_IEnumDebugExpressionContexts, (LPVOID *)ppEnum);
+    Py_BEGIN_ALLOW_THREADS
+        hr = punk->QueryInterface(IID_IEnumDebugExpressionContexts, (LPVOID *)ppEnum);
     Py_END_ALLOW_THREADS
 
-        /* done with the result; this DECREF is also for <punk> */
-        Py_DECREF(result);
+    /* done with the result; this DECREF is also for <punk> */
+    Py_DECREF(result);
 
     return PyCom_SetCOMErrorFromSimple(hr, IID_IEnumDebugExpressionContexts);
 }

--- a/com/win32comext/axdebug/src/PyIEnumDebugPropertyInfo.cpp
+++ b/com/win32comext/axdebug/src/PyIEnumDebugPropertyInfo.cpp
@@ -264,11 +264,12 @@ STDMETHODIMP PyGEnumDebugPropertyInfo::Clone(
     ** Get the interface we want. note it is returned with a refcount.
     ** This QI is actually going to instantiate a PyGEnumDebugPropertyInfo.
     */
-    Py_BEGIN_ALLOW_THREADS hr = punk->QueryInterface(IID_IEnumDebugPropertyInfo, (LPVOID *)ppEnum);
+    Py_BEGIN_ALLOW_THREADS
+        hr = punk->QueryInterface(IID_IEnumDebugPropertyInfo, (LPVOID *)ppEnum);
     Py_END_ALLOW_THREADS
 
-        /* done with the result; this DECREF is also for <punk> */
-        Py_DECREF(result);
+    /* done with the result; this DECREF is also for <punk> */
+    Py_DECREF(result);
 
     return PyCom_CheckIEnumNextResult(hr, IID_IEnumDebugPropertyInfo);
 }

--- a/com/win32comext/axdebug/src/PyIEnumDebugStackFrames.cpp
+++ b/com/win32comext/axdebug/src/PyIEnumDebugStackFrames.cpp
@@ -263,11 +263,12 @@ STDMETHODIMP PyGEnumDebugStackFrames::Clone(
     ** Get the interface we want. note it is returned with a refcount.
     ** This QI is actually going to instantiate a PyGEnumDebugStackFrames.
     */
-    Py_BEGIN_ALLOW_THREADS hr = punk->QueryInterface(IID_IEnumDebugStackFrames, (LPVOID *)ppEnum);
+    Py_BEGIN_ALLOW_THREADS
+        hr = punk->QueryInterface(IID_IEnumDebugStackFrames, (LPVOID *)ppEnum);
     Py_END_ALLOW_THREADS
 
-        /* done with the result; this DECREF is also for <punk> */
-        Py_DECREF(result);
+    /* done with the result; this DECREF is also for <punk> */
+    Py_DECREF(result);
 
     return PyCom_SetCOMErrorFromSimple(hr, IID_IEnumDebugStackFrames);
 }

--- a/com/win32comext/axdebug/src/PyIEnumRemoteDebugApplicationThreads.cpp
+++ b/com/win32comext/axdebug/src/PyIEnumRemoteDebugApplicationThreads.cpp
@@ -251,11 +251,12 @@ STDMETHODIMP PyGEnumRemoteDebugApplicationThreads::Clone(
     ** Get the interface we want. note it is returned with a refcount.
     ** This QI is actually going to instantiate a PyGEnumRemoteDebugApplicationThreads.
     */
-    Py_BEGIN_ALLOW_THREADS hr = punk->QueryInterface(IID_IEnumRemoteDebugApplicationThreads, (LPVOID *)ppEnum);
+    Py_BEGIN_ALLOW_THREADS
+        hr = punk->QueryInterface(IID_IEnumRemoteDebugApplicationThreads, (LPVOID *)ppEnum);
     Py_END_ALLOW_THREADS
 
-        /* done with the result; this DECREF is also for <punk> */
-        Py_DECREF(result);
+    /* done with the result; this DECREF is also for <punk> */
+    Py_DECREF(result);
 
     return PyCom_SetCOMErrorFromSimple(hr, IID_IEnumRemoteDebugApplicationThreads);
 }

--- a/com/win32comext/axdebug/src/PyIEnumRemoteDebugApplications.cpp
+++ b/com/win32comext/axdebug/src/PyIEnumRemoteDebugApplications.cpp
@@ -248,11 +248,12 @@ STDMETHODIMP PyGEnumRemoteDebugApplications::Clone(
     ** Get the interface we want. note it is returned with a refcount.
     ** This QI is actually going to instantiate a PyGEnumRemoteDebugApplications.
     */
-    Py_BEGIN_ALLOW_THREADS hr = punk->QueryInterface(IID_IEnumRemoteDebugApplications, (LPVOID *)ppEnum);
+    Py_BEGIN_ALLOW_THREADS
+        hr = punk->QueryInterface(IID_IEnumRemoteDebugApplications, (LPVOID *)ppEnum);
     Py_END_ALLOW_THREADS
 
-        /* done with the result; this DECREF is also for <punk> */
-        Py_DECREF(result);
+    /* done with the result; this DECREF is also for <punk> */
+    Py_DECREF(result);
 
     return PyCom_SetCOMErrorFromSimple(hr, IID_IEnumRemoteDebugApplications);
 }

--- a/com/win32comext/axscript/src/PyIActiveScript.cpp
+++ b/com/win32comext/axscript/src/PyIActiveScript.cpp
@@ -28,8 +28,11 @@ PyIActiveScript::~PyIActiveScript() {}
 
     IActiveScriptSite *pIASS;
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = punk->QueryInterface(IID_IActiveScriptSite, (LPVOID *)&pIASS);
-    Py_END_ALLOW_THREADS if (FAILED(hr)) return SetPythonCOMError(self, hr);
+    Py_BEGIN_ALLOW_THREADS
+        hr = punk->QueryInterface(IID_IActiveScriptSite, (LPVOID *)&pIASS);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr))
+        return SetPythonCOMError(self, hr);
 
     PY_INTERFACE_PRECALL;
     hr = pIAS->SetScriptSite(pIASS);

--- a/com/win32comext/directsound/src/directsound.cpp
+++ b/com/win32comext/directsound/src/directsound.cpp
@@ -53,9 +53,10 @@ static PyObject *directsound_DirectSoundCreate(PyObject *, PyObject *args)
         pguid = &guid;
     }
 
-    Py_BEGIN_ALLOW_THREADS hr = ::DirectSoundCreate(pguid, &ds, pUnkIn);
-    Py_END_ALLOW_THREADS if (FAILED(hr))
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::DirectSoundCreate(pguid, &ds, pUnkIn);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
         goto done;
     }
@@ -115,11 +116,11 @@ static PyObject *directsound_DirectSoundEnumerate(PyObject *, PyObject *args)
     }
 
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = ::DirectSoundEnumerate(dsEnumCallback, list);
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::DirectSoundEnumerate(dsEnumCallback, list);
     Py_END_ALLOW_THREADS
 
-        if (PyErr_Occurred())
-    {
+    if (PyErr_Occurred()) {
         Py_DECREF(list);
         return NULL;
     }
@@ -165,9 +166,10 @@ static PyObject *directsound_DirectSoundCaptureCreate(PyObject *, PyObject *args
         pguid = &guid;
     }
 
-    Py_BEGIN_ALLOW_THREADS hr = ::DirectSoundCaptureCreate(pguid, &dsc, pUnkIn);
-    Py_END_ALLOW_THREADS if (FAILED(hr))
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::DirectSoundCaptureCreate(pguid, &dsc, pUnkIn);
+    Py_END_ALLOW_THREADS
+    if (FAILED(hr)) {
         PyCom_BuildPyException(hr);
         goto done;
     }
@@ -193,11 +195,11 @@ static PyObject *directsound_DirectSoundCaptureEnumerate(PyObject *, PyObject *a
     }
 
     HRESULT hr;
-    Py_BEGIN_ALLOW_THREADS hr = ::DirectSoundCaptureEnumerate(dsEnumCallback, list);
+    Py_BEGIN_ALLOW_THREADS
+        hr = ::DirectSoundCaptureEnumerate(dsEnumCallback, list);
     Py_END_ALLOW_THREADS
 
-        if (PyErr_Occurred())
-    {
+    if (PyErr_Occurred()) {
         Py_DECREF(list);
         return NULL;
     }

--- a/com/win32comext/ifilter/src/PyIFilter.cpp
+++ b/com/win32comext/ifilter/src/PyIFilter.cpp
@@ -163,8 +163,9 @@ static PyObject *pyLoadIFilter(PyObject *self, PyObject *args)
     if (!PyWinObject_AsWCHAR(obPath, &path, FALSE))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS;
-    hr = LoadIFilter(path, NULL, (void **)&pOb);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        hr = LoadIFilter(path, NULL, (void **)&pOb);
     Py_END_ALLOW_THREADS;
     if (FAILED(hr))
         ret = OleSetOleError(hr);
@@ -195,9 +196,10 @@ static PyObject *pyBindIFilterFromStorage(PyObject *self, PyObject *args)
     if (!bPythonIsHappy)
         return NULL;
 
-    Py_BEGIN_ALLOW_THREADS;
-    hr = BindIFilterFromStorage(pstgDest, NULL, (void **)&pOb);
-    pstgDest->Release();
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        hr = BindIFilterFromStorage(pstgDest, NULL, (void **)&pOb);
+        pstgDest->Release();
     Py_END_ALLOW_THREADS;
     if (FAILED(hr))
         ret = OleSetOleError(hr);
@@ -227,9 +229,10 @@ static PyObject *pyBindIFilterFromStream(PyObject *self, PyObject *args)
     if (!bPythonIsHappy)
         return NULL;
 
-    Py_BEGIN_ALLOW_THREADS;
-    hr = BindIFilterFromStream(pstm, NULL, (void **)&pOb);
-    pstm->Release();
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        hr = BindIFilterFromStream(pstm, NULL, (void **)&pOb);
+        pstm->Release();
     Py_END_ALLOW_THREADS;
     if (FAILED(hr))
         ret = OleSetOleError(hr);

--- a/com/win32comext/ifilter/src/PyIFilter.cpp
+++ b/com/win32comext/ifilter/src/PyIFilter.cpp
@@ -163,9 +163,9 @@ static PyObject *pyLoadIFilter(PyObject *self, PyObject *args)
     if (!PyWinObject_AsWCHAR(obPath, &path, FALSE))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS;
-    hr = LoadIFilter(path, NULL, (void **)&pOb);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        hr = LoadIFilter(path, NULL, (void **)&pOb);
+    Py_END_ALLOW_THREADS
     if (FAILED(hr))
         ret = OleSetOleError(hr);
 
@@ -195,10 +195,10 @@ static PyObject *pyBindIFilterFromStorage(PyObject *self, PyObject *args)
     if (!bPythonIsHappy)
         return NULL;
 
-    Py_BEGIN_ALLOW_THREADS;
-    hr = BindIFilterFromStorage(pstgDest, NULL, (void **)&pOb);
-    pstgDest->Release();
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        hr = BindIFilterFromStorage(pstgDest, NULL, (void **)&pOb);
+        pstgDest->Release();
+    Py_END_ALLOW_THREADS
     if (FAILED(hr))
         ret = OleSetOleError(hr);
 
@@ -227,10 +227,10 @@ static PyObject *pyBindIFilterFromStream(PyObject *self, PyObject *args)
     if (!bPythonIsHappy)
         return NULL;
 
-    Py_BEGIN_ALLOW_THREADS;
-    hr = BindIFilterFromStream(pstm, NULL, (void **)&pOb);
-    pstm->Release();
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        hr = BindIFilterFromStream(pstm, NULL, (void **)&pOb);
+        pstm->Release();
+    Py_END_ALLOW_THREADS
     if (FAILED(hr))
         ret = OleSetOleError(hr);
     else

--- a/com/win32comext/mapi/src/PyIProfAdmin.i
+++ b/com/win32comext/mapi/src/PyIProfAdmin.i
@@ -134,9 +134,9 @@ PyObject *PyIProfAdmin::DeleteProfile(PyObject *self, PyObject *args)
 	if (!PyWinObject_AsMAPIStr(obProfileName, &lpszProfileName, ulFlags & MAPI_UNICODE, FALSE))
 		return NULL;
 
-	Py_BEGIN_ALLOW_THREADS;
+	Py_BEGIN_ALLOW_THREADS
 	hRes = _swig_self->DeleteProfile(lpszProfileName, ulFlags);
-	Py_END_ALLOW_THREADS;
+	Py_END_ALLOW_THREADS
 
 	PyWinObject_FreeMAPIStr(lpszProfileName, ulFlags & MAPI_UNICODE);
 	if (FAILED(hRes))

--- a/com/win32comext/shell/src/PyIEnumIDList.cpp
+++ b/com/win32comext/shell/src/PyIEnumIDList.cpp
@@ -237,11 +237,12 @@ STDMETHODIMP PyGEnumIDList::Clone(
     ** Get the interface we want. note it is returned with a refcount.
     ** This QI is actually going to instantiate a PyGEnumIDList.
     */
-    Py_BEGIN_ALLOW_THREADS hr = punk->QueryInterface(IID_IEnumIDList, (LPVOID *)ppEnum);
+    Py_BEGIN_ALLOW_THREADS
+        hr = punk->QueryInterface(IID_IEnumIDList, (LPVOID *)ppEnum);
     Py_END_ALLOW_THREADS
 
-        /* done with the result; this DECREF is also for <punk> */
-        Py_DECREF(result);
+    /* done with the result; this DECREF is also for <punk> */
+    Py_DECREF(result);
 
     return PyCom_CheckIEnumNextResult(hr, IID_IEnumIDList);
 }

--- a/isapi/src/PyExtensionObjects.cpp
+++ b/isapi/src/PyExtensionObjects.cpp
@@ -438,8 +438,11 @@ PyObject *PyECB::WriteClient(PyObject *self, PyObject *args)
     DWORD bytesWritten = 0;
     buffLenOut = Py_SAFE_DOWNCAST(buffLenIn, Py_ssize_t, DWORD);
     if (pecb->m_pcb) {
-        Py_BEGIN_ALLOW_THREADS bRes = pecb->m_pcb->WriteClient(buffer, &buffLenOut, reserved);
-        Py_END_ALLOW_THREADS if (!bRes) return SetPyECBError("WriteClient");
+        Py_BEGIN_ALLOW_THREADS
+            bRes = pecb->m_pcb->WriteClient(buffer, &buffLenOut, reserved);
+        Py_END_ALLOW_THREADS
+        if (!bRes)
+            return SetPyECBError("WriteClient");
     }
     return PyLong_FromLong(buffLenOut);
     // @rdesc the result is the number of bytes written.
@@ -519,31 +522,32 @@ PyObject *PyECB::ReadClient(PyObject *self, PyObject *args)
     // @pyparm int|nbytes||Default is to read all available data.
     if (!PyArg_ParseTuple(args, "|l:ReadClient", &nSize))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS assert(nSize >= 0);  // DWORD == unsigned == >= 0
+    Py_BEGIN_ALLOW_THREADS
+        assert(nSize >= 0);  // DWORD == unsigned == >= 0
 
-    DWORD orgSize = nSize;
-    DWORD bytesGot = nSize;
+        DWORD orgSize = nSize;
+        DWORD bytesGot = nSize;
 
-    pBuff = new BYTE[nSize];
-    bRes = pecb->m_pcb->ReadClient(pBuff, &bytesGot);
-    if (bytesGot < orgSize) {
-        DWORD extraBytes = orgSize - bytesGot;
-        DWORD offset = bytesGot;
-        while (extraBytes > 0) {
-            bytesGot = extraBytes;
-            bRes = pecb->m_pcb->ReadClient(&pBuff[offset], &bytesGot);
-            if (bytesGot < 1)
-                break;
+        pBuff = new BYTE[nSize];
+        bRes = pecb->m_pcb->ReadClient(pBuff, &bytesGot);
+        if (bytesGot < orgSize) {
+            DWORD extraBytes = orgSize - bytesGot;
+            DWORD offset = bytesGot;
+            while (extraBytes > 0) {
+                bytesGot = extraBytes;
+                bRes = pecb->m_pcb->ReadClient(&pBuff[offset], &bytesGot);
+                if (bytesGot < 1)
+                    break;
 
-            extraBytes -= bytesGot;
-            offset += bytesGot;
+                extraBytes -= bytesGot;
+                offset += bytesGot;
+            }
+            if (extraBytes > 0)
+                nSize -= extraBytes;
         }
-        if (extraBytes > 0)
-            nSize -= extraBytes;
-    }
 
-    Py_END_ALLOW_THREADS if (!bRes)
-    {
+    Py_END_ALLOW_THREADS
+    if (!bRes) {
         delete[] pBuff;
         return SetPyECBError("ReadClient");
     }
@@ -592,8 +596,11 @@ PyObject *PyECB::SendResponseHeaders(PyObject *self, PyObject *args)
             //  by itself..
             //  Send header
             EXTENSION_CONTROL_BLOCK *ecb = pecb->m_pcb->GetECB();
-        bRes = ecb->ServerSupportFunction(ecb->ConnID, HSE_REQ_SEND_RESPONSE_HEADER_EX, &SendHeaderExInfo, NULL, NULL);
-        Py_END_ALLOW_THREADS if (!bRes) return SetPyECBError("ServerSupportFunction(HSE_REQ_SEND_RESPONSE_HEADER_EX)");
+            bRes =
+                ecb->ServerSupportFunction(ecb->ConnID, HSE_REQ_SEND_RESPONSE_HEADER_EX, &SendHeaderExInfo, NULL, NULL);
+        Py_END_ALLOW_THREADS
+        if (!bRes)
+            return SetPyECBError("ServerSupportFunction(HSE_REQ_SEND_RESPONSE_HEADER_EX)");
     }
 
     Py_INCREF(Py_None);
@@ -621,9 +628,12 @@ PyObject *PyECB::SetFlushFlag(PyObject *self, PyObject *args)
 
     if (pecb->m_pcb) {
         BOOL bRes;
-        Py_BEGIN_ALLOW_THREADS EXTENSION_CONTROL_BLOCK *ecb = pecb->m_pcb->GetECB();
-        bRes = ecb->ServerSupportFunction(ecb->ConnID, HSE_REQ_SET_FLUSH_FLAG, (LPVOID)f, NULL, NULL);
-        Py_END_ALLOW_THREADS if (!bRes) return SetPyECBError("ServerSupportFunction(HSE_REQ_SET_FLUSH_FLAG)");
+        Py_BEGIN_ALLOW_THREADS
+            EXTENSION_CONTROL_BLOCK *ecb = pecb->m_pcb->GetECB();
+            bRes = ecb->ServerSupportFunction(ecb->ConnID, HSE_REQ_SET_FLUSH_FLAG, (LPVOID)f, NULL, NULL);
+        Py_END_ALLOW_THREADS
+        if (!bRes)
+            return SetPyECBError("ServerSupportFunction(HSE_REQ_SET_FLUSH_FLAG)");
     }
     Py_INCREF(Py_None);
     return Py_None;
@@ -644,8 +654,11 @@ PyObject *PyECB::Redirect(PyObject *self, PyObject *args)
         return NULL;
 
     if (pecb->m_pcb) {
-        Py_BEGIN_ALLOW_THREADS bRes = pecb->m_pcb->Redirect(url);
-        Py_END_ALLOW_THREADS if (!bRes) return SetPyECBError("ServerSupportFunction(HSE_REQ_SEND_URL_REDIRECT_RESP)");
+        Py_BEGIN_ALLOW_THREADS
+            bRes = pecb->m_pcb->Redirect(url);
+        Py_END_ALLOW_THREADS
+        if (!bRes)
+            return SetPyECBError("ServerSupportFunction(HSE_REQ_SEND_URL_REDIRECT_RESP)");
     }
 
     Py_INCREF(Py_None);
@@ -664,8 +677,11 @@ PyObject *PyECB::GetImpersonationToken(PyObject *self, PyObject *args)
         return NULL;
     HANDLE handle;
     BOOL bRes;
-    Py_BEGIN_ALLOW_THREADS bRes = pecb->m_pcb->GetImpersonationToken(&handle);
-    Py_END_ALLOW_THREADS if (!bRes) return SetPyECBError("ServerSupportFunction(HSE_REQ_GET_IMPERSONATION_TOKEN)");
+    Py_BEGIN_ALLOW_THREADS
+        bRes = pecb->m_pcb->GetImpersonationToken(&handle);
+    Py_END_ALLOW_THREADS
+    if (!bRes)
+        return SetPyECBError("ServerSupportFunction(HSE_REQ_GET_IMPERSONATION_TOKEN)");
     return PyLong_FromVoidPtr(handle);
 }
 
@@ -685,16 +701,18 @@ PyObject *PyECB::GetAnonymousToken(PyObject *self, PyObject *args)
     HANDLE handle;
     BOOL bRes;
     if (PyBytes_Check(obStr)) {
-        Py_BEGIN_ALLOW_THREADS bRes = ecb->ServerSupportFunction(ecb->ConnID, HSE_REQ_GET_ANONYMOUS_TOKEN,
-                                                                 PyBytes_AS_STRING(obStr), (DWORD *)&handle, NULL);
+        Py_BEGIN_ALLOW_THREADS
+            bRes = ecb->ServerSupportFunction(ecb->ConnID, HSE_REQ_GET_ANONYMOUS_TOKEN, PyBytes_AS_STRING(obStr),
+                                              (DWORD *)&handle, NULL);
         Py_END_ALLOW_THREADS
     }
     else if (PyUnicode_Check(obStr)) {
         TmpWCHAR tmpw = obStr;
         if (!tmpw)
             return NULL;
-        Py_BEGIN_ALLOW_THREADS bRes =
-            ecb->ServerSupportFunction(ecb->ConnID, HSE_REQ_GET_UNICODE_ANONYMOUS_TOKEN, tmpw, (DWORD *)&handle, NULL);
+        Py_BEGIN_ALLOW_THREADS
+            bRes = ecb->ServerSupportFunction(ecb->ConnID, HSE_REQ_GET_UNICODE_ANONYMOUS_TOKEN, tmpw, (DWORD *)&handle,
+                                              NULL);
         Py_END_ALLOW_THREADS
     }
     else
@@ -714,8 +732,11 @@ PyObject *PyECB::IsKeepConn(PyObject *self, PyObject *args)
     if (!pecb || !pecb->Check())
         return NULL;
     BOOL bRes, bIs;
-    Py_BEGIN_ALLOW_THREADS bRes = pecb->m_pcb->IsKeepConn(&bIs);
-    Py_END_ALLOW_THREADS if (!bRes) return SetPyECBError("ServerSupportFunction(HSE_REQ_IS_KEEP_CONN)");
+    Py_BEGIN_ALLOW_THREADS
+        bRes = pecb->m_pcb->IsKeepConn(&bIs);
+    Py_END_ALLOW_THREADS
+    if (!bRes)
+        return SetPyECBError("ServerSupportFunction(HSE_REQ_IS_KEEP_CONN)");
     return PyBool_FromLong(bIs);
 }
 
@@ -745,8 +766,11 @@ PyObject *PyECB::ExecURL(PyObject *self, PyObject *args)
     if (!pecb || !pecb->Check())
         return NULL;
     BOOL bRes;
-    Py_BEGIN_ALLOW_THREADS bRes = ecb->ServerSupportFunction(ecb->ConnID, HSE_REQ_EXEC_URL, &i, NULL, NULL);
-    Py_END_ALLOW_THREADS if (!bRes) return SetPyECBError("ServerSupportFunction(HSE_REQ_EXEC_URL)");
+    Py_BEGIN_ALLOW_THREADS
+        bRes = ecb->ServerSupportFunction(ecb->ConnID, HSE_REQ_EXEC_URL, &i, NULL, NULL);
+    Py_END_ALLOW_THREADS
+    if (!bRes)
+        return SetPyECBError("ServerSupportFunction(HSE_REQ_EXEC_URL)");
     Py_RETURN_NONE;
 }
 
@@ -762,9 +786,11 @@ PyObject *PyECB::GetExecURLStatus(PyObject *self, PyObject *args)
         return NULL;
     BOOL bRes;
     HSE_EXEC_URL_STATUS status;
-    Py_BEGIN_ALLOW_THREADS bRes =
-        ecb->ServerSupportFunction(ecb->ConnID, HSE_REQ_GET_EXEC_URL_STATUS, &status, NULL, NULL);
-    Py_END_ALLOW_THREADS if (!bRes) return SetPyECBError("ServerSupportFunction(HSE_REQ_GET_EXEC_URL_STATUS)");
+    Py_BEGIN_ALLOW_THREADS
+        bRes = ecb->ServerSupportFunction(ecb->ConnID, HSE_REQ_GET_EXEC_URL_STATUS, &status, NULL, NULL);
+    Py_END_ALLOW_THREADS
+    if (!bRes)
+        return SetPyECBError("ServerSupportFunction(HSE_REQ_GET_EXEC_URL_STATUS)");
     // @rdesc The result of a tuple of 3 integers - (uHttpStatusCode, uHttpSubStatus, dwWin32Error)
     // @pyseeapi HSE_EXEC_URL_STATUS
     return Py_BuildValue("HHk", status.uHttpStatusCode, status.uHttpSubStatus, status.dwWin32Error);
@@ -814,9 +840,11 @@ PyObject *PyECB::IOCompletion(PyObject *self, PyObject *args)
         return NULL;
 
     BOOL bRes;
-    Py_BEGIN_ALLOW_THREADS bRes =
-        ecb->ServerSupportFunction(ecb->ConnID, HSE_REQ_IO_COMPLETION, DoIOCallback, NULL, NULL);
-    Py_END_ALLOW_THREADS if (!bRes) return SetPyECBError("ServerSupportFunction(HSE_REQ_IO_COMPLETION)");
+    Py_BEGIN_ALLOW_THREADS
+        bRes = ecb->ServerSupportFunction(ecb->ConnID, HSE_REQ_IO_COMPLETION, DoIOCallback, NULL, NULL);
+    Py_END_ALLOW_THREADS
+    if (!bRes)
+        return SetPyECBError("ServerSupportFunction(HSE_REQ_IO_COMPLETION)");
     Py_RETURN_NONE;
 }
 
@@ -833,8 +861,11 @@ PyObject *PyECB::ReportUnhealthy(PyObject *self, PyObject *args)
     if (!pecb || !pecb->Check())
         return NULL;
     BOOL bRes;
-    Py_BEGIN_ALLOW_THREADS bRes = ecb->ServerSupportFunction(ecb->ConnID, HSE_REQ_REPORT_UNHEALTHY, reason, NULL, NULL);
-    Py_END_ALLOW_THREADS if (!bRes) return SetPyECBError("ServerSupportFunction(HSE_REQ_REPORT_UNHEALTHY)");
+    Py_BEGIN_ALLOW_THREADS
+        bRes = ecb->ServerSupportFunction(ecb->ConnID, HSE_REQ_REPORT_UNHEALTHY, reason, NULL, NULL);
+    Py_END_ALLOW_THREADS
+    if (!bRes)
+        return SetPyECBError("ServerSupportFunction(HSE_REQ_REPORT_UNHEALTHY)");
     Py_RETURN_NONE;
 }
 
@@ -923,9 +954,10 @@ PyObject *PyECB::TransmitFile(PyObject *self, PyObject *args)
         return NULL;
 
     BOOL bRes;
-    Py_BEGIN_ALLOW_THREADS bRes = pecb->m_pcb->TransmitFile(&info);
-    Py_END_ALLOW_THREADS if (!bRes)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bRes = pecb->m_pcb->TransmitFile(&info);
+    Py_END_ALLOW_THREADS
+    if (!bRes) {
         // ack - the completion routine will not be called - clean up!
         context->Cleanup();
         return SetPyECBError("ServerSupportFunction(HSE_REQ_TRANSMIT_FILE)");
@@ -949,7 +981,8 @@ PyObject *PyECB::IsKeepAlive(PyObject *self, PyObject *args)
         return NULL;
 
     if (pecb->m_pcb) {
-        Py_BEGIN_ALLOW_THREADS bKeepAlive = pecb->m_pcb->IsKeepAlive();
+        Py_BEGIN_ALLOW_THREADS
+            bKeepAlive = pecb->m_pcb->IsKeepAlive();
         Py_END_ALLOW_THREADS
     }
 
@@ -973,8 +1006,11 @@ PyObject *PyECB::MapURLToPath(PyObject *self, PyObject *args)
     DWORD bufSize = sizeof(buffer);
     BOOL ok;
 
-    Py_BEGIN_ALLOW_THREADS ok = pecb->m_pcb->MapURLToPath(buffer, &bufSize);
-    Py_END_ALLOW_THREADS if (!ok) return SetPyECBError("ServerSupportFunction(HSE_REQ_MAP_URL_TO_PATH)");
+    Py_BEGIN_ALLOW_THREADS
+        ok = pecb->m_pcb->MapURLToPath(buffer, &bufSize);
+    Py_END_ALLOW_THREADS
+    if (!ok)
+        return SetPyECBError("ServerSupportFunction(HSE_REQ_MAP_URL_TO_PATH)");
     return PyBytes_FromString(buffer);
 }
 
@@ -995,8 +1031,10 @@ PyObject *PyECB::DoneWithSession(PyObject *self, PyObject *args)
     // currently means just the io-completion callback.
     CleanupIOCallback(pecb->m_pcb->GetECB());
 
-    Py_BEGIN_ALLOW_THREADS pecb->m_pcb->DoneWithSession(status);
-    Py_END_ALLOW_THREADS pecb->m_pcb->Done();
+    Py_BEGIN_ALLOW_THREADS
+        pecb->m_pcb->DoneWithSession(status);
+    Py_END_ALLOW_THREADS
+    pecb->m_pcb->Done();
     pecb->m_pcb = NULL;
     Py_INCREF(Py_None);
     return Py_None;

--- a/isapi/src/PyFilterObjects.cpp
+++ b/isapi/src/PyFilterObjects.cpp
@@ -202,9 +202,12 @@ PyObject *PyHFC::WriteClient(PyObject *self, PyObject *args)
 
     if (phfc->m_pfc) {
         HTTP_FILTER_CONTEXT *fc = phfc->m_pfc->m_pHFC;
-        Py_BEGIN_ALLOW_THREADS DWORD dwBufLen = Py_SAFE_DOWNCAST(buffLen, Py_ssize_t, DWORD);
-        bRes = fc->WriteClient(fc, (void *)buffer, &dwBufLen, reserved);
-        Py_END_ALLOW_THREADS if (!bRes) return SetPyHFCError("WriteClient");
+        Py_BEGIN_ALLOW_THREADS
+            DWORD dwBufLen = Py_SAFE_DOWNCAST(buffLen, Py_ssize_t, DWORD);
+            bRes = fc->WriteClient(fc, (void *)buffer, &dwBufLen, reserved);
+        Py_END_ALLOW_THREADS
+        if (!bRes)
+            return SetPyHFCError("WriteClient");
     }
 
     Py_INCREF(Py_None);
@@ -225,8 +228,11 @@ PyObject *PyHFC::AddResponseHeaders(PyObject *self, PyObject *args)
         return NULL;
 
     if (phfc->m_pfc) {
-        Py_BEGIN_ALLOW_THREADS bRes = phfc->m_pfc->AddResponseHeaders(buffer, reserved);
-        Py_END_ALLOW_THREADS if (!bRes) return SetPyHFCError("AddResponseHeaders");
+        Py_BEGIN_ALLOW_THREADS
+            bRes = phfc->m_pfc->AddResponseHeaders(buffer, reserved);
+        Py_END_ALLOW_THREADS
+        if (!bRes)
+            return SetPyHFCError("AddResponseHeaders");
     }
 
     Py_INCREF(Py_None);
@@ -312,7 +318,9 @@ PyObject *PyHFC::SendResponseHeader(PyObject *self, PyObject *args)
         // but docs clearly have second as unused.  Either way, I can't see the
         // specific header!
         bRes = phfc->m_pfc->ServerSupportFunction(SF_REQ_SEND_RESPONSE_HEADER, status, (DWORD)header, 0);
-    Py_END_ALLOW_THREADS if (!bRes) return SetPyHFCError("SendResponseHeader");
+    Py_END_ALLOW_THREADS
+    if (!bRes)
+        return SetPyHFCError("SendResponseHeader");
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -329,8 +337,11 @@ PyObject *PyHFC::DisableNotifications(PyObject *self, PyObject *args)
 
     if (!phfc->m_pfc)
         return PyErr_Format(PyExc_RuntimeError, "No filtercontext!");
-    Py_BEGIN_ALLOW_THREADS bRes = phfc->m_pfc->ServerSupportFunction(SF_REQ_DISABLE_NOTIFICATIONS, 0, flags, 0);
-    Py_END_ALLOW_THREADS if (!bRes) return SetPyHFCError("DisableNotifications");
+    Py_BEGIN_ALLOW_THREADS
+        bRes = phfc->m_pfc->ServerSupportFunction(SF_REQ_DISABLE_NOTIFICATIONS, 0, flags, 0);
+    Py_END_ALLOW_THREADS
+    if (!bRes)
+        return SetPyHFCError("DisableNotifications");
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -604,9 +615,10 @@ PyObject *PyPREPROC_HEADERS_GetHeader(PyObject *self, PyObject *args)
     HTTP_FILTER_CONTEXT *pfc = ((PyPREPROC_HEADERS *)self)->GetFILTER_CONTEXT();
     if (!pp || !pfc)
         return NULL;
-    Py_BEGIN_ALLOW_THREADS ok = pp->GetHeader(pfc, name, buffer, &bufSize);
-    Py_END_ALLOW_THREADS if (!ok || bufSize == 0)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        ok = pp->GetHeader(pfc, name, buffer, &bufSize);
+    Py_END_ALLOW_THREADS
+    if (!ok || bufSize == 0) {
         if (def == NULL)
             return SetPyHFCError("GetHeader");
         Py_INCREF(def);
@@ -628,8 +640,11 @@ PyObject *PyPREPROC_HEADERS_SetHeader(PyObject *self, PyObject *args)
     // @pyparm string|val||
     if (!PyArg_ParseTuple(args, "ss:SetHeader", &name, &val))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS ok = pp->SetHeader(pfc, name, val);
-    Py_END_ALLOW_THREADS if (!ok) return SetPyHFCError("SetHeader");
+    Py_BEGIN_ALLOW_THREADS
+        ok = pp->SetHeader(pfc, name, val);
+    Py_END_ALLOW_THREADS
+    if (!ok)
+        return SetPyHFCError("SetHeader");
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -645,8 +660,11 @@ PyObject *PyPREPROC_HEADERS_AddHeader(PyObject *self, PyObject *args)
         return NULL;
     if (!PyArg_ParseTuple(args, "ss:AddHeader", &name, &val))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS ok = pp->AddHeader(pfc, name, val);
-    Py_END_ALLOW_THREADS if (!ok) return SetPyHFCError("AddHeader");
+    Py_BEGIN_ALLOW_THREADS
+        ok = pp->AddHeader(pfc, name, val);
+    Py_END_ALLOW_THREADS
+    if (!ok)
+        return SetPyHFCError("AddHeader");
     Py_INCREF(Py_None);
     return Py_None;
 }

--- a/win32/src/PyHANDLE.cpp
+++ b/win32/src/PyHANDLE.cpp
@@ -192,41 +192,40 @@ BOOL PyHANDLE::Close(void)
     if (m_handle) {
         Py_BEGIN_ALLOW_THREADS
 #ifdef Py_DEBUG
-            __try
-        {
+            __try {
 #endif  // Py_DEBUG
-            rc = CloseHandle(m_handle);
+                rc = CloseHandle(m_handle);
 #ifdef Py_DEBUG
-        }
-        __except (1)
-        {
-            // according to the docs on CloseHandle(), this
-            // can happen when run under the debugger.  This is a
-            // PITA, as it makes it hard to debug whatever we are here
-            // for (unless we are here to debug this!).  So we break into
-            // the debugger, which gives the developer the option of continuing
-            static bool is_first_exception = true;
-            static bool break_on_exception = true;
-            // It *seems* that handles that raise an exception under
-            // the debugger actually *succeed* calling Close running normally.
-            static bool raise_python_exception = false;
-            if (break_on_exception) {
-                if (is_first_exception)
-                    break_on_exception = false;
-                DebugBreak();
-                // reset 'break_on_exception' to true if you want to
-                // continue breaking on every invalid handle exception
+            }
+            __except (1) {
+                // according to the docs on CloseHandle(), this
+                // can happen when run under the debugger.  This is a
+                // PITA, as it makes it hard to debug whatever we are here
+                // for (unless we are here to debug this!).  So we break into
+                // the debugger, which gives the developer the option of continuing
+                static bool is_first_exception = true;
+                static bool break_on_exception = true;
+                // It *seems* that handles that raise an exception under
+                // the debugger actually *succeed* calling Close running normally.
+                static bool raise_python_exception = false;
+                if (break_on_exception) {
+                    if (is_first_exception)
+                        break_on_exception = false;
+                    DebugBreak();
+                    // reset 'break_on_exception' to true if you want to
+                    // continue breaking on every invalid handle exception
 
-                // set 'raise_python_exception' to true to send the exception to Python.
+                    // set 'raise_python_exception' to true to send the exception to Python.
+                }
+                is_first_exception = false;
+                if (raise_python_exception) {
+                    rc = FALSE;
+                    ::SetLastError(ERROR_INVALID_HANDLE);
+                }
             }
-            is_first_exception = false;
-            if (raise_python_exception) {
-                rc = FALSE;
-                ::SetLastError(ERROR_INVALID_HANDLE);
-            }
-        }
 #endif  // Py_DEBUG
-        Py_END_ALLOW_THREADS m_handle = 0;
+        Py_END_ALLOW_THREADS
+        m_handle = 0;
     }
     if (!rc)
         PyWin_SetAPIError("CloseHandle");

--- a/win32/src/PyHANDLE.cpp
+++ b/win32/src/PyHANDLE.cpp
@@ -191,41 +191,40 @@ BOOL PyHANDLE::Close(void)
     if (m_handle) {
         Py_BEGIN_ALLOW_THREADS
 #ifdef Py_DEBUG
-            __try
-        {
+            __try {
 #endif  // Py_DEBUG
-            rc = CloseHandle(m_handle);
+                rc = CloseHandle(m_handle);
 #ifdef Py_DEBUG
-        }
-        __except (1)
-        {
-            // according to the docs on CloseHandle(), this
-            // can happen when run under the debugger.  This is a
-            // PITA, as it makes it hard to debug whatever we are here
-            // for (unless we are here to debug this!).  So we break into
-            // the debugger, which gives the developer the option of continuing
-            static bool is_first_exception = true;
-            static bool break_on_exception = true;
-            // It *seems* that handles that raise an exception under
-            // the debugger actually *succeed* calling Close running normally.
-            static bool raise_python_exception = false;
-            if (break_on_exception) {
-                if (is_first_exception)
-                    break_on_exception = false;
-                DebugBreak();
-                // reset 'break_on_exception' to true if you want to
-                // continue breaking on every invalid handle exception
+            }
+            __except (1) {
+                // according to the docs on CloseHandle(), this
+                // can happen when run under the debugger.  This is a
+                // PITA, as it makes it hard to debug whatever we are here
+                // for (unless we are here to debug this!).  So we break into
+                // the debugger, which gives the developer the option of continuing
+                static bool is_first_exception = true;
+                static bool break_on_exception = true;
+                // It *seems* that handles that raise an exception under
+                // the debugger actually *succeed* calling Close running normally.
+                static bool raise_python_exception = false;
+                if (break_on_exception) {
+                    if (is_first_exception)
+                        break_on_exception = false;
+                    DebugBreak();
+                    // reset 'break_on_exception' to true if you want to
+                    // continue breaking on every invalid handle exception
 
-                // set 'raise_python_exception' to true to send the exception to Python.
+                    // set 'raise_python_exception' to true to send the exception to Python.
+                }
+                is_first_exception = false;
+                if (raise_python_exception) {
+                    rc = FALSE;
+                    ::SetLastError(ERROR_INVALID_HANDLE);
+                }
             }
-            is_first_exception = false;
-            if (raise_python_exception) {
-                rc = FALSE;
-                ::SetLastError(ERROR_INVALID_HANDLE);
-            }
-        }
 #endif  // Py_DEBUG
-        Py_END_ALLOW_THREADS m_handle = 0;
+        Py_END_ALLOW_THREADS
+        m_handle = 0;
     }
     if (!rc)
         PyWin_SetAPIError("CloseHandle");

--- a/win32/src/PyHANDLE.cpp
+++ b/win32/src/PyHANDLE.cpp
@@ -191,41 +191,40 @@ BOOL PyHANDLE::Close(void)
     if (m_handle) {
         Py_BEGIN_ALLOW_THREADS
 #ifdef Py_DEBUG
-            __try
-        {
+            __try {
 #endif  // Py_DEBUG
-            rc = CloseHandle(m_handle);
+                rc = CloseHandle(m_handle);
 #ifdef Py_DEBUG
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER)
-        {
-            // according to the docs on CloseHandle(), this
-            // can happen when run under the debugger.  This is a
-            // PITA, as it makes it hard to debug whatever we are here
-            // for (unless we are here to debug this!).  So we break into
-            // the debugger, which gives the developer the option of continuing
-            static bool is_first_exception = true;
-            static bool break_on_exception = true;
-            // It *seems* that handles that raise an exception under
-            // the debugger actually *succeed* calling Close running normally.
-            static bool raise_python_exception = false;
-            if (break_on_exception) {
-                if (is_first_exception)
-                    break_on_exception = false;
-                DebugBreak();
-                // reset 'break_on_exception' to true if you want to
-                // continue breaking on every invalid handle exception
+            }
+            __except (EXCEPTION_EXECUTE_HANDLER) {
+                // according to the docs on CloseHandle(), this
+                // can happen when run under the debugger.  This is a
+                // PITA, as it makes it hard to debug whatever we are here
+                // for (unless we are here to debug this!).  So we break into
+                // the debugger, which gives the developer the option of continuing
+                static bool is_first_exception = true;
+                static bool break_on_exception = true;
+                // It *seems* that handles that raise an exception under
+                // the debugger actually *succeed* calling Close running normally.
+                static bool raise_python_exception = false;
+                if (break_on_exception) {
+                    if (is_first_exception)
+                        break_on_exception = false;
+                    DebugBreak();
+                    // reset 'break_on_exception' to true if you want to
+                    // continue breaking on every invalid handle exception
 
-                // set 'raise_python_exception' to true to send the exception to Python.
+                    // set 'raise_python_exception' to true to send the exception to Python.
+                }
+                is_first_exception = false;
+                if (raise_python_exception) {
+                    rc = FALSE;
+                    ::SetLastError(ERROR_INVALID_HANDLE);
+                }
             }
-            is_first_exception = false;
-            if (raise_python_exception) {
-                rc = FALSE;
-                ::SetLastError(ERROR_INVALID_HANDLE);
-            }
-        }
 #endif  // Py_DEBUG
-        Py_END_ALLOW_THREADS m_handle = 0;
+        Py_END_ALLOW_THREADS
+        m_handle = 0;
     }
     if (!rc)
         PyWin_SetAPIError("CloseHandle");

--- a/win32/src/PythonService.cpp
+++ b/win32/src/PythonService.cpp
@@ -152,8 +152,9 @@ static PyObject *DoLogMessage(WORD errorType, PyObject *obMsg)
     DWORD errorCode = errorType == EVENTLOG_ERROR_TYPE ? PYS_E_GENERIC_ERROR : PYS_E_GENERIC_WARNING;
     LPCTSTR inserts[] = {msg, NULL};
     BOOL ok;
-    Py_BEGIN_ALLOW_THREADS;
-    ok = ReportError(errorCode, inserts, errorType);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        ok = ReportError(errorCode, inserts, errorType);
     Py_END_ALLOW_THREADS;
     PyWinObject_FreeWCHAR(msg);  // free msg before potentially raising error
     if (!ok)
@@ -205,13 +206,15 @@ static PyObject *PyLogMsg(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_TypeError, "strings must be None or a sequence");
         goto cleanup;
     }
-    Py_BEGIN_ALLOW_THREADS ok = ReportError(code, pStrings, errorType);
-    Py_END_ALLOW_THREADS if (ok)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        ok = ReportError(code, pStrings, errorType);
+    Py_END_ALLOW_THREADS
+    if (ok) {
         Py_INCREF(Py_None);
         rc = Py_None;
     }
-    else PyWin_SetAPIError("RegisterEventSource/ReportEvent");
+    else
+        PyWin_SetAPIError("RegisterEventSource/ReportEvent");
 
 cleanup:
     if (pStrings) {
@@ -385,24 +388,28 @@ static PyObject *PyPumpWaitingMessages(PyObject *self, PyObject *args)
     long result = 0;
     // Read all of the messages in this next loop,
     // removing each message as we read it.
-    Py_BEGIN_ALLOW_THREADS while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-    {
-        // If it's a quit message, we're out of here.
-        if (msg.message == WM_QUIT) {
-            result = 1;
-            break;
-        }
-        // Otherwise, dispatch the message.
-        DispatchMessage(&msg);
-    }  // End of PeekMessage while loop
-    Py_END_ALLOW_THREADS return PyLong_FromLong(result);
+    Py_BEGIN_ALLOW_THREADS
+        while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
+            // If it's a quit message, we're out of here.
+            if (msg.message == WM_QUIT) {
+                result = 1;
+                break;
+            }
+            // Otherwise, dispatch the message.
+            DispatchMessage(&msg);
+        }  // End of PeekMessage while loop
+    Py_END_ALLOW_THREADS
+    return PyLong_FromLong(result);
 }
 
 static PyObject *PyStartServiceCtrlDispatcher(PyObject *self)
 {
     BOOL ok;
-    Py_BEGIN_ALLOW_THREADS ok = PythonService_StartServiceCtrlDispatcher();
-    Py_END_ALLOW_THREADS if (!ok) return PyWin_SetAPIError("StartServiceCtrlDispatcher");
+    Py_BEGIN_ALLOW_THREADS
+        ok = PythonService_StartServiceCtrlDispatcher();
+    Py_END_ALLOW_THREADS
+    if (!ok)
+        return PyWin_SetAPIError("StartServiceCtrlDispatcher");
     Py_INCREF(Py_None);
     return Py_None;
 }

--- a/win32/src/PythonService.cpp
+++ b/win32/src/PythonService.cpp
@@ -152,9 +152,9 @@ static PyObject *DoLogMessage(WORD errorType, PyObject *obMsg)
     DWORD errorCode = errorType == EVENTLOG_ERROR_TYPE ? PYS_E_GENERIC_ERROR : PYS_E_GENERIC_WARNING;
     LPCTSTR inserts[] = {msg, NULL};
     BOOL ok;
-    Py_BEGIN_ALLOW_THREADS;
-    ok = ReportError(errorCode, inserts, errorType);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        ok = ReportError(errorCode, inserts, errorType);
+    Py_END_ALLOW_THREADS
     PyWinObject_FreeWCHAR(msg);  // free msg before potentially raising error
     if (!ok)
         return PyWin_SetAPIError("RegisterEventSource/ReportEvent");
@@ -205,13 +205,15 @@ static PyObject *PyLogMsg(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_TypeError, "strings must be None or a sequence");
         goto cleanup;
     }
-    Py_BEGIN_ALLOW_THREADS ok = ReportError(code, pStrings, errorType);
-    Py_END_ALLOW_THREADS if (ok)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        ok = ReportError(code, pStrings, errorType);
+    Py_END_ALLOW_THREADS
+    if (ok) {
         Py_INCREF(Py_None);
         rc = Py_None;
     }
-    else PyWin_SetAPIError("RegisterEventSource/ReportEvent");
+    else
+        PyWin_SetAPIError("RegisterEventSource/ReportEvent");
 
 cleanup:
     if (pStrings) {
@@ -385,24 +387,28 @@ static PyObject *PyPumpWaitingMessages(PyObject *self, PyObject *args)
     long result = 0;
     // Read all of the messages in this next loop,
     // removing each message as we read it.
-    Py_BEGIN_ALLOW_THREADS while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-    {
-        // If it's a quit message, we're out of here.
-        if (msg.message == WM_QUIT) {
-            result = 1;
-            break;
-        }
-        // Otherwise, dispatch the message.
-        DispatchMessage(&msg);
-    }  // End of PeekMessage while loop
-    Py_END_ALLOW_THREADS return PyLong_FromLong(result);
+    Py_BEGIN_ALLOW_THREADS
+        while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
+            // If it's a quit message, we're out of here.
+            if (msg.message == WM_QUIT) {
+                result = 1;
+                break;
+            }
+            // Otherwise, dispatch the message.
+            DispatchMessage(&msg);
+        }  // End of PeekMessage while loop
+    Py_END_ALLOW_THREADS
+    return PyLong_FromLong(result);
 }
 
 static PyObject *PyStartServiceCtrlDispatcher(PyObject *self)
 {
     BOOL ok;
-    Py_BEGIN_ALLOW_THREADS ok = PythonService_StartServiceCtrlDispatcher();
-    Py_END_ALLOW_THREADS if (!ok) return PyWin_SetAPIError("StartServiceCtrlDispatcher");
+    Py_BEGIN_ALLOW_THREADS
+        ok = PythonService_StartServiceCtrlDispatcher();
+    Py_END_ALLOW_THREADS
+    if (!ok)
+        return PyWin_SetAPIError("StartServiceCtrlDispatcher");
     Py_INCREF(Py_None);
     return Py_None;
 }

--- a/win32/src/odbc.cpp
+++ b/win32/src/odbc.cpp
@@ -238,10 +238,11 @@ static int doConnect(connectionObject *conn)
 {
     RETCODE rc;
     short connectionStringLength;
-    Py_BEGIN_ALLOW_THREADS rc = SQLDriverConnect(conn->hdbc, NULL, (SQLTCHAR *)conn->connectionString, SQL_NTS, NULL, 0,
-                                                 &connectionStringLength, SQL_DRIVER_NOPROMPT);
-    Py_END_ALLOW_THREADS if (unsuccessful(rc))
-    {
+    Py_BEGIN_ALLOW_THREADS
+        rc = SQLDriverConnect(conn->hdbc, NULL, (SQLTCHAR *)conn->connectionString, SQL_NTS, NULL, 0,
+                              &connectionStringLength, SQL_DRIVER_NOPROMPT);
+    Py_END_ALLOW_THREADS
+    if (unsuccessful(rc)) {
         odbcPrintError(Env, conn, SQL_NULL_HSTMT, _T("LOGIN"));
         return 1;
     }
@@ -308,14 +309,14 @@ static PyObject *odbcSetAutoCommit(PyObject *self, PyObject *args)
 static PyObject *odbcCommit(PyObject *self, PyObject *args)
 {
     RETCODE rc;
-    Py_BEGIN_ALLOW_THREADS rc = SQLTransact(Env, connection(self)->hdbc, SQL_COMMIT);
-    Py_END_ALLOW_THREADS if (unsuccessful(rc))
-    {
+    Py_BEGIN_ALLOW_THREADS
+        rc = SQLTransact(Env, connection(self)->hdbc, SQL_COMMIT);
+    Py_END_ALLOW_THREADS
+    if (unsuccessful(rc)) {
         connectionError(connection(self), _T("COMMIT"));
         return 0;
     }
-    else
-    {
+    else {
         Py_INCREF(Py_None);
         return Py_None;
     }
@@ -325,14 +326,14 @@ static PyObject *odbcCommit(PyObject *self, PyObject *args)
 static PyObject *odbcRollback(PyObject *self, PyObject *args)
 {
     RETCODE rc;
-    Py_BEGIN_ALLOW_THREADS rc = SQLTransact(Env, connection(self)->hdbc, SQL_ROLLBACK);
-    Py_END_ALLOW_THREADS if (unsuccessful(rc))
-    {
+    Py_BEGIN_ALLOW_THREADS
+        rc = SQLTransact(Env, connection(self)->hdbc, SQL_ROLLBACK);
+    Py_END_ALLOW_THREADS
+    if (unsuccessful(rc)) {
         connectionError(connection(self), _T("ROLLBACK"));
         return 0;
     }
-    else
-    {
+    else {
         Py_INCREF(Py_None);
         return Py_None;
     }
@@ -1054,44 +1055,45 @@ static RETCODE sendSQLInputData(cursorObject *cur)
     RETCODE rc = SQL_SUCCESS;
     char *pIndx;
 
-    Py_BEGIN_ALLOW_THREADS rc = SQLParamData(cur->hstmt, (void **)&pIndx);
-    while (rc == SQL_NEED_DATA) {
-        InputBinding *pInputBinding = cur->inputVars;
-
-        /* find the input to put */
-        while (pInputBinding) {
-            if (pIndx != pInputBinding->bind_area) {
-                pInputBinding = pInputBinding->next;
-            }
-            else {
-                break;
-            }
-        }
-
-        if (pInputBinding) {
-            size_t putTimes = pInputBinding->len / 1024;
-            size_t remainder = pInputBinding->len % 1024;
-            rc = SQL_SUCCESS;
-
-            if (!putTimes && !remainder) {
-                rc = SQLPutData(cur->hstmt, pInputBinding->bind_area, 0);
-            }
-            size_t i;
-            for (i = 0; i < putTimes && rc == SQL_SUCCESS; i++) {
-                rc = SQLPutData(cur->hstmt, (void *)(&pInputBinding->bind_area[i * 1024]), 1024);
-            }
-
-            if (remainder && rc == SQL_SUCCESS) {
-                rc = SQLPutData(cur->hstmt, (void *)(&pInputBinding->bind_area[i * 1024]), remainder);
-            }
-        }
-
-        /* see if additional data is needed. */
+    Py_BEGIN_ALLOW_THREADS
         rc = SQLParamData(cur->hstmt, (void **)&pIndx);
-    }
+        while (rc == SQL_NEED_DATA) {
+            InputBinding *pInputBinding = cur->inputVars;
+
+            /* find the input to put */
+            while (pInputBinding) {
+                if (pIndx != pInputBinding->bind_area) {
+                    pInputBinding = pInputBinding->next;
+                }
+                else {
+                    break;
+                }
+            }
+
+            if (pInputBinding) {
+                size_t putTimes = pInputBinding->len / 1024;
+                size_t remainder = pInputBinding->len % 1024;
+                rc = SQL_SUCCESS;
+
+                if (!putTimes && !remainder) {
+                    rc = SQLPutData(cur->hstmt, pInputBinding->bind_area, 0);
+                }
+                size_t i;
+                for (i = 0; i < putTimes && rc == SQL_SUCCESS; i++) {
+                    rc = SQLPutData(cur->hstmt, (void *)(&pInputBinding->bind_area[i * 1024]), 1024);
+                }
+
+                if (remainder && rc == SQL_SUCCESS) {
+                    rc = SQLPutData(cur->hstmt, (void *)(&pInputBinding->bind_area[i * 1024]), remainder);
+                }
+            }
+
+            /* see if additional data is needed. */
+            rc = SQLParamData(cur->hstmt, (void **)&pIndx);
+        }
     Py_END_ALLOW_THREADS
 
-        return rc;
+    return rc;
 }
 
 /* @pymethod int|cursor|execute|Execute some SQL */
@@ -1164,9 +1166,10 @@ static PyObject *odbcCurExec(PyObject *self, PyObject *args)
     SQLFreeStmt(cur->hstmt, SQL_CLOSE); /* ignore errors here */
     RETCODE rc = SQL_SUCCESS;
     n_columns = rewriteQuery(sqlbuf, sql);
-    Py_BEGIN_ALLOW_THREADS rc = SQLPrepare(cur->hstmt, (SQLTCHAR *)sqlbuf, SQL_NTS);
-    Py_END_ALLOW_THREADS if (unsuccessful(rc))
-    {
+    Py_BEGIN_ALLOW_THREADS
+        rc = SQLPrepare(cur->hstmt, (SQLTCHAR *)sqlbuf, SQL_NTS);
+    Py_END_ALLOW_THREADS
+    if (unsuccessful(rc)) {
         cursorError(cur, _T("EXEC"));
         goto Error;
     }
@@ -1187,11 +1190,11 @@ static PyObject *odbcCurExec(PyObject *self, PyObject *args)
             if (!bindInput(cur, inputvars, n_columns)) {
                 goto Error;
             }
-            Py_BEGIN_ALLOW_THREADS rc = SQLExecDirect(cur->hstmt, (SQLTCHAR *)sqlbuf, SQL_NTS);
+            Py_BEGIN_ALLOW_THREADS
+                rc = SQLExecDirect(cur->hstmt, (SQLTCHAR *)sqlbuf, SQL_NTS);
             Py_END_ALLOW_THREADS
-                /* move data here. */
-                if (rc == SQL_NEED_DATA)
-            {
+            /* move data here. */
+            if (rc == SQL_NEED_DATA) {
                 rc = sendSQLInputData(cur);
             }
             if (unsuccessful(rc)) {
@@ -1200,8 +1203,10 @@ static PyObject *odbcCurExec(PyObject *self, PyObject *args)
             }
             /* Success! */
             /* Note: multiple result sets aren't supported here, just bulk inserts... */
-            Py_BEGIN_ALLOW_THREADS SQLRowCount(cur->hstmt, &t);
-            Py_END_ALLOW_THREADS n_rows += t;
+            Py_BEGIN_ALLOW_THREADS
+                SQLRowCount(cur->hstmt, &t);
+            Py_END_ALLOW_THREADS
+            n_rows += t;
             deleteBinding(cur);
             Py_DECREF(inputvars);
             inputvars = NULL;
@@ -1211,8 +1216,12 @@ static PyObject *odbcCurExec(PyObject *self, PyObject *args)
         if (!bindInput(cur, inputvars, n_columns)) {
             goto Error;
         }
-        Py_BEGIN_ALLOW_THREADS rc = SQLExecDirect(cur->hstmt, (SQLTCHAR *)sqlbuf, SQL_NTS);
-        Py_END_ALLOW_THREADS if (rc == SQL_NEED_DATA) { rc = sendSQLInputData(cur); }
+        Py_BEGIN_ALLOW_THREADS
+            rc = SQLExecDirect(cur->hstmt, (SQLTCHAR *)sqlbuf, SQL_NTS);
+        Py_END_ALLOW_THREADS
+        if (rc == SQL_NEED_DATA) {
+            rc = sendSQLInputData(cur);
+        }
         if (unsuccessful(rc)) {
             cursorError(cur, _T("EXEC"));
             goto Error;
@@ -1272,9 +1281,10 @@ static PyObject *processOutput(cursorObject *cur)
                     ob->vsize += cur->max_width;
                     /* Some BLOBs can be huge, be paranoid about allowing
                        other threads to run. */
-                    Py_BEGIN_ALLOW_THREADS ob->bind_area = realloc(ob->bind_area, ob->vsize);
-                    Py_END_ALLOW_THREADS if (ob->bind_area == NULL)
-                    {
+                    Py_BEGIN_ALLOW_THREADS
+                        ob->bind_area = realloc(ob->bind_area, ob->vsize);
+                    Py_END_ALLOW_THREADS
+                    if (ob->bind_area == NULL) {
                         PyErr_NoMemory();
                         ob->vsize -= cur->max_width;
                         ob->bind_area = pTemp;
@@ -1283,10 +1293,11 @@ static PyObject *processOutput(cursorObject *cur)
                     }
                 }
 
-                Py_BEGIN_ALLOW_THREADS rc = SQLGetData(cur->hstmt, ob->pos, ob->vtype, (char *)ob->bind_area + cbRead,
-                                                       ob->vsize - cbRead, &ob->rcode);
-                Py_END_ALLOW_THREADS if (unsuccessful(rc))
-                {
+                Py_BEGIN_ALLOW_THREADS
+                    rc = SQLGetData(cur->hstmt, ob->pos, ob->vtype, (char *)ob->bind_area + cbRead, ob->vsize - cbRead,
+                                    &ob->rcode);
+                Py_END_ALLOW_THREADS
+                if (unsuccessful(rc)) {
                     Py_DECREF(row);
                     cursorError(cur, _T("SQLGetData"));
                     return NULL;
@@ -1342,14 +1353,14 @@ static PyObject *processOutput(cursorObject *cur)
 static PyObject *fetchOne(cursorObject *cur)
 {
     RETCODE rc;
-    Py_BEGIN_ALLOW_THREADS rc = SQLFetch(cur->hstmt);
-    Py_END_ALLOW_THREADS if (rc == SQL_NO_DATA_FOUND)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        rc = SQLFetch(cur->hstmt);
+    Py_END_ALLOW_THREADS
+    if (rc == SQL_NO_DATA_FOUND) {
         Py_INCREF(Py_None);
         return Py_None;
     }
-    else if (unsuccessful(rc))
-    {
+    else if (unsuccessful(rc)) {
         cursorError(cur, _T("FETCH"));
         return 0;
     }
@@ -1556,21 +1567,21 @@ static PyObject *odbcSQLDataSources(PyObject *self, PyObject *args)
     SQLSMALLINT svr_size = sizeof(svr) / sizeof(svr[0]);
     SQLSMALLINT desc_size = sizeof(desc) / sizeof(desc[0]);
     RETCODE rc;
-    Py_BEGIN_ALLOW_THREADS rc = SQLDataSources(Env, direction, svr, svr_size, &svr_size, desc, desc_size, &desc_size);
+    Py_BEGIN_ALLOW_THREADS
+        rc = SQLDataSources(Env, direction, svr, svr_size, &svr_size, desc, desc_size, &desc_size);
     Py_END_ALLOW_THREADS
 
-        if (rc == SQL_NO_DATA)
-    {
+    if (rc == SQL_NO_DATA) {
         ret = Py_None;
         Py_INCREF(Py_None);
     }
-    else if (unsuccessful(rc))
-    {
+    else if (unsuccessful(rc)) {
         connectionError(NULL, _T("SQLDataSources"));
         ret = NULL;
     }
-    else ret = Py_BuildValue("NN", PyWinObject_FromTCHAR((TCHAR *)svr, svr_size),
-                             PyWinObject_FromTCHAR((TCHAR *)desc, desc_size));
+    else
+        ret = Py_BuildValue("NN", PyWinObject_FromTCHAR((TCHAR *)svr, svr_size),
+                            PyWinObject_FromTCHAR((TCHAR *)desc, desc_size));
     return ret;
 }
 

--- a/win32/src/timermodule.cpp
+++ b/win32/src/timermodule.cpp
@@ -72,8 +72,9 @@ static PyObject *py_timer_set_timer(PyObject *self, PyObject *args)
     }
 
     // create the win32 timer
-    Py_BEGIN_ALLOW_THREADS;
-    timer_id = ::SetTimer(NULL, 0, elapse, py_win32_timer_callback);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        timer_id = ::SetTimer(NULL, 0, elapse, py_win32_timer_callback);
     Py_END_ALLOW_THREADS;
 
     if (!timer_id)
@@ -110,8 +111,9 @@ static PyObject *py_timer_kill_timer(PyObject *self, PyObject *args)
             return NULL;
 
     BOOL rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = ::KillTimer(NULL, timer_id);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        rc = ::KillTimer(NULL, timer_id);
     Py_END_ALLOW_THREADS;
     return PyBool_FromLong(rc);
 }

--- a/win32/src/timermodule.cpp
+++ b/win32/src/timermodule.cpp
@@ -72,9 +72,9 @@ static PyObject *py_timer_set_timer(PyObject *self, PyObject *args)
     }
 
     // create the win32 timer
-    Py_BEGIN_ALLOW_THREADS;
-    timer_id = ::SetTimer(NULL, 0, elapse, py_win32_timer_callback);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        timer_id = ::SetTimer(NULL, 0, elapse, py_win32_timer_callback);
+    Py_END_ALLOW_THREADS
 
     if (!timer_id)
         return PyWin_SetAPIError("SetTimer");
@@ -110,9 +110,9 @@ static PyObject *py_timer_kill_timer(PyObject *self, PyObject *args)
             return NULL;
 
     BOOL rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = ::KillTimer(NULL, timer_id);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        rc = ::KillTimer(NULL, timer_id);
+    Py_END_ALLOW_THREADS
     return PyBool_FromLong(rc);
 }
 

--- a/win32/src/win32api_cputopo.cpp
+++ b/win32/src/win32api_cputopo.cpp
@@ -195,8 +195,9 @@ PyObject *PyGetSystemCpuSetInformation(PyObject *self, PyObject *args)
 
     // second call to get the actual data
     BOOL result;
-    Py_BEGIN_ALLOW_THREADS;
-    result = (*pfnGetSystemCpuSetInformation)(buffer, length, &length, NULL, 0);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        result = (*pfnGetSystemCpuSetInformation)(buffer, length, &length, NULL, 0);
     Py_END_ALLOW_THREADS;
 
     if (!result) {

--- a/win32/src/win32api_cputopo.cpp
+++ b/win32/src/win32api_cputopo.cpp
@@ -195,9 +195,9 @@ PyObject *PyGetSystemCpuSetInformation(PyObject *self, PyObject *args)
 
     // second call to get the actual data
     BOOL result;
-    Py_BEGIN_ALLOW_THREADS;
-    result = (*pfnGetSystemCpuSetInformation)(buffer, length, &length, NULL, 0);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        result = (*pfnGetSystemCpuSetInformation)(buffer, length, &length, NULL, 0);
+    Py_END_ALLOW_THREADS
 
     if (!result) {
         DWORD err = GetLastError();

--- a/win32/src/win32apimodule.cpp
+++ b/win32/src/win32apimodule.cpp
@@ -379,9 +379,10 @@ static PyObject *PyGetEnvironmentVariableW(PyObject *self, PyObject *args)
                 break;
             }
         }
-        Py_BEGIN_ALLOW_THREADS returned_size = GetEnvironmentVariableW(Name, pResult, allocated_size);
-        Py_END_ALLOW_THREADS if (!returned_size)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            returned_size = GetEnvironmentVariableW(Name, pResult, allocated_size);
+        Py_END_ALLOW_THREADS
+        if (!returned_size) {
             DWORD err = GetLastError();
             if (err == ERROR_ENVVAR_NOT_FOUND) {
                 Py_INCREF(Py_None);
@@ -4137,9 +4138,10 @@ static PyObject *PyRegGetKeySecurity(PyObject *self, PyObject *args)
     PSECURITY_DESCRIPTOR psd = (SECURITY_DESCRIPTOR *)malloc(cb);
     if (psd == NULL)
         return PyErr_NoMemory();
-    Py_BEGIN_ALLOW_THREADS rc = RegGetKeySecurity(hKey, si, psd, &cb);
-    Py_END_ALLOW_THREADS if (rc != ERROR_SUCCESS)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        rc = RegGetKeySecurity(hKey, si, psd, &cb);
+    Py_END_ALLOW_THREADS
+    if (rc != ERROR_SUCCESS) {
         free(psd);
         return ReturnAPIError("RegGetKeySecurity", rc);
     }
@@ -5435,9 +5437,10 @@ PyObject *PyGetFileVersionInfo(PyObject *self, PyObject *args)
         goto done;
     if (!PyWinObject_AsWCHAR(obinfo, &info, FALSE))
         goto done;
-    Py_BEGIN_ALLOW_THREADS buf_len = GetFileVersionInfoSizeW(file_name, &dwHandle);  // handle is ignored
-    Py_END_ALLOW_THREADS if (buf_len == 0)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        buf_len = GetFileVersionInfoSizeW(file_name, &dwHandle);  // handle is ignored
+    Py_END_ALLOW_THREADS
+    if (buf_len == 0) {
         PyWin_SetAPIError("GetFileVersionInfo:GetFileVersionInfoSize", GetLastError());
         goto done;
     }
@@ -5446,9 +5449,10 @@ PyObject *PyGetFileVersionInfo(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_MemoryError, "GetFileVersionInfo");
         goto done;
     }
-    Py_BEGIN_ALLOW_THREADS success = GetFileVersionInfoW(file_name, dwHandle, buf_len, buf);
-    Py_END_ALLOW_THREADS if (!success)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        success = GetFileVersionInfoW(file_name, dwHandle, buf_len, buf);
+    Py_END_ALLOW_THREADS
+    if (!success) {
         PyWin_SetAPIError("GetFileVersionInfo");
         goto done;
     }
@@ -5866,8 +5870,11 @@ PyObject *PySetSystemPowerState(PyObject *self, PyObject *args)
         return NULL;
     bSuspend = PyObject_IsTrue(obSuspend);
     bForce = PyObject_IsTrue(obForce);
-    Py_BEGIN_ALLOW_THREADS bsuccess = SetSystemPowerState(bSuspend, bForce);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("SetSystemPowerState");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = SetSystemPowerState(bSuspend, bForce);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("SetSystemPowerState");
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -5918,8 +5925,9 @@ PyObject *PyGetSystemPowerStatus(PyObject *self, PyObject *args)
 {
     SYSTEM_POWER_STATUS sps;
     BOOL res = FALSE;
-    Py_BEGIN_ALLOW_THREADS;
-    res = GetSystemPowerStatus(&sps);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        res = GetSystemPowerStatus(&sps);
     Py_END_ALLOW_THREADS;
     if (!res)
         return PyWin_SetAPIError("GetSystemPowerStatus");

--- a/win32/src/win32apimodule.cpp
+++ b/win32/src/win32apimodule.cpp
@@ -379,9 +379,10 @@ static PyObject *PyGetEnvironmentVariableW(PyObject *self, PyObject *args)
                 break;
             }
         }
-        Py_BEGIN_ALLOW_THREADS returned_size = GetEnvironmentVariableW(Name, pResult, allocated_size);
-        Py_END_ALLOW_THREADS if (!returned_size)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            returned_size = GetEnvironmentVariableW(Name, pResult, allocated_size);
+        Py_END_ALLOW_THREADS
+        if (!returned_size) {
             DWORD err = GetLastError();
             if (err == ERROR_ENVVAR_NOT_FOUND) {
                 Py_INCREF(Py_None);
@@ -4137,9 +4138,10 @@ static PyObject *PyRegGetKeySecurity(PyObject *self, PyObject *args)
     PSECURITY_DESCRIPTOR psd = (SECURITY_DESCRIPTOR *)malloc(cb);
     if (psd == NULL)
         return PyErr_NoMemory();
-    Py_BEGIN_ALLOW_THREADS rc = RegGetKeySecurity(hKey, si, psd, &cb);
-    Py_END_ALLOW_THREADS if (rc != ERROR_SUCCESS)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        rc = RegGetKeySecurity(hKey, si, psd, &cb);
+    Py_END_ALLOW_THREADS
+    if (rc != ERROR_SUCCESS) {
         free(psd);
         return ReturnAPIError("RegGetKeySecurity", rc);
     }
@@ -5433,9 +5435,10 @@ PyObject *PyGetFileVersionInfo(PyObject *self, PyObject *args)
         goto done;
     if (!PyWinObject_AsWCHAR(obinfo, &info, FALSE))
         goto done;
-    Py_BEGIN_ALLOW_THREADS buf_len = GetFileVersionInfoSizeW(file_name, &dwHandle);  // handle is ignored
-    Py_END_ALLOW_THREADS if (buf_len == 0)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        buf_len = GetFileVersionInfoSizeW(file_name, &dwHandle);  // handle is ignored
+    Py_END_ALLOW_THREADS
+    if (buf_len == 0) {
         PyWin_SetAPIError("GetFileVersionInfo:GetFileVersionInfoSize", GetLastError());
         goto done;
     }
@@ -5444,9 +5447,10 @@ PyObject *PyGetFileVersionInfo(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_MemoryError, "GetFileVersionInfo");
         goto done;
     }
-    Py_BEGIN_ALLOW_THREADS success = GetFileVersionInfoW(file_name, dwHandle, buf_len, buf);
-    Py_END_ALLOW_THREADS if (!success)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        success = GetFileVersionInfoW(file_name, dwHandle, buf_len, buf);
+    Py_END_ALLOW_THREADS
+    if (!success) {
         PyWin_SetAPIError("GetFileVersionInfo");
         goto done;
     }
@@ -5864,8 +5868,11 @@ PyObject *PySetSystemPowerState(PyObject *self, PyObject *args)
         return NULL;
     bSuspend = PyObject_IsTrue(obSuspend);
     bForce = PyObject_IsTrue(obForce);
-    Py_BEGIN_ALLOW_THREADS bsuccess = SetSystemPowerState(bSuspend, bForce);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("SetSystemPowerState");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = SetSystemPowerState(bSuspend, bForce);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("SetSystemPowerState");
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -5916,9 +5923,9 @@ PyObject *PyGetSystemPowerStatus(PyObject *self, PyObject *args)
 {
     SYSTEM_POWER_STATUS sps;
     BOOL res = FALSE;
-    Py_BEGIN_ALLOW_THREADS;
-    res = GetSystemPowerStatus(&sps);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        res = GetSystemPowerStatus(&sps);
+    Py_END_ALLOW_THREADS
     if (!res)
         return PyWin_SetAPIError("GetSystemPowerStatus");
     return Py_BuildValue(

--- a/win32/src/win32apimodule.cpp
+++ b/win32/src/win32apimodule.cpp
@@ -379,9 +379,10 @@ static PyObject *PyGetEnvironmentVariableW(PyObject *self, PyObject *args)
                 break;
             }
         }
-        Py_BEGIN_ALLOW_THREADS returned_size = GetEnvironmentVariableW(Name, pResult, allocated_size);
-        Py_END_ALLOW_THREADS if (!returned_size)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            returned_size = GetEnvironmentVariableW(Name, pResult, allocated_size);
+        Py_END_ALLOW_THREADS
+        if (!returned_size) {
             DWORD err = GetLastError();
             if (err == ERROR_ENVVAR_NOT_FOUND) {
                 Py_INCREF(Py_None);
@@ -4160,9 +4161,10 @@ static PyObject *PyRegGetKeySecurity(PyObject *self, PyObject *args)
     PSECURITY_DESCRIPTOR psd = (SECURITY_DESCRIPTOR *)malloc(cb);
     if (psd == NULL)
         return PyErr_NoMemory();
-    Py_BEGIN_ALLOW_THREADS rc = RegGetKeySecurity(hKey, si, psd, &cb);
-    Py_END_ALLOW_THREADS if (rc != ERROR_SUCCESS)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        rc = RegGetKeySecurity(hKey, si, psd, &cb);
+    Py_END_ALLOW_THREADS
+    if (rc != ERROR_SUCCESS) {
         free(psd);
         return ReturnAPIError("RegGetKeySecurity", rc);
     }
@@ -5457,9 +5459,10 @@ PyObject *PyGetFileVersionInfo(PyObject *self, PyObject *args)
         goto done;
     if (!PyWinObject_AsWCHAR(obinfo, &info, FALSE))
         goto done;
-    Py_BEGIN_ALLOW_THREADS buf_len = GetFileVersionInfoSizeW(file_name, &dwHandle);  // handle is ignored
-    Py_END_ALLOW_THREADS if (buf_len == 0)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        buf_len = GetFileVersionInfoSizeW(file_name, &dwHandle);  // handle is ignored
+    Py_END_ALLOW_THREADS
+    if (buf_len == 0) {
         PyWin_SetAPIError("GetFileVersionInfo:GetFileVersionInfoSize", GetLastError());
         goto done;
     }
@@ -5468,9 +5471,10 @@ PyObject *PyGetFileVersionInfo(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_MemoryError, "GetFileVersionInfo");
         goto done;
     }
-    Py_BEGIN_ALLOW_THREADS success = GetFileVersionInfoW(file_name, dwHandle, buf_len, buf);
-    Py_END_ALLOW_THREADS if (!success)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        success = GetFileVersionInfoW(file_name, dwHandle, buf_len, buf);
+    Py_END_ALLOW_THREADS
+    if (!success) {
         PyWin_SetAPIError("GetFileVersionInfo");
         goto done;
     }
@@ -5925,8 +5929,11 @@ PyObject *PySetSystemPowerState(PyObject *self, PyObject *args)
         return NULL;
     bSuspend = PyObject_IsTrue(obSuspend);
     bForce = PyObject_IsTrue(obForce);
-    Py_BEGIN_ALLOW_THREADS bsuccess = SetSystemPowerState(bSuspend, bForce);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("SetSystemPowerState");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = SetSystemPowerState(bSuspend, bForce);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("SetSystemPowerState");
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -5977,9 +5984,9 @@ PyObject *PyGetSystemPowerStatus(PyObject *self, PyObject *args)
 {
     SYSTEM_POWER_STATUS sps;
     BOOL res = FALSE;
-    Py_BEGIN_ALLOW_THREADS;
-    res = GetSystemPowerStatus(&sps);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        res = GetSystemPowerStatus(&sps);
+    Py_END_ALLOW_THREADS
     if (!res)
         return PyWin_SetAPIError("GetSystemPowerStatus");
     return Py_BuildValue(

--- a/win32/src/win32clipboardmodule.cpp
+++ b/win32/src/win32clipboardmodule.cpp
@@ -65,8 +65,9 @@ static PyObject *py_change_clipboard_chain(PyObject *self, PyObject *args)
         return NULL;
 
     BOOL rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = ChangeClipboardChain(hWndRemove, hWndNewNext);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        rc = ChangeClipboardChain(hWndRemove, hWndNewNext);
     Py_END_ALLOW_THREADS;
 
     return (Py_BuildValue("i", (int)rc));
@@ -95,8 +96,9 @@ static PyObject *py_close_clipboard(PyObject *self, PyObject *args)
     CHECK_NO_ARGS2(args, "CloseClipboard");
 
     BOOL rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = CloseClipboard();
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        rc = CloseClipboard();
     Py_END_ALLOW_THREADS;
 
     if (!rc) {
@@ -128,8 +130,9 @@ static PyObject *py_count_clipboard_formats(PyObject *self, PyObject *args)
     CHECK_NO_ARGS2(args, "CountClipboardFormats");
 
     int rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = CountClipboardFormats();
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        rc = CountClipboardFormats();
     Py_END_ALLOW_THREADS;
 
     if (!rc) {
@@ -158,8 +161,9 @@ static PyObject *py_empty_clipboard(PyObject *self, PyObject *args)
     CHECK_NO_ARGS2(args, "EmptyClipboard");
 
     BOOL rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = EmptyClipboard();
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        rc = EmptyClipboard();
     Py_END_ALLOW_THREADS;
 
     if (!rc) {
@@ -201,8 +205,9 @@ static PyObject *py_enum_clipboard_formats(PyObject *self, PyObject *args)
     }
 
     UINT rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = EnumClipboardFormats(format);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        rc = EnumClipboardFormats(format);
     Py_END_ALLOW_THREADS;
 
     if (!rc) {
@@ -262,8 +267,9 @@ static PyObject *py_get_clipboard_data_handle(PyObject *self, PyObject *args)
     if (!IsClipboardFormatAvailable(format))
         return PyErr_Format(PyExc_TypeError, "The clipboard format %d is not available", format);
     HANDLE handle;
-    Py_BEGIN_ALLOW_THREADS;
-    handle = GetClipboardData((UINT)format);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        handle = GetClipboardData((UINT)format);
     Py_END_ALLOW_THREADS;
     if (!handle)
         return ReturnAPIError("GetClipboardData");
@@ -298,8 +304,9 @@ static PyObject *py_get_clipboard_data(PyObject *self, PyObject *args)
     PyObject *obfilename = NULL;
     UINT filecnt = 0, fileind = 0, filenamesize = 0;
     HDROP hdrop;
-    Py_BEGIN_ALLOW_THREADS;
-    handle = GetClipboardData((UINT)format);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        handle = GetClipboardData((UINT)format);
     Py_END_ALLOW_THREADS;
 
     if (!handle) {
@@ -484,8 +491,9 @@ static PyObject *py_get_clipboard_formatName(PyObject *self, PyObject *args)
 
     TCHAR buf[256];
     int rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = GetClipboardFormatName((UINT)format, buf, 255);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        rc = GetClipboardFormatName((UINT)format, buf, 255);
     Py_END_ALLOW_THREADS;
 
     if (!rc) {
@@ -511,8 +519,9 @@ static PyObject *py_get_clipboard_owner(PyObject *self, PyObject *args)
     CHECK_NO_ARGS2(args, "GetClipboardOwner");
 
     HWND rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = GetClipboardOwner();
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        rc = GetClipboardOwner();
     Py_END_ALLOW_THREADS;
 
     if (!rc)
@@ -555,8 +564,9 @@ static PyObject *py_get_clipboard_sequence_number(PyObject *self, PyObject *args
     CHECK_NO_ARGS2(args, "GetClipboardSequenceNumber");
 
     DWORD rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = GetClipboardSequenceNumber();
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        rc = GetClipboardSequenceNumber();
     Py_END_ALLOW_THREADS;
 
     return (Py_BuildValue("i", (int)rc));
@@ -586,8 +596,9 @@ static PyObject *py_get_clipboard_viewer(PyObject *self, PyObject *args)
     CHECK_NO_ARGS2(args, "GetClipboardViewer");
 
     HWND rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = GetClipboardViewer();
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        rc = GetClipboardViewer();
     Py_END_ALLOW_THREADS;
 
     if (!rc)
@@ -613,8 +624,9 @@ static PyObject *py_get_open_clipboard_window(PyObject *self, PyObject *args)
     CHECK_NO_ARGS2(args, "GetOpenClipboardWindow");
 
     HWND rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = GetOpenClipboardWindow();
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        rc = GetOpenClipboardWindow();
     Py_END_ALLOW_THREADS;
 
     if (!rc)
@@ -656,8 +668,9 @@ static PyObject *py_getPriority_clipboard_format(PyObject *self, PyObject *args)
         return NULL;
 
     int rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = GetPriorityClipboardFormat(format_list, num_formats);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        rc = GetPriorityClipboardFormat(format_list, num_formats);
     Py_END_ALLOW_THREADS;
 
     free(format_list);
@@ -688,8 +701,9 @@ static PyObject *py_is_clipboard_format_available(PyObject *self, PyObject *args
     }
 
     BOOL rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = IsClipboardFormatAvailable((UINT)format);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        rc = IsClipboardFormatAvailable((UINT)format);
     Py_END_ALLOW_THREADS;
 
     return (Py_BuildValue("i", (int)rc));
@@ -727,8 +741,9 @@ static PyObject *py_open_clipboard(PyObject *self, PyObject *args)
     if (!PyWinObject_AsHANDLE(obhWnd, (HANDLE *)&hWnd))
         return NULL;
     BOOL rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = OpenClipboard(hWnd);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        rc = OpenClipboard(hWnd);
     Py_END_ALLOW_THREADS;
 
     if (!rc) {
@@ -766,8 +781,9 @@ static PyObject *py_register_clipboard_format(PyObject *self, PyObject *args)
     if (!PyWinObject_AsTCHAR(obname, &name, FALSE))
         return NULL;
     UINT rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = RegisterClipboardFormat(name);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        rc = RegisterClipboardFormat(name);
     Py_END_ALLOW_THREADS;
     PyWinObject_FreeTCHAR(name);
     if (!rc)
@@ -860,8 +876,9 @@ static PyObject *py_set_clipboard_data(PyObject *self, PyObject *args)
         GlobalUnlock(handle);
     }
     HANDLE data;
-    Py_BEGIN_ALLOW_THREADS;
-    data = SetClipboardData((UINT)format, handle);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        data = SetClipboardData((UINT)format, handle);
     Py_END_ALLOW_THREADS;
 
     if (!data)
@@ -939,8 +956,9 @@ static PyObject *py_set_clipboard_text(PyObject *self, PyObject *args)
         memset(dest + cb, 0, size_null);
         GlobalUnlock(hMem);
         HANDLE data;
-        Py_BEGIN_ALLOW_THREADS;
-        data = SetClipboardData((UINT)format, hMem);
+        Py_BEGIN_ALLOW_THREADS
+            ;
+            data = SetClipboardData((UINT)format, hMem);
         Py_END_ALLOW_THREADS;
         if (!data)
             PyWin_SetAPIError("SetClipboardText");
@@ -978,8 +996,9 @@ static PyObject *py_set_clipboard_viewer(PyObject *self, PyObject *args)
     if (!PyWinObject_AsHANDLE(obhwnd, (HANDLE *)&hWndNewViewer))
         return NULL;
     HWND rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = SetClipboardViewer(hWndNewViewer);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        rc = SetClipboardViewer(hWndNewViewer);
     Py_END_ALLOW_THREADS;
 
     // Function can return NULL on success if there is no other viewer

--- a/win32/src/win32clipboardmodule.cpp
+++ b/win32/src/win32clipboardmodule.cpp
@@ -65,9 +65,9 @@ static PyObject *py_change_clipboard_chain(PyObject *self, PyObject *args)
         return NULL;
 
     BOOL rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = ChangeClipboardChain(hWndRemove, hWndNewNext);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        rc = ChangeClipboardChain(hWndRemove, hWndNewNext);
+    Py_END_ALLOW_THREADS
 
     return (Py_BuildValue("i", (int)rc));
 
@@ -95,9 +95,9 @@ static PyObject *py_close_clipboard(PyObject *self, PyObject *args)
     CHECK_NO_ARGS2(args, "CloseClipboard");
 
     BOOL rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = CloseClipboard();
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        rc = CloseClipboard();
+    Py_END_ALLOW_THREADS
 
     if (!rc) {
         return ReturnAPIError("CloseClipboard");
@@ -128,9 +128,9 @@ static PyObject *py_count_clipboard_formats(PyObject *self, PyObject *args)
     CHECK_NO_ARGS2(args, "CountClipboardFormats");
 
     int rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = CountClipboardFormats();
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        rc = CountClipboardFormats();
+    Py_END_ALLOW_THREADS
 
     if (!rc) {
         return ReturnAPIError("CountClipboardFormats");
@@ -158,9 +158,9 @@ static PyObject *py_empty_clipboard(PyObject *self, PyObject *args)
     CHECK_NO_ARGS2(args, "EmptyClipboard");
 
     BOOL rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = EmptyClipboard();
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        rc = EmptyClipboard();
+    Py_END_ALLOW_THREADS
 
     if (!rc) {
         return ReturnAPIError("EmptyClipboard");
@@ -201,9 +201,9 @@ static PyObject *py_enum_clipboard_formats(PyObject *self, PyObject *args)
     }
 
     UINT rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = EnumClipboardFormats(format);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        rc = EnumClipboardFormats(format);
+    Py_END_ALLOW_THREADS
 
     if (!rc) {
         DWORD errNum = GetLastError();
@@ -262,9 +262,9 @@ static PyObject *py_get_clipboard_data_handle(PyObject *self, PyObject *args)
     if (!IsClipboardFormatAvailable(format))
         return PyErr_Format(PyExc_TypeError, "The clipboard format %d is not available", format);
     HANDLE handle;
-    Py_BEGIN_ALLOW_THREADS;
-    handle = GetClipboardData((UINT)format);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        handle = GetClipboardData((UINT)format);
+    Py_END_ALLOW_THREADS
     if (!handle)
         return ReturnAPIError("GetClipboardData");
     return PyWinLong_FromHANDLE(handle);
@@ -298,9 +298,9 @@ static PyObject *py_get_clipboard_data(PyObject *self, PyObject *args)
     PyObject *obfilename = NULL;
     UINT filecnt = 0, fileind = 0, filenamesize = 0;
     HDROP hdrop;
-    Py_BEGIN_ALLOW_THREADS;
-    handle = GetClipboardData((UINT)format);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        handle = GetClipboardData((UINT)format);
+    Py_END_ALLOW_THREADS
 
     if (!handle) {
         return ReturnAPIError("GetClipboardData");
@@ -484,9 +484,9 @@ static PyObject *py_get_clipboard_formatName(PyObject *self, PyObject *args)
 
     TCHAR buf[256];
     int rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = GetClipboardFormatName((UINT)format, buf, 255);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        rc = GetClipboardFormatName((UINT)format, buf, 255);
+    Py_END_ALLOW_THREADS
 
     if (!rc) {
         return ReturnAPIError("GetClipboardFormatName");
@@ -511,9 +511,9 @@ static PyObject *py_get_clipboard_owner(PyObject *self, PyObject *args)
     CHECK_NO_ARGS2(args, "GetClipboardOwner");
 
     HWND rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = GetClipboardOwner();
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        rc = GetClipboardOwner();
+    Py_END_ALLOW_THREADS
 
     if (!rc)
         return ReturnAPIError("GetClipboardOwner");
@@ -555,9 +555,9 @@ static PyObject *py_get_clipboard_sequence_number(PyObject *self, PyObject *args
     CHECK_NO_ARGS2(args, "GetClipboardSequenceNumber");
 
     DWORD rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = GetClipboardSequenceNumber();
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        rc = GetClipboardSequenceNumber();
+    Py_END_ALLOW_THREADS
 
     return (Py_BuildValue("i", (int)rc));
 
@@ -586,9 +586,9 @@ static PyObject *py_get_clipboard_viewer(PyObject *self, PyObject *args)
     CHECK_NO_ARGS2(args, "GetClipboardViewer");
 
     HWND rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = GetClipboardViewer();
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        rc = GetClipboardViewer();
+    Py_END_ALLOW_THREADS
 
     if (!rc)
         return ReturnAPIError("GetClipboardViewer");
@@ -613,9 +613,9 @@ static PyObject *py_get_open_clipboard_window(PyObject *self, PyObject *args)
     CHECK_NO_ARGS2(args, "GetOpenClipboardWindow");
 
     HWND rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = GetOpenClipboardWindow();
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        rc = GetOpenClipboardWindow();
+    Py_END_ALLOW_THREADS
 
     if (!rc)
         return ReturnAPIError("GetOpenClipboardWindow");
@@ -656,9 +656,9 @@ static PyObject *py_getPriority_clipboard_format(PyObject *self, PyObject *args)
         return NULL;
 
     int rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = GetPriorityClipboardFormat(format_list, num_formats);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        rc = GetPriorityClipboardFormat(format_list, num_formats);
+    Py_END_ALLOW_THREADS
 
     free(format_list);
     return PyLong_FromLong(rc);
@@ -688,9 +688,9 @@ static PyObject *py_is_clipboard_format_available(PyObject *self, PyObject *args
     }
 
     BOOL rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = IsClipboardFormatAvailable((UINT)format);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        rc = IsClipboardFormatAvailable((UINT)format);
+    Py_END_ALLOW_THREADS
 
     return (Py_BuildValue("i", (int)rc));
 
@@ -727,9 +727,9 @@ static PyObject *py_open_clipboard(PyObject *self, PyObject *args)
     if (!PyWinObject_AsHANDLE(obhWnd, (HANDLE *)&hWnd))
         return NULL;
     BOOL rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = OpenClipboard(hWnd);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        rc = OpenClipboard(hWnd);
+    Py_END_ALLOW_THREADS
 
     if (!rc) {
         return ReturnAPIError("OpenClipboard");
@@ -766,9 +766,9 @@ static PyObject *py_register_clipboard_format(PyObject *self, PyObject *args)
     if (!PyWinObject_AsTCHAR(obname, &name, FALSE))
         return NULL;
     UINT rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = RegisterClipboardFormat(name);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        rc = RegisterClipboardFormat(name);
+    Py_END_ALLOW_THREADS
     PyWinObject_FreeTCHAR(name);
     if (!rc)
         return ReturnAPIError("RegisterClipboardFormat");
@@ -860,9 +860,9 @@ static PyObject *py_set_clipboard_data(PyObject *self, PyObject *args)
         GlobalUnlock(handle);
     }
     HANDLE data;
-    Py_BEGIN_ALLOW_THREADS;
-    data = SetClipboardData((UINT)format, handle);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        data = SetClipboardData((UINT)format, handle);
+    Py_END_ALLOW_THREADS
 
     if (!data)
         // XXX - should we GlobalFree the mem?
@@ -939,9 +939,9 @@ static PyObject *py_set_clipboard_text(PyObject *self, PyObject *args)
         memset(dest + cb, 0, size_null);
         GlobalUnlock(hMem);
         HANDLE data;
-        Py_BEGIN_ALLOW_THREADS;
-        data = SetClipboardData((UINT)format, hMem);
-        Py_END_ALLOW_THREADS;
+        Py_BEGIN_ALLOW_THREADS
+            data = SetClipboardData((UINT)format, hMem);
+        Py_END_ALLOW_THREADS
         if (!data)
             PyWin_SetAPIError("SetClipboardText");
         else
@@ -978,9 +978,9 @@ static PyObject *py_set_clipboard_viewer(PyObject *self, PyObject *args)
     if (!PyWinObject_AsHANDLE(obhwnd, (HANDLE *)&hWndNewViewer))
         return NULL;
     HWND rc;
-    Py_BEGIN_ALLOW_THREADS;
-    rc = SetClipboardViewer(hWndNewViewer);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        rc = SetClipboardViewer(hWndNewViewer);
+    Py_END_ALLOW_THREADS
 
     // Function can return NULL on success if there is no other viewer
     if (rc != NULL)

--- a/win32/src/win32credmodule.cpp
+++ b/win32/src/win32credmodule.cpp
@@ -547,8 +547,9 @@ PyObject *PyCredGetSessionTypes(PyObject *self, PyObject *args, PyObject *kwargs
     }
     BOOL res = TRUE;
     DWORD arr[CRED_TYPE_MAXIMUM];
-    Py_BEGIN_ALLOW_THREADS;
-    res = CredGetSessionTypes(mpc, arr);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        res = CredGetSessionTypes(mpc, arr);
     Py_END_ALLOW_THREADS;
     if (!res)
         return PyWin_SetAPIError("CredGetSessionTypes");

--- a/win32/src/win32credmodule.cpp
+++ b/win32/src/win32credmodule.cpp
@@ -547,9 +547,9 @@ PyObject *PyCredGetSessionTypes(PyObject *self, PyObject *args, PyObject *kwargs
     }
     BOOL res = TRUE;
     DWORD arr[CRED_TYPE_MAXIMUM];
-    Py_BEGIN_ALLOW_THREADS;
-    res = CredGetSessionTypes(mpc, arr);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        res = CredGetSessionTypes(mpc, arr);
+    Py_END_ALLOW_THREADS
     if (!res)
         return PyWin_SetAPIError("CredGetSessionTypes");
     PyObject *ret = PyList_New(mpc);
@@ -724,13 +724,13 @@ PyObject *PyCredWrite(PyObject *self, PyObject *args, PyObject *kwargs)
         return NULL;
     BOOL ok;
     DWORD err;
-    Py_BEGIN_ALLOW_THREADS;
-    ok = CredWrite(&cred, flags);
-    // Capture error before Py_END_ALLOW_THREADS reacquires the GIL,
-    // which may call Win32 functions that overwrite GetLastError().
-    if (!ok)
-        err = GetLastError();
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        ok = CredWrite(&cred, flags);
+        // Capture error before Py_END_ALLOW_THREADS reacquires the GIL,
+        // which may call Win32 functions that overwrite GetLastError().
+        if (!ok)
+            err = GetLastError();
+    Py_END_ALLOW_THREADS
     if (!ok)
         PyWin_SetAPIError("CredWrite", err);
     else {
@@ -948,10 +948,10 @@ PyObject *PyCredUIPromptForCredentials(PyObject *self, PyObject *args, PyObject 
     if (!PyWinObject_AsCREDUI_INFO(obuiinfo, &uiinfo))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS;
-    reterr = CredUIPromptForCredentials(uiinfo, targetname, reserved, autherror, username_io, maxusername, password_io,
-                                        maxpassword, &save, flags);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        reterr = CredUIPromptForCredentials(uiinfo, targetname, reserved, autherror, username_io, maxusername,
+                                            password_io, maxpassword, &save, flags);
+    Py_END_ALLOW_THREADS
     if (reterr == NO_ERROR)
         ret = Py_BuildValue("uuN", username_io, password_io, PyBool_FromLong(save));
     else

--- a/win32/src/win32crypt/PyCERTSTORE.cpp
+++ b/win32/src/win32crypt/PyCERTSTORE.cpp
@@ -148,8 +148,9 @@ PyObject *PyCERTSTORE::PyCertCloseStore(PyObject *self, PyObject *args, PyObject
                    "The Flags param to CertCloseStore is deprecated; a non-zero value is likely to crash");
     }
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = CertCloseStore(hcertstore, CERT_CLOSE_STORE_CHECK_FLAG);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        bsuccess = CertCloseStore(hcertstore, CERT_CLOSE_STORE_CHECK_FLAG);
     Py_END_ALLOW_THREADS;
     // On failure, the message just says the free is "pending" - so we still want to invalidate it
     // so we don't try and free it outselves later.
@@ -179,8 +180,9 @@ PyObject *PyCERTSTORE::PyCertControlStore(PyObject *self, PyObject *args, PyObje
     if (!PyWinObject_AsHANDLE(obCtrlPara, &hevent))
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = CertControlStore(hcertstore, dwFlags, dwCtrlType, hevent);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        bsuccess = CertControlStore(hcertstore, dwFlags, dwCtrlType, hevent);
     Py_END_ALLOW_THREADS;
     if (!bsuccess)
         return PyWin_SetAPIError("CertControlStore");
@@ -200,8 +202,9 @@ PyObject *PyCERTSTORE::PyCertEnumCertificatesInStore(PyObject *self, PyObject *a
     if (ret == NULL)
         return NULL;
     do {
-        Py_BEGIN_ALLOW_THREADS;
-        pccert_context = CertEnumCertificatesInStore(hcertstore, pccert_context);
+        Py_BEGIN_ALLOW_THREADS
+            ;
+            pccert_context = CertEnumCertificatesInStore(hcertstore, pccert_context);
         Py_END_ALLOW_THREADS;
         if (pccert_context != NULL) {
             // increments reference count
@@ -238,8 +241,9 @@ PyObject *PyCERTSTORE::PyCertEnumCTLsInStore(PyObject *self, PyObject *args)
     if (ret == NULL)
         return NULL;
     do {
-        Py_BEGIN_ALLOW_THREADS;
-        ctl_context = CertEnumCTLsInStore(hcertstore, ctl_context);
+        Py_BEGIN_ALLOW_THREADS
+            ;
+            ctl_context = CertEnumCTLsInStore(hcertstore, ctl_context);
         Py_END_ALLOW_THREADS;
         if (ctl_context != NULL) {
             py_ctl_context = CertDuplicateCTLContext(ctl_context);
@@ -304,8 +308,9 @@ PyObject *PyCERTSTORE::PyCertSaveStore(PyObject *self, PyObject *args, PyObject 
         }
     }
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = CertSaveStore(hcertstore, dwMsgAndCertEncodingType, dwSaveAs, dwSaveTo, pvSaveToPara, dwFlags);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        bsuccess = CertSaveStore(hcertstore, dwMsgAndCertEncodingType, dwSaveAs, dwSaveTo, pvSaveToPara, dwFlags);
     Py_END_ALLOW_THREADS;
     if (!bsuccess)
         PyWin_SetAPIError("PyCERTSTORE::CertSaveStore");
@@ -340,9 +345,10 @@ PyObject *PyCERTSTORE::PyCertAddEncodedCertificateToStore(PyObject *self, PyObje
     if (!pybuf.ok())
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = CertAddEncodedCertificateToStore(hcertstore, dwCertEncodingType, (BYTE *)pybuf.ptr(), pybuf.len(),
-                                                dwAddDisposition, (const struct _CERT_CONTEXT **)&newcert_context);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        bsuccess = CertAddEncodedCertificateToStore(hcertstore, dwCertEncodingType, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                                    dwAddDisposition, (const struct _CERT_CONTEXT **)&newcert_context);
     Py_END_ALLOW_THREADS;
     if (!bsuccess)
         return PyWin_SetAPIError("PyCERTSTORE::CertAddEncodedCertificateToStore");
@@ -366,8 +372,9 @@ PyObject *PyCERTSTORE::PyCertAddCertificateContextToStore(PyObject *self, PyObje
     if (!PyWinObject_AsCERT_CONTEXT(obcertcontext, &pcert_context, FALSE))
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = CertAddCertificateContextToStore(hcertstore, pcert_context, dwAddDisposition, &newcert_context);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        bsuccess = CertAddCertificateContextToStore(hcertstore, pcert_context, dwAddDisposition, &newcert_context);
     Py_END_ALLOW_THREADS;
     if (!bsuccess)
         return PyWin_SetAPIError("CertAddCertificateContextToStore");
@@ -391,8 +398,9 @@ PyObject *PyCERTSTORE::PyCertAddCertificateLinkToStore(PyObject *self, PyObject 
     if (!PyWinObject_AsCERT_CONTEXT(obcertcontext, &pcert_context, FALSE))
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = CertAddCertificateLinkToStore(hcertstore, pcert_context, dwAddDisposition, &newcert_context);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        bsuccess = CertAddCertificateLinkToStore(hcertstore, pcert_context, dwAddDisposition, &newcert_context);
     Py_END_ALLOW_THREADS;
     if (!bsuccess)
         return PyWin_SetAPIError("CertAddCertificateLinkToStore");
@@ -415,8 +423,9 @@ PyObject *PyCERTSTORE::PyCertAddCTLContextToStore(PyObject *self, PyObject *args
     if (!PyWinObject_AsCTL_CONTEXT(obctl, &pctl, FALSE))
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = CertAddCTLContextToStore(hcertstore, pctl, dwAddDisposition, &new_pctl);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        bsuccess = CertAddCTLContextToStore(hcertstore, pctl, dwAddDisposition, &new_pctl);
     Py_END_ALLOW_THREADS;
     if (!bsuccess)
         return PyWin_SetAPIError("CertAddCTLContextToStore");
@@ -440,8 +449,9 @@ PyObject *PyCERTSTORE::PyCertAddCTLLinkToStore(PyObject *self, PyObject *args, P
     if (!PyWinObject_AsCTL_CONTEXT(obctl, &pctl, FALSE))
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = CertAddCTLLinkToStore(hcertstore, pctl, dwAddDisposition, &new_pctl);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        bsuccess = CertAddCTLLinkToStore(hcertstore, pctl, dwAddDisposition, &new_pctl);
     Py_END_ALLOW_THREADS;
     if (!bsuccess)
         return PyWin_SetAPIError("CertAddCTLLinkToStore");
@@ -467,8 +477,9 @@ PyObject *PyCERTSTORE::PyCertAddStoreToCollection(PyObject *self, PyObject *args
     if (!PyWinObject_AsCERTSTORE(obsibling, &sibling, TRUE))
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = CertAddStoreToCollection(hcertstore, sibling, flags, priority);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        bsuccess = CertAddStoreToCollection(hcertstore, sibling, flags, priority);
     Py_END_ALLOW_THREADS;
     if (!bsuccess)
         return PyWin_SetAPIError("CertAddStoreToCollection");
@@ -492,8 +503,9 @@ PyObject *PyCERTSTORE::PyCertRemoveStoreFromCollection(PyObject *self, PyObject 
     if (!PyWinObject_AsCERTSTORE(obsibling, &sibling, TRUE))
         return NULL;
     // does not return a value
-    Py_BEGIN_ALLOW_THREADS;
-    CertRemoveStoreFromCollection(hcertstore, sibling);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        CertRemoveStoreFromCollection(hcertstore, sibling);
     Py_END_ALLOW_THREADS;
     Py_INCREF(Py_None);
     return Py_None;
@@ -519,8 +531,9 @@ PyObject *PyCERTSTORE::PyPFXExportCertStoreEx(PyObject *self, PyObject *args, Py
     CRYPT_DATA_BLOB out = {0};
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = PFXExportCertStoreEx(hcertstore, &out, password, NULL, flags);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        bsuccess = PFXExportCertStoreEx(hcertstore, &out, password, NULL, flags);
     Py_END_ALLOW_THREADS;
     if (!bsuccess)
         return PyWin_SetAPIError("PFXExportCertStoreEx");
@@ -529,8 +542,9 @@ PyObject *PyCERTSTORE::PyPFXExportCertStoreEx(PyObject *self, PyObject *args, Py
         return PyErr_NoMemory();
 
     PyObject *ret = NULL;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = PFXExportCertStoreEx(hcertstore, &out, password, NULL, flags);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        bsuccess = PFXExportCertStoreEx(hcertstore, &out, password, NULL, flags);
     Py_END_ALLOW_THREADS;
     if (!bsuccess)
         PyWin_SetAPIError("PFXExportCertStoreEx");

--- a/win32/src/win32crypt/PyCERTSTORE.cpp
+++ b/win32/src/win32crypt/PyCERTSTORE.cpp
@@ -148,12 +148,13 @@ PyObject *PyCERTSTORE::PyCertCloseStore(PyObject *self, PyObject *args, PyObject
                    "The Flags param to CertCloseStore is deprecated; a non-zero value is likely to crash");
     }
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = CertCloseStore(hcertstore, CERT_CLOSE_STORE_CHECK_FLAG);
-    Py_END_ALLOW_THREADS;
-    // On failure, the message just says the free is "pending" - so we still want to invalidate it
-    // so we don't try and free it outselves later.
-    ((PyCERTSTORE *)self)->hcertstore = NULL;
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertCloseStore(hcertstore, CERT_CLOSE_STORE_CHECK_FLAG);
+    Py_END_ALLOW_THREADS
+        // On failure, the message just says the free is "pending" - so we still want to invalidate it
+        // so we don't try and free it outselves later.
+        ((PyCERTSTORE *)self)
+            ->hcertstore = NULL;
     Py_XDECREF(((PyCERTSTORE *)self)->obcertstore);
     ((PyCERTSTORE *)self)->obcertstore = NULL;
     if (!bsuccess)
@@ -179,9 +180,9 @@ PyObject *PyCERTSTORE::PyCertControlStore(PyObject *self, PyObject *args, PyObje
     if (!PyWinObject_AsHANDLE(obCtrlPara, &hevent))
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = CertControlStore(hcertstore, dwFlags, dwCtrlType, hevent);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertControlStore(hcertstore, dwFlags, dwCtrlType, hevent);
+    Py_END_ALLOW_THREADS
     if (!bsuccess)
         return PyWin_SetAPIError("CertControlStore");
     Py_INCREF(Py_None);
@@ -200,9 +201,9 @@ PyObject *PyCERTSTORE::PyCertEnumCertificatesInStore(PyObject *self, PyObject *a
     if (ret == NULL)
         return NULL;
     do {
-        Py_BEGIN_ALLOW_THREADS;
-        pccert_context = CertEnumCertificatesInStore(hcertstore, pccert_context);
-        Py_END_ALLOW_THREADS;
+        Py_BEGIN_ALLOW_THREADS
+            pccert_context = CertEnumCertificatesInStore(hcertstore, pccert_context);
+        Py_END_ALLOW_THREADS
         if (pccert_context != NULL) {
             // increments reference count
             py_pccert_context = CertDuplicateCertificateContext(pccert_context);
@@ -238,9 +239,9 @@ PyObject *PyCERTSTORE::PyCertEnumCTLsInStore(PyObject *self, PyObject *args)
     if (ret == NULL)
         return NULL;
     do {
-        Py_BEGIN_ALLOW_THREADS;
-        ctl_context = CertEnumCTLsInStore(hcertstore, ctl_context);
-        Py_END_ALLOW_THREADS;
+        Py_BEGIN_ALLOW_THREADS
+            ctl_context = CertEnumCTLsInStore(hcertstore, ctl_context);
+        Py_END_ALLOW_THREADS
         if (ctl_context != NULL) {
             py_ctl_context = CertDuplicateCTLContext(ctl_context);
             ret_item = PyWinObject_FromCTL_CONTEXT(py_ctl_context);
@@ -304,9 +305,9 @@ PyObject *PyCERTSTORE::PyCertSaveStore(PyObject *self, PyObject *args, PyObject 
         }
     }
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = CertSaveStore(hcertstore, dwMsgAndCertEncodingType, dwSaveAs, dwSaveTo, pvSaveToPara, dwFlags);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertSaveStore(hcertstore, dwMsgAndCertEncodingType, dwSaveAs, dwSaveTo, pvSaveToPara, dwFlags);
+    Py_END_ALLOW_THREADS
     if (!bsuccess)
         PyWin_SetAPIError("PyCERTSTORE::CertSaveStore");
     else {
@@ -340,10 +341,10 @@ PyObject *PyCERTSTORE::PyCertAddEncodedCertificateToStore(PyObject *self, PyObje
     if (!pybuf.ok())
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = CertAddEncodedCertificateToStore(hcertstore, dwCertEncodingType, (BYTE *)pybuf.ptr(), pybuf.len(),
-                                                dwAddDisposition, (const struct _CERT_CONTEXT **)&newcert_context);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertAddEncodedCertificateToStore(hcertstore, dwCertEncodingType, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                                    dwAddDisposition, (const struct _CERT_CONTEXT **)&newcert_context);
+    Py_END_ALLOW_THREADS
     if (!bsuccess)
         return PyWin_SetAPIError("PyCERTSTORE::CertAddEncodedCertificateToStore");
     return PyWinObject_FromCERT_CONTEXT(newcert_context);
@@ -366,9 +367,9 @@ PyObject *PyCERTSTORE::PyCertAddCertificateContextToStore(PyObject *self, PyObje
     if (!PyWinObject_AsCERT_CONTEXT(obcertcontext, &pcert_context, FALSE))
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = CertAddCertificateContextToStore(hcertstore, pcert_context, dwAddDisposition, &newcert_context);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertAddCertificateContextToStore(hcertstore, pcert_context, dwAddDisposition, &newcert_context);
+    Py_END_ALLOW_THREADS
     if (!bsuccess)
         return PyWin_SetAPIError("CertAddCertificateContextToStore");
     return PyWinObject_FromCERT_CONTEXT(newcert_context);
@@ -391,9 +392,9 @@ PyObject *PyCERTSTORE::PyCertAddCertificateLinkToStore(PyObject *self, PyObject 
     if (!PyWinObject_AsCERT_CONTEXT(obcertcontext, &pcert_context, FALSE))
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = CertAddCertificateLinkToStore(hcertstore, pcert_context, dwAddDisposition, &newcert_context);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertAddCertificateLinkToStore(hcertstore, pcert_context, dwAddDisposition, &newcert_context);
+    Py_END_ALLOW_THREADS
     if (!bsuccess)
         return PyWin_SetAPIError("CertAddCertificateLinkToStore");
     return PyWinObject_FromCERT_CONTEXT(newcert_context);
@@ -415,9 +416,9 @@ PyObject *PyCERTSTORE::PyCertAddCTLContextToStore(PyObject *self, PyObject *args
     if (!PyWinObject_AsCTL_CONTEXT(obctl, &pctl, FALSE))
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = CertAddCTLContextToStore(hcertstore, pctl, dwAddDisposition, &new_pctl);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertAddCTLContextToStore(hcertstore, pctl, dwAddDisposition, &new_pctl);
+    Py_END_ALLOW_THREADS
     if (!bsuccess)
         return PyWin_SetAPIError("CertAddCTLContextToStore");
     return PyWinObject_FromCTL_CONTEXT(new_pctl);
@@ -440,9 +441,9 @@ PyObject *PyCERTSTORE::PyCertAddCTLLinkToStore(PyObject *self, PyObject *args, P
     if (!PyWinObject_AsCTL_CONTEXT(obctl, &pctl, FALSE))
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = CertAddCTLLinkToStore(hcertstore, pctl, dwAddDisposition, &new_pctl);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertAddCTLLinkToStore(hcertstore, pctl, dwAddDisposition, &new_pctl);
+    Py_END_ALLOW_THREADS
     if (!bsuccess)
         return PyWin_SetAPIError("CertAddCTLLinkToStore");
     return PyWinObject_FromCTL_CONTEXT(new_pctl);
@@ -467,9 +468,9 @@ PyObject *PyCERTSTORE::PyCertAddStoreToCollection(PyObject *self, PyObject *args
     if (!PyWinObject_AsCERTSTORE(obsibling, &sibling, TRUE))
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = CertAddStoreToCollection(hcertstore, sibling, flags, priority);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertAddStoreToCollection(hcertstore, sibling, flags, priority);
+    Py_END_ALLOW_THREADS
     if (!bsuccess)
         return PyWin_SetAPIError("CertAddStoreToCollection");
 
@@ -492,9 +493,9 @@ PyObject *PyCERTSTORE::PyCertRemoveStoreFromCollection(PyObject *self, PyObject 
     if (!PyWinObject_AsCERTSTORE(obsibling, &sibling, TRUE))
         return NULL;
     // does not return a value
-    Py_BEGIN_ALLOW_THREADS;
-    CertRemoveStoreFromCollection(hcertstore, sibling);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        CertRemoveStoreFromCollection(hcertstore, sibling);
+    Py_END_ALLOW_THREADS
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -519,9 +520,9 @@ PyObject *PyCERTSTORE::PyPFXExportCertStoreEx(PyObject *self, PyObject *args, Py
     CRYPT_DATA_BLOB out = {0};
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = PFXExportCertStoreEx(hcertstore, &out, password, NULL, flags);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = PFXExportCertStoreEx(hcertstore, &out, password, NULL, flags);
+    Py_END_ALLOW_THREADS
     if (!bsuccess)
         return PyWin_SetAPIError("PFXExportCertStoreEx");
     out.pbData = (BYTE *)malloc(out.cbData);
@@ -529,9 +530,9 @@ PyObject *PyCERTSTORE::PyPFXExportCertStoreEx(PyObject *self, PyObject *args, Py
         return PyErr_NoMemory();
 
     PyObject *ret = NULL;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = PFXExportCertStoreEx(hcertstore, &out, password, NULL, flags);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = PFXExportCertStoreEx(hcertstore, &out, password, NULL, flags);
+    Py_END_ALLOW_THREADS
     if (!bsuccess)
         PyWin_SetAPIError("PFXExportCertStoreEx");
     else

--- a/win32/src/win32crypt/PyCERT_CONTEXT.cpp
+++ b/win32/src/win32crypt/PyCERT_CONTEXT.cpp
@@ -257,8 +257,9 @@ PyObject *PyCERT_CONTEXT::PyCertFreeCertificateContext(PyObject *self, PyObject 
 {
     GET_CERT_CONTEXT(pcc);
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = CertFreeCertificateContext(pcc);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        bsuccess = CertFreeCertificateContext(pcc);
     Py_END_ALLOW_THREADS;
     if (!bsuccess)
         return PyWin_SetAPIError("CertFreeCertificateContext");
@@ -277,8 +278,11 @@ PyObject *PyCERT_CONTEXT::PyCertEnumCertificateContextProperties(PyObject *self,
     if (ret == NULL)
         return NULL;
     while (TRUE) {
-        Py_BEGIN_ALLOW_THREADS dwPropId = CertEnumCertificateContextProperties(pccert_context, dwPropId);
-        Py_END_ALLOW_THREADS if (dwPropId == 0) break;
+        Py_BEGIN_ALLOW_THREADS
+            dwPropId = CertEnumCertificateContextProperties(pccert_context, dwPropId);
+        Py_END_ALLOW_THREADS
+        if (dwPropId == 0)
+            break;
         ret_item = PyLong_FromUnsignedLong(dwPropId);
         if ((ret_item == NULL) || (PyList_Append(ret, ret_item) == -1)) {
             Py_XDECREF(ret_item);
@@ -308,9 +312,12 @@ PyObject *PyCERT_CONTEXT::PyCryptAcquireCertificatePrivateKey(PyObject *self, Py
                                      &flags))  // @pyparm int|Flags|0|Combination of CRYPT_ACQUIRE_*_FLAG constants
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptAcquireCertificatePrivateKey(pccert_context, flags, reserved, &hcryptprov, &keyspec, &callerfree);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptAcquireCertificatePrivateKey");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess =
+            CryptAcquireCertificatePrivateKey(pccert_context, flags, reserved, &hcryptprov, &keyspec, &callerfree);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CryptAcquireCertificatePrivateKey");
 
     /* If callerfree returns false, CSP handle shouldn't be freed, so increase its refcount since
         CryptReleaseContext is called when python object is destroyed */
@@ -336,14 +343,21 @@ PyObject *PyCERT_CONTEXT::PyCertGetEnhancedKeyUsage(PyObject *self, PyObject *ar
                                                // CERT_FIND_PROP_ONLY_ENHKEY_USAGE_FLAG, or 0
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertGetEnhancedKeyUsage(pccert_context, flags, pceu, &bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CertGetEnhancedKeyUsage");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertGetEnhancedKeyUsage(pccert_context, flags, pceu, &bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CertGetEnhancedKeyUsage");
     pceu = (PCERT_ENHKEY_USAGE)malloc(bufsize);
     if (pceu == NULL)
         return PyErr_Format(PyExc_MemoryError, "Failed to allocate %d bytes", bufsize);
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertGetEnhancedKeyUsage(pccert_context, flags, pceu, &bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CertGetEnhancedKeyUsage");
-    else ret = PyWinObject_FromCTL_USAGE(pceu);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertGetEnhancedKeyUsage(pccert_context, flags, pceu, &bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CertGetEnhancedKeyUsage");
+    else
+        ret = PyWinObject_FromCTL_USAGE(pceu);
     free(pceu);
     return ret;
 }
@@ -357,9 +371,12 @@ PyObject *PyCERT_CONTEXT::PyCertGetIntendedKeyUsage(PyObject *self, PyObject *ar
     DWORD buf;
     DWORD bufsize = sizeof(DWORD);
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CertGetIntendedKeyUsage(pccert_context->dwCertEncodingType, pccert_context->pCertInfo, (BYTE *)&buf, bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CertGetIntendedKeyUsage");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertGetIntendedKeyUsage(pccert_context->dwCertEncodingType, pccert_context->pCertInfo, (BYTE *)&buf,
+                                           bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CertGetIntendedKeyUsage");
     return PyLong_FromUnsignedLong(buf);
 }
 
@@ -376,15 +393,22 @@ PyObject *PyCERT_CONTEXT::PyCertSerializeCertificateStoreElement(PyObject *self,
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertSerializeCertificateStoreElement(pccert_context, flags, buf, &bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CertSerializeCertificateStoreElement");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertSerializeCertificateStoreElement(pccert_context, flags, buf, &bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CertSerializeCertificateStoreElement");
     buf = (BYTE *)malloc(bufsize);
     if (buf == NULL)
         return PyErr_Format(PyExc_MemoryError, "Unable to allocate %d bytes", bufsize);
 
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertSerializeCertificateStoreElement(pccert_context, flags, buf, &bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CertSerializeCertificateStoreElement");
-    else ret = PyBytes_FromStringAndSize((char *)buf, bufsize);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertSerializeCertificateStoreElement(pccert_context, flags, buf, &bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CertSerializeCertificateStoreElement");
+    else
+        ret = PyBytes_FromStringAndSize((char *)buf, bufsize);
     free(buf);
     return ret;
 }
@@ -407,8 +431,11 @@ PyObject *PyCERT_CONTEXT::PyCertVerifySubjectCertificateContext(PyObject *self, 
     if (!PyWinObject_AsCERT_CONTEXT(obissuer, &issuer, TRUE))
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertVerifySubjectCertificateContext(pccert_context, issuer, &flags);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CertVerifySubjectCertificateContext");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertVerifySubjectCertificateContext(pccert_context, issuer, &flags);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CertVerifySubjectCertificateContext");
     return PyLong_FromUnsignedLong(flags);
 }
 
@@ -417,12 +444,15 @@ PyObject *PyCERT_CONTEXT::PyCertDeleteCertificateFromStore(PyObject *self, PyObj
 {
     GET_CERT_CONTEXT(pcert_context);
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertDeleteCertificateFromStore(pcert_context);
-    // CertDeleteCertificateFromStore internally calls CertFreeCertificateContext, so we need to zero
-    // the context like we do in PyCertFreeCertificateContext, in order to prevent an attempt to free
-    // it again later in the destructor.
-    ((PyCERT_CONTEXT *)self)->pccert_context = NULL;
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CertDeleteCertificateFromStore");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertDeleteCertificateFromStore(pcert_context);
+        // CertDeleteCertificateFromStore internally calls CertFreeCertificateContext, so we need to zero
+        // the context like we do in PyCertFreeCertificateContext, in order to prevent an attempt to free
+        // it again later in the destructor.
+        ((PyCERT_CONTEXT *)self)->pccert_context = NULL;
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CertDeleteCertificateFromStore");
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -443,9 +473,10 @@ PyObject *PyCERT_CONTEXT::PyCertGetCertificateContextProperty(PyObject *self, Py
                                      &dwPropId))  // @pyparm int|PropId||One of the CERT_*_PROP_ID constants
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertGetCertificateContextProperty(pccert_context, dwPropId, pvData, &pcbData);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertGetCertificateContextProperty(pccert_context, dwPropId, pvData, &pcbData);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         PyWin_SetAPIError("CertGetCertificateContextProperty");
         return NULL;
     }
@@ -456,9 +487,10 @@ PyObject *PyCERT_CONTEXT::PyCertGetCertificateContextProperty(PyObject *self, Py
             return PyErr_Format(PyExc_MemoryError, "CertGetCertificateContextProperty: unable to allocate %d bytes",
                                 pcbData);
         ZeroMemory(pvData, pcbData);
-        Py_BEGIN_ALLOW_THREADS bsuccess = CertGetCertificateContextProperty(pccert_context, dwPropId, pvData, &pcbData);
-        Py_END_ALLOW_THREADS if (!bsuccess)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            bsuccess = CertGetCertificateContextProperty(pccert_context, dwPropId, pvData, &pcbData);
+        Py_END_ALLOW_THREADS
+        if (!bsuccess) {
             PyWin_SetAPIError("CertGetCertificateContextProperty");
             free(pvData);
             return NULL;
@@ -559,10 +591,12 @@ PyObject *PyCERT_CONTEXT::PyCertSetCertificateContextProperty(PyObject *self, Py
     BOOL bsuccess;
     // When Data is None, property is to be deleted so no conversion necessary
     if (obData == Py_None) {
-        Py_BEGIN_ALLOW_THREADS bsuccess = CertSetCertificateContextProperty(pccert_context, prop, flags, NULL);
-        Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CertSetCertificateContextProperty");
-        else
-        {
+        Py_BEGIN_ALLOW_THREADS
+            bsuccess = CertSetCertificateContextProperty(pccert_context, prop, flags, NULL);
+        Py_END_ALLOW_THREADS
+        if (!bsuccess)
+            return PyWin_SetAPIError("CertSetCertificateContextProperty");
+        else {
             Py_INCREF(Py_None);
             return Py_None;
         }
@@ -650,10 +684,12 @@ PyObject *PyCERT_CONTEXT::PyCertSetCertificateContextProperty(PyObject *self, Py
             goto cleanup;
     }
 
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertSetCertificateContextProperty(pccert_context, prop, flags, pvData);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CertSetCertificateContextProperty");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertSetCertificateContextProperty(pccert_context, prop, flags, pvData);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CertSetCertificateContextProperty");
+    else {
         Py_INCREF(Py_None);
         ret = Py_None;
     }

--- a/win32/src/win32crypt/PyCERT_CONTEXT.cpp
+++ b/win32/src/win32crypt/PyCERT_CONTEXT.cpp
@@ -257,9 +257,9 @@ PyObject *PyCERT_CONTEXT::PyCertFreeCertificateContext(PyObject *self, PyObject 
 {
     GET_CERT_CONTEXT(pcc);
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = CertFreeCertificateContext(pcc);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertFreeCertificateContext(pcc);
+    Py_END_ALLOW_THREADS
     if (!bsuccess)
         return PyWin_SetAPIError("CertFreeCertificateContext");
     ((PyCERT_CONTEXT *)self)->pccert_context = NULL;
@@ -277,8 +277,11 @@ PyObject *PyCERT_CONTEXT::PyCertEnumCertificateContextProperties(PyObject *self,
     if (ret == NULL)
         return NULL;
     while (TRUE) {
-        Py_BEGIN_ALLOW_THREADS dwPropId = CertEnumCertificateContextProperties(pccert_context, dwPropId);
-        Py_END_ALLOW_THREADS if (dwPropId == 0) break;
+        Py_BEGIN_ALLOW_THREADS
+            dwPropId = CertEnumCertificateContextProperties(pccert_context, dwPropId);
+        Py_END_ALLOW_THREADS
+        if (dwPropId == 0)
+            break;
         ret_item = PyLong_FromUnsignedLong(dwPropId);
         if ((ret_item == NULL) || (PyList_Append(ret, ret_item) == -1)) {
             Py_XDECREF(ret_item);
@@ -308,9 +311,12 @@ PyObject *PyCERT_CONTEXT::PyCryptAcquireCertificatePrivateKey(PyObject *self, Py
                                      &flags))  // @pyparm int|Flags|0|Combination of CRYPT_ACQUIRE_*_FLAG constants
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptAcquireCertificatePrivateKey(pccert_context, flags, reserved, &hcryptprov, &keyspec, &callerfree);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptAcquireCertificatePrivateKey");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess =
+            CryptAcquireCertificatePrivateKey(pccert_context, flags, reserved, &hcryptprov, &keyspec, &callerfree);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CryptAcquireCertificatePrivateKey");
 
     /* If callerfree returns false, CSP handle shouldn't be freed, so increase its refcount since
         CryptReleaseContext is called when python object is destroyed */
@@ -336,14 +342,21 @@ PyObject *PyCERT_CONTEXT::PyCertGetEnhancedKeyUsage(PyObject *self, PyObject *ar
                                                // CERT_FIND_PROP_ONLY_ENHKEY_USAGE_FLAG, or 0
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertGetEnhancedKeyUsage(pccert_context, flags, pceu, &bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CertGetEnhancedKeyUsage");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertGetEnhancedKeyUsage(pccert_context, flags, pceu, &bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CertGetEnhancedKeyUsage");
     pceu = (PCERT_ENHKEY_USAGE)malloc(bufsize);
     if (pceu == NULL)
         return PyErr_Format(PyExc_MemoryError, "Failed to allocate %d bytes", bufsize);
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertGetEnhancedKeyUsage(pccert_context, flags, pceu, &bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CertGetEnhancedKeyUsage");
-    else ret = PyWinObject_FromCTL_USAGE(pceu);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertGetEnhancedKeyUsage(pccert_context, flags, pceu, &bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CertGetEnhancedKeyUsage");
+    else
+        ret = PyWinObject_FromCTL_USAGE(pceu);
     free(pceu);
     return ret;
 }
@@ -357,9 +370,12 @@ PyObject *PyCERT_CONTEXT::PyCertGetIntendedKeyUsage(PyObject *self, PyObject *ar
     DWORD buf;
     DWORD bufsize = sizeof(DWORD);
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CertGetIntendedKeyUsage(pccert_context->dwCertEncodingType, pccert_context->pCertInfo, (BYTE *)&buf, bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CertGetIntendedKeyUsage");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertGetIntendedKeyUsage(pccert_context->dwCertEncodingType, pccert_context->pCertInfo, (BYTE *)&buf,
+                                           bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CertGetIntendedKeyUsage");
     return PyLong_FromUnsignedLong(buf);
 }
 
@@ -376,15 +392,22 @@ PyObject *PyCERT_CONTEXT::PyCertSerializeCertificateStoreElement(PyObject *self,
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertSerializeCertificateStoreElement(pccert_context, flags, buf, &bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CertSerializeCertificateStoreElement");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertSerializeCertificateStoreElement(pccert_context, flags, buf, &bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CertSerializeCertificateStoreElement");
     buf = (BYTE *)malloc(bufsize);
     if (buf == NULL)
         return PyErr_Format(PyExc_MemoryError, "Unable to allocate %d bytes", bufsize);
 
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertSerializeCertificateStoreElement(pccert_context, flags, buf, &bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CertSerializeCertificateStoreElement");
-    else ret = PyBytes_FromStringAndSize((char *)buf, bufsize);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertSerializeCertificateStoreElement(pccert_context, flags, buf, &bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CertSerializeCertificateStoreElement");
+    else
+        ret = PyBytes_FromStringAndSize((char *)buf, bufsize);
     free(buf);
     return ret;
 }
@@ -407,8 +430,11 @@ PyObject *PyCERT_CONTEXT::PyCertVerifySubjectCertificateContext(PyObject *self, 
     if (!PyWinObject_AsCERT_CONTEXT(obissuer, &issuer, TRUE))
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertVerifySubjectCertificateContext(pccert_context, issuer, &flags);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CertVerifySubjectCertificateContext");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertVerifySubjectCertificateContext(pccert_context, issuer, &flags);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CertVerifySubjectCertificateContext");
     return PyLong_FromUnsignedLong(flags);
 }
 
@@ -417,12 +443,15 @@ PyObject *PyCERT_CONTEXT::PyCertDeleteCertificateFromStore(PyObject *self, PyObj
 {
     GET_CERT_CONTEXT(pcert_context);
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertDeleteCertificateFromStore(pcert_context);
-    // CertDeleteCertificateFromStore internally calls CertFreeCertificateContext, so we need to zero
-    // the context like we do in PyCertFreeCertificateContext, in order to prevent an attempt to free
-    // it again later in the destructor.
-    ((PyCERT_CONTEXT *)self)->pccert_context = NULL;
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CertDeleteCertificateFromStore");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertDeleteCertificateFromStore(pcert_context);
+        // CertDeleteCertificateFromStore internally calls CertFreeCertificateContext, so we need to zero
+        // the context like we do in PyCertFreeCertificateContext, in order to prevent an attempt to free
+        // it again later in the destructor.
+        ((PyCERT_CONTEXT *)self)->pccert_context = NULL;
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CertDeleteCertificateFromStore");
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -443,9 +472,10 @@ PyObject *PyCERT_CONTEXT::PyCertGetCertificateContextProperty(PyObject *self, Py
                                      &dwPropId))  // @pyparm int|PropId||One of the CERT_*_PROP_ID constants
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertGetCertificateContextProperty(pccert_context, dwPropId, pvData, &pcbData);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertGetCertificateContextProperty(pccert_context, dwPropId, pvData, &pcbData);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         PyWin_SetAPIError("CertGetCertificateContextProperty");
         return NULL;
     }
@@ -456,9 +486,10 @@ PyObject *PyCERT_CONTEXT::PyCertGetCertificateContextProperty(PyObject *self, Py
             return PyErr_Format(PyExc_MemoryError, "CertGetCertificateContextProperty: unable to allocate %d bytes",
                                 pcbData);
         ZeroMemory(pvData, pcbData);
-        Py_BEGIN_ALLOW_THREADS bsuccess = CertGetCertificateContextProperty(pccert_context, dwPropId, pvData, &pcbData);
-        Py_END_ALLOW_THREADS if (!bsuccess)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            bsuccess = CertGetCertificateContextProperty(pccert_context, dwPropId, pvData, &pcbData);
+        Py_END_ALLOW_THREADS
+        if (!bsuccess) {
             PyWin_SetAPIError("CertGetCertificateContextProperty");
             free(pvData);
             return NULL;
@@ -559,10 +590,12 @@ PyObject *PyCERT_CONTEXT::PyCertSetCertificateContextProperty(PyObject *self, Py
     BOOL bsuccess;
     // When Data is None, property is to be deleted so no conversion necessary
     if (obData == Py_None) {
-        Py_BEGIN_ALLOW_THREADS bsuccess = CertSetCertificateContextProperty(pccert_context, prop, flags, NULL);
-        Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CertSetCertificateContextProperty");
-        else
-        {
+        Py_BEGIN_ALLOW_THREADS
+            bsuccess = CertSetCertificateContextProperty(pccert_context, prop, flags, NULL);
+        Py_END_ALLOW_THREADS
+        if (!bsuccess)
+            return PyWin_SetAPIError("CertSetCertificateContextProperty");
+        else {
             Py_INCREF(Py_None);
             return Py_None;
         }
@@ -650,10 +683,12 @@ PyObject *PyCERT_CONTEXT::PyCertSetCertificateContextProperty(PyObject *self, Py
             goto cleanup;
     }
 
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertSetCertificateContextProperty(pccert_context, prop, flags, pvData);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CertSetCertificateContextProperty");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertSetCertificateContextProperty(pccert_context, prop, flags, pvData);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CertSetCertificateContextProperty");
+    else {
         Py_INCREF(Py_None);
         ret = Py_None;
     }

--- a/win32/src/win32crypt/win32cryptmodule.cpp
+++ b/win32/src/win32crypt/win32cryptmodule.cpp
@@ -49,11 +49,12 @@ static PyObject *PyCryptProtectData(PyObject *self, PyObject *args, PyObject *kw
 
     PyObject *ret = NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptProtectData(&DataIn, DataDescr, pOptionalEntropy, pReserved, pPromptStruct, Flags, &DataOut);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptProtectData");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptProtectData(&DataIn, DataDescr, pOptionalEntropy, pReserved, pPromptStruct, Flags, &DataOut);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptProtectData");
+    else {
         ret = PyWinObject_FromDATA_BLOB(&DataOut);
         LocalFree(DataOut.pbData);
     }
@@ -106,11 +107,12 @@ static PyObject *PyCryptUnprotectData(PyObject *self, PyObject *args, PyObject *
     WCHAR *DataDescr = NULL;
     PyObject *ret = NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptUnprotectData(&DataIn, &DataDescr, pOptionalEntropy, pReserved, pPromptStruct, Flags, &DataOut);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptUnprotectData");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptUnprotectData(&DataIn, &DataDescr, pOptionalEntropy, pReserved, pPromptStruct, Flags, &DataOut);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptUnprotectData");
+    else {
         ret = Py_BuildValue("NN", PyWinObject_FromWCHAR(DataDescr), PyWinObject_FromDATA_BLOB(&DataOut));
         if (DataDescr)
             LocalFree(DataDescr);
@@ -130,9 +132,10 @@ static PyObject *PyCertAlgIdToOID(PyObject *self, PyObject *args, PyObject *kwar
     // @pyparm int|AlgId||An algorithm identifier
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "I:CertAlgIdToOID", keywords, &algid))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS szoid = CertAlgIdToOID(algid);
-    Py_END_ALLOW_THREADS if (szoid == NULL)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        szoid = CertAlgIdToOID(algid);
+    Py_END_ALLOW_THREADS
+    if (szoid == NULL) {
         Py_INCREF(Py_None);
         return Py_None;
     }
@@ -149,8 +152,10 @@ static PyObject *PyCertOIDToAlgId(PyObject *self, PyObject *args, PyObject *kwar
     // @pyparm string|ObjId||String szOID_* identifier
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s:CertOIDToAlgId", keywords, &szoid))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS algid = CertOIDToAlgId(szoid);
-    Py_END_ALLOW_THREADS return PyLong_FromUnsignedLong(algid);
+    Py_BEGIN_ALLOW_THREADS
+        algid = CertOIDToAlgId(szoid);
+    Py_END_ALLOW_THREADS
+    return PyLong_FromUnsignedLong(algid);
 }
 
 // @pymethod <o PyCRYPTPROV>|win32crypt|CryptAcquireContext|Retrieve handle to a cryptographic service provider
@@ -177,11 +182,12 @@ static PyObject *PyCryptAcquireContext(PyObject *self, PyObject *args, PyObject 
         goto done;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptAcquireContext(&hcryptprov, container_name, provider_name, dwProvType, dwFlags);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptAcquireContext");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptAcquireContext(&hcryptprov, container_name, provider_name, dwProvType, dwFlags);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptAcquireContext");
+    else {
         if (dwFlags & CRYPT_DELETEKEYSET) {  // when key is being deleted, no context is returned
             Py_INCREF(Py_None);
             ret = Py_None;
@@ -214,9 +220,10 @@ static PyObject *PyCryptEnumProviders(PyObject *self, PyObject *args)
         cbProvName = 0;
         pszProvName = NULL;
         ret_item = NULL;
-        Py_BEGIN_ALLOW_THREADS bsuccess = CryptEnumProviders(dwIndex, NULL, dwFlags, &dwProvType, NULL, &cbProvName);
-        Py_END_ALLOW_THREADS if (!bsuccess)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            bsuccess = CryptEnumProviders(dwIndex, NULL, dwFlags, &dwProvType, NULL, &cbProvName);
+        Py_END_ALLOW_THREADS
+        if (!bsuccess) {
             err = GetLastError();
             break;
         }
@@ -225,10 +232,10 @@ static PyObject *PyCryptEnumProviders(PyObject *self, PyObject *args)
             PyErr_Format(PyExc_MemoryError, "CryptEnumProviders: Unable to allocate %d bytes", cbProvName);
             break;
         }
-        Py_BEGIN_ALLOW_THREADS bsuccess =
-            CryptEnumProviders(dwIndex, NULL, dwFlags, &dwProvType, pszProvName, &cbProvName);
-        Py_END_ALLOW_THREADS if (!bsuccess)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            bsuccess = CryptEnumProviders(dwIndex, NULL, dwFlags, &dwProvType, pszProvName, &cbProvName);
+        Py_END_ALLOW_THREADS
+        if (!bsuccess) {
             err = GetLastError();
             break;
         }
@@ -273,10 +280,10 @@ static PyObject *PyCryptEnumProviderTypes(PyObject *self, PyObject *args)
         cbTypeName = 0;
         pszTypeName = NULL;
         ret_item = NULL;
-        Py_BEGIN_ALLOW_THREADS bsuccess =
-            CryptEnumProviderTypes(dwIndex, NULL, dwFlags, &dwProvType, NULL, &cbTypeName);
-        Py_END_ALLOW_THREADS if (!bsuccess)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            bsuccess = CryptEnumProviderTypes(dwIndex, NULL, dwFlags, &dwProvType, NULL, &cbTypeName);
+        Py_END_ALLOW_THREADS
+        if (!bsuccess) {
             err = GetLastError();
             break;
         }
@@ -285,10 +292,10 @@ static PyObject *PyCryptEnumProviderTypes(PyObject *self, PyObject *args)
             PyErr_Format(PyExc_MemoryError, "Unable to allocate %d bytes", cbTypeName);
             break;
         }
-        Py_BEGIN_ALLOW_THREADS bsuccess =
-            CryptEnumProviderTypes(dwIndex, NULL, dwFlags, &dwProvType, pszTypeName, &cbTypeName);
-        Py_END_ALLOW_THREADS if (!bsuccess)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            bsuccess = CryptEnumProviderTypes(dwIndex, NULL, dwFlags, &dwProvType, pszTypeName, &cbTypeName);
+        Py_END_ALLOW_THREADS
+        if (!bsuccess) {
             err = GetLastError();
             break;
         }
@@ -331,14 +338,21 @@ static PyObject *PyCryptGetDefaultProvider(PyObject *self, PyObject *args, PyObj
     PyObject *ret = NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptGetDefaultProvider(dwProvType, NULL, dwFlags, NULL, &cbProvName);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptGetDefaultProvider");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptGetDefaultProvider(dwProvType, NULL, dwFlags, NULL, &cbProvName);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CryptGetDefaultProvider");
     pszProvName = (WCHAR *)malloc(cbProvName);
     if (pszProvName == NULL)
         return PyErr_Format(PyExc_MemoryError, "Unable to allocate %d bytes", cbProvName);
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptGetDefaultProvider(dwProvType, NULL, dwFlags, pszProvName, &cbProvName);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptGetDefaultProvider");
-    else ret = PyWinObject_FromWCHAR(pszProvName);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptGetDefaultProvider(dwProvType, NULL, dwFlags, pszProvName, &cbProvName);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptGetDefaultProvider");
+    else
+        ret = PyWinObject_FromWCHAR(pszProvName);
     free(pszProvName);
     return ret;
 }
@@ -363,10 +377,12 @@ static PyObject *PyCryptSetProviderEx(PyObject *self, PyObject *args, PyObject *
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptSetProviderEx(ProvName, dwProvType, NULL, dwFlags);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptSetProviderEx");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptSetProviderEx(ProvName, dwProvType, NULL, dwFlags);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptSetProviderEx");
+    else {
         Py_INCREF(Py_None);
         ret = Py_None;
     }
@@ -387,13 +403,15 @@ static PyObject *PyCryptFindLocalizedName(PyObject *self, PyObject *args, PyObje
         return NULL;
     if (!PyWinObject_AsWCHAR(obstore_name, &store_name, FALSE))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS localized_name = CryptFindLocalizedName(store_name);
-    Py_END_ALLOW_THREADS if (localized_name == NULL)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        localized_name = CryptFindLocalizedName(store_name);
+    Py_END_ALLOW_THREADS
+    if (localized_name == NULL) {
         Py_INCREF(Py_None);
         ret = Py_None;
     }
-    else ret = PyWinObject_FromWCHAR(localized_name);
+    else
+        ret = PyWinObject_FromWCHAR(localized_name);
     PyWinObject_FreeWCHAR(store_name);
     return ret;
 }
@@ -423,9 +441,10 @@ static PyObject *PyCertEnumSystemStoreLocation(PyObject *self, PyObject *args, P
     if (ret == NULL)
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertEnumSystemStoreLocation(dwFlags, ret, CertEnumSystemStoreLocationCallback);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertEnumSystemStoreLocation(dwFlags, ret, CertEnumSystemStoreLocationCallback);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         Py_DECREF(ret);
         ret = NULL;
         if (!PyErr_Occurred())
@@ -479,12 +498,11 @@ static PyObject *PyCertEnumSystemStore(PyObject *self, PyObject *args, PyObject 
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CertEnumSystemStore(dwFlags, pvSystemStoreLocationPara, ret, CertEnumSystemStoreCallback);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertEnumSystemStore(dwFlags, pvSystemStoreLocationPara, ret, CertEnumSystemStoreCallback);
     Py_END_ALLOW_THREADS
 
-        if (!bsuccess)
-    {
+    if (!bsuccess) {
         Py_DECREF(ret);
         ret = NULL;
         if (!PyErr_Occurred())
@@ -535,10 +553,10 @@ static PyObject *PyCertEnumPhysicalStore(PyObject *self, PyObject *args, PyObjec
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CertEnumPhysicalStore(pvSystemStore, dwFlags, (void *)ret, CertEnumPhysicalStoreCallback);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertEnumPhysicalStore(pvSystemStore, dwFlags, (void *)ret, CertEnumPhysicalStoreCallback);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         Py_DECREF(ret);
         ret = NULL;
         if (!PyErr_Occurred())
@@ -623,9 +641,10 @@ static PyObject *PyCertOpenStore(PyObject *self, PyObject *args, PyObject *kwarg
         }
     }
 
-    Py_BEGIN_ALLOW_THREADS hcertstore = CertOpenStore(StoreProvider, dwEncodingType, hcryptprov, dwFlags, pvPara);
-    Py_END_ALLOW_THREADS if (hcertstore == NULL)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hcertstore = CertOpenStore(StoreProvider, dwEncodingType, hcryptprov, dwFlags, pvPara);
+    Py_END_ALLOW_THREADS
+    if (hcertstore == NULL) {
         err = GetLastError();
         // when delete is specified, return value is always NULL
         if ((dwFlags & CERT_STORE_DELETE_FLAG) && (err == 0)) {
@@ -635,7 +654,8 @@ static PyObject *PyCertOpenStore(PyObject *self, PyObject *args, PyObject *kwarg
         else
             PyWin_SetAPIError("CertOpenStore", err);
     }
-    else ret = PyWinObject_FromCERTSTORE(hcertstore);
+    else
+        ret = PyWinObject_FromCERTSTORE(hcertstore);
     if (free_wchar)
         PyWinObject_FreeWCHAR((WCHAR *)pvPara);
     return ret;
@@ -659,9 +679,13 @@ static PyObject *PyCertOpenSystemStore(PyObject *self, PyObject *args, PyObject 
         return NULL;
     if (!PyWinObject_AsWCHAR(obstore_name, &store_name, FALSE))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS hcertstore = CertOpenSystemStore(hcryptprov, store_name);
-    Py_END_ALLOW_THREADS if (hcertstore == NULL) PyWin_SetAPIError("CertOpenSystemStore");
-    else ret = PyWinObject_FromCERTSTORE(hcertstore);
+    Py_BEGIN_ALLOW_THREADS
+        hcertstore = CertOpenSystemStore(hcryptprov, store_name);
+    Py_END_ALLOW_THREADS
+    if (hcertstore == NULL)
+        PyWin_SetAPIError("CertOpenSystemStore");
+    else
+        ret = PyWinObject_FromCERTSTORE(hcertstore);
     PyWinObject_FreeWCHAR(store_name);
     return ret;
 }
@@ -693,10 +717,12 @@ static PyObject *PyCertRegisterSystemStore(PyObject *self, PyObject *args, PyObj
     else if (!PyWinObject_AsWCHAR(obSystemStore, (WCHAR **)&pvSystemStore))
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertRegisterSystemStore(pvSystemStore, dwFlags, pStoreInfo, pvReserved);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CertRegisterSystemStore");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertRegisterSystemStore(pvSystemStore, dwFlags, pStoreInfo, pvReserved);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CertRegisterSystemStore");
+    else {
         Py_INCREF(Py_None);
         ret = Py_None;
     }
@@ -724,10 +750,12 @@ static PyObject *PyCertUnregisterSystemStore(PyObject *self, PyObject *args, PyO
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertUnregisterSystemStore(pvSystemStore, dwFlags);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CertUnregisterSystemStore");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertUnregisterSystemStore(pvSystemStore, dwFlags);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CertUnregisterSystemStore");
+    else {
         Py_INCREF(Py_None);
         ret = Py_None;
     }
@@ -788,8 +816,11 @@ static PyObject *PyCryptFindOIDInfo(PyObject *self, PyObject *args, PyObject *kw
             PyErr_SetString(PyExc_ValueError, "Unrecognized key type");
             return NULL;
     }
-    Py_BEGIN_ALLOW_THREADS oid_info = CryptFindOIDInfo(keytype, key, groupid);
-    Py_END_ALLOW_THREADS if (oid_info == NULL) return PyWin_SetAPIError("CryptFindOIDInfo");
+    Py_BEGIN_ALLOW_THREADS
+        oid_info = CryptFindOIDInfo(keytype, key, groupid);
+    Py_END_ALLOW_THREADS
+    if (oid_info == NULL)
+        return PyWin_SetAPIError("CryptFindOIDInfo");
     // docs say do NOT free the returned CRYPT_OID_INFO
     return PyWinObject_FromCRYPT_OID_INFO(oid_info);
 }
@@ -826,9 +857,11 @@ static PyObject *PyCryptGetKeyIdentifierProperty(PyObject *self, PyObject *args,
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptGetKeyIdentifierProperty(&chb, propid, flags, computername, reserved, &buf, &bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptGetKeyIdentifierProperty");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptGetKeyIdentifierProperty(&chb, propid, flags, computername, reserved, &buf, &bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CryptGetKeyIdentifierProperty");
 
     /* Usually only CERT_KEY_PROV_INFO_PROP_ID is used with this function.
         However, according to the docs other certificate properties can be requested.
@@ -938,10 +971,11 @@ static PyObject *PyCryptEnumKeyIdentifierProperties(PyObject *self, PyObject *ar
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptEnumKeyIdentifierProperties(
-        pchb, propid, flags, computername, reserved, (void *)ret, CryptEnumKeyIdentifierProperties_callback);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptEnumKeyIdentifierProperties(pchb, propid, flags, computername, reserved, (void *)ret,
+                                                    CryptEnumKeyIdentifierProperties_callback);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         Py_DECREF(ret);
         ret = NULL;
         if (!PyErr_Occurred())
@@ -980,9 +1014,10 @@ static PyObject *PyCryptEnumOIDInfo(PyObject *self, PyObject *args, PyObject *kw
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptEnumOIDInfo(groupid, flags, (void *)ret, CryptEnumOIDInfo_callback);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptEnumOIDInfo(groupid, flags, (void *)ret, CryptEnumOIDInfo_callback);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         Py_DECREF(ret);
         ret = NULL;
         if (!PyErr_Occurred())
@@ -1020,11 +1055,13 @@ static PyObject *PyCertAddSerializedElementToStore(PyObject *self, PyObject *arg
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertAddSerializedElementToStore(
-        hcertstore, (BYTE *)pybuf.ptr(), pybuf.len(), adddisposition, flags, contexttype, &contexttype_out, &context);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertAddSerializedElementToStore(hcertstore, (BYTE *)pybuf.ptr(), pybuf.len(), adddisposition, flags,
+                                                   contexttype, &contexttype_out, &context);
     Py_END_ALLOW_THREADS
 
-        if (!bsuccess) return PyWin_SetAPIError("CertAddSerializedElementToStore");
+    if (!bsuccess)
+        return PyWin_SetAPIError("CertAddSerializedElementToStore");
     if (contexttype_out == CERT_STORE_CERTIFICATE_CONTEXT)
         return PyWinObject_FromCERT_CONTEXT((PCCERT_CONTEXT)context);
     else if (contexttype_out == CERT_STORE_CTL_CONTEXT)
@@ -1086,9 +1123,10 @@ static PyObject *PyCryptQueryObject(PyObject *self, PyObject *args, PyObject *kw
     }
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = CryptQueryObject(objecttype, input, contenttype, formattype, flags, &encoding, &contenttypeout,
-                                &formattypeout, &hcertstore, &hcryptmsg, (const void **)&context);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        bsuccess = CryptQueryObject(objecttype, input, contenttype, formattype, flags, &encoding, &contenttypeout,
+                                    &formattypeout, &hcertstore, &hcryptmsg, (const void **)&context);
     Py_END_ALLOW_THREADS;
     if (!bsuccess)
         return PyWin_SetAPIError("CryptQueryObject");
@@ -1163,11 +1201,12 @@ static PyObject *PyCryptDecodeMessage(PyObject *self, PyObject *args, PyObject *
     if (!PyWinObject_AsCRYPT_DECRYPT_MESSAGE_PARA(obcdmp, &cdmp))
         return NULL;
 
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptDecodeMessage(msg_type_flags, &cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), prev_inner_type,
-                           &msg_type, &inner_type, output_buf, &output_bufsize, &exchange_cert, &signer_cert);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptDecodeMessage(msg_type_flags, &cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                      prev_inner_type, &msg_type, &inner_type, output_buf, &output_bufsize,
+                                      &exchange_cert, &signer_cert);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         // Callback may raise an exception
         if (!PyErr_Occurred())
             PyWin_SetAPIError("CryptDecodeMessage");
@@ -1184,18 +1223,19 @@ static PyObject *PyCryptDecodeMessage(PyObject *self, PyObject *args, PyObject *
     output_buf = (BYTE *)malloc(output_bufsize);
     if (output_buf == NULL)
         return PyErr_NoMemory();
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptDecodeMessage(msg_type_flags, &cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), prev_inner_type,
-                           &msg_type, &inner_type, output_buf, &output_bufsize, NULL, NULL);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptDecodeMessage(msg_type_flags, &cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                      prev_inner_type, &msg_type, &inner_type, output_buf, &output_bufsize, NULL, NULL);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         if (!PyErr_Occurred())
             PyWin_SetAPIError("CryptDecodeMessage");
     }
-    else ret = Py_BuildValue("{s:k,s:k,s:N,s:N,s:N}", "MsgType", msg_type, "InnerContentType", inner_type, "Decoded",
-                             PyBytes_FromStringAndSize((char *)output_buf, output_bufsize), "XchgCert",
-                             PyWinObject_FromCERT_CONTEXT(exchange_cert), "SignerCert",
-                             PyWinObject_FromCERT_CONTEXT(signer_cert));
+    else
+        ret = Py_BuildValue("{s:k,s:k,s:N,s:N,s:N}", "MsgType", msg_type, "InnerContentType", inner_type, "Decoded",
+                            PyBytes_FromStringAndSize((char *)output_buf, output_bufsize), "XchgCert",
+                            PyWinObject_FromCERT_CONTEXT(exchange_cert), "SignerCert",
+                            PyWinObject_FromCERT_CONTEXT(signer_cert));
 
     free(output_buf);
     if (!ret) {
@@ -1233,19 +1273,25 @@ static PyObject *PyCryptEncryptMessage(PyObject *self, PyObject *args, PyObject 
         return NULL;
     if (!PyWinObject_AsCERT_CONTEXTArray(obrecipients, &recipients, &recipient_cnt))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptEncryptMessage(&cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(),
-                                                          pybuf.len(), outputbuf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptEncryptMessage");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptEncryptMessage(&cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(), pybuf.len(), outputbuf,
+                                       &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptEncryptMessage");
+    else {
         outputbuf = (BYTE *)malloc(output_bufsize);
         if (outputbuf == NULL)
             PyErr_Format(PyExc_MemoryError, "CryptEncryptMessage: Unable to allocate %d bytes", output_bufsize);
         else {
-            Py_BEGIN_ALLOW_THREADS bsuccess = CryptEncryptMessage(&cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(),
-                                                                  pybuf.len(), outputbuf, &output_bufsize);
-            Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptEncryptMessage");
-            else ret = PyBytes_FromStringAndSize((char *)outputbuf, output_bufsize);
+            Py_BEGIN_ALLOW_THREADS
+                bsuccess = CryptEncryptMessage(&cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                               outputbuf, &output_bufsize);
+            Py_END_ALLOW_THREADS
+            if (!bsuccess)
+                PyWin_SetAPIError("CryptEncryptMessage");
+            else
+                ret = PyBytes_FromStringAndSize((char *)outputbuf, output_bufsize);
         }
     }
 
@@ -1278,19 +1324,25 @@ static PyObject *PyCryptDecryptMessage(PyObject *self, PyObject *args, PyObject 
     if (!PyWinObject_AsCRYPT_DECRYPT_MESSAGE_PARA(obcdmp, &cdmp))
         return NULL;
 
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptDecryptMessage(&cdmp, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize, NULL);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptDecryptMessage");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptDecryptMessage(&cdmp, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize, NULL);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CryptDecryptMessage");
 
     output_buf = (BYTE *)malloc(output_bufsize);
     if (output_buf == NULL)
         return PyErr_NoMemory();
 
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptDecryptMessage(&cdmp, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize, &exchange_cert);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptDecryptMessage");
-    else ret = Py_BuildValue("NN", PyBytes_FromStringAndSize((char *)output_buf, output_bufsize),
-                             PyWinObject_FromCERT_CONTEXT(exchange_cert));
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess =
+            CryptDecryptMessage(&cdmp, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize, &exchange_cert);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptDecryptMessage");
+    else
+        ret = Py_BuildValue("NN", PyBytes_FromStringAndSize((char *)output_buf, output_bufsize),
+                            PyWinObject_FromCERT_CONTEXT(exchange_cert));
     free(output_buf);
     return ret;
 }
@@ -1324,10 +1376,11 @@ static PyObject *PyCryptSignAndEncryptMessage(PyObject *self, PyObject *args, Py
         goto cleanup;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptSignAndEncryptMessage(
-        &csmp, &cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptSignAndEncryptMessage(&csmp, &cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                              output_buf, &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         PyWin_SetAPIError("CryptSignAndEncryptMessage");
         goto cleanup;
     }
@@ -1338,10 +1391,11 @@ static PyObject *PyCryptSignAndEncryptMessage(PyObject *self, PyObject *args, Py
         goto cleanup;
     }
 
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptSignAndEncryptMessage(
-        &csmp, &cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptSignAndEncryptMessage(&csmp, &cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                              output_buf, &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         PyWin_SetAPIError("CryptSignAndEncryptMessage");
         goto cleanup;
     }
@@ -1382,12 +1436,12 @@ static PyObject *PyCryptVerifyMessageSignature(PyObject *self, PyObject *args, P
 
     if (!PyWinObject_AsCRYPT_VERIFY_MESSAGE_PARA(obcvmp, &cvmp))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptVerifyMessageSignature(&cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(),
-                                                                  output_buf, &output_bufsize, &signer_cert);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptVerifyMessageSignature(&cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf,
+                                               &output_bufsize, &signer_cert);
     Py_END_ALLOW_THREADS
-        // Callback may have already set an exception
-        if (!bsuccess)
-    {
+    // Callback may have already set an exception
+    if (!bsuccess) {
         if (!PyErr_Occurred())
             PyWin_SetAPIError("CryptVerifyMessageSignature");
         return NULL;
@@ -1401,16 +1455,18 @@ static PyObject *PyCryptVerifyMessageSignature(PyObject *self, PyObject *args, P
     if (output_buf == NULL)
         PyErr_NoMemory();
     else {
-        Py_BEGIN_ALLOW_THREADS bsuccess = CryptVerifyMessageSignature(&cvmp, signer_ind, (BYTE *)pybuf.ptr(),
-                                                                      pybuf.len(), output_buf, &output_bufsize, NULL);
-        Py_END_ALLOW_THREADS if (!bsuccess)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            bsuccess = CryptVerifyMessageSignature(&cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf,
+                                                   &output_bufsize, NULL);
+        Py_END_ALLOW_THREADS
+        if (!bsuccess) {
             // Callback may have already set an exception
             if (!PyErr_Occurred())
                 PyWin_SetAPIError("CryptVerifyMessageSignature");
         }
-        else ret = Py_BuildValue("{s:N, s:N}", "SignerCert", PyWinObject_FromCERT_CONTEXT(signer_cert), "Decoded",
-                                 PyBytes_FromStringAndSize((char *)output_buf, output_bufsize));
+        else
+            ret = Py_BuildValue("{s:N, s:N}", "SignerCert", PyWinObject_FromCERT_CONTEXT(signer_cert), "Decoded",
+                                PyBytes_FromStringAndSize((char *)output_buf, output_bufsize));
     }
     if (output_buf)
         free(output_buf);
@@ -1441,9 +1497,11 @@ static PyObject *PyCryptGetMessageCertificates(PyObject *self, PyObject *args, P
         return NULL;
     if (!PyWinObject_AsHCRYPTPROV(obcsp, &csp, TRUE))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS hcertstore =
-        CryptGetMessageCertificates(encoding_type, csp, flags, (BYTE *)pybuf.ptr(), pybuf.len());
-    Py_END_ALLOW_THREADS if (hcertstore == NULL) return PyWin_SetAPIError("CryptGetMessageCertificates");
+    Py_BEGIN_ALLOW_THREADS
+        hcertstore = CryptGetMessageCertificates(encoding_type, csp, flags, (BYTE *)pybuf.ptr(), pybuf.len());
+    Py_END_ALLOW_THREADS
+    if (hcertstore == NULL)
+        return PyWin_SetAPIError("CryptGetMessageCertificates");
     return PyWinObject_FromCERTSTORE(hcertstore);
 }
 
@@ -1464,8 +1522,11 @@ static PyObject *PyCryptGetMessageSignerCount(PyObject *self, PyObject *args, Py
     PyWinBufferView pybuf(obbuf);
     if (!pybuf.ok())
         return NULL;
-    Py_BEGIN_ALLOW_THREADS signer_cnt = CryptGetMessageSignerCount(encoding_type, (BYTE *)pybuf.ptr(), pybuf.len());
-    Py_END_ALLOW_THREADS if (signer_cnt == -1) return PyWin_SetAPIError("CryptGetMessageSignerCount");
+    Py_BEGIN_ALLOW_THREADS
+        signer_cnt = CryptGetMessageSignerCount(encoding_type, (BYTE *)pybuf.ptr(), pybuf.len());
+    Py_END_ALLOW_THREADS
+    if (signer_cnt == -1)
+        return PyWin_SetAPIError("CryptGetMessageSignerCount");
     return PyLong_FromLong(signer_cnt);
 }
 
@@ -1494,10 +1555,11 @@ static PyObject *PyCryptSignMessage(PyObject *self, PyObject *args, PyObject *kw
         goto cleanup;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptSignMessage(&csmp, detached_sig, msg_cnt, (const BYTE **)msgs, msg_sizes, output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess =
+            CryptSignMessage(&csmp, detached_sig, msg_cnt, (const BYTE **)msgs, msg_sizes, output_buf, &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         PyWin_SetAPIError("CryptSignMessage");
         goto cleanup;
     }
@@ -1507,10 +1569,11 @@ static PyObject *PyCryptSignMessage(PyObject *self, PyObject *args, PyObject *kw
         goto cleanup;
     }
 
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptSignMessage(&csmp, detached_sig, msg_cnt, (const BYTE **)msgs, msg_sizes, output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess =
+            CryptSignMessage(&csmp, detached_sig, msg_cnt, (const BYTE **)msgs, msg_sizes, output_buf, &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         PyWin_SetAPIError("CryptSignMessage");
         goto cleanup;
     }
@@ -1553,10 +1616,14 @@ static PyObject *PyCryptVerifyDetachedMessageSignature(PyObject *self, PyObject 
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptVerifyDetachedMessageSignature(
-        &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), msg_cnt, (const BYTE **)msgs, msg_sizes, &signer_cert);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptVerifyDetachedMessageSignature");
-    else ret = PyWinObject_FromCERT_CONTEXT(signer_cert);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptVerifyDetachedMessageSignature(&cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), msg_cnt,
+                                                       (const BYTE **)msgs, msg_sizes, &signer_cert);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptVerifyDetachedMessageSignature");
+    else
+        ret = PyWinObject_FromCERT_CONTEXT(signer_cert);
 
     PyWinObject_FreePBYTEArray(msgs, msg_sizes, msg_cnt);
     return ret;
@@ -1596,20 +1663,26 @@ static PyObject *PyCryptDecryptAndVerifyMessageSignature(PyObject *self, PyObjec
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptDecryptAndVerifyMessageSignature(
-        &cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize, NULL, NULL);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptDecryptAndVerifyMessageSignature");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptDecryptAndVerifyMessageSignature(&cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                                         output_buf, &output_bufsize, NULL, NULL);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CryptDecryptAndVerifyMessageSignature");
 
     output_buf = (BYTE *)malloc(output_bufsize);
     if (output_buf == NULL)
         return PyErr_NoMemory();
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptDecryptAndVerifyMessageSignature(&cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf,
-                                              &output_bufsize, &exchange_cert, &signer_cert);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptDecryptAndVerifyMessageSignature");
-    else ret = Py_BuildValue(
-        "{s:N,s:N,s:N}", "Decrypted", PyBytes_FromStringAndSize((char *)output_buf, output_bufsize), "XchgCert",
-        PyWinObject_FromCERT_CONTEXT(exchange_cert), "SignerCert", PyWinObject_FromCERT_CONTEXT(signer_cert));
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptDecryptAndVerifyMessageSignature(&cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                                         output_buf, &output_bufsize, &exchange_cert, &signer_cert);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptDecryptAndVerifyMessageSignature");
+    else
+        ret = Py_BuildValue("{s:N,s:N,s:N}", "Decrypted", PyBytes_FromStringAndSize((char *)output_buf, output_bufsize),
+                            "XchgCert", PyWinObject_FromCERT_CONTEXT(exchange_cert), "SignerCert",
+                            PyWinObject_FromCERT_CONTEXT(signer_cert));
 
     free(output_buf);
     return ret;
@@ -1696,10 +1769,13 @@ static PyObject *PyCryptEncodeObjectEx(PyObject *self, PyObject *args, PyObject 
         goto cleanup;
     }
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptEncodeObjectEx(encoding, structtype, input_buf, flags, NULL, &output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptDecodeObjectEx");
-    else ret = PyBytes_FromStringAndSize((char *)output_buf, output_bufsize);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptEncodeObjectEx(encoding, structtype, input_buf, flags, NULL, &output_buf, &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptDecodeObjectEx");
+    else
+        ret = PyBytes_FromStringAndSize((char *)output_buf, output_bufsize);
 
 cleanup:
     if ((oid_is_str && (strcmp(structtype, szOID_ENHANCED_KEY_USAGE) == 0)) || (structtype == X509_ENHANCED_KEY_USAGE))
@@ -1745,10 +1821,11 @@ static PyObject *PyCryptDecodeObjectEx(PyObject *self, PyObject *args, PyObject 
     }
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptDecodeObjectEx(encoding, structtype, (BYTE *)pybuf.ptr(), pybuf.len(), flags,
-                                                          NULL, &output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptDecodeObjectEx(encoding, structtype, (BYTE *)pybuf.ptr(), pybuf.len(), flags, NULL, &output_buf,
+                                       &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         PyWin_SetAPIError("CryptDecodeObjectEx");
         goto cleanup;
     }
@@ -1878,14 +1955,21 @@ static PyObject *PyCertNameToStr(PyObject *self, PyObject *args, PyObject *kwarg
     cnb.pbData = (BYTE *)pybuf.ptr();
     cnb.cbData = pybuf.len();
 
-    Py_BEGIN_ALLOW_THREADS output_buflen = CertNameToStr(encoding, &cnb, strtype, output_buf, output_buflen);
-    Py_END_ALLOW_THREADS if (output_buflen == 0) return PyWin_SetAPIError("CertNameToStr");
+    Py_BEGIN_ALLOW_THREADS
+        output_buflen = CertNameToStr(encoding, &cnb, strtype, output_buf, output_buflen);
+    Py_END_ALLOW_THREADS
+    if (output_buflen == 0)
+        return PyWin_SetAPIError("CertNameToStr");
     output_buf = (WCHAR *)malloc(output_buflen * sizeof(WCHAR));
     if (output_buf == NULL)
         return PyErr_Format(PyExc_MemoryError, "Unable to allocate %d bytes", output_buflen);
-    Py_BEGIN_ALLOW_THREADS output_buflen = CertNameToStr(encoding, &cnb, strtype, output_buf, output_buflen);
-    Py_END_ALLOW_THREADS if (output_buflen == 0) PyWin_SetAPIError("CertNameToStr");
-    else ret = PyWinObject_FromWCHAR(output_buf);
+    Py_BEGIN_ALLOW_THREADS
+        output_buflen = CertNameToStr(encoding, &cnb, strtype, output_buf, output_buflen);
+    Py_END_ALLOW_THREADS
+    if (output_buflen == 0)
+        PyWin_SetAPIError("CertNameToStr");
+    else
+        ret = PyWinObject_FromWCHAR(output_buf);
     free(output_buf);
     return ret;
 }
@@ -1926,17 +2010,24 @@ static PyObject *PyCryptFormatObject(PyObject *self, PyObject *args, PyObject *k
     }
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptFormatObject(encoding, fmt_type, string_fmt, fmt_struct, oid,
-                                                        (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptFormatObject");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptFormatObject(encoding, fmt_type, string_fmt, fmt_struct, oid, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                     output_buf, &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CryptFormatObject");
     output_buf = malloc(output_bufsize);
     if (output_buf == NULL)
         return PyErr_Format(PyExc_MemoryError, "Unable to allocate %d bytes", output_bufsize);
 
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptFormatObject(encoding, fmt_type, string_fmt, fmt_struct, oid,
-                                                        (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptFormatObject");
-    else ret = PyWinObject_FromWCHAR((WCHAR *)output_buf);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptFormatObject(encoding, fmt_type, string_fmt, fmt_struct, oid, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                     output_buf, &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptFormatObject");
+    else
+        ret = PyWinObject_FromWCHAR((WCHAR *)output_buf);
     free(output_buf);
     return ret;
 }
@@ -1966,8 +2057,11 @@ static PyObject *PyPFXImportCertStore(PyObject *self, PyObject *args, PyObject *
         return NULL;
     if (!PyWinObject_AsWCHAR(obpassword, &password, TRUE))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS hcertstore = PFXImportCertStore(&input_buf, password, flags);
-    Py_END_ALLOW_THREADS if (hcertstore == NULL) return PyWin_SetAPIError("PFXImportCertStore");
+    Py_BEGIN_ALLOW_THREADS
+        hcertstore = PFXImportCertStore(&input_buf, password, flags);
+    Py_END_ALLOW_THREADS
+    if (hcertstore == NULL)
+        return PyWin_SetAPIError("PFXImportCertStore");
     return PyWinObject_FromCERTSTORE(hcertstore);
 }
 
@@ -1993,8 +2087,10 @@ static PyObject *PyPFXVerifyPassword(PyObject *self, PyObject *args, PyObject *k
     if (!PyWinObject_AsWCHAR(obpassword, &password, TRUE))
         return NULL;
     BOOL out;
-    Py_BEGIN_ALLOW_THREADS out = PFXVerifyPassword(&input_buf, password, flags);
-    Py_END_ALLOW_THREADS return PyBool_FromLong(out);
+    Py_BEGIN_ALLOW_THREADS
+        out = PFXVerifyPassword(&input_buf, password, flags);
+    Py_END_ALLOW_THREADS
+    return PyBool_FromLong(out);
 }
 
 // @pymethod boolean|win32crypt|PFXIsPFXBlob|Checks if data buffer contains a PFX blob
@@ -2010,8 +2106,10 @@ static PyObject *PyPFXIsPFXBlob(PyObject *self, PyObject *args, PyObject *kwargs
     if (!PyWinObject_AsDATA_BLOB(obinput_buf, &input_buf))
         return NULL;
     BOOL out;
-    Py_BEGIN_ALLOW_THREADS out = PFXIsPFXBlob(&input_buf);
-    Py_END_ALLOW_THREADS return PyBool_FromLong(out);
+    Py_BEGIN_ALLOW_THREADS
+        out = PFXIsPFXBlob(&input_buf);
+    Py_END_ALLOW_THREADS
+    return PyBool_FromLong(out);
 }
 
 // @pymethod str|win32crypt|CryptBinaryToString|Formats a binary buffer into the specified type of string
@@ -2032,18 +2130,23 @@ static PyObject *PyCryptBinaryToString(PyObject *self, PyObject *args, PyObject 
     if (!pybuf.ok())
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptBinaryToString((BYTE *)pybuf.ptr(), pybuf.len(), flags, output_buf, &output_size);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptBinaryToString");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptBinaryToString((BYTE *)pybuf.ptr(), pybuf.len(), flags, output_buf, &output_size);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CryptBinaryToString");
     output_buf = (WCHAR *)malloc(output_size * sizeof(WCHAR));
     if (output_buf == NULL)
         return PyErr_NoMemory();
 
     PyObject *ret = NULL;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptBinaryToString((BYTE *)pybuf.ptr(), pybuf.len(), flags, output_buf, &output_size);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptBinaryToString");
-    else ret = PyWinObject_FromWCHAR(output_buf, output_size);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptBinaryToString((BYTE *)pybuf.ptr(), pybuf.len(), flags, output_buf, &output_size);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptBinaryToString");
+    else
+        ret = PyWinObject_FromWCHAR(output_buf, output_size);
     free(output_buf);
     return ret;
 }
@@ -2068,17 +2171,19 @@ static PyObject *PyCryptStringToBinary(PyObject *self, PyObject *args, PyObject 
     if (!PyWinObject_AsWCHAR(obinput_buf, &input_buf, FALSE, &input_size))
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptStringToBinary(input_buf, input_size, flags, output_buf, &output_size, &skip, &out_flags);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptStringToBinary");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptStringToBinary(input_buf, input_size, flags, output_buf, &output_size, &skip, &out_flags);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CryptStringToBinary");
     oboutput_buf = PyBytes_FromStringAndSize(NULL, output_size);
     if (oboutput_buf == NULL)
         return NULL;
     output_buf = (BYTE *)PyBytes_AS_STRING(oboutput_buf);
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptStringToBinary(input_buf, input_size, flags, output_buf, &output_size, &skip, &out_flags);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptStringToBinary(input_buf, input_size, flags, output_buf, &output_size, &skip, &out_flags);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         Py_DECREF(oboutput_buf);
         return PyWin_SetAPIError("CryptStringToBinary");
     }

--- a/win32/src/win32crypt/win32cryptmodule.cpp
+++ b/win32/src/win32crypt/win32cryptmodule.cpp
@@ -49,11 +49,12 @@ static PyObject *PyCryptProtectData(PyObject *self, PyObject *args, PyObject *kw
 
     PyObject *ret = NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptProtectData(&DataIn, DataDescr, pOptionalEntropy, pReserved, pPromptStruct, Flags, &DataOut);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptProtectData");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptProtectData(&DataIn, DataDescr, pOptionalEntropy, pReserved, pPromptStruct, Flags, &DataOut);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptProtectData");
+    else {
         ret = PyWinObject_FromDATA_BLOB(&DataOut);
         LocalFree(DataOut.pbData);
     }
@@ -106,11 +107,12 @@ static PyObject *PyCryptUnprotectData(PyObject *self, PyObject *args, PyObject *
     WCHAR *DataDescr = NULL;
     PyObject *ret = NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptUnprotectData(&DataIn, &DataDescr, pOptionalEntropy, pReserved, pPromptStruct, Flags, &DataOut);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptUnprotectData");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptUnprotectData(&DataIn, &DataDescr, pOptionalEntropy, pReserved, pPromptStruct, Flags, &DataOut);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptUnprotectData");
+    else {
         ret = Py_BuildValue("NN", PyWinObject_FromWCHAR(DataDescr), PyWinObject_FromDATA_BLOB(&DataOut));
         if (DataDescr)
             LocalFree(DataDescr);
@@ -130,9 +132,10 @@ static PyObject *PyCertAlgIdToOID(PyObject *self, PyObject *args, PyObject *kwar
     // @pyparm int|AlgId||An algorithm identifier
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "I:CertAlgIdToOID", keywords, &algid))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS szoid = CertAlgIdToOID(algid);
-    Py_END_ALLOW_THREADS if (szoid == NULL)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        szoid = CertAlgIdToOID(algid);
+    Py_END_ALLOW_THREADS
+    if (szoid == NULL) {
         Py_INCREF(Py_None);
         return Py_None;
     }
@@ -149,8 +152,10 @@ static PyObject *PyCertOIDToAlgId(PyObject *self, PyObject *args, PyObject *kwar
     // @pyparm string|ObjId||String szOID_* identifier
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s:CertOIDToAlgId", keywords, &szoid))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS algid = CertOIDToAlgId(szoid);
-    Py_END_ALLOW_THREADS return PyLong_FromUnsignedLong(algid);
+    Py_BEGIN_ALLOW_THREADS
+        algid = CertOIDToAlgId(szoid);
+    Py_END_ALLOW_THREADS
+    return PyLong_FromUnsignedLong(algid);
 }
 
 // @pymethod <o PyCRYPTPROV>|win32crypt|CryptAcquireContext|Retrieve handle to a cryptographic service provider
@@ -177,11 +182,12 @@ static PyObject *PyCryptAcquireContext(PyObject *self, PyObject *args, PyObject 
         goto done;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptAcquireContext(&hcryptprov, container_name, provider_name, dwProvType, dwFlags);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptAcquireContext");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptAcquireContext(&hcryptprov, container_name, provider_name, dwProvType, dwFlags);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptAcquireContext");
+    else {
         if (dwFlags & CRYPT_DELETEKEYSET) {  // when key is being deleted, no context is returned
             Py_INCREF(Py_None);
             ret = Py_None;
@@ -214,9 +220,10 @@ static PyObject *PyCryptEnumProviders(PyObject *self, PyObject *args)
         cbProvName = 0;
         pszProvName = NULL;
         ret_item = NULL;
-        Py_BEGIN_ALLOW_THREADS bsuccess = CryptEnumProviders(dwIndex, NULL, dwFlags, &dwProvType, NULL, &cbProvName);
-        Py_END_ALLOW_THREADS if (!bsuccess)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            bsuccess = CryptEnumProviders(dwIndex, NULL, dwFlags, &dwProvType, NULL, &cbProvName);
+        Py_END_ALLOW_THREADS
+        if (!bsuccess) {
             err = GetLastError();
             break;
         }
@@ -225,10 +232,10 @@ static PyObject *PyCryptEnumProviders(PyObject *self, PyObject *args)
             PyErr_Format(PyExc_MemoryError, "CryptEnumProviders: Unable to allocate %d bytes", cbProvName);
             break;
         }
-        Py_BEGIN_ALLOW_THREADS bsuccess =
-            CryptEnumProviders(dwIndex, NULL, dwFlags, &dwProvType, pszProvName, &cbProvName);
-        Py_END_ALLOW_THREADS if (!bsuccess)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            bsuccess = CryptEnumProviders(dwIndex, NULL, dwFlags, &dwProvType, pszProvName, &cbProvName);
+        Py_END_ALLOW_THREADS
+        if (!bsuccess) {
             err = GetLastError();
             break;
         }
@@ -273,10 +280,10 @@ static PyObject *PyCryptEnumProviderTypes(PyObject *self, PyObject *args)
         cbTypeName = 0;
         pszTypeName = NULL;
         ret_item = NULL;
-        Py_BEGIN_ALLOW_THREADS bsuccess =
-            CryptEnumProviderTypes(dwIndex, NULL, dwFlags, &dwProvType, NULL, &cbTypeName);
-        Py_END_ALLOW_THREADS if (!bsuccess)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            bsuccess = CryptEnumProviderTypes(dwIndex, NULL, dwFlags, &dwProvType, NULL, &cbTypeName);
+        Py_END_ALLOW_THREADS
+        if (!bsuccess) {
             err = GetLastError();
             break;
         }
@@ -285,10 +292,10 @@ static PyObject *PyCryptEnumProviderTypes(PyObject *self, PyObject *args)
             PyErr_Format(PyExc_MemoryError, "Unable to allocate %d bytes", cbTypeName);
             break;
         }
-        Py_BEGIN_ALLOW_THREADS bsuccess =
-            CryptEnumProviderTypes(dwIndex, NULL, dwFlags, &dwProvType, pszTypeName, &cbTypeName);
-        Py_END_ALLOW_THREADS if (!bsuccess)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            bsuccess = CryptEnumProviderTypes(dwIndex, NULL, dwFlags, &dwProvType, pszTypeName, &cbTypeName);
+        Py_END_ALLOW_THREADS
+        if (!bsuccess) {
             err = GetLastError();
             break;
         }
@@ -331,14 +338,21 @@ static PyObject *PyCryptGetDefaultProvider(PyObject *self, PyObject *args, PyObj
     PyObject *ret = NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptGetDefaultProvider(dwProvType, NULL, dwFlags, NULL, &cbProvName);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptGetDefaultProvider");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptGetDefaultProvider(dwProvType, NULL, dwFlags, NULL, &cbProvName);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CryptGetDefaultProvider");
     pszProvName = (WCHAR *)malloc(cbProvName);
     if (pszProvName == NULL)
         return PyErr_Format(PyExc_MemoryError, "Unable to allocate %d bytes", cbProvName);
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptGetDefaultProvider(dwProvType, NULL, dwFlags, pszProvName, &cbProvName);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptGetDefaultProvider");
-    else ret = PyWinObject_FromWCHAR(pszProvName);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptGetDefaultProvider(dwProvType, NULL, dwFlags, pszProvName, &cbProvName);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptGetDefaultProvider");
+    else
+        ret = PyWinObject_FromWCHAR(pszProvName);
     free(pszProvName);
     return ret;
 }
@@ -363,10 +377,12 @@ static PyObject *PyCryptSetProviderEx(PyObject *self, PyObject *args, PyObject *
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptSetProviderEx(ProvName, dwProvType, NULL, dwFlags);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptSetProviderEx");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptSetProviderEx(ProvName, dwProvType, NULL, dwFlags);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptSetProviderEx");
+    else {
         Py_INCREF(Py_None);
         ret = Py_None;
     }
@@ -387,13 +403,15 @@ static PyObject *PyCryptFindLocalizedName(PyObject *self, PyObject *args, PyObje
         return NULL;
     if (!PyWinObject_AsWCHAR(obstore_name, &store_name, FALSE))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS localized_name = CryptFindLocalizedName(store_name);
-    Py_END_ALLOW_THREADS if (localized_name == NULL)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        localized_name = CryptFindLocalizedName(store_name);
+    Py_END_ALLOW_THREADS
+    if (localized_name == NULL) {
         Py_INCREF(Py_None);
         ret = Py_None;
     }
-    else ret = PyWinObject_FromWCHAR(localized_name);
+    else
+        ret = PyWinObject_FromWCHAR(localized_name);
     PyWinObject_FreeWCHAR(store_name);
     return ret;
 }
@@ -423,9 +441,10 @@ static PyObject *PyCertEnumSystemStoreLocation(PyObject *self, PyObject *args, P
     if (ret == NULL)
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertEnumSystemStoreLocation(dwFlags, ret, CertEnumSystemStoreLocationCallback);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertEnumSystemStoreLocation(dwFlags, ret, CertEnumSystemStoreLocationCallback);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         Py_DECREF(ret);
         ret = NULL;
         if (!PyErr_Occurred())
@@ -479,12 +498,11 @@ static PyObject *PyCertEnumSystemStore(PyObject *self, PyObject *args, PyObject 
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CertEnumSystemStore(dwFlags, pvSystemStoreLocationPara, ret, CertEnumSystemStoreCallback);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertEnumSystemStore(dwFlags, pvSystemStoreLocationPara, ret, CertEnumSystemStoreCallback);
     Py_END_ALLOW_THREADS
 
-        if (!bsuccess)
-    {
+    if (!bsuccess) {
         Py_DECREF(ret);
         ret = NULL;
         if (!PyErr_Occurred())
@@ -535,10 +553,10 @@ static PyObject *PyCertEnumPhysicalStore(PyObject *self, PyObject *args, PyObjec
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CertEnumPhysicalStore(pvSystemStore, dwFlags, (void *)ret, CertEnumPhysicalStoreCallback);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertEnumPhysicalStore(pvSystemStore, dwFlags, (void *)ret, CertEnumPhysicalStoreCallback);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         Py_DECREF(ret);
         ret = NULL;
         if (!PyErr_Occurred())
@@ -623,9 +641,10 @@ static PyObject *PyCertOpenStore(PyObject *self, PyObject *args, PyObject *kwarg
         }
     }
 
-    Py_BEGIN_ALLOW_THREADS hcertstore = CertOpenStore(StoreProvider, dwEncodingType, hcryptprov, dwFlags, pvPara);
-    Py_END_ALLOW_THREADS if (hcertstore == NULL)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hcertstore = CertOpenStore(StoreProvider, dwEncodingType, hcryptprov, dwFlags, pvPara);
+    Py_END_ALLOW_THREADS
+    if (hcertstore == NULL) {
         err = GetLastError();
         // when delete is specified, return value is always NULL
         if ((dwFlags & CERT_STORE_DELETE_FLAG) && (err == 0)) {
@@ -635,7 +654,8 @@ static PyObject *PyCertOpenStore(PyObject *self, PyObject *args, PyObject *kwarg
         else
             PyWin_SetAPIError("CertOpenStore", err);
     }
-    else ret = PyWinObject_FromCERTSTORE(hcertstore);
+    else
+        ret = PyWinObject_FromCERTSTORE(hcertstore);
     if (free_wchar)
         PyWinObject_FreeWCHAR((WCHAR *)pvPara);
     return ret;
@@ -659,9 +679,13 @@ static PyObject *PyCertOpenSystemStore(PyObject *self, PyObject *args, PyObject 
         return NULL;
     if (!PyWinObject_AsWCHAR(obstore_name, &store_name, FALSE))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS hcertstore = CertOpenSystemStore(hcryptprov, store_name);
-    Py_END_ALLOW_THREADS if (hcertstore == NULL) PyWin_SetAPIError("CertOpenSystemStore");
-    else ret = PyWinObject_FromCERTSTORE(hcertstore);
+    Py_BEGIN_ALLOW_THREADS
+        hcertstore = CertOpenSystemStore(hcryptprov, store_name);
+    Py_END_ALLOW_THREADS
+    if (hcertstore == NULL)
+        PyWin_SetAPIError("CertOpenSystemStore");
+    else
+        ret = PyWinObject_FromCERTSTORE(hcertstore);
     PyWinObject_FreeWCHAR(store_name);
     return ret;
 }
@@ -693,10 +717,12 @@ static PyObject *PyCertRegisterSystemStore(PyObject *self, PyObject *args, PyObj
     else if (!PyWinObject_AsWCHAR(obSystemStore, (WCHAR **)&pvSystemStore))
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertRegisterSystemStore(pvSystemStore, dwFlags, pStoreInfo, pvReserved);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CertRegisterSystemStore");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertRegisterSystemStore(pvSystemStore, dwFlags, pStoreInfo, pvReserved);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CertRegisterSystemStore");
+    else {
         Py_INCREF(Py_None);
         ret = Py_None;
     }
@@ -724,10 +750,12 @@ static PyObject *PyCertUnregisterSystemStore(PyObject *self, PyObject *args, PyO
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertUnregisterSystemStore(pvSystemStore, dwFlags);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CertUnregisterSystemStore");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertUnregisterSystemStore(pvSystemStore, dwFlags);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CertUnregisterSystemStore");
+    else {
         Py_INCREF(Py_None);
         ret = Py_None;
     }
@@ -788,8 +816,11 @@ static PyObject *PyCryptFindOIDInfo(PyObject *self, PyObject *args, PyObject *kw
             PyErr_SetString(PyExc_ValueError, "Unrecognized key type");
             return NULL;
     }
-    Py_BEGIN_ALLOW_THREADS oid_info = CryptFindOIDInfo(keytype, key, groupid);
-    Py_END_ALLOW_THREADS if (oid_info == NULL) return PyWin_SetAPIError("CryptFindOIDInfo");
+    Py_BEGIN_ALLOW_THREADS
+        oid_info = CryptFindOIDInfo(keytype, key, groupid);
+    Py_END_ALLOW_THREADS
+    if (oid_info == NULL)
+        return PyWin_SetAPIError("CryptFindOIDInfo");
     // docs say do NOT free the returned CRYPT_OID_INFO
     return PyWinObject_FromCRYPT_OID_INFO(oid_info);
 }
@@ -826,9 +857,11 @@ static PyObject *PyCryptGetKeyIdentifierProperty(PyObject *self, PyObject *args,
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptGetKeyIdentifierProperty(&chb, propid, flags, computername, reserved, &buf, &bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptGetKeyIdentifierProperty");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptGetKeyIdentifierProperty(&chb, propid, flags, computername, reserved, &buf, &bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CryptGetKeyIdentifierProperty");
 
     /* Usually only CERT_KEY_PROV_INFO_PROP_ID is used with this function.
         However, according to the docs other certificate properties can be requested.
@@ -938,10 +971,11 @@ static PyObject *PyCryptEnumKeyIdentifierProperties(PyObject *self, PyObject *ar
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptEnumKeyIdentifierProperties(
-        pchb, propid, flags, computername, reserved, (void *)ret, CryptEnumKeyIdentifierProperties_callback);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptEnumKeyIdentifierProperties(pchb, propid, flags, computername, reserved, (void *)ret,
+                                                    CryptEnumKeyIdentifierProperties_callback);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         Py_DECREF(ret);
         ret = NULL;
         if (!PyErr_Occurred())
@@ -980,9 +1014,10 @@ static PyObject *PyCryptEnumOIDInfo(PyObject *self, PyObject *args, PyObject *kw
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptEnumOIDInfo(groupid, flags, (void *)ret, CryptEnumOIDInfo_callback);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptEnumOIDInfo(groupid, flags, (void *)ret, CryptEnumOIDInfo_callback);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         Py_DECREF(ret);
         ret = NULL;
         if (!PyErr_Occurred())
@@ -1020,11 +1055,13 @@ static PyObject *PyCertAddSerializedElementToStore(PyObject *self, PyObject *arg
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertAddSerializedElementToStore(
-        hcertstore, (BYTE *)pybuf.ptr(), pybuf.len(), adddisposition, flags, contexttype, &contexttype_out, &context);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertAddSerializedElementToStore(hcertstore, (BYTE *)pybuf.ptr(), pybuf.len(), adddisposition, flags,
+                                                   contexttype, &contexttype_out, &context);
     Py_END_ALLOW_THREADS
 
-        if (!bsuccess) return PyWin_SetAPIError("CertAddSerializedElementToStore");
+    if (!bsuccess)
+        return PyWin_SetAPIError("CertAddSerializedElementToStore");
     if (contexttype_out == CERT_STORE_CERTIFICATE_CONTEXT)
         return PyWinObject_FromCERT_CONTEXT((PCCERT_CONTEXT)context);
     else if (contexttype_out == CERT_STORE_CTL_CONTEXT)
@@ -1086,10 +1123,10 @@ static PyObject *PyCryptQueryObject(PyObject *self, PyObject *args, PyObject *kw
     }
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = CryptQueryObject(objecttype, input, contenttype, formattype, flags, &encoding, &contenttypeout,
-                                &formattypeout, &hcertstore, &hcryptmsg, (const void **)&context);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptQueryObject(objecttype, input, contenttype, formattype, flags, &encoding, &contenttypeout,
+                                    &formattypeout, &hcertstore, &hcryptmsg, (const void **)&context);
+    Py_END_ALLOW_THREADS
     if (!bsuccess)
         return PyWin_SetAPIError("CryptQueryObject");
 
@@ -1163,11 +1200,12 @@ static PyObject *PyCryptDecodeMessage(PyObject *self, PyObject *args, PyObject *
     if (!PyWinObject_AsCRYPT_DECRYPT_MESSAGE_PARA(obcdmp, &cdmp))
         return NULL;
 
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptDecodeMessage(msg_type_flags, &cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), prev_inner_type,
-                           &msg_type, &inner_type, output_buf, &output_bufsize, &exchange_cert, &signer_cert);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptDecodeMessage(msg_type_flags, &cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                      prev_inner_type, &msg_type, &inner_type, output_buf, &output_bufsize,
+                                      &exchange_cert, &signer_cert);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         // Callback may raise an exception
         if (!PyErr_Occurred())
             PyWin_SetAPIError("CryptDecodeMessage");
@@ -1184,18 +1222,19 @@ static PyObject *PyCryptDecodeMessage(PyObject *self, PyObject *args, PyObject *
     output_buf = (BYTE *)malloc(output_bufsize);
     if (output_buf == NULL)
         return PyErr_NoMemory();
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptDecodeMessage(msg_type_flags, &cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), prev_inner_type,
-                           &msg_type, &inner_type, output_buf, &output_bufsize, NULL, NULL);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptDecodeMessage(msg_type_flags, &cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                      prev_inner_type, &msg_type, &inner_type, output_buf, &output_bufsize, NULL, NULL);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         if (!PyErr_Occurred())
             PyWin_SetAPIError("CryptDecodeMessage");
     }
-    else ret = Py_BuildValue("{s:k,s:k,s:N,s:N,s:N}", "MsgType", msg_type, "InnerContentType", inner_type, "Decoded",
-                             PyBytes_FromStringAndSize((char *)output_buf, output_bufsize), "XchgCert",
-                             PyWinObject_FromCERT_CONTEXT(exchange_cert), "SignerCert",
-                             PyWinObject_FromCERT_CONTEXT(signer_cert));
+    else
+        ret = Py_BuildValue("{s:k,s:k,s:N,s:N,s:N}", "MsgType", msg_type, "InnerContentType", inner_type, "Decoded",
+                            PyBytes_FromStringAndSize((char *)output_buf, output_bufsize), "XchgCert",
+                            PyWinObject_FromCERT_CONTEXT(exchange_cert), "SignerCert",
+                            PyWinObject_FromCERT_CONTEXT(signer_cert));
 
     free(output_buf);
     if (!ret) {
@@ -1233,19 +1272,25 @@ static PyObject *PyCryptEncryptMessage(PyObject *self, PyObject *args, PyObject 
         return NULL;
     if (!PyWinObject_AsCERT_CONTEXTArray(obrecipients, &recipients, &recipient_cnt))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptEncryptMessage(&cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(),
-                                                          pybuf.len(), outputbuf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptEncryptMessage");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptEncryptMessage(&cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(), pybuf.len(), outputbuf,
+                                       &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptEncryptMessage");
+    else {
         outputbuf = (BYTE *)malloc(output_bufsize);
         if (outputbuf == NULL)
             PyErr_Format(PyExc_MemoryError, "CryptEncryptMessage: Unable to allocate %d bytes", output_bufsize);
         else {
-            Py_BEGIN_ALLOW_THREADS bsuccess = CryptEncryptMessage(&cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(),
-                                                                  pybuf.len(), outputbuf, &output_bufsize);
-            Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptEncryptMessage");
-            else ret = PyBytes_FromStringAndSize((char *)outputbuf, output_bufsize);
+            Py_BEGIN_ALLOW_THREADS
+                bsuccess = CryptEncryptMessage(&cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                               outputbuf, &output_bufsize);
+            Py_END_ALLOW_THREADS
+            if (!bsuccess)
+                PyWin_SetAPIError("CryptEncryptMessage");
+            else
+                ret = PyBytes_FromStringAndSize((char *)outputbuf, output_bufsize);
         }
     }
 
@@ -1278,19 +1323,25 @@ static PyObject *PyCryptDecryptMessage(PyObject *self, PyObject *args, PyObject 
     if (!PyWinObject_AsCRYPT_DECRYPT_MESSAGE_PARA(obcdmp, &cdmp))
         return NULL;
 
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptDecryptMessage(&cdmp, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize, NULL);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptDecryptMessage");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptDecryptMessage(&cdmp, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize, NULL);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CryptDecryptMessage");
 
     output_buf = (BYTE *)malloc(output_bufsize);
     if (output_buf == NULL)
         return PyErr_NoMemory();
 
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptDecryptMessage(&cdmp, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize, &exchange_cert);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptDecryptMessage");
-    else ret = Py_BuildValue("NN", PyBytes_FromStringAndSize((char *)output_buf, output_bufsize),
-                             PyWinObject_FromCERT_CONTEXT(exchange_cert));
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess =
+            CryptDecryptMessage(&cdmp, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize, &exchange_cert);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptDecryptMessage");
+    else
+        ret = Py_BuildValue("NN", PyBytes_FromStringAndSize((char *)output_buf, output_bufsize),
+                            PyWinObject_FromCERT_CONTEXT(exchange_cert));
     free(output_buf);
     return ret;
 }
@@ -1324,10 +1375,11 @@ static PyObject *PyCryptSignAndEncryptMessage(PyObject *self, PyObject *args, Py
         goto cleanup;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptSignAndEncryptMessage(
-        &csmp, &cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptSignAndEncryptMessage(&csmp, &cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                              output_buf, &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         PyWin_SetAPIError("CryptSignAndEncryptMessage");
         goto cleanup;
     }
@@ -1338,10 +1390,11 @@ static PyObject *PyCryptSignAndEncryptMessage(PyObject *self, PyObject *args, Py
         goto cleanup;
     }
 
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptSignAndEncryptMessage(
-        &csmp, &cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptSignAndEncryptMessage(&csmp, &cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                              output_buf, &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         PyWin_SetAPIError("CryptSignAndEncryptMessage");
         goto cleanup;
     }
@@ -1382,12 +1435,12 @@ static PyObject *PyCryptVerifyMessageSignature(PyObject *self, PyObject *args, P
 
     if (!PyWinObject_AsCRYPT_VERIFY_MESSAGE_PARA(obcvmp, &cvmp))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptVerifyMessageSignature(&cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(),
-                                                                  output_buf, &output_bufsize, &signer_cert);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptVerifyMessageSignature(&cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf,
+                                               &output_bufsize, &signer_cert);
     Py_END_ALLOW_THREADS
-        // Callback may have already set an exception
-        if (!bsuccess)
-    {
+    // Callback may have already set an exception
+    if (!bsuccess) {
         if (!PyErr_Occurred())
             PyWin_SetAPIError("CryptVerifyMessageSignature");
         return NULL;
@@ -1401,16 +1454,18 @@ static PyObject *PyCryptVerifyMessageSignature(PyObject *self, PyObject *args, P
     if (output_buf == NULL)
         PyErr_NoMemory();
     else {
-        Py_BEGIN_ALLOW_THREADS bsuccess = CryptVerifyMessageSignature(&cvmp, signer_ind, (BYTE *)pybuf.ptr(),
-                                                                      pybuf.len(), output_buf, &output_bufsize, NULL);
-        Py_END_ALLOW_THREADS if (!bsuccess)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            bsuccess = CryptVerifyMessageSignature(&cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf,
+                                                   &output_bufsize, NULL);
+        Py_END_ALLOW_THREADS
+        if (!bsuccess) {
             // Callback may have already set an exception
             if (!PyErr_Occurred())
                 PyWin_SetAPIError("CryptVerifyMessageSignature");
         }
-        else ret = Py_BuildValue("{s:N, s:N}", "SignerCert", PyWinObject_FromCERT_CONTEXT(signer_cert), "Decoded",
-                                 PyBytes_FromStringAndSize((char *)output_buf, output_bufsize));
+        else
+            ret = Py_BuildValue("{s:N, s:N}", "SignerCert", PyWinObject_FromCERT_CONTEXT(signer_cert), "Decoded",
+                                PyBytes_FromStringAndSize((char *)output_buf, output_bufsize));
     }
     if (output_buf)
         free(output_buf);
@@ -1441,9 +1496,11 @@ static PyObject *PyCryptGetMessageCertificates(PyObject *self, PyObject *args, P
         return NULL;
     if (!PyWinObject_AsHCRYPTPROV(obcsp, &csp, TRUE))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS hcertstore =
-        CryptGetMessageCertificates(encoding_type, csp, flags, (BYTE *)pybuf.ptr(), pybuf.len());
-    Py_END_ALLOW_THREADS if (hcertstore == NULL) return PyWin_SetAPIError("CryptGetMessageCertificates");
+    Py_BEGIN_ALLOW_THREADS
+        hcertstore = CryptGetMessageCertificates(encoding_type, csp, flags, (BYTE *)pybuf.ptr(), pybuf.len());
+    Py_END_ALLOW_THREADS
+    if (hcertstore == NULL)
+        return PyWin_SetAPIError("CryptGetMessageCertificates");
     return PyWinObject_FromCERTSTORE(hcertstore);
 }
 
@@ -1464,8 +1521,11 @@ static PyObject *PyCryptGetMessageSignerCount(PyObject *self, PyObject *args, Py
     PyWinBufferView pybuf(obbuf);
     if (!pybuf.ok())
         return NULL;
-    Py_BEGIN_ALLOW_THREADS signer_cnt = CryptGetMessageSignerCount(encoding_type, (BYTE *)pybuf.ptr(), pybuf.len());
-    Py_END_ALLOW_THREADS if (signer_cnt == -1) return PyWin_SetAPIError("CryptGetMessageSignerCount");
+    Py_BEGIN_ALLOW_THREADS
+        signer_cnt = CryptGetMessageSignerCount(encoding_type, (BYTE *)pybuf.ptr(), pybuf.len());
+    Py_END_ALLOW_THREADS
+    if (signer_cnt == -1)
+        return PyWin_SetAPIError("CryptGetMessageSignerCount");
     return PyLong_FromLong(signer_cnt);
 }
 
@@ -1494,10 +1554,11 @@ static PyObject *PyCryptSignMessage(PyObject *self, PyObject *args, PyObject *kw
         goto cleanup;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptSignMessage(&csmp, detached_sig, msg_cnt, (const BYTE **)msgs, msg_sizes, output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess =
+            CryptSignMessage(&csmp, detached_sig, msg_cnt, (const BYTE **)msgs, msg_sizes, output_buf, &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         PyWin_SetAPIError("CryptSignMessage");
         goto cleanup;
     }
@@ -1507,10 +1568,11 @@ static PyObject *PyCryptSignMessage(PyObject *self, PyObject *args, PyObject *kw
         goto cleanup;
     }
 
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptSignMessage(&csmp, detached_sig, msg_cnt, (const BYTE **)msgs, msg_sizes, output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess =
+            CryptSignMessage(&csmp, detached_sig, msg_cnt, (const BYTE **)msgs, msg_sizes, output_buf, &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         PyWin_SetAPIError("CryptSignMessage");
         goto cleanup;
     }
@@ -1553,10 +1615,14 @@ static PyObject *PyCryptVerifyDetachedMessageSignature(PyObject *self, PyObject 
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptVerifyDetachedMessageSignature(
-        &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), msg_cnt, (const BYTE **)msgs, msg_sizes, &signer_cert);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptVerifyDetachedMessageSignature");
-    else ret = PyWinObject_FromCERT_CONTEXT(signer_cert);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptVerifyDetachedMessageSignature(&cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), msg_cnt,
+                                                       (const BYTE **)msgs, msg_sizes, &signer_cert);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptVerifyDetachedMessageSignature");
+    else
+        ret = PyWinObject_FromCERT_CONTEXT(signer_cert);
 
     PyWinObject_FreePBYTEArray(msgs, msg_sizes, msg_cnt);
     return ret;
@@ -1596,20 +1662,26 @@ static PyObject *PyCryptDecryptAndVerifyMessageSignature(PyObject *self, PyObjec
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptDecryptAndVerifyMessageSignature(
-        &cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize, NULL, NULL);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptDecryptAndVerifyMessageSignature");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptDecryptAndVerifyMessageSignature(&cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                                         output_buf, &output_bufsize, NULL, NULL);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CryptDecryptAndVerifyMessageSignature");
 
     output_buf = (BYTE *)malloc(output_bufsize);
     if (output_buf == NULL)
         return PyErr_NoMemory();
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptDecryptAndVerifyMessageSignature(&cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf,
-                                              &output_bufsize, &exchange_cert, &signer_cert);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptDecryptAndVerifyMessageSignature");
-    else ret = Py_BuildValue(
-        "{s:N,s:N,s:N}", "Decrypted", PyBytes_FromStringAndSize((char *)output_buf, output_bufsize), "XchgCert",
-        PyWinObject_FromCERT_CONTEXT(exchange_cert), "SignerCert", PyWinObject_FromCERT_CONTEXT(signer_cert));
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptDecryptAndVerifyMessageSignature(&cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                                         output_buf, &output_bufsize, &exchange_cert, &signer_cert);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptDecryptAndVerifyMessageSignature");
+    else
+        ret = Py_BuildValue("{s:N,s:N,s:N}", "Decrypted", PyBytes_FromStringAndSize((char *)output_buf, output_bufsize),
+                            "XchgCert", PyWinObject_FromCERT_CONTEXT(exchange_cert), "SignerCert",
+                            PyWinObject_FromCERT_CONTEXT(signer_cert));
 
     free(output_buf);
     return ret;
@@ -1696,10 +1768,13 @@ static PyObject *PyCryptEncodeObjectEx(PyObject *self, PyObject *args, PyObject 
         goto cleanup;
     }
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptEncodeObjectEx(encoding, structtype, input_buf, flags, NULL, &output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptDecodeObjectEx");
-    else ret = PyBytes_FromStringAndSize((char *)output_buf, output_bufsize);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptEncodeObjectEx(encoding, structtype, input_buf, flags, NULL, &output_buf, &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptDecodeObjectEx");
+    else
+        ret = PyBytes_FromStringAndSize((char *)output_buf, output_bufsize);
 
 cleanup:
     if ((oid_is_str && (strcmp(structtype, szOID_ENHANCED_KEY_USAGE) == 0)) || (structtype == X509_ENHANCED_KEY_USAGE))
@@ -1745,10 +1820,11 @@ static PyObject *PyCryptDecodeObjectEx(PyObject *self, PyObject *args, PyObject 
     }
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptDecodeObjectEx(encoding, structtype, (BYTE *)pybuf.ptr(), pybuf.len(), flags,
-                                                          NULL, &output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptDecodeObjectEx(encoding, structtype, (BYTE *)pybuf.ptr(), pybuf.len(), flags, NULL, &output_buf,
+                                       &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         PyWin_SetAPIError("CryptDecodeObjectEx");
         goto cleanup;
     }
@@ -1878,14 +1954,21 @@ static PyObject *PyCertNameToStr(PyObject *self, PyObject *args, PyObject *kwarg
     cnb.pbData = (BYTE *)pybuf.ptr();
     cnb.cbData = pybuf.len();
 
-    Py_BEGIN_ALLOW_THREADS output_buflen = CertNameToStr(encoding, &cnb, strtype, output_buf, output_buflen);
-    Py_END_ALLOW_THREADS if (output_buflen == 0) return PyWin_SetAPIError("CertNameToStr");
+    Py_BEGIN_ALLOW_THREADS
+        output_buflen = CertNameToStr(encoding, &cnb, strtype, output_buf, output_buflen);
+    Py_END_ALLOW_THREADS
+    if (output_buflen == 0)
+        return PyWin_SetAPIError("CertNameToStr");
     output_buf = (WCHAR *)malloc(output_buflen * sizeof(WCHAR));
     if (output_buf == NULL)
         return PyErr_Format(PyExc_MemoryError, "Unable to allocate %d bytes", output_buflen);
-    Py_BEGIN_ALLOW_THREADS output_buflen = CertNameToStr(encoding, &cnb, strtype, output_buf, output_buflen);
-    Py_END_ALLOW_THREADS if (output_buflen == 0) PyWin_SetAPIError("CertNameToStr");
-    else ret = PyWinObject_FromWCHAR(output_buf);
+    Py_BEGIN_ALLOW_THREADS
+        output_buflen = CertNameToStr(encoding, &cnb, strtype, output_buf, output_buflen);
+    Py_END_ALLOW_THREADS
+    if (output_buflen == 0)
+        PyWin_SetAPIError("CertNameToStr");
+    else
+        ret = PyWinObject_FromWCHAR(output_buf);
     free(output_buf);
     return ret;
 }
@@ -1926,17 +2009,24 @@ static PyObject *PyCryptFormatObject(PyObject *self, PyObject *args, PyObject *k
     }
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptFormatObject(encoding, fmt_type, string_fmt, fmt_struct, oid,
-                                                        (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptFormatObject");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptFormatObject(encoding, fmt_type, string_fmt, fmt_struct, oid, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                     output_buf, &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CryptFormatObject");
     output_buf = malloc(output_bufsize);
     if (output_buf == NULL)
         return PyErr_Format(PyExc_MemoryError, "Unable to allocate %d bytes", output_bufsize);
 
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptFormatObject(encoding, fmt_type, string_fmt, fmt_struct, oid,
-                                                        (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptFormatObject");
-    else ret = PyWinObject_FromWCHAR((WCHAR *)output_buf);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptFormatObject(encoding, fmt_type, string_fmt, fmt_struct, oid, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                     output_buf, &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptFormatObject");
+    else
+        ret = PyWinObject_FromWCHAR((WCHAR *)output_buf);
     free(output_buf);
     return ret;
 }
@@ -1966,8 +2056,11 @@ static PyObject *PyPFXImportCertStore(PyObject *self, PyObject *args, PyObject *
         return NULL;
     if (!PyWinObject_AsWCHAR(obpassword, &password, TRUE))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS hcertstore = PFXImportCertStore(&input_buf, password, flags);
-    Py_END_ALLOW_THREADS if (hcertstore == NULL) return PyWin_SetAPIError("PFXImportCertStore");
+    Py_BEGIN_ALLOW_THREADS
+        hcertstore = PFXImportCertStore(&input_buf, password, flags);
+    Py_END_ALLOW_THREADS
+    if (hcertstore == NULL)
+        return PyWin_SetAPIError("PFXImportCertStore");
     return PyWinObject_FromCERTSTORE(hcertstore);
 }
 
@@ -1993,8 +2086,10 @@ static PyObject *PyPFXVerifyPassword(PyObject *self, PyObject *args, PyObject *k
     if (!PyWinObject_AsWCHAR(obpassword, &password, TRUE))
         return NULL;
     BOOL out;
-    Py_BEGIN_ALLOW_THREADS out = PFXVerifyPassword(&input_buf, password, flags);
-    Py_END_ALLOW_THREADS return PyBool_FromLong(out);
+    Py_BEGIN_ALLOW_THREADS
+        out = PFXVerifyPassword(&input_buf, password, flags);
+    Py_END_ALLOW_THREADS
+    return PyBool_FromLong(out);
 }
 
 // @pymethod boolean|win32crypt|PFXIsPFXBlob|Checks if data buffer contains a PFX blob
@@ -2010,8 +2105,10 @@ static PyObject *PyPFXIsPFXBlob(PyObject *self, PyObject *args, PyObject *kwargs
     if (!PyWinObject_AsDATA_BLOB(obinput_buf, &input_buf))
         return NULL;
     BOOL out;
-    Py_BEGIN_ALLOW_THREADS out = PFXIsPFXBlob(&input_buf);
-    Py_END_ALLOW_THREADS return PyBool_FromLong(out);
+    Py_BEGIN_ALLOW_THREADS
+        out = PFXIsPFXBlob(&input_buf);
+    Py_END_ALLOW_THREADS
+    return PyBool_FromLong(out);
 }
 
 // @pymethod str|win32crypt|CryptBinaryToString|Formats a binary buffer into the specified type of string
@@ -2032,18 +2129,23 @@ static PyObject *PyCryptBinaryToString(PyObject *self, PyObject *args, PyObject 
     if (!pybuf.ok())
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptBinaryToString((BYTE *)pybuf.ptr(), pybuf.len(), flags, output_buf, &output_size);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptBinaryToString");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptBinaryToString((BYTE *)pybuf.ptr(), pybuf.len(), flags, output_buf, &output_size);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CryptBinaryToString");
     output_buf = (WCHAR *)malloc(output_size * sizeof(WCHAR));
     if (output_buf == NULL)
         return PyErr_NoMemory();
 
     PyObject *ret = NULL;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptBinaryToString((BYTE *)pybuf.ptr(), pybuf.len(), flags, output_buf, &output_size);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptBinaryToString");
-    else ret = PyWinObject_FromWCHAR(output_buf, output_size);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptBinaryToString((BYTE *)pybuf.ptr(), pybuf.len(), flags, output_buf, &output_size);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptBinaryToString");
+    else
+        ret = PyWinObject_FromWCHAR(output_buf, output_size);
     free(output_buf);
     return ret;
 }
@@ -2068,17 +2170,19 @@ static PyObject *PyCryptStringToBinary(PyObject *self, PyObject *args, PyObject 
     if (!PyWinObject_AsWCHAR(obinput_buf, &input_buf, FALSE, &input_size))
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptStringToBinary(input_buf, input_size, flags, output_buf, &output_size, &skip, &out_flags);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptStringToBinary");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptStringToBinary(input_buf, input_size, flags, output_buf, &output_size, &skip, &out_flags);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CryptStringToBinary");
     oboutput_buf = PyBytes_FromStringAndSize(NULL, output_size);
     if (oboutput_buf == NULL)
         return NULL;
     output_buf = (BYTE *)PyBytes_AS_STRING(oboutput_buf);
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptStringToBinary(input_buf, input_size, flags, output_buf, &output_size, &skip, &out_flags);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptStringToBinary(input_buf, input_size, flags, output_buf, &output_size, &skip, &out_flags);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         Py_DECREF(oboutput_buf);
         return PyWin_SetAPIError("CryptStringToBinary");
     }

--- a/win32/src/win32crypt/win32cryptmodule.cpp
+++ b/win32/src/win32crypt/win32cryptmodule.cpp
@@ -49,11 +49,12 @@ static PyObject *PyCryptProtectData(PyObject *self, PyObject *args, PyObject *kw
 
     PyObject *ret = NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptProtectData(&DataIn, DataDescr, pOptionalEntropy, pReserved, pPromptStruct, Flags, &DataOut);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptProtectData");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptProtectData(&DataIn, DataDescr, pOptionalEntropy, pReserved, pPromptStruct, Flags, &DataOut);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptProtectData");
+    else {
         ret = PyWinObject_FromDATA_BLOB(&DataOut);
         LocalFree(DataOut.pbData);
     }
@@ -106,11 +107,12 @@ static PyObject *PyCryptUnprotectData(PyObject *self, PyObject *args, PyObject *
     WCHAR *DataDescr = NULL;
     PyObject *ret = NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptUnprotectData(&DataIn, &DataDescr, pOptionalEntropy, pReserved, pPromptStruct, Flags, &DataOut);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptUnprotectData");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptUnprotectData(&DataIn, &DataDescr, pOptionalEntropy, pReserved, pPromptStruct, Flags, &DataOut);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptUnprotectData");
+    else {
         ret = Py_BuildValue("NN", PyWinObject_FromWCHAR(DataDescr), PyWinObject_FromDATA_BLOB(&DataOut));
         if (DataDescr)
             LocalFree(DataDescr);
@@ -130,9 +132,10 @@ static PyObject *PyCertAlgIdToOID(PyObject *self, PyObject *args, PyObject *kwar
     // @pyparm int|AlgId||An algorithm identifier
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "I:CertAlgIdToOID", keywords, &algid))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS szoid = CertAlgIdToOID(algid);
-    Py_END_ALLOW_THREADS if (szoid == NULL)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        szoid = CertAlgIdToOID(algid);
+    Py_END_ALLOW_THREADS
+    if (szoid == NULL) {
         Py_INCREF(Py_None);
         return Py_None;
     }
@@ -149,8 +152,10 @@ static PyObject *PyCertOIDToAlgId(PyObject *self, PyObject *args, PyObject *kwar
     // @pyparm string|ObjId||String szOID_* identifier
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s:CertOIDToAlgId", keywords, &szoid))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS algid = CertOIDToAlgId(szoid);
-    Py_END_ALLOW_THREADS return PyLong_FromUnsignedLong(algid);
+    Py_BEGIN_ALLOW_THREADS
+        algid = CertOIDToAlgId(szoid);
+    Py_END_ALLOW_THREADS
+    return PyLong_FromUnsignedLong(algid);
 }
 
 // @pymethod <o PyCRYPTPROV>|win32crypt|CryptAcquireContext|Retrieve handle to a cryptographic service provider
@@ -177,11 +182,12 @@ static PyObject *PyCryptAcquireContext(PyObject *self, PyObject *args, PyObject 
         goto done;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptAcquireContext(&hcryptprov, container_name, provider_name, dwProvType, dwFlags);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptAcquireContext");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptAcquireContext(&hcryptprov, container_name, provider_name, dwProvType, dwFlags);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptAcquireContext");
+    else {
         if (dwFlags & CRYPT_DELETEKEYSET) {  // when key is being deleted, no context is returned
             Py_INCREF(Py_None);
             ret = Py_None;
@@ -214,9 +220,10 @@ static PyObject *PyCryptEnumProviders(PyObject *self, PyObject *args)
         cbProvName = 0;
         pszProvName = NULL;
         ret_item = NULL;
-        Py_BEGIN_ALLOW_THREADS bsuccess = CryptEnumProviders(dwIndex, NULL, dwFlags, &dwProvType, NULL, &cbProvName);
-        Py_END_ALLOW_THREADS if (!bsuccess)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            bsuccess = CryptEnumProviders(dwIndex, NULL, dwFlags, &dwProvType, NULL, &cbProvName);
+        Py_END_ALLOW_THREADS
+        if (!bsuccess) {
             err = GetLastError();
             break;
         }
@@ -225,10 +232,10 @@ static PyObject *PyCryptEnumProviders(PyObject *self, PyObject *args)
             PyErr_Format(PyExc_MemoryError, "CryptEnumProviders: Unable to allocate %d bytes", cbProvName);
             break;
         }
-        Py_BEGIN_ALLOW_THREADS bsuccess =
-            CryptEnumProviders(dwIndex, NULL, dwFlags, &dwProvType, pszProvName, &cbProvName);
-        Py_END_ALLOW_THREADS if (!bsuccess)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            bsuccess = CryptEnumProviders(dwIndex, NULL, dwFlags, &dwProvType, pszProvName, &cbProvName);
+        Py_END_ALLOW_THREADS
+        if (!bsuccess) {
             err = GetLastError();
             break;
         }
@@ -273,10 +280,10 @@ static PyObject *PyCryptEnumProviderTypes(PyObject *self, PyObject *args)
         cbTypeName = 0;
         pszTypeName = NULL;
         ret_item = NULL;
-        Py_BEGIN_ALLOW_THREADS bsuccess =
-            CryptEnumProviderTypes(dwIndex, NULL, dwFlags, &dwProvType, NULL, &cbTypeName);
-        Py_END_ALLOW_THREADS if (!bsuccess)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            bsuccess = CryptEnumProviderTypes(dwIndex, NULL, dwFlags, &dwProvType, NULL, &cbTypeName);
+        Py_END_ALLOW_THREADS
+        if (!bsuccess) {
             err = GetLastError();
             break;
         }
@@ -285,10 +292,10 @@ static PyObject *PyCryptEnumProviderTypes(PyObject *self, PyObject *args)
             PyErr_Format(PyExc_MemoryError, "Unable to allocate %d bytes", cbTypeName);
             break;
         }
-        Py_BEGIN_ALLOW_THREADS bsuccess =
-            CryptEnumProviderTypes(dwIndex, NULL, dwFlags, &dwProvType, pszTypeName, &cbTypeName);
-        Py_END_ALLOW_THREADS if (!bsuccess)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            bsuccess = CryptEnumProviderTypes(dwIndex, NULL, dwFlags, &dwProvType, pszTypeName, &cbTypeName);
+        Py_END_ALLOW_THREADS
+        if (!bsuccess) {
             err = GetLastError();
             break;
         }
@@ -331,14 +338,21 @@ static PyObject *PyCryptGetDefaultProvider(PyObject *self, PyObject *args, PyObj
     PyObject *ret = NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptGetDefaultProvider(dwProvType, NULL, dwFlags, NULL, &cbProvName);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptGetDefaultProvider");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptGetDefaultProvider(dwProvType, NULL, dwFlags, NULL, &cbProvName);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CryptGetDefaultProvider");
     pszProvName = (WCHAR *)malloc(cbProvName);
     if (pszProvName == NULL)
         return PyErr_Format(PyExc_MemoryError, "Unable to allocate %d bytes", cbProvName);
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptGetDefaultProvider(dwProvType, NULL, dwFlags, pszProvName, &cbProvName);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptGetDefaultProvider");
-    else ret = PyWinObject_FromWCHAR(pszProvName);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptGetDefaultProvider(dwProvType, NULL, dwFlags, pszProvName, &cbProvName);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptGetDefaultProvider");
+    else
+        ret = PyWinObject_FromWCHAR(pszProvName);
     free(pszProvName);
     return ret;
 }
@@ -363,10 +377,12 @@ static PyObject *PyCryptSetProviderEx(PyObject *self, PyObject *args, PyObject *
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptSetProviderEx(ProvName, dwProvType, NULL, dwFlags);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptSetProviderEx");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptSetProviderEx(ProvName, dwProvType, NULL, dwFlags);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptSetProviderEx");
+    else {
         Py_INCREF(Py_None);
         ret = Py_None;
     }
@@ -387,13 +403,15 @@ static PyObject *PyCryptFindLocalizedName(PyObject *self, PyObject *args, PyObje
         return NULL;
     if (!PyWinObject_AsWCHAR(obstore_name, &store_name, FALSE))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS localized_name = CryptFindLocalizedName(store_name);
-    Py_END_ALLOW_THREADS if (localized_name == NULL)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        localized_name = CryptFindLocalizedName(store_name);
+    Py_END_ALLOW_THREADS
+    if (localized_name == NULL) {
         Py_INCREF(Py_None);
         ret = Py_None;
     }
-    else ret = PyWinObject_FromWCHAR(localized_name);
+    else
+        ret = PyWinObject_FromWCHAR(localized_name);
     PyWinObject_FreeWCHAR(store_name);
     return ret;
 }
@@ -423,9 +441,10 @@ static PyObject *PyCertEnumSystemStoreLocation(PyObject *self, PyObject *args, P
     if (ret == NULL)
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertEnumSystemStoreLocation(dwFlags, ret, CertEnumSystemStoreLocationCallback);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertEnumSystemStoreLocation(dwFlags, ret, CertEnumSystemStoreLocationCallback);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         Py_DECREF(ret);
         ret = NULL;
         if (!PyErr_Occurred())
@@ -479,12 +498,11 @@ static PyObject *PyCertEnumSystemStore(PyObject *self, PyObject *args, PyObject 
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CertEnumSystemStore(dwFlags, pvSystemStoreLocationPara, ret, CertEnumSystemStoreCallback);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertEnumSystemStore(dwFlags, pvSystemStoreLocationPara, ret, CertEnumSystemStoreCallback);
     Py_END_ALLOW_THREADS
 
-        if (!bsuccess)
-    {
+    if (!bsuccess) {
         Py_DECREF(ret);
         ret = NULL;
         if (!PyErr_Occurred())
@@ -535,10 +553,10 @@ static PyObject *PyCertEnumPhysicalStore(PyObject *self, PyObject *args, PyObjec
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CertEnumPhysicalStore(pvSystemStore, dwFlags, (void *)ret, CertEnumPhysicalStoreCallback);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertEnumPhysicalStore(pvSystemStore, dwFlags, (void *)ret, CertEnumPhysicalStoreCallback);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         Py_DECREF(ret);
         ret = NULL;
         if (!PyErr_Occurred())
@@ -611,9 +629,10 @@ static PyObject *PyCertOpenStore(PyObject *self, PyObject *args, PyObject *kwarg
         return NULL;
     }
 
-    Py_BEGIN_ALLOW_THREADS hcertstore = CertOpenStore(StoreProvider, dwEncodingType, hcryptprov, dwFlags, pvPara);
-    Py_END_ALLOW_THREADS if (hcertstore == NULL)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hcertstore = CertOpenStore(StoreProvider, dwEncodingType, hcryptprov, dwFlags, pvPara);
+    Py_END_ALLOW_THREADS
+    if (hcertstore == NULL) {
         err = GetLastError();
         // when delete is specified, return value is always NULL
         if ((dwFlags & CERT_STORE_DELETE_FLAG) && (err == 0)) {
@@ -623,7 +642,8 @@ static PyObject *PyCertOpenStore(PyObject *self, PyObject *args, PyObject *kwarg
         else
             PyWin_SetAPIError("CertOpenStore", err);
     }
-    else ret = PyWinObject_FromCERTSTORE(hcertstore);
+    else
+        ret = PyWinObject_FromCERTSTORE(hcertstore);
     if (free_wchar)
         PyWinObject_FreeWCHAR((WCHAR *)pvPara);
     return ret;
@@ -647,9 +667,13 @@ static PyObject *PyCertOpenSystemStore(PyObject *self, PyObject *args, PyObject 
         return NULL;
     if (!PyWinObject_AsWCHAR(obstore_name, &store_name, FALSE))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS hcertstore = CertOpenSystemStore(hcryptprov, store_name);
-    Py_END_ALLOW_THREADS if (hcertstore == NULL) PyWin_SetAPIError("CertOpenSystemStore");
-    else ret = PyWinObject_FromCERTSTORE(hcertstore);
+    Py_BEGIN_ALLOW_THREADS
+        hcertstore = CertOpenSystemStore(hcryptprov, store_name);
+    Py_END_ALLOW_THREADS
+    if (hcertstore == NULL)
+        PyWin_SetAPIError("CertOpenSystemStore");
+    else
+        ret = PyWinObject_FromCERTSTORE(hcertstore);
     PyWinObject_FreeWCHAR(store_name);
     return ret;
 }
@@ -681,10 +705,12 @@ static PyObject *PyCertRegisterSystemStore(PyObject *self, PyObject *args, PyObj
     else if (!PyWinObject_AsWCHAR(obSystemStore, (WCHAR **)&pvSystemStore))
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertRegisterSystemStore(pvSystemStore, dwFlags, pStoreInfo, pvReserved);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CertRegisterSystemStore");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertRegisterSystemStore(pvSystemStore, dwFlags, pStoreInfo, pvReserved);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CertRegisterSystemStore");
+    else {
         Py_INCREF(Py_None);
         ret = Py_None;
     }
@@ -712,10 +738,12 @@ static PyObject *PyCertUnregisterSystemStore(PyObject *self, PyObject *args, PyO
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertUnregisterSystemStore(pvSystemStore, dwFlags);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CertUnregisterSystemStore");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertUnregisterSystemStore(pvSystemStore, dwFlags);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CertUnregisterSystemStore");
+    else {
         Py_INCREF(Py_None);
         ret = Py_None;
     }
@@ -776,8 +804,11 @@ static PyObject *PyCryptFindOIDInfo(PyObject *self, PyObject *args, PyObject *kw
             PyErr_SetString(PyExc_ValueError, "Unrecognized key type");
             return NULL;
     }
-    Py_BEGIN_ALLOW_THREADS oid_info = CryptFindOIDInfo(keytype, key, groupid);
-    Py_END_ALLOW_THREADS if (oid_info == NULL) return PyWin_SetAPIError("CryptFindOIDInfo");
+    Py_BEGIN_ALLOW_THREADS
+        oid_info = CryptFindOIDInfo(keytype, key, groupid);
+    Py_END_ALLOW_THREADS
+    if (oid_info == NULL)
+        return PyWin_SetAPIError("CryptFindOIDInfo");
     // docs say do NOT free the returned CRYPT_OID_INFO
     return PyWinObject_FromCRYPT_OID_INFO(oid_info);
 }
@@ -814,9 +845,11 @@ static PyObject *PyCryptGetKeyIdentifierProperty(PyObject *self, PyObject *args,
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptGetKeyIdentifierProperty(&chb, propid, flags, computername, reserved, &buf, &bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptGetKeyIdentifierProperty");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptGetKeyIdentifierProperty(&chb, propid, flags, computername, reserved, &buf, &bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CryptGetKeyIdentifierProperty");
 
     /* Usually only CERT_KEY_PROV_INFO_PROP_ID is used with this function.
         However, according to the docs other certificate properties can be requested.
@@ -926,10 +959,11 @@ static PyObject *PyCryptEnumKeyIdentifierProperties(PyObject *self, PyObject *ar
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptEnumKeyIdentifierProperties(
-        pchb, propid, flags, computername, reserved, (void *)ret, CryptEnumKeyIdentifierProperties_callback);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptEnumKeyIdentifierProperties(pchb, propid, flags, computername, reserved, (void *)ret,
+                                                    CryptEnumKeyIdentifierProperties_callback);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         Py_DECREF(ret);
         ret = NULL;
         if (!PyErr_Occurred())
@@ -968,9 +1002,10 @@ static PyObject *PyCryptEnumOIDInfo(PyObject *self, PyObject *args, PyObject *kw
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptEnumOIDInfo(groupid, flags, (void *)ret, CryptEnumOIDInfo_callback);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptEnumOIDInfo(groupid, flags, (void *)ret, CryptEnumOIDInfo_callback);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         Py_DECREF(ret);
         ret = NULL;
         if (!PyErr_Occurred())
@@ -1008,11 +1043,13 @@ static PyObject *PyCertAddSerializedElementToStore(PyObject *self, PyObject *arg
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CertAddSerializedElementToStore(
-        hcertstore, (BYTE *)pybuf.ptr(), pybuf.len(), adddisposition, flags, contexttype, &contexttype_out, &context);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CertAddSerializedElementToStore(hcertstore, (BYTE *)pybuf.ptr(), pybuf.len(), adddisposition, flags,
+                                                   contexttype, &contexttype_out, &context);
     Py_END_ALLOW_THREADS
 
-        if (!bsuccess) return PyWin_SetAPIError("CertAddSerializedElementToStore");
+    if (!bsuccess)
+        return PyWin_SetAPIError("CertAddSerializedElementToStore");
     if (contexttype_out == CERT_STORE_CERTIFICATE_CONTEXT)
         return PyWinObject_FromCERT_CONTEXT((PCCERT_CONTEXT)context);
     else if (contexttype_out == CERT_STORE_CTL_CONTEXT)
@@ -1074,10 +1111,10 @@ static PyObject *PyCryptQueryObject(PyObject *self, PyObject *args, PyObject *kw
     }
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS;
-    bsuccess = CryptQueryObject(objecttype, input, contenttype, formattype, flags, &encoding, &contenttypeout,
-                                &formattypeout, &hcertstore, &hcryptmsg, (const void **)&context);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptQueryObject(objecttype, input, contenttype, formattype, flags, &encoding, &contenttypeout,
+                                    &formattypeout, &hcertstore, &hcryptmsg, (const void **)&context);
+    Py_END_ALLOW_THREADS
     if (!bsuccess)
         return PyWin_SetAPIError("CryptQueryObject");
 
@@ -1151,11 +1188,12 @@ static PyObject *PyCryptDecodeMessage(PyObject *self, PyObject *args, PyObject *
     if (!PyWinObject_AsCRYPT_DECRYPT_MESSAGE_PARA(obcdmp, &cdmp))
         return NULL;
 
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptDecodeMessage(msg_type_flags, &cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), prev_inner_type,
-                           &msg_type, &inner_type, output_buf, &output_bufsize, &exchange_cert, &signer_cert);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptDecodeMessage(msg_type_flags, &cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                      prev_inner_type, &msg_type, &inner_type, output_buf, &output_bufsize,
+                                      &exchange_cert, &signer_cert);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         // Callback may raise an exception
         if (!PyErr_Occurred())
             PyWin_SetAPIError("CryptDecodeMessage");
@@ -1172,18 +1210,19 @@ static PyObject *PyCryptDecodeMessage(PyObject *self, PyObject *args, PyObject *
     output_buf = (BYTE *)malloc(output_bufsize);
     if (output_buf == NULL)
         return PyErr_NoMemory();
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptDecodeMessage(msg_type_flags, &cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), prev_inner_type,
-                           &msg_type, &inner_type, output_buf, &output_bufsize, NULL, NULL);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptDecodeMessage(msg_type_flags, &cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                      prev_inner_type, &msg_type, &inner_type, output_buf, &output_bufsize, NULL, NULL);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         if (!PyErr_Occurred())
             PyWin_SetAPIError("CryptDecodeMessage");
     }
-    else ret = Py_BuildValue("{s:k,s:k,s:N,s:N,s:N}", "MsgType", msg_type, "InnerContentType", inner_type, "Decoded",
-                             PyBytes_FromStringAndSize((char *)output_buf, output_bufsize), "XchgCert",
-                             PyWinObject_FromCERT_CONTEXT(exchange_cert), "SignerCert",
-                             PyWinObject_FromCERT_CONTEXT(signer_cert));
+    else
+        ret = Py_BuildValue("{s:k,s:k,s:N,s:N,s:N}", "MsgType", msg_type, "InnerContentType", inner_type, "Decoded",
+                            PyBytes_FromStringAndSize((char *)output_buf, output_bufsize), "XchgCert",
+                            PyWinObject_FromCERT_CONTEXT(exchange_cert), "SignerCert",
+                            PyWinObject_FromCERT_CONTEXT(signer_cert));
 
     free(output_buf);
     if (!ret) {
@@ -1221,19 +1260,25 @@ static PyObject *PyCryptEncryptMessage(PyObject *self, PyObject *args, PyObject 
         return NULL;
     if (!PyWinObject_AsCERT_CONTEXTArray(obrecipients, &recipients, &recipient_cnt))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptEncryptMessage(&cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(),
-                                                          pybuf.len(), outputbuf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptEncryptMessage");
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptEncryptMessage(&cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(), pybuf.len(), outputbuf,
+                                       &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptEncryptMessage");
+    else {
         outputbuf = (BYTE *)malloc(output_bufsize);
         if (outputbuf == NULL)
             PyErr_Format(PyExc_MemoryError, "CryptEncryptMessage: Unable to allocate %d bytes", output_bufsize);
         else {
-            Py_BEGIN_ALLOW_THREADS bsuccess = CryptEncryptMessage(&cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(),
-                                                                  pybuf.len(), outputbuf, &output_bufsize);
-            Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptEncryptMessage");
-            else ret = PyBytes_FromStringAndSize((char *)outputbuf, output_bufsize);
+            Py_BEGIN_ALLOW_THREADS
+                bsuccess = CryptEncryptMessage(&cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                               outputbuf, &output_bufsize);
+            Py_END_ALLOW_THREADS
+            if (!bsuccess)
+                PyWin_SetAPIError("CryptEncryptMessage");
+            else
+                ret = PyBytes_FromStringAndSize((char *)outputbuf, output_bufsize);
         }
     }
 
@@ -1266,19 +1311,25 @@ static PyObject *PyCryptDecryptMessage(PyObject *self, PyObject *args, PyObject 
     if (!PyWinObject_AsCRYPT_DECRYPT_MESSAGE_PARA(obcdmp, &cdmp))
         return NULL;
 
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptDecryptMessage(&cdmp, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize, NULL);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptDecryptMessage");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptDecryptMessage(&cdmp, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize, NULL);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CryptDecryptMessage");
 
     output_buf = (BYTE *)malloc(output_bufsize);
     if (output_buf == NULL)
         return PyErr_NoMemory();
 
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptDecryptMessage(&cdmp, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize, &exchange_cert);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptDecryptMessage");
-    else ret = Py_BuildValue("NN", PyBytes_FromStringAndSize((char *)output_buf, output_bufsize),
-                             PyWinObject_FromCERT_CONTEXT(exchange_cert));
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess =
+            CryptDecryptMessage(&cdmp, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize, &exchange_cert);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptDecryptMessage");
+    else
+        ret = Py_BuildValue("NN", PyBytes_FromStringAndSize((char *)output_buf, output_bufsize),
+                            PyWinObject_FromCERT_CONTEXT(exchange_cert));
     free(output_buf);
     return ret;
 }
@@ -1312,10 +1363,11 @@ static PyObject *PyCryptSignAndEncryptMessage(PyObject *self, PyObject *args, Py
         goto cleanup;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptSignAndEncryptMessage(
-        &csmp, &cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptSignAndEncryptMessage(&csmp, &cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                              output_buf, &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         PyWin_SetAPIError("CryptSignAndEncryptMessage");
         goto cleanup;
     }
@@ -1326,10 +1378,11 @@ static PyObject *PyCryptSignAndEncryptMessage(PyObject *self, PyObject *args, Py
         goto cleanup;
     }
 
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptSignAndEncryptMessage(
-        &csmp, &cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptSignAndEncryptMessage(&csmp, &cemp, recipient_cnt, recipients, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                              output_buf, &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         PyWin_SetAPIError("CryptSignAndEncryptMessage");
         goto cleanup;
     }
@@ -1370,12 +1423,12 @@ static PyObject *PyCryptVerifyMessageSignature(PyObject *self, PyObject *args, P
 
     if (!PyWinObject_AsCRYPT_VERIFY_MESSAGE_PARA(obcvmp, &cvmp))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptVerifyMessageSignature(&cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(),
-                                                                  output_buf, &output_bufsize, &signer_cert);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptVerifyMessageSignature(&cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf,
+                                               &output_bufsize, &signer_cert);
     Py_END_ALLOW_THREADS
-        // Callback may have already set an exception
-        if (!bsuccess)
-    {
+    // Callback may have already set an exception
+    if (!bsuccess) {
         if (!PyErr_Occurred())
             PyWin_SetAPIError("CryptVerifyMessageSignature");
         return NULL;
@@ -1389,16 +1442,18 @@ static PyObject *PyCryptVerifyMessageSignature(PyObject *self, PyObject *args, P
     if (output_buf == NULL)
         PyErr_NoMemory();
     else {
-        Py_BEGIN_ALLOW_THREADS bsuccess = CryptVerifyMessageSignature(&cvmp, signer_ind, (BYTE *)pybuf.ptr(),
-                                                                      pybuf.len(), output_buf, &output_bufsize, NULL);
-        Py_END_ALLOW_THREADS if (!bsuccess)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            bsuccess = CryptVerifyMessageSignature(&cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf,
+                                                   &output_bufsize, NULL);
+        Py_END_ALLOW_THREADS
+        if (!bsuccess) {
             // Callback may have already set an exception
             if (!PyErr_Occurred())
                 PyWin_SetAPIError("CryptVerifyMessageSignature");
         }
-        else ret = Py_BuildValue("{s:N, s:N}", "SignerCert", PyWinObject_FromCERT_CONTEXT(signer_cert), "Decoded",
-                                 PyBytes_FromStringAndSize((char *)output_buf, output_bufsize));
+        else
+            ret = Py_BuildValue("{s:N, s:N}", "SignerCert", PyWinObject_FromCERT_CONTEXT(signer_cert), "Decoded",
+                                PyBytes_FromStringAndSize((char *)output_buf, output_bufsize));
     }
     if (output_buf)
         free(output_buf);
@@ -1429,9 +1484,11 @@ static PyObject *PyCryptGetMessageCertificates(PyObject *self, PyObject *args, P
         return NULL;
     if (!PyWinObject_AsHCRYPTPROV(obcsp, &csp, TRUE))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS hcertstore =
-        CryptGetMessageCertificates(encoding_type, csp, flags, (BYTE *)pybuf.ptr(), pybuf.len());
-    Py_END_ALLOW_THREADS if (hcertstore == NULL) return PyWin_SetAPIError("CryptGetMessageCertificates");
+    Py_BEGIN_ALLOW_THREADS
+        hcertstore = CryptGetMessageCertificates(encoding_type, csp, flags, (BYTE *)pybuf.ptr(), pybuf.len());
+    Py_END_ALLOW_THREADS
+    if (hcertstore == NULL)
+        return PyWin_SetAPIError("CryptGetMessageCertificates");
     return PyWinObject_FromCERTSTORE(hcertstore);
 }
 
@@ -1452,8 +1509,11 @@ static PyObject *PyCryptGetMessageSignerCount(PyObject *self, PyObject *args, Py
     PyWinBufferView pybuf(obbuf);
     if (!pybuf.ok())
         return NULL;
-    Py_BEGIN_ALLOW_THREADS signer_cnt = CryptGetMessageSignerCount(encoding_type, (BYTE *)pybuf.ptr(), pybuf.len());
-    Py_END_ALLOW_THREADS if (signer_cnt == -1) return PyWin_SetAPIError("CryptGetMessageSignerCount");
+    Py_BEGIN_ALLOW_THREADS
+        signer_cnt = CryptGetMessageSignerCount(encoding_type, (BYTE *)pybuf.ptr(), pybuf.len());
+    Py_END_ALLOW_THREADS
+    if (signer_cnt == -1)
+        return PyWin_SetAPIError("CryptGetMessageSignerCount");
     return PyLong_FromLong(signer_cnt);
 }
 
@@ -1482,10 +1542,11 @@ static PyObject *PyCryptSignMessage(PyObject *self, PyObject *args, PyObject *kw
         goto cleanup;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptSignMessage(&csmp, detached_sig, msg_cnt, (const BYTE **)msgs, msg_sizes, output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess =
+            CryptSignMessage(&csmp, detached_sig, msg_cnt, (const BYTE **)msgs, msg_sizes, output_buf, &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         PyWin_SetAPIError("CryptSignMessage");
         goto cleanup;
     }
@@ -1495,10 +1556,11 @@ static PyObject *PyCryptSignMessage(PyObject *self, PyObject *args, PyObject *kw
         goto cleanup;
     }
 
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptSignMessage(&csmp, detached_sig, msg_cnt, (const BYTE **)msgs, msg_sizes, output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess =
+            CryptSignMessage(&csmp, detached_sig, msg_cnt, (const BYTE **)msgs, msg_sizes, output_buf, &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         PyWin_SetAPIError("CryptSignMessage");
         goto cleanup;
     }
@@ -1541,10 +1603,14 @@ static PyObject *PyCryptVerifyDetachedMessageSignature(PyObject *self, PyObject 
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptVerifyDetachedMessageSignature(
-        &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), msg_cnt, (const BYTE **)msgs, msg_sizes, &signer_cert);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptVerifyDetachedMessageSignature");
-    else ret = PyWinObject_FromCERT_CONTEXT(signer_cert);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptVerifyDetachedMessageSignature(&cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), msg_cnt,
+                                                       (const BYTE **)msgs, msg_sizes, &signer_cert);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptVerifyDetachedMessageSignature");
+    else
+        ret = PyWinObject_FromCERT_CONTEXT(signer_cert);
 
     PyWinObject_FreePBYTEArray(msgs, msg_sizes, msg_cnt);
     return ret;
@@ -1584,20 +1650,26 @@ static PyObject *PyCryptDecryptAndVerifyMessageSignature(PyObject *self, PyObjec
         return NULL;
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptDecryptAndVerifyMessageSignature(
-        &cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize, NULL, NULL);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptDecryptAndVerifyMessageSignature");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptDecryptAndVerifyMessageSignature(&cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                                         output_buf, &output_bufsize, NULL, NULL);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CryptDecryptAndVerifyMessageSignature");
 
     output_buf = (BYTE *)malloc(output_bufsize);
     if (output_buf == NULL)
         return PyErr_NoMemory();
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptDecryptAndVerifyMessageSignature(&cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(), output_buf,
-                                              &output_bufsize, &exchange_cert, &signer_cert);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptDecryptAndVerifyMessageSignature");
-    else ret = Py_BuildValue(
-        "{s:N,s:N,s:N}", "Decrypted", PyBytes_FromStringAndSize((char *)output_buf, output_bufsize), "XchgCert",
-        PyWinObject_FromCERT_CONTEXT(exchange_cert), "SignerCert", PyWinObject_FromCERT_CONTEXT(signer_cert));
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptDecryptAndVerifyMessageSignature(&cdmp, &cvmp, signer_ind, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                                         output_buf, &output_bufsize, &exchange_cert, &signer_cert);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptDecryptAndVerifyMessageSignature");
+    else
+        ret = Py_BuildValue("{s:N,s:N,s:N}", "Decrypted", PyBytes_FromStringAndSize((char *)output_buf, output_bufsize),
+                            "XchgCert", PyWinObject_FromCERT_CONTEXT(exchange_cert), "SignerCert",
+                            PyWinObject_FromCERT_CONTEXT(signer_cert));
 
     free(output_buf);
     return ret;
@@ -1684,10 +1756,13 @@ static PyObject *PyCryptEncodeObjectEx(PyObject *self, PyObject *args, PyObject 
         goto cleanup;
     }
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptEncodeObjectEx(encoding, structtype, input_buf, flags, NULL, &output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptDecodeObjectEx");
-    else ret = PyBytes_FromStringAndSize((char *)output_buf, output_bufsize);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptEncodeObjectEx(encoding, structtype, input_buf, flags, NULL, &output_buf, &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptDecodeObjectEx");
+    else
+        ret = PyBytes_FromStringAndSize((char *)output_buf, output_bufsize);
 
 cleanup:
     if ((oid_is_str && (strcmp(structtype, szOID_ENHANCED_KEY_USAGE) == 0)) || (structtype == X509_ENHANCED_KEY_USAGE))
@@ -1733,10 +1808,11 @@ static PyObject *PyCryptDecodeObjectEx(PyObject *self, PyObject *args, PyObject 
     }
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptDecodeObjectEx(encoding, structtype, (BYTE *)pybuf.ptr(), pybuf.len(), flags,
-                                                          NULL, &output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptDecodeObjectEx(encoding, structtype, (BYTE *)pybuf.ptr(), pybuf.len(), flags, NULL, &output_buf,
+                                       &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         PyWin_SetAPIError("CryptDecodeObjectEx");
         goto cleanup;
     }
@@ -1866,14 +1942,21 @@ static PyObject *PyCertNameToStr(PyObject *self, PyObject *args, PyObject *kwarg
     cnb.pbData = (BYTE *)pybuf.ptr();
     cnb.cbData = pybuf.len();
 
-    Py_BEGIN_ALLOW_THREADS output_buflen = CertNameToStr(encoding, &cnb, strtype, output_buf, output_buflen);
-    Py_END_ALLOW_THREADS if (output_buflen == 0) return PyWin_SetAPIError("CertNameToStr");
+    Py_BEGIN_ALLOW_THREADS
+        output_buflen = CertNameToStr(encoding, &cnb, strtype, output_buf, output_buflen);
+    Py_END_ALLOW_THREADS
+    if (output_buflen == 0)
+        return PyWin_SetAPIError("CertNameToStr");
     output_buf = (WCHAR *)malloc(output_buflen * sizeof(WCHAR));
     if (output_buf == NULL)
         return PyErr_Format(PyExc_MemoryError, "Unable to allocate %d bytes", output_buflen);
-    Py_BEGIN_ALLOW_THREADS output_buflen = CertNameToStr(encoding, &cnb, strtype, output_buf, output_buflen);
-    Py_END_ALLOW_THREADS if (output_buflen == 0) PyWin_SetAPIError("CertNameToStr");
-    else ret = PyWinObject_FromWCHAR(output_buf);
+    Py_BEGIN_ALLOW_THREADS
+        output_buflen = CertNameToStr(encoding, &cnb, strtype, output_buf, output_buflen);
+    Py_END_ALLOW_THREADS
+    if (output_buflen == 0)
+        PyWin_SetAPIError("CertNameToStr");
+    else
+        ret = PyWinObject_FromWCHAR(output_buf);
     free(output_buf);
     return ret;
 }
@@ -1914,17 +1997,24 @@ static PyObject *PyCryptFormatObject(PyObject *self, PyObject *args, PyObject *k
     }
 
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptFormatObject(encoding, fmt_type, string_fmt, fmt_struct, oid,
-                                                        (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptFormatObject");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptFormatObject(encoding, fmt_type, string_fmt, fmt_struct, oid, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                     output_buf, &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CryptFormatObject");
     output_buf = malloc(output_bufsize);
     if (output_buf == NULL)
         return PyErr_Format(PyExc_MemoryError, "Unable to allocate %d bytes", output_bufsize);
 
-    Py_BEGIN_ALLOW_THREADS bsuccess = CryptFormatObject(encoding, fmt_type, string_fmt, fmt_struct, oid,
-                                                        (BYTE *)pybuf.ptr(), pybuf.len(), output_buf, &output_bufsize);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptFormatObject");
-    else ret = PyWinObject_FromWCHAR((WCHAR *)output_buf);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptFormatObject(encoding, fmt_type, string_fmt, fmt_struct, oid, (BYTE *)pybuf.ptr(), pybuf.len(),
+                                     output_buf, &output_bufsize);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptFormatObject");
+    else
+        ret = PyWinObject_FromWCHAR((WCHAR *)output_buf);
     free(output_buf);
     return ret;
 }
@@ -1954,8 +2044,11 @@ static PyObject *PyPFXImportCertStore(PyObject *self, PyObject *args, PyObject *
         return NULL;
     if (!PyWinObject_AsWCHAR(obpassword, &password, TRUE))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS hcertstore = PFXImportCertStore(&input_buf, password, flags);
-    Py_END_ALLOW_THREADS if (hcertstore == NULL) return PyWin_SetAPIError("PFXImportCertStore");
+    Py_BEGIN_ALLOW_THREADS
+        hcertstore = PFXImportCertStore(&input_buf, password, flags);
+    Py_END_ALLOW_THREADS
+    if (hcertstore == NULL)
+        return PyWin_SetAPIError("PFXImportCertStore");
     return PyWinObject_FromCERTSTORE(hcertstore);
 }
 
@@ -1981,8 +2074,10 @@ static PyObject *PyPFXVerifyPassword(PyObject *self, PyObject *args, PyObject *k
     if (!PyWinObject_AsWCHAR(obpassword, &password, TRUE))
         return NULL;
     BOOL out;
-    Py_BEGIN_ALLOW_THREADS out = PFXVerifyPassword(&input_buf, password, flags);
-    Py_END_ALLOW_THREADS return PyBool_FromLong(out);
+    Py_BEGIN_ALLOW_THREADS
+        out = PFXVerifyPassword(&input_buf, password, flags);
+    Py_END_ALLOW_THREADS
+    return PyBool_FromLong(out);
 }
 
 // @pymethod boolean|win32crypt|PFXIsPFXBlob|Checks if data buffer contains a PFX blob
@@ -1998,8 +2093,10 @@ static PyObject *PyPFXIsPFXBlob(PyObject *self, PyObject *args, PyObject *kwargs
     if (!PyWinObject_AsDATA_BLOB(obinput_buf, &input_buf))
         return NULL;
     BOOL out;
-    Py_BEGIN_ALLOW_THREADS out = PFXIsPFXBlob(&input_buf);
-    Py_END_ALLOW_THREADS return PyBool_FromLong(out);
+    Py_BEGIN_ALLOW_THREADS
+        out = PFXIsPFXBlob(&input_buf);
+    Py_END_ALLOW_THREADS
+    return PyBool_FromLong(out);
 }
 
 // @pymethod str|win32crypt|CryptBinaryToString|Formats a binary buffer into the specified type of string
@@ -2020,18 +2117,23 @@ static PyObject *PyCryptBinaryToString(PyObject *self, PyObject *args, PyObject 
     if (!pybuf.ok())
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptBinaryToString((BYTE *)pybuf.ptr(), pybuf.len(), flags, output_buf, &output_size);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptBinaryToString");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptBinaryToString((BYTE *)pybuf.ptr(), pybuf.len(), flags, output_buf, &output_size);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CryptBinaryToString");
     output_buf = (WCHAR *)malloc(output_size * sizeof(WCHAR));
     if (output_buf == NULL)
         return PyErr_NoMemory();
 
     PyObject *ret = NULL;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptBinaryToString((BYTE *)pybuf.ptr(), pybuf.len(), flags, output_buf, &output_size);
-    Py_END_ALLOW_THREADS if (!bsuccess) PyWin_SetAPIError("CryptBinaryToString");
-    else ret = PyWinObject_FromWCHAR(output_buf, output_size);
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptBinaryToString((BYTE *)pybuf.ptr(), pybuf.len(), flags, output_buf, &output_size);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        PyWin_SetAPIError("CryptBinaryToString");
+    else
+        ret = PyWinObject_FromWCHAR(output_buf, output_size);
     free(output_buf);
     return ret;
 }
@@ -2056,17 +2158,19 @@ static PyObject *PyCryptStringToBinary(PyObject *self, PyObject *args, PyObject 
     if (!PyWinObject_AsWCHAR(obinput_buf, &input_buf, FALSE, &input_size))
         return NULL;
     BOOL bsuccess;
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptStringToBinary(input_buf, input_size, flags, output_buf, &output_size, &skip, &out_flags);
-    Py_END_ALLOW_THREADS if (!bsuccess) return PyWin_SetAPIError("CryptStringToBinary");
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptStringToBinary(input_buf, input_size, flags, output_buf, &output_size, &skip, &out_flags);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess)
+        return PyWin_SetAPIError("CryptStringToBinary");
     oboutput_buf = PyBytes_FromStringAndSize(NULL, output_size);
     if (oboutput_buf == NULL)
         return NULL;
     output_buf = (BYTE *)PyBytes_AS_STRING(oboutput_buf);
-    Py_BEGIN_ALLOW_THREADS bsuccess =
-        CryptStringToBinary(input_buf, input_size, flags, output_buf, &output_size, &skip, &out_flags);
-    Py_END_ALLOW_THREADS if (!bsuccess)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        bsuccess = CryptStringToBinary(input_buf, input_size, flags, output_buf, &output_size, &skip, &out_flags);
+    Py_END_ALLOW_THREADS
+    if (!bsuccess) {
         Py_DECREF(oboutput_buf);
         return PyWin_SetAPIError("CryptStringToBinary");
     }

--- a/win32/src/win32file.i
+++ b/win32/src/win32file.i
@@ -427,7 +427,6 @@ PyObject *py_DeviceIoControl(PyObject *self, PyObject *args, PyObject *kwargs)
 	DWORD numRead;
 	BOOL ok;
 	Py_BEGIN_ALLOW_THREADS
-
 	ok = DeviceIoControl(hDevice,
                          dwIoControlCode,
                          in_buf.ptr(),
@@ -1673,10 +1672,10 @@ static PyObject *py_TransmitFile( PyObject *self, PyObject *args, PyObject *kwar
 		ptf_buffers = NULL;
 
 	rc=0;
-	Py_BEGIN_ALLOW_THREADS;
+	Py_BEGIN_ALLOW_THREADS
 	if (!lpfnTransmitFile(s, hFile, bytes_to_write, bytes_per_send, pOverlapped, ptf_buffers, flags))
 		rc = WSAGetLastError();
-	Py_END_ALLOW_THREADS;
+	Py_END_ALLOW_THREADS
 
 	if (rc == 0 || rc == ERROR_IO_PENDING || rc == WSA_IO_PENDING)
 		return PyLong_FromLong(rc);
@@ -1800,10 +1799,10 @@ static PyObject *py_ConnectEx( PyObject *self, PyObject *args, PyObject *kwargs 
 	}
 
 	rc=0;
-	Py_BEGIN_ALLOW_THREADS;
+	Py_BEGIN_ALLOW_THREADS
 	if (!lpfnConnectEx(sConnecting, res->ai_addr, (int)res->ai_addrlen, pybuf.ptr(), pybuf.len(), &sent, pOverlapped))
 		rc=WSAGetLastError();
-	Py_END_ALLOW_THREADS;
+	Py_END_ALLOW_THREADS
 	WspiapiFreeAddrInfo(res);
 	if (rc==0 || rc == ERROR_IO_PENDING)
 		return Py_BuildValue("ii", rc, sent);
@@ -2147,9 +2146,9 @@ PyObject* MyWSAEventSelect
 )
 {
 	int rc;
-	Py_BEGIN_ALLOW_THREADS;
+	Py_BEGIN_ALLOW_THREADS
 	rc = WSAEventSelect(*s, hEvent, lNetworkEvents);
-	Py_END_ALLOW_THREADS;
+	Py_END_ALLOW_THREADS
 	if (rc == SOCKET_ERROR)
 	{
 		PyWin_SetAPIError("WSAEventSelect", WSAGetLastError());
@@ -2226,9 +2225,9 @@ MyWSAEnumNetworkEvents(PyObject *self, PyObject *args)
 		return NULL;
 	}
 
-	Py_BEGIN_ALLOW_THREADS;
+	Py_BEGIN_ALLOW_THREADS
 	rc = WSAEnumNetworkEvents(s, hEvent, &wsaevents);
-	Py_END_ALLOW_THREADS;
+	Py_END_ALLOW_THREADS
 	if (rc == SOCKET_ERROR)
 	{
 		PyWin_SetAPIError("WSAEnumNetworkEvents", WSAGetLastError());
@@ -2269,9 +2268,9 @@ PyObject* MyWSAAsyncSelect
 )
 {
 	int rc;
-	Py_BEGIN_ALLOW_THREADS;
+	Py_BEGIN_ALLOW_THREADS
 	rc = WSAAsyncSelect(*s, hwnd, wMsg, lNetworkEvents);
-	Py_END_ALLOW_THREADS;
+	Py_END_ALLOW_THREADS
 	if (rc == SOCKET_ERROR)
 	{
 		PyWin_SetAPIError("WSAAsyncSelect", WSAGetLastError());
@@ -2342,7 +2341,7 @@ PyObject *MyWSASend
 	wsBuf.buf = (CHAR *)pybuf.ptr();
 	wsBuf.len = pybuf.len();
 
-	Py_BEGIN_ALLOW_THREADS;
+	Py_BEGIN_ALLOW_THREADS
 	rc = WSASend(
 		s,
 		&wsBuf,
@@ -2351,7 +2350,7 @@ PyObject *MyWSASend
 		dwFlags,
 		pOverlapped,
 		NULL);
-	Py_END_ALLOW_THREADS;
+	Py_END_ALLOW_THREADS
 
 	if (rc == SOCKET_ERROR)
 	{
@@ -2440,7 +2439,7 @@ PyObject *MyWSARecv
 	wsBuf.buf = (CHAR *)pybuf.ptr();
 	wsBuf.len = pybuf.len();
 
-	Py_BEGIN_ALLOW_THREADS;
+	Py_BEGIN_ALLOW_THREADS
 	rc = WSARecv(
 		s,
 		&wsBuf,
@@ -2449,7 +2448,7 @@ PyObject *MyWSARecv
 		&dwFlags,
 		pOverlapped,
 		NULL);
-	Py_END_ALLOW_THREADS;
+	Py_END_ALLOW_THREADS
 
 	if (rc == SOCKET_ERROR)
 	{
@@ -2643,9 +2642,9 @@ static PyObject *PyClearCommError(PyObject *self, PyObject *args)
 	BOOL rc;
 	DWORD int_ret;
 	COMSTAT stat;
-	Py_BEGIN_ALLOW_THREADS;
+	Py_BEGIN_ALLOW_THREADS
 	rc = ClearCommError(handle, &int_ret, &stat);
-	Py_END_ALLOW_THREADS;
+	Py_END_ALLOW_THREADS
 	if (!rc)
 		return PyWin_SetAPIError("ClearCommError");
 	PyObject *obStat = PyWinObject_FromCOMSTAT(&stat);

--- a/win32/src/win32gui.i
+++ b/win32/src/win32gui.i
@@ -2953,9 +2953,9 @@ static PyObject *PyCascadeWindows(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_TypeError, "The child windows object is neither a tuple nor None");
         return NULL;
     }
-    Py_BEGIN_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
     res = CascadeWindows(hwnd, how, rectPtr, childCount, children);
-    Py_END_ALLOW_THREADS;
+    Py_END_ALLOW_THREADS
     if (children) {
         free(children);
     }
@@ -5226,10 +5226,10 @@ static PyObject *PyExtTextOut(PyObject *self, PyObject *args)
 	}
 
 	BOOL ok;
-	Py_BEGIN_ALLOW_THREADS;
+	Py_BEGIN_ALLOW_THREADS
 	// @pyseeapi ExtTextOut
 	ok = ExtTextOut(hdc, x, y, options, rectPtr, text, strLen, widths);
-	Py_END_ALLOW_THREADS;
+	Py_END_ALLOW_THREADS
 	PyWinObject_FreeTCHAR(text);
 	delete [] widths;
 	if (!ok)
@@ -6229,9 +6229,9 @@ static PyObject *PyGetSaveFileNameW(PyObject *self, PyObject *args, PyObject *kw
 		return NULL;
 
 	BOOL ok;
-	Py_BEGIN_ALLOW_THREADS;
+	Py_BEGIN_ALLOW_THREADS
 	ok = GetSaveFileNameW(&ofn);
-	Py_END_ALLOW_THREADS;
+	Py_END_ALLOW_THREADS
 	if (!ok)
 		PyWin_SetAPIError("GetSaveFileNameW", CommDlgExtendedError());
 	else
@@ -6253,9 +6253,9 @@ static PyObject *PyGetOpenFileNameW(PyObject *self, PyObject *args, PyObject *kw
 		return NULL;
 
 	BOOL ok;
-	Py_BEGIN_ALLOW_THREADS;
+	Py_BEGIN_ALLOW_THREADS
 	ok = GetOpenFileNameW(&ofn);
-	Py_END_ALLOW_THREADS;
+	Py_END_ALLOW_THREADS
 	if (!ok)
 		PyWin_SetAPIError("GetOpenFileNameW", CommDlgExtendedError());
 	else

--- a/win32/src/win32inet_winhttp.cpp
+++ b/win32/src/win32inet_winhttp.cpp
@@ -135,9 +135,10 @@ PyObject *PyWinHttpGetDefaultProxyConfiguration(PyObject *self, PyObject *args)
     WINHTTP_PROXY_INFO info;
     memset(&info, 0, sizeof(info));
     BOOL ok;
-    Py_BEGIN_ALLOW_THREADS ok = WinHttpGetDefaultProxyConfiguration(&info);
-    Py_END_ALLOW_THREADS if (!ok)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        ok = WinHttpGetDefaultProxyConfiguration(&info);
+    Py_END_ALLOW_THREADS
+    if (!ok) {
         PyWin_SetAPIError("WinHttpGetDefaultProxyConfiguration");
         return NULL;
     }
@@ -174,9 +175,10 @@ PyObject *PyWinHttpGetProxyForUrl(PyObject *self, PyObject *args)
     if (!PyObject_AsWINHTTP_AUTOPROXY_OPTIONS(obOptions, &opts))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS ok = WinHttpGetProxyForUrl(hi, url, &opts, &info);
-    Py_END_ALLOW_THREADS if (!ok)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        ok = WinHttpGetProxyForUrl(hi, url, &opts, &info);
+    Py_END_ALLOW_THREADS
+    if (!ok) {
         PyWin_SetAPIError("WinHttpGetProxyForUrl");
         goto done;
     }
@@ -216,9 +218,10 @@ PyObject *PyWinHttpOpen(PyObject *self, PyObject *args)
     if (!PyWinObject_AsWCHAR(obProxyBypass, &proxy_bypass, TRUE))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS hi = WinHttpOpen(ua, dwAccessType, proxy, proxy_bypass, dwFlags);
-    Py_END_ALLOW_THREADS if (!hi)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        hi = WinHttpOpen(ua, dwAccessType, proxy, proxy_bypass, dwFlags);
+    Py_END_ALLOW_THREADS
+    if (!hi) {
         PyWin_SetAPIError("WinHttpOpen");
         goto done;
     }

--- a/win32/src/win32net/win32netfile.cpp
+++ b/win32/src/win32net/win32netfile.cpp
@@ -59,13 +59,12 @@ PyObject *PyNetFileEnum(PyObject *self, PyObject *args)
     switch (info_lvl) {
         case 2: {
             do {
-                Py_BEGIN_ALLOW_THREADS nStatus =
-                    NetFileEnum(server_name, base_path, user_name, info_lvl, (LPBYTE *)&pBuf2, buff_len, &dwEntriesRead,
-                                &dwTotalEntries, &resumeHandle);
+                Py_BEGIN_ALLOW_THREADS
+                    nStatus = NetFileEnum(server_name, base_path, user_name, info_lvl, (LPBYTE *)&pBuf2, buff_len,
+                                          &dwEntriesRead, &dwTotalEntries, &resumeHandle);
                 Py_END_ALLOW_THREADS
 
-                    if ((nStatus == NERR_Success) || (nStatus == ERROR_MORE_DATA))
-                {
+                if ((nStatus == NERR_Success) || (nStatus == ERROR_MORE_DATA)) {
                     if ((pTmpBuf2 = pBuf2) != NULL) {
                         for (i = 0; (i < dwEntriesRead); i++) {
                             PyObject *curr_sess_dict = Py_BuildValue("{s:i}", "id", pTmpBuf2->fi2_id);
@@ -75,8 +74,7 @@ PyObject *PyNetFileEnum(PyObject *self, PyObject *args)
                         }
                     }
                 }
-                else
-                {
+                else {
                     ReturnNetError("NetFileEnum", nStatus);
                     Py_XDECREF(ret_list);
                     ret_list = NULL;
@@ -92,13 +90,12 @@ PyObject *PyNetFileEnum(PyObject *self, PyObject *args)
         }
         case 3: {
             do {
-                Py_BEGIN_ALLOW_THREADS nStatus =
-                    NetFileEnum(server_name, base_path, user_name, info_lvl, (LPBYTE *)&pBuf3, buff_len, &dwEntriesRead,
-                                &dwTotalEntries, &resumeHandle);
+                Py_BEGIN_ALLOW_THREADS
+                    nStatus = NetFileEnum(server_name, base_path, user_name, info_lvl, (LPBYTE *)&pBuf3, buff_len,
+                                          &dwEntriesRead, &dwTotalEntries, &resumeHandle);
                 Py_END_ALLOW_THREADS
 
-                    if ((nStatus == NERR_Success) || (nStatus == ERROR_MORE_DATA))
-                {
+                if ((nStatus == NERR_Success) || (nStatus == ERROR_MORE_DATA)) {
                     if ((pTmpBuf3 = pBuf3) != NULL) {
                         for (i = 0; (i < dwEntriesRead); i++) {
                             PyObject *curr_sess_dict =
@@ -112,8 +109,7 @@ PyObject *PyNetFileEnum(PyObject *self, PyObject *args)
                         }
                     }
                 }
-                else
-                {
+                else {
                     ReturnNetError("NetFileEnum", nStatus);
                     Py_XDECREF(ret_list);
                     ret_list = NULL;
@@ -151,10 +147,12 @@ PyObject *PyNetFileClose(PyObject *self, PyObject *args)
         return NULL;
     if (!PyWinObject_AsWCHAR(server_name_obj, &server_name, TRUE))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS nStatus = NetFileClose(server_name, file_id);
+    Py_BEGIN_ALLOW_THREADS
+        nStatus = NetFileClose(server_name, file_id);
     Py_END_ALLOW_THREADS
 
-        if (server_name != NULL) PyWinObject_FreeWCHAR(server_name);
+    if (server_name != NULL)
+        PyWinObject_FreeWCHAR(server_name);
 
     if (nStatus == NERR_Success) {
         Py_INCREF(Py_None);
@@ -193,12 +191,13 @@ PyObject *PyNetFileGetInfo(PyObject *self, PyObject *args)
         return NULL;
     switch (info_lvl) {
         case 2: {
-            Py_BEGIN_ALLOW_THREADS nStatus = NetFileGetInfo(server_name, file_id, info_lvl, (LPBYTE *)&pTmpBuf2);
+            Py_BEGIN_ALLOW_THREADS
+                nStatus = NetFileGetInfo(server_name, file_id, info_lvl, (LPBYTE *)&pTmpBuf2);
             Py_END_ALLOW_THREADS
 
-                if (nStatus == NERR_Success) ret_dict = Py_BuildValue("{s:i}", "id", pTmpBuf2->fi2_id);
-            else
-            {
+            if (nStatus == NERR_Success)
+                ret_dict = Py_BuildValue("{s:i}", "id", pTmpBuf2->fi2_id);
+            else {
                 ReturnNetError("NetFileEnum", nStatus);
                 ret_dict = NULL;
             }
@@ -207,15 +206,16 @@ PyObject *PyNetFileGetInfo(PyObject *self, PyObject *args)
             break;
         }
         case 3: {
-            Py_BEGIN_ALLOW_THREADS nStatus = NetFileGetInfo(server_name, file_id, info_lvl, (LPBYTE *)&pTmpBuf3);
+            Py_BEGIN_ALLOW_THREADS
+                nStatus = NetFileGetInfo(server_name, file_id, info_lvl, (LPBYTE *)&pTmpBuf3);
             Py_END_ALLOW_THREADS
 
-                if (nStatus == NERR_Success) ret_dict = Py_BuildValue(
-                    "{s:i,s:i,s:i,s:N,s:N}", "id", pTmpBuf3->fi3_id, "permissions", pTmpBuf3->fi3_permissions,
-                    "num_locks", pTmpBuf3->fi3_num_locks, "path_name", PyWinObject_FromWCHAR(pTmpBuf3->fi3_pathname),
-                    "user_name", PyWinObject_FromWCHAR(pTmpBuf3->fi3_username));
-            else
-            {
+            if (nStatus == NERR_Success)
+                ret_dict = Py_BuildValue("{s:i,s:i,s:i,s:N,s:N}", "id", pTmpBuf3->fi3_id, "permissions",
+                                         pTmpBuf3->fi3_permissions, "num_locks", pTmpBuf3->fi3_num_locks, "path_name",
+                                         PyWinObject_FromWCHAR(pTmpBuf3->fi3_pathname), "user_name",
+                                         PyWinObject_FromWCHAR(pTmpBuf3->fi3_username));
+            else {
                 ReturnNetError("NetFileEnum", nStatus);
                 ret_dict = NULL;
             }

--- a/win32/src/win32net/win32netmisc.cpp
+++ b/win32/src/win32net/win32netmisc.cpp
@@ -346,12 +346,12 @@ static PyObject *PyNetShareEnum1(WCHAR *szServerName)
         return NULL;  // did we err?
 
     do {
-        Py_BEGIN_ALLOW_THREADS Errno =
-            NetShareEnum(szServerName, dwLevel, (LPBYTE *)&lpBuffer, dwMaxLen, &dwCount, &dwMaxCount, &dwResume);
+        Py_BEGIN_ALLOW_THREADS
+            Errno =
+                NetShareEnum(szServerName, dwLevel, (LPBYTE *)&lpBuffer, dwMaxLen, &dwCount, &dwMaxCount, &dwResume);
         Py_END_ALLOW_THREADS
 
-            if (Errno == NERR_Success)
-        {
+        if (Errno == NERR_Success) {
             SHARE_INFO_1 *p_nr = lpBuffer;
 
             if (dwCount > 0)  // we actually got something
@@ -378,8 +378,7 @@ static PyObject *PyNetShareEnum1(WCHAR *szServerName)
                 } while (dwCount);
             };  // if dwCount
         }  // if Errno == NERR_Sucess
-        else
-        {
+        else {
             Py_DECREF(pRetlist);
             return (ReturnNetError("NetShareEnum", Errno));
         }
@@ -481,9 +480,10 @@ PyObject *PyNetShareDel(PyObject *self, PyObject *args)
     if (!PyWinObject_AsWCHAR(obName, &szName, FALSE))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS err = NetShareDel(szServer, szName, reserved);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = NetShareDel(szServer, szName, reserved);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError("NetShareDel", err);
         goto done;
     }
@@ -514,9 +514,10 @@ PyObject *PyNetShareCheck(PyObject *self, PyObject *args)
     if (!PyWinObject_AsWCHAR(obName, &deviceName, FALSE))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS err = NetShareCheck(szServer, deviceName, &type);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = NetShareCheck(szServer, deviceName, &type);
+    Py_END_ALLOW_THREADS
+    if (err) {
         if (err == NERR_DeviceNotShared) {
             ret = Py_BuildValue("(iO)", 0, Py_None);
         }
@@ -753,10 +754,11 @@ PyObject *PyNetServerEnum(PyObject *self, PyObject *args)
     if (!FindNET_STRUCT(level, server_infos, &pInfo))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS err =
-        NetServerEnum(szServer, level, &buf, dwPrefLen, &numRead, &totalEntries, serverType, szDomain, &resumeHandle);
-    Py_END_ALLOW_THREADS if (err != 0 && err != ERROR_MORE_DATA)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = NetServerEnum(szServer, level, &buf, dwPrefLen, &numRead, &totalEntries, serverType, szDomain,
+                            &resumeHandle);
+    Py_END_ALLOW_THREADS
+    if (err != 0 && err != ERROR_MORE_DATA) {
         ReturnNetError("NetServerEnum", err);
         goto done;
     }
@@ -803,9 +805,10 @@ PyObject *PyNetServerGetInfo(PyObject *self, PyObject *args)
         goto done;
     if (!FindNET_STRUCT(typ, server_infos, &pInfo))
         goto done;
-    Py_BEGIN_ALLOW_THREADS err = NetServerGetInfo(szServer, typ, &buf);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = NetServerGetInfo(szServer, typ, &buf);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError("NetServerGetInfo", err);
         goto done;
     }
@@ -844,9 +847,10 @@ PyObject *PyNetServerSetInfo(PyObject *self, PyObject *args)
     if (!PyObject_AsNET_STRUCT(obData, pInfo, &buf))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS err = NetServerSetInfo(szServer, typ, buf, NULL);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = NetServerSetInfo(szServer, typ, buf, NULL);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError("NetServerSetInfo", err);
         goto done;
     }
@@ -899,10 +903,10 @@ PyObject *PyNetWkstaUserEnum(PyObject *self, PyObject *args)
     if (!FindNET_STRUCT(level, wktau_infos, &pInfo))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS err =
-        NetWkstaUserEnum(szServer, level, &buf, dwPrefLen, &numRead, &totalEntries, &resumeHandle);
-    Py_END_ALLOW_THREADS if (err != 0 && err != ERROR_MORE_DATA)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = NetWkstaUserEnum(szServer, level, &buf, dwPrefLen, &numRead, &totalEntries, &resumeHandle);
+    Py_END_ALLOW_THREADS
+    if (err != 0 && err != ERROR_MORE_DATA) {
         ReturnNetError("NetWkstaUserEnum", err);
         goto done;
     }
@@ -950,9 +954,10 @@ PyObject *PyNetWkstaGetInfo(PyObject *self, PyObject *args)
         goto done;
     if (!FindNET_STRUCT(typ, wksta_infos, &pInfo))
         goto done;
-    Py_BEGIN_ALLOW_THREADS err = NetWkstaGetInfo(szServer, typ, &buf);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = NetWkstaGetInfo(szServer, typ, &buf);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError("NetWkstaGetInfo", err);
         goto done;
     }
@@ -991,9 +996,10 @@ PyObject *PyNetWkstaSetInfo(PyObject *self, PyObject *args)
     if (!PyObject_AsNET_STRUCT(obData, pInfo, &buf))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS err = NetWkstaSetInfo(szServer, typ, buf, NULL);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = NetWkstaSetInfo(szServer, typ, buf, NULL);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError("NetWkstaSetInfo", err);
         goto done;
     }
@@ -1046,10 +1052,10 @@ PyObject *PyNetWkstaTransportEnum(PyObject *self, PyObject *args)
     if (!FindNET_STRUCT(level, wkstransport_infos, &pInfo))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS err =
-        NetWkstaTransportEnum(szServer, level, &buf, dwPrefLen, &numRead, &totalEntries, &resumeHandle);
-    Py_END_ALLOW_THREADS if (err != 0 && err != ERROR_MORE_DATA)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = NetWkstaTransportEnum(szServer, level, &buf, dwPrefLen, &numRead, &totalEntries, &resumeHandle);
+    Py_END_ALLOW_THREADS
+    if (err != 0 && err != ERROR_MORE_DATA) {
         ReturnNetError("NetWkstaTransportEnum", err);
         goto done;
     }
@@ -1102,9 +1108,10 @@ PyObject *PyNetWkstaTransportAdd(PyObject *self, PyObject *args)
     if (!PyObject_AsNET_STRUCT(obData, pInfo, &buf))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS err = NetWkstaTransportAdd(szServer, typ, buf, NULL);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = NetWkstaTransportAdd(szServer, typ, buf, NULL);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError("NetWkstaTransportAdd", err);
         goto done;
     }
@@ -1137,9 +1144,10 @@ PyObject *PyNetWkstaTransportDel(PyObject *self, PyObject *args)
     if (!PyWinObject_AsWCHAR(obTransport, &szTransport, TRUE))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS err = NetWkstaTransportDel(szServer, szTransport, ucond);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = NetWkstaTransportDel(szServer, szTransport, ucond);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError("NetWkstaTransportDel", err);
         goto done;
     }
@@ -1173,10 +1181,10 @@ PyObject *PyNetServerDiskEnum(PyObject *self, PyObject *args)
     if (!PyWinObject_AsWCHAR(obServer, &szServer, TRUE))
         return NULL;
 
-    Py_BEGIN_ALLOW_THREADS err =
-        NetServerDiskEnum(szServer, level, &buf, dwPrefLen, &numRead, &totalEntries, &resumeHandle);
-    Py_END_ALLOW_THREADS if (err != 0)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = NetServerDiskEnum(szServer, level, &buf, dwPrefLen, &numRead, &totalEntries, &resumeHandle);
+    Py_END_ALLOW_THREADS
+    if (err != 0) {
         ReturnNetError("NetServerDiskEnum", err);
         goto done;
     }
@@ -1607,10 +1615,10 @@ PyObject *PyNetValidatePasswordPolicy(PyObject *self, PyObject *args)
             PyErr_Format(PyExc_ValueError, "Unknown validation type (%d)", valType);
             goto done;
     }
-    Py_BEGIN_ALLOW_THREADS err =
-        NetValidatePasswordPolicy(Server, NULL, (NET_VALIDATE_PASSWORD_TYPE)valType, &in_arg, (void **)&out_arg);
-    Py_END_ALLOW_THREADS if (NERR_Success != err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = NetValidatePasswordPolicy(Server, NULL, (NET_VALIDATE_PASSWORD_TYPE)valType, &in_arg, (void **)&out_arg);
+    Py_END_ALLOW_THREADS
+    if (NERR_Success != err) {
         ReturnNetError("NetValidatePasswordPolicy", err);
         goto done;
     }

--- a/win32/src/win32net/win32netmodule.cpp
+++ b/win32/src/win32net/win32netmodule.cpp
@@ -277,13 +277,10 @@ PyObject *PyDoSimpleEnum(PyObject *self, PyObject *args, PFNSIMPLEENUM pfn, char
 
     Py_BEGIN_ALLOW_THREADS
         /* Bad resume handles etc can cause access violations here - catch them. */
-        PYWINTYPES_TRY
-    {
-        err = (*pfn)(szServer, level, &buf, dwPrefLen, &numRead, &totalEntries, &resumeHandle);
-    }
-    PYWINTYPES_EXCEPT { err = ERROR_INVALID_PARAMETER; }
-    Py_END_ALLOW_THREADS if (err != 0 && err != ERROR_MORE_DATA)
-    {
+        PYWINTYPES_TRY { err = (*pfn)(szServer, level, &buf, dwPrefLen, &numRead, &totalEntries, &resumeHandle); }
+        PYWINTYPES_EXCEPT { err = ERROR_INVALID_PARAMETER; }
+    Py_END_ALLOW_THREADS
+    if (err != 0 && err != ERROR_MORE_DATA) {
         ReturnNetError(fnname, err);
         goto done;
     }
@@ -341,10 +338,10 @@ PyObject *PyDoNamedEnum(PyObject *self, PyObject *args, PFNNAMEDENUM pfn, char *
     if (!FindNET_STRUCT(level, pInfos, &pInfo))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS err =
-        (*pfn)(szServer, szGroup, level, &buf, dwPrefLen, &numRead, &totalEntries, &resumeHandle);
-    Py_END_ALLOW_THREADS if (err != 0 && err != ERROR_MORE_DATA)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = (*pfn)(szServer, szGroup, level, &buf, dwPrefLen, &numRead, &totalEntries, &resumeHandle);
+    Py_END_ALLOW_THREADS
+    if (err != 0 && err != ERROR_MORE_DATA) {
         ReturnNetError(fnname, err);
         goto done;
     }
@@ -415,9 +412,10 @@ PyObject *PyDoGroupSet(PyObject *self, PyObject *args, PFNGROUPSET pfn, char *fn
         goto done;
     }
     for (i = 0; i < numEntries; i++) memcpy(buf + (i * pI->structsize), ppTempObjects[i], pI->structsize);
-    Py_BEGIN_ALLOW_THREADS err = (*pfn)(szServer, szGroup, level, buf, numEntries);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = (*pfn)(szServer, szGroup, level, buf, numEntries);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError(fnname, err);
         goto done;
     }
@@ -455,9 +453,10 @@ PyObject *PyDoGetInfo(PyObject *self, PyObject *args, PFNGETINFO pfn, char *fnna
         goto done;
     if (!FindNET_STRUCT(typ, pInfos, &pInfo))
         goto done;
-    Py_BEGIN_ALLOW_THREADS err = (*pfn)(szServer, szName, typ, &buf);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = (*pfn)(szServer, szName, typ, &buf);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError(fnname, err);
         goto done;
     }
@@ -485,9 +484,10 @@ PyObject *PyDoGetModalsInfo(PyObject *self, PyObject *args, PFNGETMODALSINFO pfn
         goto done;
     if (!FindNET_STRUCT(typ, pInfos, &pInfo))
         goto done;
-    Py_BEGIN_ALLOW_THREADS err = (*pfn)(szServer, typ, &buf);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = (*pfn)(szServer, typ, &buf);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError(fnname, err);
         goto done;
     }
@@ -539,8 +539,8 @@ PyObject *PyNetMessageBufferSend(PyObject *self, PyObject *args)
     Py_BEGIN_ALLOW_THREADS
         // message is "BYTE *", but still expects Unicode?  Wonder why not LPTSTR like the other string args?
         rc = NetMessageBufferSend(serverName, msgName, fromName, (BYTE *)message, msgLen * sizeof(TCHAR));
-    Py_END_ALLOW_THREADS if (rc)
-    {
+    Py_END_ALLOW_THREADS
+    if (rc) {
         ReturnNetError("NetMessageBufferSend", rc);  // @pyseeapi NetMessageBufferSend
         goto done;
     }
@@ -700,9 +700,10 @@ PyObject *PyDoSetInfo(PyObject *self, PyObject *args, PFNSETINFO pfn, char *fnna
     if (!PyObject_AsNET_STRUCT(obData, pInfo, &buf))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS err = (*pfn)(szServer, szName, typ, buf, NULL);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = (*pfn)(szServer, szName, typ, buf, NULL);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError(fnname, err);
         goto done;
     }
@@ -736,9 +737,10 @@ PyObject *PyDoSetModalsInfo(PyObject *self, PyObject *args, PFNSETMODALSINFO pfn
     if (!PyObject_AsNET_STRUCT(obData, pInfo, &buf))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS err = (*pfn)(szServer, typ, buf, NULL);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = (*pfn)(szServer, typ, buf, NULL);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError(fnname, err);
         goto done;
     }
@@ -770,9 +772,10 @@ PyObject *PyDoAdd(PyObject *self, PyObject *args, PFNADD pfn, char *fnname, PyNE
     if (!PyObject_AsNET_STRUCT(obData, pInfo, &buf))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS err = (*pfn)(szServer, typ, buf, NULL);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = (*pfn)(szServer, typ, buf, NULL);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError(fnname, err);
         goto done;
     }
@@ -799,9 +802,10 @@ PyObject *PyDoDel(PyObject *self, PyObject *args, PFNDEL pfn, char *fnname)
     if (!PyWinObject_AsWCHAR(obName, &szName, FALSE))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS err = (*pfn)(szServer, szName);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = (*pfn)(szServer, szName);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError(fnname, err);
         goto done;
     }
@@ -851,9 +855,10 @@ PyObject *PyDoGroupDelMembers(PyObject *self, PyObject *args)
             goto done;
     }
 
-    Py_BEGIN_ALLOW_THREADS err = NetLocalGroupDelMembers(szServer, szGroup, 3, (BYTE *)plgrminfo, numEntries);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = NetLocalGroupDelMembers(szServer, szGroup, 3, (BYTE *)plgrminfo, numEntries);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError("NetLocalGroupDelMembers", err);
         goto done;
     }
@@ -895,9 +900,10 @@ PyObject *PyNetGetDCName(PyObject *self, PyObject *args)
         goto done;
     if (!PyWinObject_AsWCHAR(obDomain, &szDomain, TRUE))
         goto done;
-    Py_BEGIN_ALLOW_THREADS err = NetGetDCName(szServer, szDomain, (LPBYTE *)&result);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = NetGetDCName(szServer, szDomain, (LPBYTE *)&result);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError("NetGetDCName", err);
         goto done;
     }
@@ -928,9 +934,10 @@ PyObject *PyNetGetAnyDCName(PyObject *self, PyObject *args)
         goto done;
     if (!PyWinObject_AsWCHAR(obDomain, &szDomain, TRUE))
         goto done;
-    Py_BEGIN_ALLOW_THREADS err = NetGetAnyDCName(szServer, szDomain, (LPBYTE *)&result);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = NetGetAnyDCName(szServer, szDomain, (LPBYTE *)&result);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError("NetGetAnyDCName", err);
         goto done;
     }
@@ -957,9 +964,10 @@ static PyObject *PyNetGetJoinInformation(PyObject *self, PyObject *args)
         return NULL;
     if (!PyWinObject_AsWCHAR(obServer, &server, TRUE))
         goto done;
-    Py_BEGIN_ALLOW_THREADS err = NetGetJoinInformation(server, &result, &status);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = NetGetJoinInformation(server, &result, &status);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError("NetGetJoinInformation", err);
         goto done;
     }

--- a/win32/src/win32net/win32netmodule.cpp
+++ b/win32/src/win32net/win32netmodule.cpp
@@ -275,15 +275,15 @@ PyObject *PyDoSimpleEnum(PyObject *self, PyObject *args, PFNSIMPLEENUM pfn, char
     if (!FindNET_STRUCT(level, pInfos, &pInfo))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS;
-    /* Bad resume handles etc can cause access violations here - catch them. */
-    __try {
-        err = (*pfn)(szServer, level, &buf, dwPrefLen, &numRead, &totalEntries, &resumeHandle);
-    }
-    __except (EXCEPTION_EXECUTE_HANDLER) {
-        err = ERROR_INVALID_PARAMETER;
-    }
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        /* Bad resume handles etc can cause access violations here - catch them. */
+        __try {
+            err = (*pfn)(szServer, level, &buf, dwPrefLen, &numRead, &totalEntries, &resumeHandle);
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER) {
+            err = ERROR_INVALID_PARAMETER;
+        }
+    Py_END_ALLOW_THREADS
     if (err != 0 && err != ERROR_MORE_DATA) {
         ReturnNetError(fnname, err);
         goto done;
@@ -342,10 +342,10 @@ PyObject *PyDoNamedEnum(PyObject *self, PyObject *args, PFNNAMEDENUM pfn, char *
     if (!FindNET_STRUCT(level, pInfos, &pInfo))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS err =
-        (*pfn)(szServer, szGroup, level, &buf, dwPrefLen, &numRead, &totalEntries, &resumeHandle);
-    Py_END_ALLOW_THREADS if (err != 0 && err != ERROR_MORE_DATA)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = (*pfn)(szServer, szGroup, level, &buf, dwPrefLen, &numRead, &totalEntries, &resumeHandle);
+    Py_END_ALLOW_THREADS
+    if (err != 0 && err != ERROR_MORE_DATA) {
         ReturnNetError(fnname, err);
         goto done;
     }
@@ -416,9 +416,10 @@ PyObject *PyDoGroupSet(PyObject *self, PyObject *args, PFNGROUPSET pfn, char *fn
         goto done;
     }
     for (i = 0; i < numEntries; i++) memcpy(buf + (i * pI->structsize), ppTempObjects[i], pI->structsize);
-    Py_BEGIN_ALLOW_THREADS err = (*pfn)(szServer, szGroup, level, buf, numEntries);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = (*pfn)(szServer, szGroup, level, buf, numEntries);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError(fnname, err);
         goto done;
     }
@@ -456,9 +457,10 @@ PyObject *PyDoGetInfo(PyObject *self, PyObject *args, PFNGETINFO pfn, char *fnna
         goto done;
     if (!FindNET_STRUCT(typ, pInfos, &pInfo))
         goto done;
-    Py_BEGIN_ALLOW_THREADS err = (*pfn)(szServer, szName, typ, &buf);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = (*pfn)(szServer, szName, typ, &buf);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError(fnname, err);
         goto done;
     }
@@ -486,9 +488,10 @@ PyObject *PyDoGetModalsInfo(PyObject *self, PyObject *args, PFNGETMODALSINFO pfn
         goto done;
     if (!FindNET_STRUCT(typ, pInfos, &pInfo))
         goto done;
-    Py_BEGIN_ALLOW_THREADS err = (*pfn)(szServer, typ, &buf);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = (*pfn)(szServer, typ, &buf);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError(fnname, err);
         goto done;
     }
@@ -540,8 +543,8 @@ PyObject *PyNetMessageBufferSend(PyObject *self, PyObject *args)
     Py_BEGIN_ALLOW_THREADS
         // message is "BYTE *", but still expects Unicode?  Wonder why not LPTSTR like the other string args?
         rc = NetMessageBufferSend(serverName, msgName, fromName, (BYTE *)message, msgLen * sizeof(TCHAR));
-    Py_END_ALLOW_THREADS if (rc)
-    {
+    Py_END_ALLOW_THREADS
+    if (rc) {
         ReturnNetError("NetMessageBufferSend", rc);  // @pyseeapi NetMessageBufferSend
         goto done;
     }
@@ -701,9 +704,10 @@ PyObject *PyDoSetInfo(PyObject *self, PyObject *args, PFNSETINFO pfn, char *fnna
     if (!PyObject_AsNET_STRUCT(obData, pInfo, &buf))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS err = (*pfn)(szServer, szName, typ, buf, NULL);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = (*pfn)(szServer, szName, typ, buf, NULL);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError(fnname, err);
         goto done;
     }
@@ -737,9 +741,10 @@ PyObject *PyDoSetModalsInfo(PyObject *self, PyObject *args, PFNSETMODALSINFO pfn
     if (!PyObject_AsNET_STRUCT(obData, pInfo, &buf))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS err = (*pfn)(szServer, typ, buf, NULL);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = (*pfn)(szServer, typ, buf, NULL);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError(fnname, err);
         goto done;
     }
@@ -771,9 +776,10 @@ PyObject *PyDoAdd(PyObject *self, PyObject *args, PFNADD pfn, char *fnname, PyNE
     if (!PyObject_AsNET_STRUCT(obData, pInfo, &buf))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS err = (*pfn)(szServer, typ, buf, NULL);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = (*pfn)(szServer, typ, buf, NULL);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError(fnname, err);
         goto done;
     }
@@ -800,9 +806,10 @@ PyObject *PyDoDel(PyObject *self, PyObject *args, PFNDEL pfn, char *fnname)
     if (!PyWinObject_AsWCHAR(obName, &szName, FALSE))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS err = (*pfn)(szServer, szName);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = (*pfn)(szServer, szName);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError(fnname, err);
         goto done;
     }
@@ -852,9 +859,10 @@ PyObject *PyDoGroupDelMembers(PyObject *self, PyObject *args)
             goto done;
     }
 
-    Py_BEGIN_ALLOW_THREADS err = NetLocalGroupDelMembers(szServer, szGroup, 3, (BYTE *)plgrminfo, numEntries);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = NetLocalGroupDelMembers(szServer, szGroup, 3, (BYTE *)plgrminfo, numEntries);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError("NetLocalGroupDelMembers", err);
         goto done;
     }
@@ -896,9 +904,10 @@ PyObject *PyNetGetDCName(PyObject *self, PyObject *args)
         goto done;
     if (!PyWinObject_AsWCHAR(obDomain, &szDomain, TRUE))
         goto done;
-    Py_BEGIN_ALLOW_THREADS err = NetGetDCName(szServer, szDomain, (LPBYTE *)&result);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = NetGetDCName(szServer, szDomain, (LPBYTE *)&result);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError("NetGetDCName", err);
         goto done;
     }
@@ -929,9 +938,10 @@ PyObject *PyNetGetAnyDCName(PyObject *self, PyObject *args)
         goto done;
     if (!PyWinObject_AsWCHAR(obDomain, &szDomain, TRUE))
         goto done;
-    Py_BEGIN_ALLOW_THREADS err = NetGetAnyDCName(szServer, szDomain, (LPBYTE *)&result);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = NetGetAnyDCName(szServer, szDomain, (LPBYTE *)&result);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError("NetGetAnyDCName", err);
         goto done;
     }
@@ -958,9 +968,10 @@ static PyObject *PyNetGetJoinInformation(PyObject *self, PyObject *args)
         return NULL;
     if (!PyWinObject_AsWCHAR(obServer, &server, TRUE))
         goto done;
-    Py_BEGIN_ALLOW_THREADS err = NetGetJoinInformation(server, &result, &status);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = NetGetJoinInformation(server, &result, &status);
+    Py_END_ALLOW_THREADS
+    if (err) {
         ReturnNetError("NetGetJoinInformation", err);
         goto done;
     }

--- a/win32/src/win32net/win32netsession.cpp
+++ b/win32/src/win32net/win32netsession.cpp
@@ -67,13 +67,12 @@ PyObject *PyNetSessionEnum(PyObject *self, PyObject *args)
     switch (info_lvl) {
         case 0: {
             do {
-                Py_BEGIN_ALLOW_THREADS nStatus =
-                    NetSessionEnum(server_name, client_name, user_name, info_lvl, (LPBYTE *)&pBuf0, buff_len,
-                                   &dwEntriesRead, &dwTotalEntries, &dwResumeHandle);
+                Py_BEGIN_ALLOW_THREADS
+                    nStatus = NetSessionEnum(server_name, client_name, user_name, info_lvl, (LPBYTE *)&pBuf0, buff_len,
+                                             &dwEntriesRead, &dwTotalEntries, &dwResumeHandle);
                 Py_END_ALLOW_THREADS
 
-                    if ((nStatus == NERR_Success) || (nStatus == ERROR_MORE_DATA))
-                {
+                if ((nStatus == NERR_Success) || (nStatus == ERROR_MORE_DATA)) {
                     if ((pTmpBuf0 = pBuf0) != NULL) {
                         for (i = 0; (i < dwEntriesRead); i++) {
                             PyObject *curr_sess_dict =
@@ -84,8 +83,7 @@ PyObject *PyNetSessionEnum(PyObject *self, PyObject *args)
                         }
                     }
                 }
-                else
-                {
+                else {
                     ReturnNetError("NetSessionEnum", nStatus);
                     Py_XDECREF(ret_list);
                     ret_list = NULL;
@@ -102,13 +100,12 @@ PyObject *PyNetSessionEnum(PyObject *self, PyObject *args)
 
         case 1: {
             do {
-                Py_BEGIN_ALLOW_THREADS nStatus =
-                    NetSessionEnum(server_name, client_name, user_name, info_lvl, (LPBYTE *)&pBuf1, buff_len,
-                                   &dwEntriesRead, &dwTotalEntries, &dwResumeHandle);
+                Py_BEGIN_ALLOW_THREADS
+                    nStatus = NetSessionEnum(server_name, client_name, user_name, info_lvl, (LPBYTE *)&pBuf1, buff_len,
+                                             &dwEntriesRead, &dwTotalEntries, &dwResumeHandle);
                 Py_END_ALLOW_THREADS
 
-                    if ((nStatus == NERR_Success) || (nStatus == ERROR_MORE_DATA))
-                {
+                if ((nStatus == NERR_Success) || (nStatus == ERROR_MORE_DATA)) {
                     if ((pTmpBuf1 = pBuf1) != NULL) {
                         for (i = 0; (i < dwEntriesRead); i++) {
                             PyObject *curr_sess_dict = Py_BuildValue(
@@ -125,8 +122,7 @@ PyObject *PyNetSessionEnum(PyObject *self, PyObject *args)
                     }
                 }
 
-                else
-                {
+                else {
                     ReturnNetError("NetSessionEnum", nStatus);
                     Py_XDECREF(ret_list);
                     ret_list = NULL;
@@ -144,13 +140,12 @@ PyObject *PyNetSessionEnum(PyObject *self, PyObject *args)
 
         case 2: {
             do {
-                Py_BEGIN_ALLOW_THREADS nStatus =
-                    NetSessionEnum(server_name, client_name, user_name, info_lvl, (LPBYTE *)&pBuf2, buff_len,
-                                   &dwEntriesRead, &dwTotalEntries, &dwResumeHandle);
+                Py_BEGIN_ALLOW_THREADS
+                    nStatus = NetSessionEnum(server_name, client_name, user_name, info_lvl, (LPBYTE *)&pBuf2, buff_len,
+                                             &dwEntriesRead, &dwTotalEntries, &dwResumeHandle);
                 Py_END_ALLOW_THREADS
 
-                    if ((nStatus == NERR_Success) || (nStatus == ERROR_MORE_DATA))
-                {
+                if ((nStatus == NERR_Success) || (nStatus == ERROR_MORE_DATA)) {
                     if ((pTmpBuf2 = pBuf2) != NULL) {
                         for (i = 0; (i < dwEntriesRead); i++) {
                             PyObject *curr_sess_dict = Py_BuildValue(
@@ -167,8 +162,7 @@ PyObject *PyNetSessionEnum(PyObject *self, PyObject *args)
                     }
                 }
 
-                else
-                {
+                else {
                     ReturnNetError("NetSessionEnum", nStatus);
                     ret_list = NULL;
                 }
@@ -185,11 +179,11 @@ PyObject *PyNetSessionEnum(PyObject *self, PyObject *args)
 
         case 10: {
             do {
-                Py_BEGIN_ALLOW_THREADS nStatus =
-                    NetSessionEnum(server_name, client_name, user_name, info_lvl, (LPBYTE *)&pBuf10, buff_len,
-                                   &dwEntriesRead, &dwTotalEntries, &dwResumeHandle);
-                Py_END_ALLOW_THREADS if ((nStatus == NERR_Success) || (nStatus == ERROR_MORE_DATA))
-                {
+                Py_BEGIN_ALLOW_THREADS
+                    nStatus = NetSessionEnum(server_name, client_name, user_name, info_lvl, (LPBYTE *)&pBuf10, buff_len,
+                                             &dwEntriesRead, &dwTotalEntries, &dwResumeHandle);
+                Py_END_ALLOW_THREADS
+                if ((nStatus == NERR_Success) || (nStatus == ERROR_MORE_DATA)) {
                     if ((pTmpBuf10 = pBuf10) != NULL) {
                         for (i = 0; (i < dwEntriesRead); i++) {
                             PyObject *curr_sess_dict = Py_BuildValue(
@@ -203,8 +197,7 @@ PyObject *PyNetSessionEnum(PyObject *self, PyObject *args)
                     }
                 }
 
-                else
-                {
+                else {
                     ReturnNetError("NetSessionEnum", nStatus);
                     Py_XDECREF(ret_list);
                     ret_list = NULL;
@@ -222,11 +215,11 @@ PyObject *PyNetSessionEnum(PyObject *self, PyObject *args)
 
         case 502: {
             do {
-                Py_BEGIN_ALLOW_THREADS nStatus =
-                    NetSessionEnum(server_name, client_name, user_name, info_lvl, (LPBYTE *)&pBuf502, buff_len,
-                                   &dwEntriesRead, &dwTotalEntries, &dwResumeHandle);
-                Py_END_ALLOW_THREADS if ((nStatus == NERR_Success) || (nStatus == ERROR_MORE_DATA))
-                {
+                Py_BEGIN_ALLOW_THREADS
+                    nStatus = NetSessionEnum(server_name, client_name, user_name, info_lvl, (LPBYTE *)&pBuf502,
+                                             buff_len, &dwEntriesRead, &dwTotalEntries, &dwResumeHandle);
+                Py_END_ALLOW_THREADS
+                if ((nStatus == NERR_Success) || (nStatus == ERROR_MORE_DATA)) {
                     if ((pTmpBuf502 = pBuf502) != NULL) {
                         for (i = 0; (i < dwEntriesRead); i++) {
                             PyObject *curr_sess_dict = Py_BuildValue(
@@ -243,8 +236,7 @@ PyObject *PyNetSessionEnum(PyObject *self, PyObject *args)
                         }
                     }
                 }
-                else
-                {
+                else {
                     ReturnNetError("NetSessionEnum", nStatus);
                     Py_XDECREF(ret_list);
                     ret_list = NULL;
@@ -293,13 +285,15 @@ PyObject *PyNetSessionDel(PyObject *self, PyObject *args)
     if (PyWinObject_AsWCHAR(server_name_obj, &server_name, TRUE) &&
         PyWinObject_AsWCHAR(client_name_obj, &client_name, TRUE) &&
         PyWinObject_AsWCHAR(user_name_obj, &user_name, TRUE)) {
-        Py_BEGIN_ALLOW_THREADS nStatus = NetSessionDel(server_name, client_name, user_name);
-        Py_END_ALLOW_THREADS if (nStatus == NERR_Success)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            nStatus = NetSessionDel(server_name, client_name, user_name);
+        Py_END_ALLOW_THREADS
+        if (nStatus == NERR_Success) {
             Py_INCREF(Py_None);
             ret = Py_None;
         }
-        else ReturnNetError("NetSessionDel", nStatus);
+        else
+            ReturnNetError("NetSessionDel", nStatus);
     }
     if (server_name != NULL)
         PyWinObject_FreeWCHAR(server_name);
@@ -351,12 +345,12 @@ PyObject *PyNetSessionGetInfo(PyObject *self, PyObject *args)
 
     switch (info_lvl) {
         case 0: {
-            Py_BEGIN_ALLOW_THREADS nStatus =
-                NetSessionGetInfo(server_name, client_name, user_name, info_lvl, (LPBYTE *)&pTmpBuf0);
-            Py_END_ALLOW_THREADS if (nStatus == NERR_Success) ret_dict =
-                Py_BuildValue("{s:N}", "client_name", PyWinObject_FromWCHAR(pTmpBuf0->sesi0_cname));
-            else
-            {
+            Py_BEGIN_ALLOW_THREADS
+                nStatus = NetSessionGetInfo(server_name, client_name, user_name, info_lvl, (LPBYTE *)&pTmpBuf0);
+            Py_END_ALLOW_THREADS
+            if (nStatus == NERR_Success)
+                ret_dict = Py_BuildValue("{s:N}", "client_name", PyWinObject_FromWCHAR(pTmpBuf0->sesi0_cname));
+            else {
                 ReturnNetError("NetSessionGetInfo", nStatus);
                 ret_dict = NULL;
             }
@@ -368,14 +362,16 @@ PyObject *PyNetSessionGetInfo(PyObject *self, PyObject *args)
         }
 
         case 1: {
-            Py_BEGIN_ALLOW_THREADS nStatus =
-                NetSessionGetInfo(server_name, client_name, user_name, info_lvl, (LPBYTE *)&pTmpBuf1);
-            Py_END_ALLOW_THREADS if (nStatus == NERR_Success) ret_dict = Py_BuildValue(
-                "{s:N,s:N,s:i,s:i,s:i,s:i}", "client_name", PyWinObject_FromWCHAR(pTmpBuf1->sesi1_cname), "user_name",
-                PyWinObject_FromWCHAR(pTmpBuf1->sesi1_username), "num_opens", pTmpBuf1->sesi1_num_opens, "active_time",
-                pTmpBuf1->sesi1_time, "idle_time", pTmpBuf1->sesi1_idle_time, "user_flags", pTmpBuf1->sesi1_user_flags);
-            else
-            {
+            Py_BEGIN_ALLOW_THREADS
+                nStatus = NetSessionGetInfo(server_name, client_name, user_name, info_lvl, (LPBYTE *)&pTmpBuf1);
+            Py_END_ALLOW_THREADS
+            if (nStatus == NERR_Success)
+                ret_dict = Py_BuildValue("{s:N,s:N,s:i,s:i,s:i,s:i}", "client_name",
+                                         PyWinObject_FromWCHAR(pTmpBuf1->sesi1_cname), "user_name",
+                                         PyWinObject_FromWCHAR(pTmpBuf1->sesi1_username), "num_opens",
+                                         pTmpBuf1->sesi1_num_opens, "active_time", pTmpBuf1->sesi1_time, "idle_time",
+                                         pTmpBuf1->sesi1_idle_time, "user_flags", pTmpBuf1->sesi1_user_flags);
+            else {
                 ReturnNetError("NetSessionGetInfo", nStatus);
                 ret_dict = NULL;
             }
@@ -387,15 +383,17 @@ PyObject *PyNetSessionGetInfo(PyObject *self, PyObject *args)
         }
 
         case 2: {
-            Py_BEGIN_ALLOW_THREADS nStatus =
-                NetSessionGetInfo(server_name, client_name, user_name, info_lvl, (LPBYTE *)&pTmpBuf2);
-            Py_END_ALLOW_THREADS if (nStatus == NERR_Success) ret_dict = Py_BuildValue(
-                "{s:N,s:N,s:i,s:i,s:i,s:i,s:N}", "client_name", PyWinObject_FromWCHAR(pTmpBuf2->sesi2_cname),
-                "user_name", PyWinObject_FromWCHAR(pTmpBuf2->sesi2_username), "num_opens", pTmpBuf2->sesi2_num_opens,
-                "active_time", pTmpBuf2->sesi2_time, "idle_time", pTmpBuf2->sesi2_idle_time, "user_flags",
-                pTmpBuf2->sesi2_user_flags, "client_type", PyWinObject_FromWCHAR(pTmpBuf2->sesi2_cltype_name));
-            else
-            {
+            Py_BEGIN_ALLOW_THREADS
+                nStatus = NetSessionGetInfo(server_name, client_name, user_name, info_lvl, (LPBYTE *)&pTmpBuf2);
+            Py_END_ALLOW_THREADS
+            if (nStatus == NERR_Success)
+                ret_dict = Py_BuildValue("{s:N,s:N,s:i,s:i,s:i,s:i,s:N}", "client_name",
+                                         PyWinObject_FromWCHAR(pTmpBuf2->sesi2_cname), "user_name",
+                                         PyWinObject_FromWCHAR(pTmpBuf2->sesi2_username), "num_opens",
+                                         pTmpBuf2->sesi2_num_opens, "active_time", pTmpBuf2->sesi2_time, "idle_time",
+                                         pTmpBuf2->sesi2_idle_time, "user_flags", pTmpBuf2->sesi2_user_flags,
+                                         "client_type", PyWinObject_FromWCHAR(pTmpBuf2->sesi2_cltype_name));
+            else {
                 ReturnNetError("NetSessionGetInfo", nStatus);
                 ret_dict = NULL;
             }
@@ -407,14 +405,15 @@ PyObject *PyNetSessionGetInfo(PyObject *self, PyObject *args)
         }
 
         case 10: {
-            Py_BEGIN_ALLOW_THREADS nStatus =
-                NetSessionGetInfo(server_name, client_name, user_name, info_lvl, (LPBYTE *)&pTmpBuf10);
-            Py_END_ALLOW_THREADS if (nStatus == NERR_Success) ret_dict =
-                Py_BuildValue("{s:N,s:N,s:i,s:i}", "client_name", PyWinObject_FromWCHAR(pTmpBuf10->sesi10_cname),
-                              "user_name", PyWinObject_FromWCHAR(pTmpBuf10->sesi10_username), "active_time",
-                              pTmpBuf10->sesi10_time, "idle_time", pTmpBuf10->sesi10_idle_time);
-            else
-            {
+            Py_BEGIN_ALLOW_THREADS
+                nStatus = NetSessionGetInfo(server_name, client_name, user_name, info_lvl, (LPBYTE *)&pTmpBuf10);
+            Py_END_ALLOW_THREADS
+            if (nStatus == NERR_Success)
+                ret_dict =
+                    Py_BuildValue("{s:N,s:N,s:i,s:i}", "client_name", PyWinObject_FromWCHAR(pTmpBuf10->sesi10_cname),
+                                  "user_name", PyWinObject_FromWCHAR(pTmpBuf10->sesi10_username), "active_time",
+                                  pTmpBuf10->sesi10_time, "idle_time", pTmpBuf10->sesi10_idle_time);
+            else {
                 ReturnNetError("NetSessionGetInfo", nStatus);
                 ret_dict = NULL;
             }
@@ -426,17 +425,19 @@ PyObject *PyNetSessionGetInfo(PyObject *self, PyObject *args)
         }
 
         case 502: {
-            Py_BEGIN_ALLOW_THREADS nStatus =
-                NetSessionGetInfo(server_name, client_name, user_name, info_lvl, (LPBYTE *)&pTmpBuf502);
-            Py_END_ALLOW_THREADS if (nStatus == NERR_Success) ret_dict = Py_BuildValue(
-                "{s:N,s:N,s:i,s:i,s:i,s:i,s:N,s:N}", "client_name", PyWinObject_FromWCHAR(pTmpBuf502->sesi502_cname),
-                "user_name", PyWinObject_FromWCHAR(pTmpBuf502->sesi502_username), "num_opens",
-                pTmpBuf502->sesi502_num_opens, "active_time", pTmpBuf502->sesi502_time, "idle_time",
-                pTmpBuf502->sesi502_idle_time, "user_flags", pTmpBuf502->sesi502_user_flags, "client_type",
-                PyWinObject_FromWCHAR(pTmpBuf502->sesi502_cltype_name), "transport",
-                PyWinObject_FromWCHAR(pTmpBuf502->sesi502_transport));
-            else
-            {
+            Py_BEGIN_ALLOW_THREADS
+                nStatus = NetSessionGetInfo(server_name, client_name, user_name, info_lvl, (LPBYTE *)&pTmpBuf502);
+            Py_END_ALLOW_THREADS
+            if (nStatus == NERR_Success)
+                ret_dict =
+                    Py_BuildValue("{s:N,s:N,s:i,s:i,s:i,s:i,s:N,s:N}", "client_name",
+                                  PyWinObject_FromWCHAR(pTmpBuf502->sesi502_cname), "user_name",
+                                  PyWinObject_FromWCHAR(pTmpBuf502->sesi502_username), "num_opens",
+                                  pTmpBuf502->sesi502_num_opens, "active_time", pTmpBuf502->sesi502_time, "idle_time",
+                                  pTmpBuf502->sesi502_idle_time, "user_flags", pTmpBuf502->sesi502_user_flags,
+                                  "client_type", PyWinObject_FromWCHAR(pTmpBuf502->sesi502_cltype_name), "transport",
+                                  PyWinObject_FromWCHAR(pTmpBuf502->sesi502_transport));
+            else {
                 ReturnNetError("NetSessionGetInfo", nStatus);
                 ret_dict = NULL;
             }

--- a/win32/src/win32net/win32netuser.cpp
+++ b/win32/src/win32net/win32netuser.cpp
@@ -487,11 +487,12 @@ PyObject *PyNetUserGetGroups(PyObject *self, PyObject *args)
     if (pRetlist == NULL)
         return NULL;  // did we err?
 
-    Py_BEGIN_ALLOW_THREADS Errno = NetUserGetGroups((BSTR)wzServerName, (BSTR)wzUserName, 1, (LPBYTE *)&lpBuffer,
-                                                    dwBuffsize, &dwCount, &dwMaxCount);
+    Py_BEGIN_ALLOW_THREADS
+        Errno = NetUserGetGroups((BSTR)wzServerName, (BSTR)wzUserName, 1, (LPBYTE *)&lpBuffer, dwBuffsize, &dwCount,
+                                 &dwMaxCount);
     Py_END_ALLOW_THREADS
 
-        if (Errno == NERR_Success)  // if no error, then build the list
+    if (Errno == NERR_Success)  // if no error, then build the list
     {
         GROUP_USERS_INFO_1 *p_nr = lpBuffer;  // Enum Resource returns a buffer of successive structs
 
@@ -516,8 +517,7 @@ PyObject *PyNetUserGetGroups(PyObject *self, PyObject *args)
             } while (dwCount);
         };  // if (dwCount > 0)
     }
-    else
-    {  // ERROR Occurred
+    else {  // ERROR Occurred
         Py_DECREF(pRetlist);
         return ReturnNetError("NetUserGetGroups", Errno);
     }
@@ -573,11 +573,12 @@ PyObject *PyNetUserGetLocalGroups(PyObject *self, PyObject *args)
     if (pRetlist == NULL)
         return NULL;  // did we err?
 
-    Py_BEGIN_ALLOW_THREADS Errno = NetUserGetLocalGroups(wzServerName, wzUserName, 0, dwFlags, (LPBYTE *)&lpBuffer,
-                                                         dwBuffsize, &dwCount, &dwMaxCount);  // do the enumeration
+    Py_BEGIN_ALLOW_THREADS
+        Errno = NetUserGetLocalGroups(wzServerName, wzUserName, 0, dwFlags, (LPBYTE *)&lpBuffer, dwBuffsize, &dwCount,
+                                      &dwMaxCount);  // do the enumeration
     Py_END_ALLOW_THREADS
 
-        if (Errno == NERR_Success)  // if no error, then build the list
+    if (Errno == NERR_Success)  // if no error, then build the list
     {
         LOCALGROUP_USERS_INFO_0 *p_nr = lpBuffer;  // Enum Resource returns a buffer of successive structs
 

--- a/win32/src/win32net/win32netuser.cpp
+++ b/win32/src/win32net/win32netuser.cpp
@@ -373,9 +373,9 @@ PyObject *PyNetUserEnum(PyObject *self, PyObject *args)
     if (!FindNET_STRUCT(level, user_infos, &pInfo))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS;
-    err = NetUserEnum(szServer, level, filter, &buf, dwPrefLen, &numRead, &totalEntries, &resumeHandle);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        err = NetUserEnum(szServer, level, filter, &buf, dwPrefLen, &numRead, &totalEntries, &resumeHandle);
+    Py_END_ALLOW_THREADS
     if (err != 0 && err != ERROR_MORE_DATA) {
         ReturnNetError("NetUserEnum", err);  // @pyseeapi NetUserEnum
         goto done;
@@ -489,11 +489,12 @@ PyObject *PyNetUserGetGroups(PyObject *self, PyObject *args)
     if (pRetlist == NULL)
         return NULL;  // did we err?
 
-    Py_BEGIN_ALLOW_THREADS Errno = NetUserGetGroups((BSTR)wzServerName, (BSTR)wzUserName, 1, (LPBYTE *)&lpBuffer,
-                                                    dwBuffsize, &dwCount, &dwMaxCount);
+    Py_BEGIN_ALLOW_THREADS
+        Errno = NetUserGetGroups((BSTR)wzServerName, (BSTR)wzUserName, 1, (LPBYTE *)&lpBuffer, dwBuffsize, &dwCount,
+                                 &dwMaxCount);
     Py_END_ALLOW_THREADS
 
-        if (Errno == NERR_Success)  // if no error, then build the list
+    if (Errno == NERR_Success)  // if no error, then build the list
     {
         GROUP_USERS_INFO_1 *p_nr = lpBuffer;  // Enum Resource returns a buffer of successive structs
 
@@ -518,8 +519,7 @@ PyObject *PyNetUserGetGroups(PyObject *self, PyObject *args)
             } while (dwCount);
         };  // if (dwCount > 0)
     }
-    else
-    {  // ERROR Occurred
+    else {  // ERROR Occurred
         Py_DECREF(pRetlist);
         return ReturnNetError("NetUserGetGroups", Errno);
     }
@@ -575,11 +575,12 @@ PyObject *PyNetUserGetLocalGroups(PyObject *self, PyObject *args)
     if (pRetlist == NULL)
         return NULL;  // did we err?
 
-    Py_BEGIN_ALLOW_THREADS Errno = NetUserGetLocalGroups(wzServerName, wzUserName, 0, dwFlags, (LPBYTE *)&lpBuffer,
-                                                         dwBuffsize, &dwCount, &dwMaxCount);  // do the enumeration
+    Py_BEGIN_ALLOW_THREADS
+        Errno = NetUserGetLocalGroups(wzServerName, wzUserName, 0, dwFlags, (LPBYTE *)&lpBuffer, dwBuffsize, &dwCount,
+                                      &dwMaxCount);  // do the enumeration
     Py_END_ALLOW_THREADS
 
-        if (Errno == NERR_Success)  // if no error, then build the list
+    if (Errno == NERR_Success)  // if no error, then build the list
     {
         LOCALGROUP_USERS_INFO_0 *p_nr = lpBuffer;  // Enum Resource returns a buffer of successive structs
 

--- a/win32/src/win32pdhmodule.cpp
+++ b/win32/src/win32pdhmodule.cpp
@@ -83,21 +83,22 @@ static PyObject *PyEnumObjectItems(PyObject *self, PyObject *args)
 
     PDH_STATUS pdhStatus;
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhEnumObjectItems(DataSource,            // Perf log file
-                                                          Machine,               // local machine
-                                                          Object,                // object to enumerate
-                                                          szCounterListBuffer,   // pass in NULL buffers
-                                                          &dwCounterListSize,    // an 0 length to get
-                                                          szInstanceListBuffer,  // required size
-                                                          &dwInstanceListSize,   // of the buffers in chars
-                                                          detailLevel,           // counter detail level
-                                                          flags);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhEnumObjectItems(DataSource,            // Perf log file
+                                       Machine,               // local machine
+                                       Object,                // object to enumerate
+                                       szCounterListBuffer,   // pass in NULL buffers
+                                       &dwCounterListSize,    // an 0 length to get
+                                       szInstanceListBuffer,  // required size
+                                       &dwInstanceListSize,   // of the buffers in chars
+                                       detailLevel,           // counter detail level
+                                       flags);
     Py_END_ALLOW_THREADS
 
-        // it appears NT/2k will return 0, while XP will return
-        // PDH_MORE_DATA
-        if (pdhStatus != ERROR_SUCCESS && pdhStatus != PDH_MORE_DATA) return PyWin_SetAPIError(
-            "EnumObjectItems for buffer size", pdhStatus);
+    // it appears NT/2k will return 0, while XP will return
+    // PDH_MORE_DATA
+    if (pdhStatus != ERROR_SUCCESS && pdhStatus != PDH_MORE_DATA)
+        return PyWin_SetAPIError("EnumObjectItems for buffer size", pdhStatus);
 
     // Allocate the buffers and try the call again.
     if (dwCounterListSize) {
@@ -116,21 +117,24 @@ static PyObject *PyEnumObjectItems(PyObject *self, PyObject *args)
         }
     }
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhEnumObjectItems(DataSource,            // Perf log file
-                                                          Machine,               // local machine
-                                                          Object,                // object to enumerate
-                                                          szCounterListBuffer,   // pass in NULL buffers
-                                                          &dwCounterListSize,    // an 0 length to get
-                                                          szInstanceListBuffer,  // required size
-                                                          &dwInstanceListSize,   // of the buffers in chars
-                                                          detailLevel,           // counter detail level
-                                                          flags);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhEnumObjectItems(DataSource,            // Perf log file
+                                       Machine,               // local machine
+                                       Object,                // object to enumerate
+                                       szCounterListBuffer,   // pass in NULL buffers
+                                       &dwCounterListSize,    // an 0 length to get
+                                       szInstanceListBuffer,  // required size
+                                       &dwInstanceListSize,   // of the buffers in chars
+                                       detailLevel,           // counter detail level
+                                       flags);
     Py_END_ALLOW_THREADS
 
-        if (pdhStatus != ERROR_SUCCESS) PyWin_SetAPIError("EnumObjectItems for data", pdhStatus);
-    else ret =
-        Py_BuildValue("NN", szCounterListBuffer ? PyWinObject_FromMultipleString(szCounterListBuffer) : PyList_New(0),
-                      szInstanceListBuffer ? PyWinObject_FromMultipleString(szInstanceListBuffer) : PyList_New(0));
+    if (pdhStatus != ERROR_SUCCESS)
+        PyWin_SetAPIError("EnumObjectItems for data", pdhStatus);
+    else
+        ret = Py_BuildValue(
+            "NN", szCounterListBuffer ? PyWinObject_FromMultipleString(szCounterListBuffer) : PyList_New(0),
+            szInstanceListBuffer ? PyWinObject_FromMultipleString(szInstanceListBuffer) : PyList_New(0));
 
 cleanup:
     if (szInstanceListBuffer)
@@ -164,18 +168,19 @@ static PyObject *PyEnumObjects(PyObject *self, PyObject *args)
 
     PDH_STATUS pdhStatus;
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhEnumObjects(DataSource,          // perf log file
-                                                      Machine,             // local machine
-                                                      szObjectListBuffer,  // pass in NULL buffers
-                                                      &dwObjectListSize,   // an 0 length to get
-                                                      detailLevel,         // counter detail level
-                                                      refresh);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhEnumObjects(DataSource,          // perf log file
+                                   Machine,             // local machine
+                                   szObjectListBuffer,  // pass in NULL buffers
+                                   &dwObjectListSize,   // an 0 length to get
+                                   detailLevel,         // counter detail level
+                                   refresh);
     Py_END_ALLOW_THREADS
 
-        // it appears NT/2k will return 0, while XP will return
-        // PDH_MORE_DATA
-        if (pdhStatus != ERROR_SUCCESS && pdhStatus != PDH_MORE_DATA) return PyWin_SetAPIError(
-            "EnumObjects for buffer size", pdhStatus);
+    // it appears NT/2k will return 0, while XP will return
+    // PDH_MORE_DATA
+    if (pdhStatus != ERROR_SUCCESS && pdhStatus != PDH_MORE_DATA)
+        return PyWin_SetAPIError("EnumObjects for buffer size", pdhStatus);
 
     // Allocate the buffers and try the call again.
     if (dwObjectListSize) {
@@ -186,16 +191,19 @@ static PyObject *PyEnumObjects(PyObject *self, PyObject *args)
         }
     }
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhEnumObjects(DataSource,          // Perf log file
-                                                      Machine,             // local machine
-                                                      szObjectListBuffer,  // pass in NULL buffers
-                                                      &dwObjectListSize,   // an 0 length to get
-                                                      detailLevel,         // counter detail level
-                                                      0);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhEnumObjects(DataSource,          // Perf log file
+                                   Machine,             // local machine
+                                   szObjectListBuffer,  // pass in NULL buffers
+                                   &dwObjectListSize,   // an 0 length to get
+                                   detailLevel,         // counter detail level
+                                   0);
     Py_END_ALLOW_THREADS
 
-        if (pdhStatus != ERROR_SUCCESS) PyWin_SetAPIError("EnumObjects for data", pdhStatus);
-    else ret = szObjectListBuffer ? PyWinObject_FromMultipleString(szObjectListBuffer) : PyList_New(0);
+    if (pdhStatus != ERROR_SUCCESS)
+        PyWin_SetAPIError("EnumObjects for data", pdhStatus);
+    else
+        ret = szObjectListBuffer ? PyWinObject_FromMultipleString(szObjectListBuffer) : PyList_New(0);
 
     if (szObjectListBuffer)
         free(szObjectListBuffer);
@@ -226,7 +234,8 @@ static PyObject *PyAddCounter(PyObject *self, PyObject *args)
         return NULL;
     HCOUNTER hCounter;
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhAddCounter(hQuery, szPath, userData, &hCounter);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhAddCounter(hQuery, szPath, userData, &hCounter);
 
     Py_END_ALLOW_THREADS;
     PyWinObject_FreeTCHAR(szPath);
@@ -261,7 +270,8 @@ static PyObject *PyAddEnglishCounter(PyObject *self, PyObject *args)
         return NULL;
     HCOUNTER hCounter;
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhAddEnglishCounter(hQuery, szPath, userData, &hCounter);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhAddEnglishCounter(hQuery, szPath, userData, &hCounter);
 
     Py_END_ALLOW_THREADS;
     PyWinObject_FreeTCHAR(szPath);
@@ -283,10 +293,12 @@ static PyObject *PyRemoveCounter(PyObject *self, PyObject *args)
     if (!PyWinObject_AsHANDLE(obhandle, &handle))
         return NULL;
     // @comm See also <om win32pdh.AddCounter>
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhRemoveCounter(handle);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhRemoveCounter(handle);
     Py_END_ALLOW_THREADS
 
-        if (pdhStatus != ERROR_SUCCESS) return PyWin_SetAPIError("RemoveCounter", pdhStatus);
+    if (pdhStatus != ERROR_SUCCESS)
+        return PyWin_SetAPIError("RemoveCounter", pdhStatus);
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -311,10 +323,11 @@ static PyObject *PyOpenQuery(PyObject *self, PyObject *args)
     if (!PyWinObject_AsTCHAR(obDataSource, &DataSource, TRUE))
         return NULL;
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhOpenQuery(DataSource, userData, &hQuery);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhOpenQuery(DataSource, userData, &hQuery);
     Py_END_ALLOW_THREADS
 
-        PyWinObject_FreeTCHAR(DataSource);
+    PyWinObject_FreeTCHAR(DataSource);
     if (pdhStatus != ERROR_SUCCESS)
         return PyWin_SetAPIError("OpenQuery", pdhStatus);
     return PyWinLong_FromHANDLE(hQuery);
@@ -333,10 +346,12 @@ static PyObject *PyCloseQuery(PyObject *self, PyObject *args)
     if (!PyWinObject_AsHANDLE(obhandle, &handle))
         return NULL;
     // @comm See also <om win32pdh.OpenQuery>
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhCloseQuery(handle);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhCloseQuery(handle);
     Py_END_ALLOW_THREADS
 
-        if (pdhStatus != ERROR_SUCCESS) return PyWin_SetAPIError("CloseQuery", pdhStatus);
+    if (pdhStatus != ERROR_SUCCESS)
+        return PyWin_SetAPIError("CloseQuery", pdhStatus);
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -377,9 +392,13 @@ static PyObject *PyMakeCounterPath(PyObject *self, PyObject *args)
     }
 
     PDH_STATUS pdhStatus;
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhMakeCounterPath(&cpe, szResult, &bufSize, flags);
-    Py_END_ALLOW_THREADS if (pdhStatus != ERROR_SUCCESS) PyWin_SetAPIError("PdhMakeCounterPath", pdhStatus);
-    else ret = PyWinObject_FromTCHAR(szResult);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhMakeCounterPath(&cpe, szResult, &bufSize, flags);
+    Py_END_ALLOW_THREADS
+    if (pdhStatus != ERROR_SUCCESS)
+        PyWin_SetAPIError("PdhMakeCounterPath", pdhStatus);
+    else
+        ret = PyWinObject_FromTCHAR(szResult);
 
 done:
     if (szResult)
@@ -408,11 +427,12 @@ static PyObject *PyGetCounterInfo(PyObject *self, PyObject *args)
     // First call to get buffer size
     DWORD bufSize = 0;
     PDH_STATUS pdhStatus;
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhGetCounterInfo(handle, bExplainText, &bufSize, NULL);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhGetCounterInfo(handle, bExplainText, &bufSize, NULL);
     Py_END_ALLOW_THREADS
-        // as usual, pre-xp returns ERROR_SUCCESS, xp returns PDH_MORE_DATA
-        if (pdhStatus != ERROR_SUCCESS && pdhStatus != PDH_MORE_DATA) return PyWin_SetAPIError(
-            "GetCounterInfo for size", pdhStatus);
+    // as usual, pre-xp returns ERROR_SUCCESS, xp returns PDH_MORE_DATA
+    if (pdhStatus != ERROR_SUCCESS && pdhStatus != PDH_MORE_DATA)
+        return PyWin_SetAPIError("GetCounterInfo for size", pdhStatus);
 
     PPDH_COUNTER_INFO pInfo = (PPDH_COUNTER_INFO)malloc(bufSize);
     if (pInfo == NULL) {
@@ -421,8 +441,10 @@ static PyObject *PyGetCounterInfo(PyObject *self, PyObject *args)
     }
     pInfo->dwLength = bufSize;
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhGetCounterInfo(handle, bExplainText, &bufSize, pInfo);
-    Py_END_ALLOW_THREADS PyObject *rc;
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhGetCounterInfo(handle, bExplainText, &bufSize, pInfo);
+    Py_END_ALLOW_THREADS
+    PyObject *rc;
     if (pdhStatus != ERROR_SUCCESS)
         rc = PyWin_SetAPIError("GetCounterInfo for data", pdhStatus);
     else {
@@ -462,9 +484,11 @@ static PyObject *PyGetFormattedCounterValue(PyObject *self, PyObject *args)
     DWORD type;
     PDH_FMT_COUNTERVALUE result;
     PDH_STATUS pdhStatus;
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhGetFormattedCounterValue(handle, format, &type, &result);
-    Py_END_ALLOW_THREADS if (pdhStatus != ERROR_SUCCESS) return PyWin_SetAPIError("GetFormattedCounterValue",
-                                                                                  pdhStatus);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhGetFormattedCounterValue(handle, format, &type, &result);
+    Py_END_ALLOW_THREADS
+    if (pdhStatus != ERROR_SUCCESS)
+        return PyWin_SetAPIError("GetFormattedCounterValue", pdhStatus);
     if (!CheckCounterStatusOK(result.CStatus))
         return NULL;
 
@@ -503,8 +527,9 @@ static PyObject *PyPdhGetFormattedCounterArray(PyObject *self, PyObject *args)
     DWORD count;
     PDH_FMT_COUNTERVALUE_ITEM *pItems = NULL;
 
-    Py_BEGIN_ALLOW_THREADS;
-    pdhStatus = PdhGetFormattedCounterArray(handle, format, &size, &count, pItems);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        pdhStatus = PdhGetFormattedCounterArray(handle, format, &size, &count, pItems);
     Py_END_ALLOW_THREADS;
     if (pdhStatus != PDH_MORE_DATA) {
         return PyWin_SetAPIError("PdhGetFormattedCounterArray", pdhStatus);
@@ -515,8 +540,9 @@ static PyObject *PyPdhGetFormattedCounterArray(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    Py_BEGIN_ALLOW_THREADS;
-    pdhStatus = PdhGetFormattedCounterArray(handle, format, &size, &count, pItems);
+    Py_BEGIN_ALLOW_THREADS
+        ;
+        pdhStatus = PdhGetFormattedCounterArray(handle, format, &size, &count, pItems);
     Py_END_ALLOW_THREADS;
     if (pdhStatus != ERROR_SUCCESS) {
         free(pItems);
@@ -567,10 +593,12 @@ static PyObject *PyCollectQueryData(PyObject *self, PyObject *args)
     if (!PyWinObject_AsHANDLE(obhQuery, &hQuery))
         return NULL;
     PDH_STATUS pdhStatus;
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhCollectQueryData(hQuery);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhCollectQueryData(hQuery);
     Py_END_ALLOW_THREADS
 
-        if (pdhStatus != ERROR_SUCCESS) return PyWin_SetAPIError("CollectQueryData", pdhStatus);
+    if (pdhStatus != ERROR_SUCCESS)
+        return PyWin_SetAPIError("CollectQueryData", pdhStatus);
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -622,10 +650,12 @@ static PyObject *PyExpandCounterPath(PyObject *self, PyObject *args)
 
     DWORD dwSize = 0;
     PDH_STATUS pdhStatus;
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhExpandCounterPath(path, NULL, &dwSize);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhExpandCounterPath(path, NULL, &dwSize);
     Py_END_ALLOW_THREADS
 
-        if (dwSize == 0) return PyWin_SetAPIError("ExpandCounterPath for size", pdhStatus);
+    if (dwSize == 0)
+        return PyWin_SetAPIError("ExpandCounterPath for size", pdhStatus);
     dwSize++;
     TCHAR *buf = (TCHAR *)malloc(dwSize * sizeof(TCHAR));
     if (buf == NULL) {
@@ -633,8 +663,10 @@ static PyObject *PyExpandCounterPath(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhExpandCounterPath(path, buf, &dwSize);
-    Py_END_ALLOW_THREADS PyObject *rc;
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhExpandCounterPath(path, buf, &dwSize);
+    Py_END_ALLOW_THREADS
+    PyObject *rc;
     if (pdhStatus != ERROR_SUCCESS)
         rc = PyWin_SetAPIError("ExpandCounterPath for data", pdhStatus);
     else
@@ -665,8 +697,11 @@ static PyObject *PyParseCounterPath(PyObject *self, PyObject *args)
     DWORD size = 0;
     PDH_STATUS pdhStatus;
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhParseCounterPath(path, NULL, &size, flags);
-    Py_END_ALLOW_THREADS if (size == 0) return PyWin_SetAPIError("ParseCounterPath for size", pdhStatus);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhParseCounterPath(path, NULL, &size, flags);
+    Py_END_ALLOW_THREADS
+    if (size == 0)
+        return PyWin_SetAPIError("ParseCounterPath for size", pdhStatus);
     void *pBuf = malloc(size);
     if (pBuf == NULL) {
         PyErr_SetString(PyExc_MemoryError, "allocating buffer for PDH_COUNTER_PATH_ELEMENTS(+strings)");
@@ -674,10 +709,11 @@ static PyObject *PyParseCounterPath(PyObject *self, PyObject *args)
     }
 
     PDH_COUNTER_PATH_ELEMENTS *pCPE = (PDH_COUNTER_PATH_ELEMENTS *)pBuf;
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhParseCounterPath(path, pCPE, &size, flags);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhParseCounterPath(path, pCPE, &size, flags);
     Py_END_ALLOW_THREADS
 
-        PyObject *rc;
+    PyObject *rc;
     if (pdhStatus != 0) {
         rc = PyWin_SetAPIError("ParseCounterPath", pdhStatus);
     }
@@ -706,9 +742,10 @@ static PyObject *PyParseInstanceName(PyObject *self, PyObject *args)
     TCHAR szName[_MAX_PATH], szParent[_MAX_PATH];
     DWORD nameSize = _MAX_PATH, parentSize = _MAX_PATH;
     DWORD dwInstance;
-    Py_BEGIN_ALLOW_THREADS pdhStatus =
-        PdhParseInstanceName(iname, szName, &nameSize, szParent, &parentSize, &dwInstance);
-    Py_END_ALLOW_THREADS PyWinObject_FreeTCHAR(iname);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhParseInstanceName(iname, szName, &nameSize, szParent, &parentSize, &dwInstance);
+    Py_END_ALLOW_THREADS
+    PyWinObject_FreeTCHAR(iname);
     if (pdhStatus != 0)
         return PyWin_SetAPIError("ParseInstanceName", pdhStatus);
     return Py_BuildValue("NNk", PyWinObject_FromTCHAR(szName), PyWinObject_FromTCHAR(szParent), dwInstance);
@@ -728,8 +765,11 @@ static PyObject *PySetCounterScaleFactor(PyObject *self, PyObject *args)
         return NULL;
     if (!PyWinObject_AsHANDLE(obhCounter, &hCounter))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhSetCounterScaleFactor(hCounter, lFactor);
-    Py_END_ALLOW_THREADS if (pdhStatus != 0) return PyWin_SetAPIError("SetCounterScaleFactor", pdhStatus);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhSetCounterScaleFactor(hCounter, lFactor);
+    Py_END_ALLOW_THREADS
+    if (pdhStatus != 0)
+        return PyWin_SetAPIError("SetCounterScaleFactor", pdhStatus);
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -894,12 +934,15 @@ static PyObject *PyBrowseCounters(PyObject *self, PyObject *args, PyObject *kwar
     if (!PyWinObject_AsTCHAR(obDataSource, &myCfg.cfg.szDataSource, TRUE))
         goto cleanup;
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhBrowseCounters(&myCfg.cfg);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhBrowseCounters(&myCfg.cfg);
     Py_END_ALLOW_THREADS
 
-        if (pdhStatus != 0 && pdhStatus != PDH_DIALOG_CANCELLED) PyWin_SetAPIError("PdhBrowseCounters", pdhStatus);
-    else ret = myCfg.bReturnMultiple ? PyWinObject_FromMultipleString(myCfg.cfg.szReturnPathBuffer)
-                                     : PyWinObject_FromTCHAR(myCfg.cfg.szReturnPathBuffer);
+    if (pdhStatus != 0 && pdhStatus != PDH_DIALOG_CANCELLED)
+        PyWin_SetAPIError("PdhBrowseCounters", pdhStatus);
+    else
+        ret = myCfg.bReturnMultiple ? PyWinObject_FromMultipleString(myCfg.cfg.szReturnPathBuffer)
+                                    : PyWinObject_FromTCHAR(myCfg.cfg.szReturnPathBuffer);
 
 cleanup:
     // Note - myCfg does not own any references
@@ -924,8 +967,10 @@ static PyObject *PyConnectMachine(PyObject *self, PyObject *args)
     if (!PyWinObject_AsTCHAR(obPath, &path, TRUE))
         return NULL;
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhConnectMachine(path);
-    Py_END_ALLOW_THREADS PyWinObject_FreeTCHAR(path);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhConnectMachine(path);
+    Py_END_ALLOW_THREADS
+    PyWinObject_FreeTCHAR(path);
 
     PyObject *rc;
     if (pdhStatus != 0) {
@@ -955,10 +1000,12 @@ static PyObject *PyLookupPerfIndexByName(PyObject *self, PyObject *args)
         return NULL;
 
     DWORD dwIndex;
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhLookupPerfIndexByName(mname, iname, &dwIndex);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhLookupPerfIndexByName(mname, iname, &dwIndex);
     Py_END_ALLOW_THREADS
 
-        if (pdhStatus != 0) return PyWin_SetAPIError("LookupPerfIndexByName", pdhStatus);
+    if (pdhStatus != 0)
+        return PyWin_SetAPIError("LookupPerfIndexByName", pdhStatus);
     return PyLong_FromLong(dwIndex);
 }
 
@@ -998,9 +1045,10 @@ static PyObject *PyLookupPerfNameByIndex(PyObject *self, PyObject *args)
             PyErr_NoMemory();
             return NULL;
         }
-        Py_BEGIN_ALLOW_THREADS pdhStatus = PdhLookupPerfNameByIndex(mname, index, buffer, &buf_size);
-        Py_END_ALLOW_THREADS if (pdhStatus == ERROR_SUCCESS)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            pdhStatus = PdhLookupPerfNameByIndex(mname, index, buffer, &buf_size);
+        Py_END_ALLOW_THREADS
+        if (pdhStatus == ERROR_SUCCESS) {
             ret = PyWinObject_FromTCHAR(buffer);
             break;
         }

--- a/win32/src/win32pdhmodule.cpp
+++ b/win32/src/win32pdhmodule.cpp
@@ -83,21 +83,22 @@ static PyObject *PyEnumObjectItems(PyObject *self, PyObject *args)
 
     PDH_STATUS pdhStatus;
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhEnumObjectItems(DataSource,            // Perf log file
-                                                          Machine,               // local machine
-                                                          Object,                // object to enumerate
-                                                          szCounterListBuffer,   // pass in NULL buffers
-                                                          &dwCounterListSize,    // an 0 length to get
-                                                          szInstanceListBuffer,  // required size
-                                                          &dwInstanceListSize,   // of the buffers in chars
-                                                          detailLevel,           // counter detail level
-                                                          flags);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhEnumObjectItems(DataSource,            // Perf log file
+                                       Machine,               // local machine
+                                       Object,                // object to enumerate
+                                       szCounterListBuffer,   // pass in NULL buffers
+                                       &dwCounterListSize,    // an 0 length to get
+                                       szInstanceListBuffer,  // required size
+                                       &dwInstanceListSize,   // of the buffers in chars
+                                       detailLevel,           // counter detail level
+                                       flags);
     Py_END_ALLOW_THREADS
 
-        // it appears NT/2k will return 0, while XP will return
-        // PDH_MORE_DATA
-        if (pdhStatus != ERROR_SUCCESS && pdhStatus != PDH_MORE_DATA) return PyWin_SetAPIError(
-            "EnumObjectItems for buffer size", pdhStatus);
+    // it appears NT/2k will return 0, while XP will return
+    // PDH_MORE_DATA
+    if (pdhStatus != ERROR_SUCCESS && pdhStatus != PDH_MORE_DATA)
+        return PyWin_SetAPIError("EnumObjectItems for buffer size", pdhStatus);
 
     // Allocate the buffers and try the call again.
     if (dwCounterListSize) {
@@ -116,21 +117,24 @@ static PyObject *PyEnumObjectItems(PyObject *self, PyObject *args)
         }
     }
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhEnumObjectItems(DataSource,            // Perf log file
-                                                          Machine,               // local machine
-                                                          Object,                // object to enumerate
-                                                          szCounterListBuffer,   // pass in NULL buffers
-                                                          &dwCounterListSize,    // an 0 length to get
-                                                          szInstanceListBuffer,  // required size
-                                                          &dwInstanceListSize,   // of the buffers in chars
-                                                          detailLevel,           // counter detail level
-                                                          flags);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhEnumObjectItems(DataSource,            // Perf log file
+                                       Machine,               // local machine
+                                       Object,                // object to enumerate
+                                       szCounterListBuffer,   // pass in NULL buffers
+                                       &dwCounterListSize,    // an 0 length to get
+                                       szInstanceListBuffer,  // required size
+                                       &dwInstanceListSize,   // of the buffers in chars
+                                       detailLevel,           // counter detail level
+                                       flags);
     Py_END_ALLOW_THREADS
 
-        if (pdhStatus != ERROR_SUCCESS) PyWin_SetAPIError("EnumObjectItems for data", pdhStatus);
-    else ret =
-        Py_BuildValue("NN", szCounterListBuffer ? PyWinObject_FromMultipleString(szCounterListBuffer) : PyList_New(0),
-                      szInstanceListBuffer ? PyWinObject_FromMultipleString(szInstanceListBuffer) : PyList_New(0));
+    if (pdhStatus != ERROR_SUCCESS)
+        PyWin_SetAPIError("EnumObjectItems for data", pdhStatus);
+    else
+        ret = Py_BuildValue(
+            "NN", szCounterListBuffer ? PyWinObject_FromMultipleString(szCounterListBuffer) : PyList_New(0),
+            szInstanceListBuffer ? PyWinObject_FromMultipleString(szInstanceListBuffer) : PyList_New(0));
 
 cleanup:
     if (szInstanceListBuffer)
@@ -164,18 +168,19 @@ static PyObject *PyEnumObjects(PyObject *self, PyObject *args)
 
     PDH_STATUS pdhStatus;
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhEnumObjects(DataSource,          // perf log file
-                                                      Machine,             // local machine
-                                                      szObjectListBuffer,  // pass in NULL buffers
-                                                      &dwObjectListSize,   // an 0 length to get
-                                                      detailLevel,         // counter detail level
-                                                      refresh);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhEnumObjects(DataSource,          // perf log file
+                                   Machine,             // local machine
+                                   szObjectListBuffer,  // pass in NULL buffers
+                                   &dwObjectListSize,   // an 0 length to get
+                                   detailLevel,         // counter detail level
+                                   refresh);
     Py_END_ALLOW_THREADS
 
-        // it appears NT/2k will return 0, while XP will return
-        // PDH_MORE_DATA
-        if (pdhStatus != ERROR_SUCCESS && pdhStatus != PDH_MORE_DATA) return PyWin_SetAPIError(
-            "EnumObjects for buffer size", pdhStatus);
+    // it appears NT/2k will return 0, while XP will return
+    // PDH_MORE_DATA
+    if (pdhStatus != ERROR_SUCCESS && pdhStatus != PDH_MORE_DATA)
+        return PyWin_SetAPIError("EnumObjects for buffer size", pdhStatus);
 
     // Allocate the buffers and try the call again.
     if (dwObjectListSize) {
@@ -186,16 +191,19 @@ static PyObject *PyEnumObjects(PyObject *self, PyObject *args)
         }
     }
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhEnumObjects(DataSource,          // Perf log file
-                                                      Machine,             // local machine
-                                                      szObjectListBuffer,  // pass in NULL buffers
-                                                      &dwObjectListSize,   // an 0 length to get
-                                                      detailLevel,         // counter detail level
-                                                      0);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhEnumObjects(DataSource,          // Perf log file
+                                   Machine,             // local machine
+                                   szObjectListBuffer,  // pass in NULL buffers
+                                   &dwObjectListSize,   // an 0 length to get
+                                   detailLevel,         // counter detail level
+                                   0);
     Py_END_ALLOW_THREADS
 
-        if (pdhStatus != ERROR_SUCCESS) PyWin_SetAPIError("EnumObjects for data", pdhStatus);
-    else ret = szObjectListBuffer ? PyWinObject_FromMultipleString(szObjectListBuffer) : PyList_New(0);
+    if (pdhStatus != ERROR_SUCCESS)
+        PyWin_SetAPIError("EnumObjects for data", pdhStatus);
+    else
+        ret = szObjectListBuffer ? PyWinObject_FromMultipleString(szObjectListBuffer) : PyList_New(0);
 
     if (szObjectListBuffer)
         free(szObjectListBuffer);
@@ -226,9 +234,10 @@ static PyObject *PyAddCounter(PyObject *self, PyObject *args)
         return NULL;
     HCOUNTER hCounter;
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhAddCounter(hQuery, szPath, userData, &hCounter);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhAddCounter(hQuery, szPath, userData, &hCounter);
 
-    Py_END_ALLOW_THREADS;
+    Py_END_ALLOW_THREADS
     PyWinObject_FreeTCHAR(szPath);
     if (pdhStatus != ERROR_SUCCESS)
         return PyWin_SetAPIError("AddCounter", pdhStatus);
@@ -261,9 +270,10 @@ static PyObject *PyAddEnglishCounter(PyObject *self, PyObject *args)
         return NULL;
     HCOUNTER hCounter;
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhAddEnglishCounter(hQuery, szPath, userData, &hCounter);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhAddEnglishCounter(hQuery, szPath, userData, &hCounter);
 
-    Py_END_ALLOW_THREADS;
+    Py_END_ALLOW_THREADS
     PyWinObject_FreeTCHAR(szPath);
     if (pdhStatus != ERROR_SUCCESS)
         return PyWin_SetAPIError("AddEnglishCounter", pdhStatus);
@@ -283,10 +293,12 @@ static PyObject *PyRemoveCounter(PyObject *self, PyObject *args)
     if (!PyWinObject_AsHANDLE(obhandle, &handle))
         return NULL;
     // @comm See also <om win32pdh.AddCounter>
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhRemoveCounter(handle);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhRemoveCounter(handle);
     Py_END_ALLOW_THREADS
 
-        if (pdhStatus != ERROR_SUCCESS) return PyWin_SetAPIError("RemoveCounter", pdhStatus);
+    if (pdhStatus != ERROR_SUCCESS)
+        return PyWin_SetAPIError("RemoveCounter", pdhStatus);
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -311,10 +323,11 @@ static PyObject *PyOpenQuery(PyObject *self, PyObject *args)
     if (!PyWinObject_AsTCHAR(obDataSource, &DataSource, TRUE))
         return NULL;
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhOpenQuery(DataSource, userData, &hQuery);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhOpenQuery(DataSource, userData, &hQuery);
     Py_END_ALLOW_THREADS
 
-        PyWinObject_FreeTCHAR(DataSource);
+    PyWinObject_FreeTCHAR(DataSource);
     if (pdhStatus != ERROR_SUCCESS)
         return PyWin_SetAPIError("OpenQuery", pdhStatus);
     return PyWinLong_FromHANDLE(hQuery);
@@ -333,10 +346,12 @@ static PyObject *PyCloseQuery(PyObject *self, PyObject *args)
     if (!PyWinObject_AsHANDLE(obhandle, &handle))
         return NULL;
     // @comm See also <om win32pdh.OpenQuery>
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhCloseQuery(handle);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhCloseQuery(handle);
     Py_END_ALLOW_THREADS
 
-        if (pdhStatus != ERROR_SUCCESS) return PyWin_SetAPIError("CloseQuery", pdhStatus);
+    if (pdhStatus != ERROR_SUCCESS)
+        return PyWin_SetAPIError("CloseQuery", pdhStatus);
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -377,9 +392,13 @@ static PyObject *PyMakeCounterPath(PyObject *self, PyObject *args)
     }
 
     PDH_STATUS pdhStatus;
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhMakeCounterPath(&cpe, szResult, &bufSize, flags);
-    Py_END_ALLOW_THREADS if (pdhStatus != ERROR_SUCCESS) PyWin_SetAPIError("PdhMakeCounterPath", pdhStatus);
-    else ret = PyWinObject_FromTCHAR(szResult);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhMakeCounterPath(&cpe, szResult, &bufSize, flags);
+    Py_END_ALLOW_THREADS
+    if (pdhStatus != ERROR_SUCCESS)
+        PyWin_SetAPIError("PdhMakeCounterPath", pdhStatus);
+    else
+        ret = PyWinObject_FromTCHAR(szResult);
 
 done:
     if (szResult)
@@ -408,11 +427,12 @@ static PyObject *PyGetCounterInfo(PyObject *self, PyObject *args)
     // First call to get buffer size
     DWORD bufSize = 0;
     PDH_STATUS pdhStatus;
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhGetCounterInfo(handle, bExplainText, &bufSize, NULL);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhGetCounterInfo(handle, bExplainText, &bufSize, NULL);
     Py_END_ALLOW_THREADS
-        // as usual, pre-xp returns ERROR_SUCCESS, xp returns PDH_MORE_DATA
-        if (pdhStatus != ERROR_SUCCESS && pdhStatus != PDH_MORE_DATA) return PyWin_SetAPIError(
-            "GetCounterInfo for size", pdhStatus);
+    // as usual, pre-xp returns ERROR_SUCCESS, xp returns PDH_MORE_DATA
+    if (pdhStatus != ERROR_SUCCESS && pdhStatus != PDH_MORE_DATA)
+        return PyWin_SetAPIError("GetCounterInfo for size", pdhStatus);
 
     PPDH_COUNTER_INFO pInfo = (PPDH_COUNTER_INFO)malloc(bufSize);
     if (pInfo == NULL) {
@@ -421,8 +441,10 @@ static PyObject *PyGetCounterInfo(PyObject *self, PyObject *args)
     }
     pInfo->dwLength = bufSize;
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhGetCounterInfo(handle, bExplainText, &bufSize, pInfo);
-    Py_END_ALLOW_THREADS PyObject *rc;
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhGetCounterInfo(handle, bExplainText, &bufSize, pInfo);
+    Py_END_ALLOW_THREADS
+    PyObject *rc;
     if (pdhStatus != ERROR_SUCCESS)
         rc = PyWin_SetAPIError("GetCounterInfo for data", pdhStatus);
     else {
@@ -462,9 +484,11 @@ static PyObject *PyGetFormattedCounterValue(PyObject *self, PyObject *args)
     DWORD type;
     PDH_FMT_COUNTERVALUE result;
     PDH_STATUS pdhStatus;
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhGetFormattedCounterValue(handle, format, &type, &result);
-    Py_END_ALLOW_THREADS if (pdhStatus != ERROR_SUCCESS) return PyWin_SetAPIError("GetFormattedCounterValue",
-                                                                                  pdhStatus);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhGetFormattedCounterValue(handle, format, &type, &result);
+    Py_END_ALLOW_THREADS
+    if (pdhStatus != ERROR_SUCCESS)
+        return PyWin_SetAPIError("GetFormattedCounterValue", pdhStatus);
     if (!CheckCounterStatusOK(result.CStatus))
         return NULL;
 
@@ -503,9 +527,9 @@ static PyObject *PyPdhGetFormattedCounterArray(PyObject *self, PyObject *args)
     DWORD count;
     PDH_FMT_COUNTERVALUE_ITEM *pItems = NULL;
 
-    Py_BEGIN_ALLOW_THREADS;
-    pdhStatus = PdhGetFormattedCounterArray(handle, format, &size, &count, pItems);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhGetFormattedCounterArray(handle, format, &size, &count, pItems);
+    Py_END_ALLOW_THREADS
     if (pdhStatus != PDH_MORE_DATA) {
         return PyWin_SetAPIError("PdhGetFormattedCounterArray", pdhStatus);
     }
@@ -515,9 +539,9 @@ static PyObject *PyPdhGetFormattedCounterArray(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    Py_BEGIN_ALLOW_THREADS;
-    pdhStatus = PdhGetFormattedCounterArray(handle, format, &size, &count, pItems);
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhGetFormattedCounterArray(handle, format, &size, &count, pItems);
+    Py_END_ALLOW_THREADS
     if (pdhStatus != ERROR_SUCCESS) {
         free(pItems);
         return PyWin_SetAPIError("PdhGetFormattedCounterArray", pdhStatus);
@@ -567,10 +591,12 @@ static PyObject *PyCollectQueryData(PyObject *self, PyObject *args)
     if (!PyWinObject_AsHANDLE(obhQuery, &hQuery))
         return NULL;
     PDH_STATUS pdhStatus;
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhCollectQueryData(hQuery);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhCollectQueryData(hQuery);
     Py_END_ALLOW_THREADS
 
-        if (pdhStatus != ERROR_SUCCESS) return PyWin_SetAPIError("CollectQueryData", pdhStatus);
+    if (pdhStatus != ERROR_SUCCESS)
+        return PyWin_SetAPIError("CollectQueryData", pdhStatus);
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -622,10 +648,12 @@ static PyObject *PyExpandCounterPath(PyObject *self, PyObject *args)
 
     DWORD dwSize = 0;
     PDH_STATUS pdhStatus;
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhExpandCounterPath(path, NULL, &dwSize);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhExpandCounterPath(path, NULL, &dwSize);
     Py_END_ALLOW_THREADS
 
-        if (dwSize == 0) return PyWin_SetAPIError("ExpandCounterPath for size", pdhStatus);
+    if (dwSize == 0)
+        return PyWin_SetAPIError("ExpandCounterPath for size", pdhStatus);
     dwSize++;
     TCHAR *buf = (TCHAR *)malloc(dwSize * sizeof(TCHAR));
     if (buf == NULL) {
@@ -633,8 +661,10 @@ static PyObject *PyExpandCounterPath(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhExpandCounterPath(path, buf, &dwSize);
-    Py_END_ALLOW_THREADS PyObject *rc;
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhExpandCounterPath(path, buf, &dwSize);
+    Py_END_ALLOW_THREADS
+    PyObject *rc;
     if (pdhStatus != ERROR_SUCCESS)
         rc = PyWin_SetAPIError("ExpandCounterPath for data", pdhStatus);
     else
@@ -665,8 +695,11 @@ static PyObject *PyParseCounterPath(PyObject *self, PyObject *args)
     DWORD size = 0;
     PDH_STATUS pdhStatus;
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhParseCounterPath(path, NULL, &size, flags);
-    Py_END_ALLOW_THREADS if (size == 0) return PyWin_SetAPIError("ParseCounterPath for size", pdhStatus);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhParseCounterPath(path, NULL, &size, flags);
+    Py_END_ALLOW_THREADS
+    if (size == 0)
+        return PyWin_SetAPIError("ParseCounterPath for size", pdhStatus);
     void *pBuf = malloc(size);
     if (pBuf == NULL) {
         PyErr_SetString(PyExc_MemoryError, "allocating buffer for PDH_COUNTER_PATH_ELEMENTS(+strings)");
@@ -674,10 +707,11 @@ static PyObject *PyParseCounterPath(PyObject *self, PyObject *args)
     }
 
     PDH_COUNTER_PATH_ELEMENTS *pCPE = (PDH_COUNTER_PATH_ELEMENTS *)pBuf;
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhParseCounterPath(path, pCPE, &size, flags);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhParseCounterPath(path, pCPE, &size, flags);
     Py_END_ALLOW_THREADS
 
-        PyObject *rc;
+    PyObject *rc;
     if (pdhStatus != 0) {
         rc = PyWin_SetAPIError("ParseCounterPath", pdhStatus);
     }
@@ -706,9 +740,10 @@ static PyObject *PyParseInstanceName(PyObject *self, PyObject *args)
     TCHAR szName[_MAX_PATH], szParent[_MAX_PATH];
     DWORD nameSize = _MAX_PATH, parentSize = _MAX_PATH;
     DWORD dwInstance;
-    Py_BEGIN_ALLOW_THREADS pdhStatus =
-        PdhParseInstanceName(iname, szName, &nameSize, szParent, &parentSize, &dwInstance);
-    Py_END_ALLOW_THREADS PyWinObject_FreeTCHAR(iname);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhParseInstanceName(iname, szName, &nameSize, szParent, &parentSize, &dwInstance);
+    Py_END_ALLOW_THREADS
+    PyWinObject_FreeTCHAR(iname);
     if (pdhStatus != 0)
         return PyWin_SetAPIError("ParseInstanceName", pdhStatus);
     return Py_BuildValue("NNk", PyWinObject_FromTCHAR(szName), PyWinObject_FromTCHAR(szParent), dwInstance);
@@ -728,8 +763,11 @@ static PyObject *PySetCounterScaleFactor(PyObject *self, PyObject *args)
         return NULL;
     if (!PyWinObject_AsHANDLE(obhCounter, &hCounter))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhSetCounterScaleFactor(hCounter, lFactor);
-    Py_END_ALLOW_THREADS if (pdhStatus != 0) return PyWin_SetAPIError("SetCounterScaleFactor", pdhStatus);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhSetCounterScaleFactor(hCounter, lFactor);
+    Py_END_ALLOW_THREADS
+    if (pdhStatus != 0)
+        return PyWin_SetAPIError("SetCounterScaleFactor", pdhStatus);
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -894,12 +932,15 @@ static PyObject *PyBrowseCounters(PyObject *self, PyObject *args, PyObject *kwar
     if (!PyWinObject_AsTCHAR(obDataSource, &myCfg.cfg.szDataSource, TRUE))
         goto cleanup;
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhBrowseCounters(&myCfg.cfg);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhBrowseCounters(&myCfg.cfg);
     Py_END_ALLOW_THREADS
 
-        if (pdhStatus != 0 && pdhStatus != PDH_DIALOG_CANCELLED) PyWin_SetAPIError("PdhBrowseCounters", pdhStatus);
-    else ret = myCfg.bReturnMultiple ? PyWinObject_FromMultipleString(myCfg.cfg.szReturnPathBuffer)
-                                     : PyWinObject_FromTCHAR(myCfg.cfg.szReturnPathBuffer);
+    if (pdhStatus != 0 && pdhStatus != PDH_DIALOG_CANCELLED)
+        PyWin_SetAPIError("PdhBrowseCounters", pdhStatus);
+    else
+        ret = myCfg.bReturnMultiple ? PyWinObject_FromMultipleString(myCfg.cfg.szReturnPathBuffer)
+                                    : PyWinObject_FromTCHAR(myCfg.cfg.szReturnPathBuffer);
 
 cleanup:
     // Note - myCfg does not own any references
@@ -924,8 +965,10 @@ static PyObject *PyConnectMachine(PyObject *self, PyObject *args)
     if (!PyWinObject_AsTCHAR(obPath, &path, TRUE))
         return NULL;
 
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhConnectMachine(path);
-    Py_END_ALLOW_THREADS PyWinObject_FreeTCHAR(path);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhConnectMachine(path);
+    Py_END_ALLOW_THREADS
+    PyWinObject_FreeTCHAR(path);
 
     PyObject *rc;
     if (pdhStatus != 0) {
@@ -955,10 +998,12 @@ static PyObject *PyLookupPerfIndexByName(PyObject *self, PyObject *args)
         return NULL;
 
     DWORD dwIndex;
-    Py_BEGIN_ALLOW_THREADS pdhStatus = PdhLookupPerfIndexByName(mname, iname, &dwIndex);
+    Py_BEGIN_ALLOW_THREADS
+        pdhStatus = PdhLookupPerfIndexByName(mname, iname, &dwIndex);
     Py_END_ALLOW_THREADS
 
-        if (pdhStatus != 0) return PyWin_SetAPIError("LookupPerfIndexByName", pdhStatus);
+    if (pdhStatus != 0)
+        return PyWin_SetAPIError("LookupPerfIndexByName", pdhStatus);
     return PyLong_FromLong(dwIndex);
 }
 
@@ -998,9 +1043,10 @@ static PyObject *PyLookupPerfNameByIndex(PyObject *self, PyObject *args)
             PyErr_NoMemory();
             return NULL;
         }
-        Py_BEGIN_ALLOW_THREADS pdhStatus = PdhLookupPerfNameByIndex(mname, index, buffer, &buf_size);
-        Py_END_ALLOW_THREADS if (pdhStatus == ERROR_SUCCESS)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            pdhStatus = PdhLookupPerfNameByIndex(mname, index, buffer, &buf_size);
+        Py_END_ALLOW_THREADS
+        if (pdhStatus == ERROR_SUCCESS) {
             ret = PyWinObject_FromTCHAR(buffer);
             break;
         }

--- a/win32/src/win32print/win32print.cpp
+++ b/win32/src/win32print/win32print.cpp
@@ -95,9 +95,13 @@ static PyObject *PyOpenPrinter(PyObject *self, PyObject *args)
     }
     if (PyWinObject_AsTCHAR(obprinter, &printer, TRUE)) {
         BOOL bsuccess;
-        Py_BEGIN_ALLOW_THREADS bsuccess = OpenPrinter(printer, &handle, pprinter_defaults);
-        Py_END_ALLOW_THREADS if (bsuccess) ret = PyWinObject_FromPrinterHANDLE(handle);
-        else PyWin_SetAPIError("OpenPrinter");
+        Py_BEGIN_ALLOW_THREADS
+            bsuccess = OpenPrinter(printer, &handle, pprinter_defaults);
+        Py_END_ALLOW_THREADS
+        if (bsuccess)
+            ret = PyWinObject_FromPrinterHANDLE(handle);
+        else
+            PyWin_SetAPIError("OpenPrinter");
     }
     PyWinObject_FreePRINTER_DEFAULTS(&printer_defaults);
     PyWinObject_FreeTCHAR(printer);
@@ -753,9 +757,13 @@ static PyObject *PyStartDocPrinter(PyObject *self, PyObject *args)
         info.pDocName = pDocName;
         info.pOutputFile = pOutputFile;
         info.pDatatype = pDatatype;
-        Py_BEGIN_ALLOW_THREADS JobID = StartDocPrinter(hprinter, level, (LPBYTE)&info);
-        Py_END_ALLOW_THREADS if (0 == JobID) PyWin_SetAPIError("StartDocPrinter");
-        else ret = PyLong_FromUnsignedLong(JobID);
+        Py_BEGIN_ALLOW_THREADS
+            JobID = StartDocPrinter(hprinter, level, (LPBYTE)&info);
+        Py_END_ALLOW_THREADS
+        if (0 == JobID)
+            PyWin_SetAPIError("StartDocPrinter");
+        else
+            ret = PyLong_FromUnsignedLong(JobID);
     }
     PyWinObject_FreeTCHAR(pDocName);
     PyWinObject_FreeTCHAR(pOutputFile);

--- a/win32/src/win32profilemodule.cpp
+++ b/win32/src/win32profilemodule.cpp
@@ -135,13 +135,13 @@ PyObject *PyLoadUserProfile(PyObject *self, PyObject *args, PyObject *kwargs)
         return NULL;
     BOOL ok;
     DWORD err;
-    Py_BEGIN_ALLOW_THREADS;
-    ok = LoadUserProfile(hToken, &profileinfo);
-    // Capture error before Py_END_ALLOW_THREADS reacquires the GIL,
-    // which may call Win32 functions that overwrite GetLastError().
-    if (!ok)
-        err = GetLastError();
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        ok = LoadUserProfile(hToken, &profileinfo);
+        // Capture error before Py_END_ALLOW_THREADS reacquires the GIL,
+        // which may call Win32 functions that overwrite GetLastError().
+        if (!ok)
+            err = GetLastError();
+    Py_END_ALLOW_THREADS
     if (!ok)
         PyWin_SetAPIError("LoadUserProfile", err);
     else
@@ -170,11 +170,11 @@ PyObject *PyUnloadUserProfile(PyObject *self, PyObject *args, PyObject *kwargs)
         return NULL;
     BOOL ok;
     DWORD err;
-    Py_BEGIN_ALLOW_THREADS;
-    ok = UnloadUserProfile(hToken, hProfile);
-    if (!ok)
-        err = GetLastError();
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        ok = UnloadUserProfile(hToken, hProfile);
+        if (!ok)
+            err = GetLastError();
+    Py_END_ALLOW_THREADS
     if (!ok) {
         PyWin_SetAPIError("UnloadUserProfile", err);
         return NULL;
@@ -353,11 +353,11 @@ PyObject *PyCreateEnvironmentBlock(PyObject *self, PyObject *args, PyObject *kwa
         return NULL;
     BOOL ok;
     DWORD err;
-    Py_BEGIN_ALLOW_THREADS;
-    ok = CreateEnvironmentBlock(&env, hToken, inherit);
-    if (!ok)
-        err = GetLastError();
-    Py_END_ALLOW_THREADS;
+    Py_BEGIN_ALLOW_THREADS
+        ok = CreateEnvironmentBlock(&env, hToken, inherit);
+        if (!ok)
+            err = GetLastError();
+    Py_END_ALLOW_THREADS
     if (!ok)
         PyWin_SetAPIError("CreateEnvironmentBlock", err);
     else {

--- a/win32/src/win32rasmodule.cpp
+++ b/win32/src/win32rasmodule.cpp
@@ -565,9 +565,10 @@ static PyObject *PyRasDial(PyObject *self, PyObject *args)
     }
 
     // @pyseeapi RasDial
-    Py_BEGIN_ALLOW_THREADS rc = RasDial(dialExts, fileName, &dialParams, notType, pNotification, &hRas);
-    Py_END_ALLOW_THREADS if (hRas == 0 && notType == 1)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        rc = RasDial(dialExts, fileName, &dialParams, notType, pNotification, &hRas);
+    Py_END_ALLOW_THREADS
+    if (hRas == 0 && notType == 1) {
         PyDict_DelItem(obHandleMap, Py_None);
         PyErr_Clear();
     }
@@ -600,8 +601,11 @@ static PyObject *PyRasEditPhonebookEntry(PyObject *self, PyObject *args)
         return NULL;
     if (hwnd != 0 && !IsWindow(hwnd))
         return ReturnError("The first parameter must be a valid window handle", "<EditPhonebookEntry param parsing>");
-    Py_BEGIN_ALLOW_THREADS rc = RasEditPhonebookEntry(hwnd, fileName, entryName);
-    Py_END_ALLOW_THREADS if (rc) return ReturnRasError("RasEditPhonebookEntry", rc);  // @pyseeapi RasEditPhonebookEntry
+    Py_BEGIN_ALLOW_THREADS
+        rc = RasEditPhonebookEntry(hwnd, fileName, entryName);
+    Py_END_ALLOW_THREADS
+    if (rc)
+        return ReturnRasError("RasEditPhonebookEntry", rc);  // @pyseeapi RasEditPhonebookEntry
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -618,9 +622,11 @@ static PyObject *PyRasEnumConnections(PyObject *self, PyObject *args)
     RASCONN *pCon = NULL;
     // make dummy call to determine buffer size.
     tc.dwSize = bufSize = sizeof(RASCONN);
-    Py_BEGIN_ALLOW_THREADS rc = RasEnumConnections(&tc, &bufSize, &noConns);
-    Py_END_ALLOW_THREADS if (rc != 0 && rc != ERROR_BUFFER_TOO_SMALL) return ReturnRasError("RasEnumConnections(NULL)",
-                                                                                            rc);
+    Py_BEGIN_ALLOW_THREADS
+        rc = RasEnumConnections(&tc, &bufSize, &noConns);
+    Py_END_ALLOW_THREADS
+    if (rc != 0 && rc != ERROR_BUFFER_TOO_SMALL)
+        return ReturnRasError("RasEnumConnections(NULL)", rc);
     if (rc == ERROR_BUFFER_TOO_SMALL) {
         if (bufSize == 0)
             return ReturnRasError("RasEnumConnections buffer size is invalid");
@@ -631,8 +637,11 @@ static PyObject *PyRasEnumConnections(PyObject *self, PyObject *args)
         }
         // @pyseeapi RasEnumConnections
         pCon[0].dwSize = sizeof(RASCONN);
-        Py_BEGIN_ALLOW_THREADS rc = RasEnumConnections(pCon, &bufSize, &noConns);
-        Py_END_ALLOW_THREADS if (rc != 0) return ReturnRasError("RasEnumConnections", rc);
+        Py_BEGIN_ALLOW_THREADS
+            rc = RasEnumConnections(pCon, &bufSize, &noConns);
+        Py_END_ALLOW_THREADS
+        if (rc != 0)
+            return ReturnRasError("RasEnumConnections", rc);
     }
     else {
         pCon = &tc;
@@ -686,8 +695,11 @@ static PyObject *PyRasEnumEntries(PyObject *self, PyObject *args)
         }
         // ??? Not sure if this is needed, only sets the size of first struct in buf ???
         buf->dwSize = sizeof(RASENTRYNAME);
-        Py_BEGIN_ALLOW_THREADS rc = RasEnumEntries(reserved, bookName, buf, &bufSize, &noConns);
-        Py_END_ALLOW_THREADS if (rc == 0) break;
+        Py_BEGIN_ALLOW_THREADS
+            rc = RasEnumEntries(reserved, bookName, buf, &bufSize, &noConns);
+        Py_END_ALLOW_THREADS
+        if (rc == 0)
+            break;
         if (rc == ERROR_BUFFER_TOO_SMALL)
             continue;
         ReturnRasError("RasEnumEntries", rc);
@@ -871,9 +883,13 @@ static PyObject *PyRasGetEapUserIdentity(PyObject *self, PyObject *args)
         // @pyseeapi RasGetEapUserIdentity
         DWORD rc;
         RASEAPUSERIDENTITY *identity;
-        Py_BEGIN_ALLOW_THREADS rc = RasGetEapUserIdentity(phoneBook, entry, flags, hwnd, &identity);
-        Py_END_ALLOW_THREADS if (rc != 0) ReturnRasError("RasGetEapUserIdentity", rc);
-        else ret = PyWinObject_FromRASEAPUSERIDENTITY(identity);
+        Py_BEGIN_ALLOW_THREADS
+            rc = RasGetEapUserIdentity(phoneBook, entry, flags, hwnd, &identity);
+        Py_END_ALLOW_THREADS
+        if (rc != 0)
+            ReturnRasError("RasGetEapUserIdentity", rc);
+        else
+            ret = PyWinObject_FromRASEAPUSERIDENTITY(identity);
     }
     PyWinObject_FreeTCHAR(phoneBook);
     PyWinObject_FreeTCHAR(entry);

--- a/win32/src/win32security_ds.cpp
+++ b/win32/src/win32security_ds.cpp
@@ -52,9 +52,13 @@ extern PyObject *PyDsBind(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "|OO:DsBind", obdc, obdomain))
         return NULL;
     if (PyWinObject_AsWCHAR(obdc, &dc, TRUE) && PyWinObject_AsWCHAR(obdomain, &domain, TRUE)) {
-        Py_BEGIN_ALLOW_THREADS err = DsBind(dc, domain, &dshandle);
-        Py_END_ALLOW_THREADS if (err == NO_ERROR) ret = new PyDS_HANDLE(dshandle);
-        else PyWin_SetAPIError("DsBind", err);
+        Py_BEGIN_ALLOW_THREADS
+            err = DsBind(dc, domain, &dshandle);
+        Py_END_ALLOW_THREADS
+        if (err == NO_ERROR)
+            ret = new PyDS_HANDLE(dshandle);
+        else
+            PyWin_SetAPIError("DsBind", err);
     }
     PyWinObject_FreeWCHAR(dc);
     PyWinObject_FreeWCHAR(domain);
@@ -70,9 +74,10 @@ extern PyObject *PyDsUnBind(PyObject *self, PyObject *args)
         return NULL;
     if (!PyWinObject_AsHANDLE(obhandle, &dshandle))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS err = DsUnBind(&dshandle);
-    Py_END_ALLOW_THREADS if (err == NO_ERROR)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = DsUnBind(&dshandle);
+    Py_END_ALLOW_THREADS
+    if (err == NO_ERROR) {
         Py_INCREF(Py_None);
         return Py_None;
     }
@@ -141,11 +146,13 @@ extern PyObject *PyDsGetSpn(PyObject *self, PyObject *args)
         }
     }
 
-    Py_BEGIN_ALLOW_THREADS err = DsGetSpn(ServiceType, ServiceClass, ServiceName, InstancePort, cInstanceNames,
-                                          (LPCWSTR *)InstanceNames, InstancePorts, &cSpns, &Spns);
-    Py_END_ALLOW_THREADS if (err != STATUS_SUCCESS) PyWin_SetAPIError("DsGetSpn", err);
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = DsGetSpn(ServiceType, ServiceClass, ServiceName, InstancePort, cInstanceNames, (LPCWSTR *)InstanceNames,
+                       InstancePorts, &cSpns, &Spns);
+    Py_END_ALLOW_THREADS
+    if (err != STATUS_SUCCESS)
+        PyWin_SetAPIError("DsGetSpn", err);
+    else {
         ret = PyTuple_New(cSpns);
         if (ret != NULL) {
             for (tuple_index = 0; tuple_index < cSpns; tuple_index++) {
@@ -188,10 +195,12 @@ extern PyObject *PyDsWriteAccountSpn(PyObject *self, PyObject *args)
         goto done;
     if (!PyWinObject_AsWCHARArray(obspns, &spns, &spn_cnt))
         goto done;
-    Py_BEGIN_ALLOW_THREADS err = DsWriteAccountSpn(dshandle, Operation, acct, spn_cnt, (LPCWSTR *)spns);
-    Py_END_ALLOW_THREADS if (err != STATUS_SUCCESS) PyWin_SetAPIError("DsWriteAccountSpn", err);
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = DsWriteAccountSpn(dshandle, Operation, acct, spn_cnt, (LPCWSTR *)spns);
+    Py_END_ALLOW_THREADS
+    if (err != STATUS_SUCCESS)
+        PyWin_SetAPIError("DsWriteAccountSpn", err);
+    else {
         Py_INCREF(Py_None);
         ret = Py_None;
     }
@@ -228,9 +237,10 @@ PyObject *PyDsGetDcName(PyObject *self, PyObject *args, PyObject *kw)
             goto done;
         pGUID = &guidBuf;
     }
-    Py_BEGIN_ALLOW_THREADS err = DsGetDcName(szServer, szDomain, pGUID, szSiteName, flags, &pdci);
-    Py_END_ALLOW_THREADS if (err)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = DsGetDcName(szServer, szDomain, pGUID, szSiteName, flags, &pdci);
+    Py_END_ALLOW_THREADS
+    if (err) {
         PyWin_SetAPIError("DsGetDcName", err);
         goto done;
     }
@@ -269,9 +279,13 @@ PyObject *PyDsCrackNames(PyObject *self, PyObject *args)
         return NULL;
     if (!PyWinObject_AsWCHARArray(obNames, &names, &cnames))
         goto done;
-    Py_BEGIN_ALLOW_THREADS err = DsCrackNames(dshandle, flags, formatOffered, formatDesired, cnames, names, &dsresult);
-    Py_END_ALLOW_THREADS if (err != STATUS_SUCCESS || !dsresult) PyWin_SetAPIError("DsCrackNames", err);
-    else ret = PyObject_FromDS_NAME_RESULT(dsresult);
+    Py_BEGIN_ALLOW_THREADS
+        err = DsCrackNames(dshandle, flags, formatOffered, formatDesired, cnames, names, &dsresult);
+    Py_END_ALLOW_THREADS
+    if (err != STATUS_SUCCESS || !dsresult)
+        PyWin_SetAPIError("DsCrackNames", err);
+    else
+        ret = PyObject_FromDS_NAME_RESULT(dsresult);
 done:
     PyWinObject_FreeWCHARArray(names, cnames);
     if (dsresult)
@@ -295,9 +309,13 @@ PyObject *PyDsListInfoForServer(PyObject *self, PyObject *args)
         return NULL;
     if (!PyWinObject_AsWCHAR(obName, &name))
         goto done;
-    Py_BEGIN_ALLOW_THREADS err = DsListInfoForServer(dshandle, name, &dsresult);
-    Py_END_ALLOW_THREADS if (err != STATUS_SUCCESS || !dsresult) PyWin_SetAPIError("DsListInfoForServer", err);
-    else ret = PyObject_FromDS_NAME_RESULT(dsresult);
+    Py_BEGIN_ALLOW_THREADS
+        err = DsListInfoForServer(dshandle, name, &dsresult);
+    Py_END_ALLOW_THREADS
+    if (err != STATUS_SUCCESS || !dsresult)
+        PyWin_SetAPIError("DsListInfoForServer", err);
+    else
+        ret = PyObject_FromDS_NAME_RESULT(dsresult);
 done:
     PyWinObject_FreeWCHAR(name);
     if (dsresult)
@@ -323,9 +341,13 @@ PyObject *PyDsListServersForDomainInSite(PyObject *self, PyObject *args)
         goto done;
     if (!PyWinObject_AsWCHAR(obSite, &site))
         goto done;
-    Py_BEGIN_ALLOW_THREADS err = DsListServersForDomainInSite(dshandle, name, site, &dsresult);
-    Py_END_ALLOW_THREADS if (err != STATUS_SUCCESS || !dsresult) PyWin_SetAPIError("DsListServersForDomainInSite", err);
-    else ret = PyObject_FromDS_NAME_RESULT(dsresult);
+    Py_BEGIN_ALLOW_THREADS
+        err = DsListServersForDomainInSite(dshandle, name, site, &dsresult);
+    Py_END_ALLOW_THREADS
+    if (err != STATUS_SUCCESS || !dsresult)
+        PyWin_SetAPIError("DsListServersForDomainInSite", err);
+    else
+        ret = PyObject_FromDS_NAME_RESULT(dsresult);
 done:
     PyWinObject_FreeWCHAR(name);
     PyWinObject_FreeWCHAR(site);
@@ -350,9 +372,13 @@ PyObject *PyDsListServersInSite(PyObject *self, PyObject *args)
         return NULL;
     if (!PyWinObject_AsWCHAR(obName, &name))
         goto done;
-    Py_BEGIN_ALLOW_THREADS err = DsListServersInSite(dshandle, name, &dsresult);
-    Py_END_ALLOW_THREADS if (err != STATUS_SUCCESS || !dsresult) PyWin_SetAPIError("DsListServersInSite", err);
-    else ret = PyObject_FromDS_NAME_RESULT(dsresult);
+    Py_BEGIN_ALLOW_THREADS
+        err = DsListServersInSite(dshandle, name, &dsresult);
+    Py_END_ALLOW_THREADS
+    if (err != STATUS_SUCCESS || !dsresult)
+        PyWin_SetAPIError("DsListServersInSite", err);
+    else
+        ret = PyObject_FromDS_NAME_RESULT(dsresult);
 done:
     PyWinObject_FreeWCHAR(name);
     if (dsresult)
@@ -371,9 +397,13 @@ PyObject *PyDsListSites(PyObject *self, PyObject *args)
         return NULL;
     if (!PyWinObject_AsHANDLE(obhandle, &dshandle))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS err = DsListSites(dshandle, &dsresult);
-    Py_END_ALLOW_THREADS if (err != STATUS_SUCCESS || !dsresult) PyWin_SetAPIError("DsListSites", err);
-    else ret = PyObject_FromDS_NAME_RESULT(dsresult);
+    Py_BEGIN_ALLOW_THREADS
+        err = DsListSites(dshandle, &dsresult);
+    Py_END_ALLOW_THREADS
+    if (err != STATUS_SUCCESS || !dsresult)
+        PyWin_SetAPIError("DsListSites", err);
+    else
+        ret = PyObject_FromDS_NAME_RESULT(dsresult);
     if (dsresult)
         DsFreeNameResult(dsresult);
     return ret;
@@ -390,9 +420,13 @@ PyObject *PyDsListRoles(PyObject *self, PyObject *args)
         return NULL;
     if (!PyWinObject_AsHANDLE(obhandle, &dshandle))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS err = DsListRoles(dshandle, &dsresult);
-    Py_END_ALLOW_THREADS if (err != STATUS_SUCCESS || !dsresult) PyWin_SetAPIError("DsListRoles", err);
-    else ret = PyObject_FromDS_NAME_RESULT(dsresult);
+    Py_BEGIN_ALLOW_THREADS
+        err = DsListRoles(dshandle, &dsresult);
+    Py_END_ALLOW_THREADS
+    if (err != STATUS_SUCCESS || !dsresult)
+        PyWin_SetAPIError("DsListRoles", err);
+    else
+        ret = PyObject_FromDS_NAME_RESULT(dsresult);
     if (dsresult)
         DsFreeNameResult(dsresult);
     return ret;
@@ -414,9 +448,13 @@ PyObject *PyDsListDomainsInSite(PyObject *self, PyObject *args)
         return NULL;
     if (!PyWinObject_AsWCHAR(obName, &name))
         goto done;
-    Py_BEGIN_ALLOW_THREADS err = DsListDomainsInSite(dshandle, name, &dsresult);
-    Py_END_ALLOW_THREADS if (err != STATUS_SUCCESS || !dsresult) PyWin_SetAPIError("DsListDomainsInSite", err);
-    else ret = PyObject_FromDS_NAME_RESULT(dsresult);
+    Py_BEGIN_ALLOW_THREADS
+        err = DsListDomainsInSite(dshandle, name, &dsresult);
+    Py_END_ALLOW_THREADS
+    if (err != STATUS_SUCCESS || !dsresult)
+        PyWin_SetAPIError("DsListDomainsInSite", err);
+    else
+        ret = PyObject_FromDS_NAME_RESULT(dsresult);
 done:
     PyWinObject_FreeWCHAR(name);
     if (dsresult)

--- a/win32/src/win32security_sspi.cpp
+++ b/win32/src/win32security_sspi.cpp
@@ -629,9 +629,10 @@ PyObject *PyCtxtHandle::MakeSignature(PyObject *self, PyObject *args)
     if (!PyWinObject_AsSecBufferDesc(obdesc, &psecbufferdesc, FALSE))
         return NULL;
     PCtxtHandle pctxt = ((PyCtxtHandle *)self)->GetCtxtHandle();
-    Py_BEGIN_ALLOW_THREADS err = (*psecurityfunctiontable->MakeSignature)(pctxt, fqop, psecbufferdesc, seq_no);
-    Py_END_ALLOW_THREADS if (err < 0)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = (*psecurityfunctiontable->MakeSignature)(pctxt, fqop, psecbufferdesc, seq_no);
+    Py_END_ALLOW_THREADS
+    if (err < 0) {
         PyWin_SetAPIError("MakeSignature", err);
         return NULL;
     }
@@ -691,9 +692,10 @@ PyObject *PyCtxtHandle::EncryptMessage(PyObject *self, PyObject *args)
     if (!PyWinObject_AsSecBufferDesc(obdesc, &psecbufferdesc, FALSE))
         return NULL;
     PCtxtHandle pctxt = ((PyCtxtHandle *)self)->GetCtxtHandle();
-    Py_BEGIN_ALLOW_THREADS err = (*psecurityfunctiontable->EncryptMessage)(pctxt, fqop, psecbufferdesc, seq_no);
-    Py_END_ALLOW_THREADS if (err < 0)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = (*psecurityfunctiontable->EncryptMessage)(pctxt, fqop, psecbufferdesc, seq_no);
+    Py_END_ALLOW_THREADS
+    if (err < 0) {
         PyWin_SetAPIError("EncryptMessage", err);
         return NULL;
     }
@@ -724,7 +726,8 @@ PyObject *PyCtxtHandle::DecryptMessage(PyObject *self, PyObject *args)
     if (!PyWinObject_AsSecBufferDesc(obdesc, &psecbufferdesc, FALSE))
         return NULL;
     PCtxtHandle pctxt = ((PyCtxtHandle *)self)->GetCtxtHandle();
-    Py_BEGIN_ALLOW_THREADS err = (*psecurityfunctiontable->DecryptMessage)(pctxt, psecbufferdesc, seq_no, &fqop);
+    Py_BEGIN_ALLOW_THREADS
+        err = (*psecurityfunctiontable->DecryptMessage)(pctxt, psecbufferdesc, seq_no, &fqop);
     Py_END_ALLOW_THREADS((PySecBufferDesc *)obdesc)->modify_in_place();
     if (err == SEC_E_OK)
         return Py_BuildValue("l", fqop);
@@ -779,9 +782,10 @@ PyObject *PyCtxtHandle::CompleteAuthToken(PyObject *self, PyObject *args)
     if (!PyWinObject_AsSecBufferDesc(obsecbufferdesc, &psecbufferdesc, FALSE))
         return NULL;
     pctxt = ((PyCtxtHandle *)self)->GetCtxtHandle();
-    Py_BEGIN_ALLOW_THREADS err = (*psecurityfunctiontable->CompleteAuthToken)(pctxt, psecbufferdesc);
-    Py_END_ALLOW_THREADS if (err == SEC_E_OK)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = (*psecurityfunctiontable->CompleteAuthToken)(pctxt, psecbufferdesc);
+    Py_END_ALLOW_THREADS
+    if (err == SEC_E_OK) {
         Py_INCREF(Py_None);
         return Py_None;
     }
@@ -803,9 +807,10 @@ PyObject *PyCtxtHandle::QueryContextAttributes(PyObject *self, PyObject *args)
         return NULL;
 
     pctxt = ((PyCtxtHandle *)self)->GetCtxtHandle();
-    Py_BEGIN_ALLOW_THREADS err = (*psecurityfunctiontable->QueryContextAttributesW)(pctxt, attr, &buf);
-    Py_END_ALLOW_THREADS if (err != SEC_E_OK)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = (*psecurityfunctiontable->QueryContextAttributesW)(pctxt, attr, &buf);
+    Py_END_ALLOW_THREADS
+    if (err != SEC_E_OK) {
         PyWin_SetAPIError("QueryContextAttributes", err);
         return NULL;
     }
@@ -955,8 +960,11 @@ PyObject *PyCtxtHandle::QuerySecurityContextToken(PyObject *self, PyObject *args
     if (!PyArg_ParseTuple(args, ":QuerySecurityContextToken"))
         return NULL;
     pctxt = ((PyCtxtHandle *)self)->GetCtxtHandle();
-    Py_BEGIN_ALLOW_THREADS err = (*psecurityfunctiontable->QuerySecurityContextToken)(pctxt, &htoken);
-    Py_END_ALLOW_THREADS if (err == SEC_E_OK) return PyWinObject_FromHANDLE(htoken);
+    Py_BEGIN_ALLOW_THREADS
+        err = (*psecurityfunctiontable->QuerySecurityContextToken)(pctxt, &htoken);
+    Py_END_ALLOW_THREADS
+    if (err == SEC_E_OK)
+        return PyWinObject_FromHANDLE(htoken);
     PyWin_SetAPIError("QuerySecurityContextToken", err);
     return NULL;
 }
@@ -969,9 +977,10 @@ PyObject *PyCtxtHandle::ImpersonateSecurityContext(PyObject *self, PyObject *arg
     if (!PyArg_ParseTuple(args, ":ImpersonateSecurityContext"))
         return NULL;
     pctxt = ((PyCtxtHandle *)self)->GetCtxtHandle();
-    Py_BEGIN_ALLOW_THREADS err = (*psecurityfunctiontable->ImpersonateSecurityContext)(pctxt);
-    Py_END_ALLOW_THREADS if (err == SEC_E_OK)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = (*psecurityfunctiontable->ImpersonateSecurityContext)(pctxt);
+    Py_END_ALLOW_THREADS
+    if (err == SEC_E_OK) {
         Py_INCREF(Py_None);
         return Py_None;
     }
@@ -988,9 +997,10 @@ PyObject *PyCtxtHandle::RevertSecurityContext(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, ":RevertSecurityContext"))
         return NULL;
     pctxt = ((PyCtxtHandle *)self)->GetCtxtHandle();
-    Py_BEGIN_ALLOW_THREADS err = (*psecurityfunctiontable->RevertSecurityContext)(pctxt);
-    Py_END_ALLOW_THREADS if (err == SEC_E_OK)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = (*psecurityfunctiontable->RevertSecurityContext)(pctxt);
+    Py_END_ALLOW_THREADS
+    if (err == SEC_E_OK) {
         Py_INCREF(Py_None);
         return Py_None;
     }
@@ -1160,9 +1170,10 @@ PyObject *PyCredHandle::QueryCredentialsAttributes(PyObject *self, PyObject *arg
     PCredHandle pcredhandle = This->GetCredHandle();
     if (!PyArg_ParseTuple(args, "l:QueryCredentialsAttributes", &attr))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS err = (*psecurityfunctiontable->QueryCredentialsAttributesW)(pcredhandle, attr, &buf);
-    Py_END_ALLOW_THREADS if (err != SEC_E_OK)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        err = (*psecurityfunctiontable->QueryCredentialsAttributesW)(pcredhandle, attr, &buf);
+    Py_END_ALLOW_THREADS
+    if (err != SEC_E_OK) {
         PyWin_SetAPIError("QueryCredentialsAttributes", err);
         return NULL;
     }

--- a/win32/src/win32service.i
+++ b/win32/src/win32service.i
@@ -825,7 +825,6 @@ static PyObject *MyEnumServicesStatus(PyObject *self, PyObject *args)
 	char *buffer = NULL;
 
 	Py_BEGIN_ALLOW_THREADS
-
 	EnumServicesStatus(hscm, serviceType, serviceState, services, sizeof(tmp), &bytesNeeded,
 		&servicesReturned, &resumeHandle);
 
@@ -986,7 +985,6 @@ static PyObject *MyEnumDependentServices(PyObject *self, PyObject *args)
 	char *buffer = NULL;
 
 	Py_BEGIN_ALLOW_THREADS
-
 	result = EnumDependentServices(hsc, serviceState, services, sizeof(tmp), &bytesNeeded,
 		&servicesReturned);
 
@@ -1052,7 +1050,6 @@ static PyObject *MyQueryServiceConfig(PyObject *self, PyObject *args)
 	char *buffer = NULL;
 
 	Py_BEGIN_ALLOW_THREADS
-
 	result = QueryServiceConfig(hsc, config, sizeof(tmp), &bytesNeeded);
 
 	if (GetLastError() == ERROR_INSUFFICIENT_BUFFER)

--- a/win32/src/win32trace.cpp
+++ b/win32/src/win32trace.cpp
@@ -236,16 +236,17 @@ BOOL DoOpenMap(HANDLE *pHandle, VOID **ppPtr)
         ReturnError("DoOpenMap, already open");
         return FALSE;
     }
-    Py_BEGIN_ALLOW_THREADS *pHandle =
-        CreateFileMapping((HANDLE)-1, &sa, PAGE_READWRITE, 0, BUFFER_SIZE, FixupObjectName(MAP_OBJECT_NAME));
-    Py_END_ALLOW_THREADS if (*pHandle == NULL)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        *pHandle = CreateFileMapping((HANDLE)-1, &sa, PAGE_READWRITE, 0, BUFFER_SIZE, FixupObjectName(MAP_OBJECT_NAME));
+    Py_END_ALLOW_THREADS
+    if (*pHandle == NULL) {
         PyWin_SetAPIError("CreateFileMapping");
         return FALSE;
     }
-    Py_BEGIN_ALLOW_THREADS *ppPtr = MapViewOfFile(*pHandle, FILE_MAP_ALL_ACCESS, 0, 0, BUFFER_SIZE);
-    Py_END_ALLOW_THREADS if (*ppPtr == NULL)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        *ppPtr = MapViewOfFile(*pHandle, FILE_MAP_ALL_ACCESS, 0, 0, BUFFER_SIZE);
+    Py_END_ALLOW_THREADS
+    if (*ppPtr == NULL) {
         // not allowed to access the interpreter inside
         // Py_BEGIN_ALLOW_THREADS block
         PyWin_SetAPIError("MapViewOfFile");
@@ -311,38 +312,40 @@ BOOL PyTraceObject::WriteData(const char *data, unsigned len)
         return FALSE;
     }
     BOOL rc = TRUE;
-    Py_BEGIN_ALLOW_THREADS const char *data_this = data;
-    while (len) {
-        unsigned len_this = min(len, BUFFER_SIZE / 2);
-        BOOL ok = GetMyMutex();
-        if (ok) {
-            // must use types with identical size on win32 and win64
-            unsigned long *pLen = (unsigned long *)pMapBaseWrite;
-            unsigned long sizeLeft = (BUFFER_SIZE - sizeof(unsigned long)) - *pLen;
-            // If less than double we need left, wait for it to empty, or .1 sec.
-            if (sizeLeft < len_this * 2) {
-                ReleaseMyMutex();
+    Py_BEGIN_ALLOW_THREADS
+        const char *data_this = data;
+        while (len) {
+            unsigned len_this = min(len, BUFFER_SIZE / 2);
+            BOOL ok = GetMyMutex();
+            if (ok) {
+                // must use types with identical size on win32 and win64
+                unsigned long *pLen = (unsigned long *)pMapBaseWrite;
+                unsigned long sizeLeft = (BUFFER_SIZE - sizeof(unsigned long)) - *pLen;
+                // If less than double we need left, wait for it to empty, or .1 sec.
+                if (sizeLeft < len_this * 2) {
+                    ReleaseMyMutex();
+                    SetEvent(hEvent);
+                    WaitForSingleObject(hEventEmpty, 100);
+                    ok = GetMyMutex();
+                }
+            }
+            if (ok) {
+                unsigned long *pLen = (unsigned long *)pMapBaseWrite;
+                char *buffer = (char *)(((unsigned long *)pMapBaseWrite) + 1);
+
+                unsigned long sizeLeft = (BUFFER_SIZE - sizeof(unsigned long)) - *pLen;
+                if (sizeLeft < len_this)
+                    *pLen = 0;
+                memcpy(buffer + (*pLen), data_this, len_this);
+                *pLen += len_this;
+                rc = ReleaseMyMutex();
                 SetEvent(hEvent);
-                WaitForSingleObject(hEventEmpty, 100);
-                ok = GetMyMutex();
+                data_this += len_this;
+                len -= len_this;
             }
         }
-        if (ok) {
-            unsigned long *pLen = (unsigned long *)pMapBaseWrite;
-            char *buffer = (char *)(((unsigned long *)pMapBaseWrite) + 1);
-
-            unsigned long sizeLeft = (BUFFER_SIZE - sizeof(unsigned long)) - *pLen;
-            if (sizeLeft < len_this)
-                *pLen = 0;
-            memcpy(buffer + (*pLen), data_this, len_this);
-            *pLen += len_this;
-            rc = ReleaseMyMutex();
-            SetEvent(hEvent);
-            data_this += len_this;
-            len -= len_this;
-        }
-    }
-    Py_END_ALLOW_THREADS return rc;
+    Py_END_ALLOW_THREADS
+    return rc;
 }
 
 BOOL PyTraceObject::ReadData(char **ppResult, int *retSize, int waitMilliseconds)
@@ -353,32 +356,36 @@ BOOL PyTraceObject::ReadData(char **ppResult, int *retSize, int waitMilliseconds
     }
     if (waitMilliseconds != 0) {
         DWORD rc;
-        Py_BEGIN_ALLOW_THREADS rc = WaitForSingleObject(hEvent, waitMilliseconds);
-        Py_END_ALLOW_THREADS if (rc == WAIT_FAILED)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            rc = WaitForSingleObject(hEvent, waitMilliseconds);
+        Py_END_ALLOW_THREADS
+        if (rc == WAIT_FAILED) {
             PyWin_SetAPIError("WaitForSingleObject", GetLastError());
             return FALSE;
         }
     }
     BOOL rc = FALSE;
     char *result = NULL;
-    Py_BEGIN_ALLOW_THREADS if (GetMyMutex())
-    {
-        // must use sizes that are identical on win32 and win64
-        unsigned long *pLen = (unsigned long *)pMapBaseRead;
-        char *buffer = (char *)(((unsigned long *)pMapBaseRead) + 1);
+    Py_BEGIN_ALLOW_THREADS
+        if (GetMyMutex()) {
+            // must use sizes that are identical on win32 and win64
+            unsigned long *pLen = (unsigned long *)pMapBaseRead;
+            char *buffer = (char *)(((unsigned long *)pMapBaseRead) + 1);
 
-        result = (char *)malloc(*pLen + 1);
-        if (result) {
-            memcpy(result, buffer, *pLen);
-            result[*pLen] = '\0';
-            *retSize = *pLen;
-            *pLen = 0;
+            result = (char *)malloc(*pLen + 1);
+            if (result) {
+                memcpy(result, buffer, *pLen);
+                result[*pLen] = '\0';
+                *retSize = *pLen;
+                *pLen = 0;
+            }
+            rc = ReleaseMyMutex();
+            SetEvent(hEventEmpty);  // in case anyone wants to optimize waiting.
         }
-        rc = ReleaseMyMutex();
-        SetEvent(hEventEmpty);  // in case anyone wants to optimize waiting.
+    Py_END_ALLOW_THREADS
+    if (!rc && result) {
+        free(result);
     }
-    Py_END_ALLOW_THREADS if (!rc && result) { free(result); }
     if (rc && result == NULL) {
         PyErr_SetString(PyExc_MemoryError, "Allocating buffer for trace data");
         rc = FALSE;
@@ -444,8 +451,11 @@ static PyObject *win32trace_TermRead(PyObject *self, PyObject *args)
         // can't terminate something that you haven't started
         return ReturnError("The module has not been setup for reading");
     }
-    Py_BEGIN_ALLOW_THREADS ok = static_cast<PyTraceObject *>(traceObject)->CloseReadMap();
-    Py_END_ALLOW_THREADS if (!ok) return NULL;
+    Py_BEGIN_ALLOW_THREADS
+        ok = static_cast<PyTraceObject *>(traceObject)->CloseReadMap();
+    Py_END_ALLOW_THREADS
+    if (!ok)
+        return NULL;
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -458,8 +468,11 @@ static PyObject *win32trace_TermWrite(PyObject *self, PyObject *args)
         // can't terminate something that you haven't started
         return ReturnError("The module has not been setup for writing");
     }
-    Py_BEGIN_ALLOW_THREADS ok = static_cast<PyTraceObject *>(traceObject)->CloseWriteMap();
-    Py_END_ALLOW_THREADS if (!ok) return NULL;
+    Py_BEGIN_ALLOW_THREADS
+        ok = static_cast<PyTraceObject *>(traceObject)->CloseWriteMap();
+    Py_END_ALLOW_THREADS
+    if (!ok)
+        return NULL;
     Py_INCREF(Py_None);
     return Py_None;
 }

--- a/win32/src/win32transactionmodule.cpp
+++ b/win32/src/win32transactionmodule.cpp
@@ -35,9 +35,10 @@ static PyObject *PyCreateTransaction(PyObject *self, PyObject *args, PyObject *k
     }
     if (!PyWinObject_AsWCHAR(obdescription, &description, TRUE))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS hret =
-        CreateTransaction(psa, uow, createoptions, isolationlevel, isolationflags, timeout, description);
-    Py_END_ALLOW_THREADS PyWinObject_FreeWCHAR(description);
+    Py_BEGIN_ALLOW_THREADS
+        hret = CreateTransaction(psa, uow, createoptions, isolationlevel, isolationflags, timeout, description);
+    Py_END_ALLOW_THREADS
+    PyWinObject_FreeWCHAR(description);
     if (hret == INVALID_HANDLE_VALUE)
         return PyWin_SetAPIError("CreateTransaction");
     return PyWinObject_FromHANDLE(hret);
@@ -56,8 +57,11 @@ static PyObject *PyRollbackTransaction(PyObject *self, PyObject *args, PyObject 
         return NULL;
     if (!PyWinObject_AsHANDLE(obtrans, &htrans))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS ret = RollbackTransaction(htrans);
-    Py_END_ALLOW_THREADS if (!ret) return PyWin_SetAPIError("RollbackTransaction");
+    Py_BEGIN_ALLOW_THREADS
+        ret = RollbackTransaction(htrans);
+    Py_END_ALLOW_THREADS
+    if (!ret)
+        return PyWin_SetAPIError("RollbackTransaction");
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -75,8 +79,11 @@ static PyObject *PyRollbackTransactionAsync(PyObject *self, PyObject *args, PyOb
         return NULL;
     if (!PyWinObject_AsHANDLE(obtrans, &htrans))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS ret = RollbackTransactionAsync(htrans);
-    Py_END_ALLOW_THREADS if (!ret) return PyWin_SetAPIError("RollbackTransactionAsync");
+    Py_BEGIN_ALLOW_THREADS
+        ret = RollbackTransactionAsync(htrans);
+    Py_END_ALLOW_THREADS
+    if (!ret)
+        return PyWin_SetAPIError("RollbackTransactionAsync");
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -94,8 +101,11 @@ static PyObject *PyCommitTransaction(PyObject *self, PyObject *args, PyObject *k
         return NULL;
     if (!PyWinObject_AsHANDLE(obtrans, &htrans))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS ret = CommitTransaction(htrans);
-    Py_END_ALLOW_THREADS if (!ret) return PyWin_SetAPIError("CommitTransaction");
+    Py_BEGIN_ALLOW_THREADS
+        ret = CommitTransaction(htrans);
+    Py_END_ALLOW_THREADS
+    if (!ret)
+        return PyWin_SetAPIError("CommitTransaction");
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -113,8 +123,11 @@ static PyObject *PyCommitTransactionAsync(PyObject *self, PyObject *args, PyObje
         return NULL;
     if (!PyWinObject_AsHANDLE(obtrans, &htrans))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS ret = CommitTransactionAsync(htrans);
-    Py_END_ALLOW_THREADS if (!ret) return PyWin_SetAPIError("CommitTransactionAsync");
+    Py_BEGIN_ALLOW_THREADS
+        ret = CommitTransactionAsync(htrans);
+    Py_END_ALLOW_THREADS
+    if (!ret)
+        return PyWin_SetAPIError("CommitTransactionAsync");
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -132,8 +145,11 @@ static PyObject *PyGetTransactionId(PyObject *self, PyObject *args, PyObject *kw
         return NULL;
     if (!PyWinObject_AsHANDLE(obtrans, &htrans))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS ret = GetTransactionId(htrans, &guid);
-    Py_END_ALLOW_THREADS if (!ret) return PyWin_SetAPIError("GetTransactionId");
+    Py_BEGIN_ALLOW_THREADS
+        ret = GetTransactionId(htrans, &guid);
+    Py_END_ALLOW_THREADS
+    if (!ret)
+        return PyWin_SetAPIError("GetTransactionId");
     return PyWinObject_FromIID(guid);
 }
 
@@ -151,8 +167,11 @@ static PyObject *PyOpenTransaction(PyObject *self, PyObject *args, PyObject *kwa
         return NULL;
     if (!PyWinObject_AsIID(obguid, &guid))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS htrans = OpenTransaction(access, &guid);
-    Py_END_ALLOW_THREADS if (htrans == INVALID_HANDLE_VALUE) return PyWin_SetAPIError("OpenTransaction");
+    Py_BEGIN_ALLOW_THREADS
+        htrans = OpenTransaction(access, &guid);
+    Py_END_ALLOW_THREADS
+    if (htrans == INVALID_HANDLE_VALUE)
+        return PyWin_SetAPIError("OpenTransaction");
     return PyWinObject_FromHANDLE(htrans);
 }
 

--- a/win32/src/win32wnet/win32wnet.cpp
+++ b/win32/src/win32wnet/win32wnet.cpp
@@ -149,10 +149,12 @@ static PyObject *PyWNetAddConnection2(PyObject *self, PyObject *args, PyObject *
     if (!PyWinObject_AsTCHAR(obPassword, &Password, TRUE) || !PyWinObject_AsTCHAR(obUsername, &Username, TRUE))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS ErrorNo = WNetAddConnection2(pNetResource, Password, Username, flags);
-    Py_END_ALLOW_THREADS if (ErrorNo != NO_ERROR) ReturnNetError("WNetAddConnection2", ErrorNo);
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        ErrorNo = WNetAddConnection2(pNetResource, Password, Username, flags);
+    Py_END_ALLOW_THREADS
+    if (ErrorNo != NO_ERROR)
+        ReturnNetError("WNetAddConnection2", ErrorNo);
+    else {
         Py_INCREF(Py_None);
         ret = Py_None;
     }
@@ -197,10 +199,12 @@ static PyObject *PyWNetAddConnection3(PyObject *self, PyObject *args, PyObject *
     if (!PyWinObject_AsTCHAR(obPassword, &Password, TRUE) || !PyWinObject_AsTCHAR(obUsername, &Username, TRUE))
         goto done;
 
-    Py_BEGIN_ALLOW_THREADS ErrorNo = WNetAddConnection3(hwnd, pNetResource, Password, Username, flags);
-    Py_END_ALLOW_THREADS if (ErrorNo != NO_ERROR) ReturnNetError("WNetAddConnection3", ErrorNo);
-    else
-    {
+    Py_BEGIN_ALLOW_THREADS
+        ErrorNo = WNetAddConnection3(hwnd, pNetResource, Password, Username, flags);
+    Py_END_ALLOW_THREADS
+    if (ErrorNo != NO_ERROR)
+        ReturnNetError("WNetAddConnection3", ErrorNo);
+    else {
         Py_INCREF(Py_None);
         ret = Py_None;
     }
@@ -225,8 +229,10 @@ static PyObject *PyWNetCancelConnection2(PyObject *self, PyObject *args)
         return NULL;
     if (!PyWinObject_AsTCHAR(obName, &lpName, FALSE))
         return NULL;
-    Py_BEGIN_ALLOW_THREADS ErrorNo = WNetCancelConnection2(lpName, dwFlags, (BOOL)bForce);
-    Py_END_ALLOW_THREADS PyWinObject_FreeTCHAR(lpName);
+    Py_BEGIN_ALLOW_THREADS
+        ErrorNo = WNetCancelConnection2(lpName, dwFlags, (BOOL)bForce);
+    Py_END_ALLOW_THREADS
+    PyWinObject_FreeTCHAR(lpName);
     if (ErrorNo != NO_ERROR) {
         return ReturnNetError("WNetCancelConnection2", ErrorNo);
     }
@@ -254,10 +260,12 @@ static PyObject *PyWNetOpenEnum(PyObject *self, PyObject *args)
     if (!PyWinObject_AsNETRESOURCE(ob_nr, &p_nr, TRUE))
         return NULL;
 
-    Py_BEGIN_ALLOW_THREADS Errno = WNetOpenEnum(dwScope, dwType, dwUsage, p_nr, &hEnum);
+    Py_BEGIN_ALLOW_THREADS
+        Errno = WNetOpenEnum(dwScope, dwType, dwUsage, p_nr, &hEnum);
     Py_END_ALLOW_THREADS
 
-        if (Errno != NO_ERROR) return (ReturnNetError("WNetOpenEnum", Errno));
+    if (Errno != NO_ERROR)
+        return (ReturnNetError("WNetOpenEnum", Errno));
 
     return (PyNETENUMObject_FromHANDLE(hEnum));
     // @rdesc PyHANDLE representing the Win32 HANDLE for the open resource.
@@ -339,10 +347,11 @@ static PyObject *PyWNetEnumResource(PyObject *self, PyObject *args)
             }
         }
 
-        Py_BEGIN_ALLOW_THREADS Errno = WNetEnumResource(hEnum, &dwCount, lpBuffer, &dwBuffsize);  // do the enumeration
+        Py_BEGIN_ALLOW_THREADS
+            Errno = WNetEnumResource(hEnum, &dwCount, lpBuffer, &dwBuffsize);  // do the enumeration
         Py_END_ALLOW_THREADS
 
-            if (Errno == NO_ERROR)  // if no error, then build the list
+        if (Errno == NO_ERROR)  // if no error, then build the list
         {
             NETRESOURCE *p_nr =
                 (NETRESOURCE *)lpBuffer;  // Enum Resource returns a buffer of successive NETRESOURCE structs
@@ -400,7 +409,8 @@ static PyObject *PyWNetGetUser(PyObject *self, PyObject *args)
         goto done;
     // get the buffer size
     {
-        Py_BEGIN_ALLOW_THREADS errcode = WNetGetUser(szConnection, NULL, &length);
+        Py_BEGIN_ALLOW_THREADS
+            errcode = WNetGetUser(szConnection, NULL, &length);
         Py_END_ALLOW_THREADS
     }
     if (length == 0) {
@@ -412,9 +422,10 @@ static PyObject *PyWNetGetUser(PyObject *self, PyObject *args)
         PyErr_Format(PyExc_MemoryError, "Unable to allocate %d bytes", sizeof(TCHAR) * length);
         goto done;
     }
-    Py_BEGIN_ALLOW_THREADS errcode = WNetGetUser(szConnection, buf, &length);
-    Py_END_ALLOW_THREADS if (0 != errcode)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        errcode = WNetGetUser(szConnection, buf, &length);
+    Py_END_ALLOW_THREADS
+    if (0 != errcode) {
         ReturnNetError("WNetGetUser", errcode);
         goto done;
     }
@@ -457,8 +468,9 @@ static PyObject *PyWNetGetUniversalName(PyObject *self, PyObject *args)
 
     // First get the buffer size.
     {
-        Py_BEGIN_ALLOW_THREADS char temp_buf[] = "";  // doesn't appear to like NULL!!
-        errcode = WNetGetUniversalName(szLocalPath, level, &temp_buf, &length);
+        Py_BEGIN_ALLOW_THREADS
+            char temp_buf[] = "";  // doesn't appear to like NULL!!
+            errcode = WNetGetUniversalName(szLocalPath, level, &temp_buf, &length);
         Py_END_ALLOW_THREADS
     }
     if (errcode != ERROR_MORE_DATA || length == 0) {
@@ -527,14 +539,14 @@ PyObject *PyWNetGetResourceInformation(PyObject *self, PyObject *args)
         nrout = (NETRESOURCE *)malloc(bufsize);
         if (nrout == NULL)
             return PyErr_Format(PyExc_MemoryError, "Unable to allocate %d bytes", bufsize);
-        Py_BEGIN_ALLOW_THREADS err = WNetGetResourceInformation(nrin, nrout, &bufsize, &szFilePath);
-        Py_END_ALLOW_THREADS if (err == NO_ERROR)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            err = WNetGetResourceInformation(nrin, nrout, &bufsize, &szFilePath);
+        Py_END_ALLOW_THREADS
+        if (err == NO_ERROR) {
             ret = Py_BuildValue("NN", PyWinObject_FromNETRESOURCE(nrout), PyWinObject_FromTCHAR(szFilePath));
             break;
         }
-        else if (err != ERROR_MORE_DATA)
-        {
+        else if (err != ERROR_MORE_DATA) {
             ReturnNetError("WNetGetResourceInformation", err);
             break;
         }
@@ -553,8 +565,10 @@ PyObject *PyWinMethod_Netbios(PyObject *self, PyObject *args)
         return NULL;
     PyNCB *pyncb = (PyNCB *)obncb;
     UCHAR rc;
-    Py_BEGIN_ALLOW_THREADS rc = Netbios(&pyncb->m_ncb);
-    Py_END_ALLOW_THREADS return PyLong_FromLong((long)rc);
+    Py_BEGIN_ALLOW_THREADS
+        rc = Netbios(&pyncb->m_ncb);
+    Py_END_ALLOW_THREADS
+    return PyLong_FromLong((long)rc);
 }
 
 // @pymethod buffer|win32wnet|NCBBuffer|Creates an NCB buffer of the relevant size.
@@ -578,10 +592,12 @@ PyObject *PyWNetGetLastError(PyObject *self, PyObject *args)
         return NULL;
     DWORD err, extendederr;
     TCHAR errstr[1024], provider[256];
-    Py_BEGIN_ALLOW_THREADS err = WNetGetLastError(&extendederr, errstr, sizeof(errstr) / sizeof(TCHAR), provider,
-                                                  sizeof(provider) / sizeof(TCHAR));
-    Py_END_ALLOW_THREADS if (err == NO_ERROR) return Py_BuildValue("kNN", extendederr, PyWinObject_FromTCHAR(errstr),
-                                                                   PyWinObject_FromTCHAR(provider));
+    Py_BEGIN_ALLOW_THREADS
+        err = WNetGetLastError(&extendederr, errstr, sizeof(errstr) / sizeof(TCHAR), provider,
+                               sizeof(provider) / sizeof(TCHAR));
+    Py_END_ALLOW_THREADS
+    if (err == NO_ERROR)
+        return Py_BuildValue("kNN", extendederr, PyWinObject_FromTCHAR(errstr), PyWinObject_FromTCHAR(provider));
     return ReturnNetError("WNetGetLastError", err);
 }
 
@@ -608,14 +624,14 @@ PyObject *PyWNetGetResourceParent(PyObject *self, PyObject *args)
         parentnr = (NETRESOURCE *)malloc(bufsize);
         if (parentnr == NULL)
             return PyErr_Format(PyExc_MemoryError, "Unable to allocate %d bytes", bufsize);
-        Py_BEGIN_ALLOW_THREADS err = WNetGetResourceParent(nr, parentnr, &bufsize);
-        Py_END_ALLOW_THREADS if (err == NO_ERROR)
-        {
+        Py_BEGIN_ALLOW_THREADS
+            err = WNetGetResourceParent(nr, parentnr, &bufsize);
+        Py_END_ALLOW_THREADS
+        if (err == NO_ERROR) {
             ret = PyWinObject_FromNETRESOURCE(parentnr);
             break;
         }
-        else if (err != ERROR_MORE_DATA)
-        {
+        else if (err != ERROR_MORE_DATA) {
             ReturnNetError("WNetGetResourceParent", err);
             break;
         }
@@ -646,7 +662,8 @@ static PyObject *PyWNetGetConnection(PyObject *self, PyObject *args)
         goto done;
     // get the buffer size
     {
-        Py_BEGIN_ALLOW_THREADS errcode = WNetGetConnection(szConnection, NULL, &length);
+        Py_BEGIN_ALLOW_THREADS
+            errcode = WNetGetConnection(szConnection, NULL, &length);
         Py_END_ALLOW_THREADS
     }
     if (length == 0) {
@@ -658,9 +675,10 @@ static PyObject *PyWNetGetConnection(PyObject *self, PyObject *args)
         PyErr_Format(PyExc_MemoryError, "Unable to allocate %d bytes", sizeof(TCHAR) * length);
         goto done;
     }
-    Py_BEGIN_ALLOW_THREADS errcode = WNetGetConnection(szConnection, buf, &length);
-    Py_END_ALLOW_THREADS if (0 != errcode)
-    {
+    Py_BEGIN_ALLOW_THREADS
+        errcode = WNetGetConnection(szConnection, buf, &length);
+    Py_END_ALLOW_THREADS
+    if (0 != errcode) {
         ReturnNetError("WNetGetConnection", errcode);
         goto done;
     }


### PR DESCRIPTION
Do not squash merge, to preserve the commit hash in .git-blame-ignore-revs

The first commit is applied formatting using the second commit's configs, and is 100% automated by just running clang-format.

Alternatively there's also `Macros` https://clang.llvm.org/docs/ClangFormatStyleOptions.html#macros which gets clang-format to try and expand specific macros, but that makes the formatter non-portable (I ran this PR on my Linux machine, and `Macros` makes clang-format crash because I don't have `llvm-symbolizer` on my PATH)

---

I prefer doing this over adding `;` everywhere because then clang-format will also correctly increase indentation inside the macro block. Adding visual clarity that it is, indeed, a block.

`Py_*_ALLOW_THREADS` is standard to Python, so I don't feel like this is "special-casing" the formatter configs to pywin32.

`PY_INTERFACE_PRECALL`/`PY_INTERFACE_POSTCALL`, `GUI_BGN_SAVE`/`GUI_END_SAVE` and `PyW32_BEGIN_ALLOW_THREADS`/`PyW32_END_ALLOW_THREADS` (which are all the same thing), differ in that they're not block-scoped.