### PR TITLE
Remove leftover `__long__` dunder definition from Python 2

### DIFF
--- a/win32/src/PyHANDLE.cpp
+++ b/win32/src/PyHANDLE.cpp
@@ -129,9 +129,8 @@ static PyNumberMethods PyHANDLE_NumberMethods = {
     PyHANDLE::binaryFailureFunc, /* nb_xor */
     PyHANDLE::binaryFailureFunc, /* nb_or */
     PyHANDLE::intFunc,           /* nb_int */
-    PyHANDLE::longFunc,          /* nb_long */
+    Py_None,                     /* nb_reserved, used to be nb_long */
     PyHANDLE::unaryFailureFunc,  /* nb_float */
-                                 // These removed in 3.0
 };
 // @pymeth __int__|Used when an integer representation of the handle object is required.
 
@@ -266,10 +265,6 @@ PyObject *PyHANDLE::richcompare(PyObject *other, int op)
 // @pymethod |PyHANDLE|__int__|Used when the handle as an integer is required.
 // @comm To get the underling win32 handle from a PyHANDLE object, use int(handleObject)
 PyObject *PyHANDLE::intFunc(PyObject *ob) { return PyWinLong_FromHANDLE(((PyHANDLE *)ob)->m_handle); }
-
-// @pymethod |PyHANDLE|__long__|Used when the handle as an integer is required.
-// @comm To get the underling win32 handle from a PyHANDLE object, use long(handleObject)
-PyObject *PyHANDLE::longFunc(PyObject *ob) { return PyWinLong_FromHANDLE(((PyHANDLE *)ob)->m_handle); }
 
 // @pymethod |PyHANDLE|__print__|Used when the HANDLE object is printed.
 int PyHANDLE::printFunc(PyObject *ob, FILE *fp, int flags) { return ((PyHANDLE *)ob)->print(fp, flags); }

--- a/win32/src/PyWinObjects.h
+++ b/win32/src/PyWinObjects.h
@@ -103,7 +103,6 @@ class PYWINTYPES_EXPORT PyHANDLE : public PyObject {
 
     static PyObject *strFunc(PyObject *ob);
     static PyObject *intFunc(PyObject *ob);
-    static PyObject *longFunc(PyObject *ob);
     static PyObject *unaryFailureFunc(PyObject *ob);
     static PyObject *binaryFailureFunc(PyObject *ob1, PyObject *ob2);
     static PyObject *ternaryFailureFunc(PyObject *ob1, PyObject *ob2, PyObject *ob3);


### PR DESCRIPTION
Remove leftover `__long__` dunder definition from Python 2

This would currently fails under more restrictive compilers (since the signature technically doesn't match)



See note under https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods