### PR TITLE
`not` is a reserved C++ keyword

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -279,7 +279,7 @@ class WinExt_win32com_mapi(WinExt_win32com):
         # Additional utility functions are only available for 32-bit builds.
         if not platform.machine() in ("AMD64", "ARM64"):
             libs += " version user32 advapi32 Ex2KSdk sadapi netapi32"
-        kw["libraries"] = kw.get("libraries", "")
+        kw["libraries"] = libs
         super().__init__(name, **kw)
 
     def get_pywin32_dir(self):

--- a/win32/src/win32gui.i
+++ b/win32/src/win32gui.i
@@ -7405,13 +7405,13 @@ PyObject *PyRegisterDeviceNotification(PyObject *self, PyObject *args)
 				"structure says it has %d bytes, but %d was provided",
 				(int)struct_bytes, (int)pybuf.len());
 	// @pyseeapi RegisterDeviceNotification
-	HDEVNOTIFY not;
+	HDEVNOTIFY notify;
 	Py_BEGIN_ALLOW_THREADS
-	not = RegisterDeviceNotification(handle, pybuf.ptr(), flags);
+	notify = RegisterDeviceNotification(handle, pybuf.ptr(), flags);
 	Py_END_ALLOW_THREADS
-	if (not == NULL)
+	if (notify == NULL)
 		return PyWin_SetAPIError("RegisterDeviceNotification");
-	return PyWinObject_FromHDEVNOTIFY(not);
+	return PyWinObject_FromHDEVNOTIFY(notify);
 }
 %}
 %native(RegisterDeviceNotification) PyRegisterDeviceNotification;


### PR DESCRIPTION
MSVC is less strict about alternative operator tokens. But basically no other compiler allows this. Fixes one of the few leftover cross-compilation issues