### PR TITLE
Fix 2 more character encodings in source file comments

### DIFF
--- a/win32/Lib/win32timezone.py
+++ b/win32/Lib/win32timezone.py
@@ -686,7 +686,7 @@ class TimeZoneInfo(datetime.tzinfo):
         """
         # https://docs.python.org/3/library/datetime.html#datetime.tzinfo.tzname
         # > [...] returning `None` is appropriate if the class wishes to say
-        # > that `time` objects don’t participate in the `tzinfo` protocols.
+        # > that `time` objects don't participate in the `tzinfo` protocols.
         if dt is None:
             return None
 

--- a/win32/src/PyOVERLAPPED.cpp
+++ b/win32/src/PyOVERLAPPED.cpp
@@ -110,7 +110,7 @@ PYWINTYPES_EXPORT PyTypeObject PyOVERLAPPEDType = {
     {"Offset", T_ULONG,
      OFF(m_overlapped.Offset)},  // @prop integer|Offset|Specifies a file position at which to start the transfer. The
                                  // file position is a byte offset from the start of the file. The calling process sets
-                                 // this member before calling the ReadFile or WriteFile function. This member is
+                                 // this member before calling the ReadFile or WriteFile function. This member is
                                  // ignored when reading from or writing to named pipes and communications devices.
     {"OffsetHigh", T_ULONG, OFF(m_overlapped.OffsetHigh)},  // @prop integer|OffsetHigh|Specifies the high word of the
                                                             // byte offset at which to start the transfer.
@@ -123,7 +123,7 @@ PYWINTYPES_EXPORT PyTypeObject PyOVERLAPPEDType = {
     {"hEvent", T_OBJECT, OFF(obDummy)},  // @prop <o PyHANDLE>|hEvent|Identifies an event set to the signaled state when
                                          // the transfer has been completed. The calling process sets this member before
                                          // calling the <om win32file.ReadFile>, <om win32file.WriteFile>, <om
-                                         // win32pipe.ConnectNamedPipe>, or <om win32pipe.TransactNamedPipe> function.
+                                         // win32pipe.ConnectNamedPipe>, or <om win32pipe.TransactNamedPipe> function.
     {"Internal", T_OBJECT,
      OFF(obDummy)},  // @prop integer|Internal|Reserved for operating system use. (pointer-sized value)
     {"InternalHigh", T_OBJECT,

--- a/win32/src/PyWAVEFORMATEX.cpp
+++ b/win32/src/PyWAVEFORMATEX.cpp
@@ -112,7 +112,7 @@ PYWINTYPES_EXPORT PyTypeObject PyWAVEFORMATEXType = {
                                                        // nBlockAlign should be equal to the product of nChannels and
                                                        // wBitsPerSample divided by 8 (bits per byte). For non-PCM
                                                        // formats, this member must be computed according to the
-                                                       // manufacturer’s specification of the format tag.
+                                                       // manufacturer's specification of the format tag.
     {"wBitsPerSample", T_SHORT, OFF(m_wfx.wBitsPerSample), 0,
      "Bits per sample for the wFormatTag format type. If wFormatTag is WAVE_FORMAT_PCM, then wBitsPerSample should be "
      "equal to 8 or 16."},  // @prop integer|wBitsPerSample|Bits per sample for the wFormatTag format type. If


### PR DESCRIPTION
Noticed a few PRs (mine included), where these accidentally resulted in � and had to be reverted.

Fixing it here so it's not a problem anymore.