### PR TITLE
Fix invalid string preprocessing tokens for mingw

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -279,7 +279,7 @@ class WinExt_win32com_mapi(WinExt_win32com):
         # Additional utility functions are only available for 32-bit builds.
         if not platform.machine() in ("AMD64", "ARM64"):
             libs += " version user32 advapi32 Ex2KSdk sadapi netapi32"
-        kw["libraries"] = kw.get("libraries", "")
+        kw["libraries"] = libs
         super().__init__(name, **kw)
 
     def get_pywin32_dir(self):

--- a/win32/src/PyWinTypesmodule.cpp
+++ b/win32/src/PyWinTypesmodule.cpp
@@ -1034,10 +1034,10 @@ extern "C" __declspec(dllexport) BOOL WINAPI DllMain(HANDLE hInstance, DWORD dwR
 }
 
 // Function to format a python traceback into a character string.
-#define GPEM_ERROR(what)                                      \
-    {                                                         \
-        errorMsg = L"<Error getting traceback - "##what##">"; \
-        goto done;                                            \
+#define GPEM_ERROR(what)                                    \
+    {                                                       \
+        errorMsg = L"<Error getting traceback - " what ">"; \
+        goto done;                                          \
     }
 PYWINTYPES_EXPORT WCHAR *GetPythonTraceback(PyObject *exc_type, PyObject *exc_value, PyObject *exc_tb)
 {

--- a/win32/src/win32file_comm.cpp
+++ b/win32/src/win32file_comm.cpp
@@ -162,10 +162,10 @@ PyDCB::PyDCB(const DCB &other)
 
 PyDCB::~PyDCB(void) {}
 
-#define GET_BITFIELD_ENTRY(bitfield_name)                     \
-    else if (strcmp(name, #bitfield_name) == 0)               \
-    {                                                         \
-        return PyLong_FromLong(pydcb->m_DCB.##bitfield_name); \
+#define GET_BITFIELD_ENTRY(bitfield_name)                   \
+    else if (strcmp(name, #bitfield_name) == 0)             \
+    {                                                       \
+        return PyLong_FromLong(pydcb->m_DCB.bitfield_name); \
     }
 
 PyObject *PyDCB::getattro(PyObject *self, PyObject *obname)
@@ -201,7 +201,7 @@ PyObject *PyDCB::getattro(PyObject *self, PyObject *obname)
             PyErr_Format(PyExc_TypeError, szNeedIntAttr, #bitfield_name); \
             return -1;                                                    \
         }                                                                 \
-        pydcb->m_DCB.##bitfield_name = PyLong_AsLong(v);                  \
+        pydcb->m_DCB.bitfield_name = PyLong_AsLong(v);                    \
         return 0;                                                         \
     }
 
@@ -364,10 +364,10 @@ PyCOMSTAT::PyCOMSTAT(const COMSTAT &other)
 PyCOMSTAT::~PyCOMSTAT(void) {}
 
 #undef GET_BITFIELD_ENTRY
-#define GET_BITFIELD_ENTRY(bitfield_name)                             \
-    else if (strcmp(name, #bitfield_name) == 0)                       \
-    {                                                                 \
-        return PyLong_FromLong(pyCOMSTAT->m_COMSTAT.##bitfield_name); \
+#define GET_BITFIELD_ENTRY(bitfield_name)                           \
+    else if (strcmp(name, #bitfield_name) == 0)                     \
+    {                                                               \
+        return PyLong_FromLong(pyCOMSTAT->m_COMSTAT.bitfield_name); \
     }
 
 PyObject *PyCOMSTAT::getattro(PyObject *self, PyObject *obname)
@@ -397,7 +397,7 @@ PyObject *PyCOMSTAT::getattro(PyObject *self, PyObject *obname)
             PyErr_Format(PyExc_TypeError, szNeedIntAttr, #bitfield_name); \
             return -1;                                                    \
         }                                                                 \
-        pyCOMSTAT->m_COMSTAT.##bitfield_name = PyLong_AsLong(v);          \
+        pyCOMSTAT->m_COMSTAT.bitfield_name = PyLong_AsLong(v);            \
         return 0;                                                         \
     }
 

--- a/win32/src/win32pdhmodule.cpp
+++ b/win32/src/win32pdhmodule.cpp
@@ -805,7 +805,7 @@ PDH_STATUS __stdcall PyCounterPathCallback(DWORD_PTR dwArg)
     {                                                             \
         if (i < seqLen) {                                         \
             PyObject *subItem = PyTuple_GET_ITEM(flags_tuple, i); \
-            myCfg.cfg.##r = PyObject_IsTrue(subItem);             \
+            myCfg.cfg.r = PyObject_IsTrue(subItem);               \
         }                                                         \
     }
 


### PR DESCRIPTION
Fixed invalid preprocessing tokens that MSVC was happy to just let slip by. Fixes one of the few leftover cross-compilation issues.