### PR TITLE
More header filename cases fixes

### DIFF
--- a/com/win32comext/mapi/src/PyIConverterSession.i
+++ b/com/win32comext/mapi/src/PyIConverterSession.i
@@ -30,14 +30,14 @@
 }
 
 %{
-#include <MapiUtil.h>
+#include <MAPIUtil.h>
 #include <initguid.h>
 #include "IConverterSession.h"
 #include "PyIConverterSession.h"
 
-#include "PYIStream.h"
-#include "PYIMapiProp.h"
-#include "PYIMessage.h"
+#include "PyIStream.h"
+#include "PyIMAPIProp.h"
+#include "PyIMessage.h"
 
 PyIConverterSession::PyIConverterSession(IUnknown *pDisp) :
 	PyIUnknown(pDisp)

--- a/com/win32comext/mapi/src/PyIExchangeManageStore.i
+++ b/com/win32comext/mapi/src/PyIExchangeManageStore.i
@@ -15,7 +15,7 @@
 #define INITGUID
 #include <initguid.h>
 #define USES_IID_IExchangeManageStore
-#include <edkguid.h>
+#include <EdkGuid.h>
 %}
 
 %typemap(python,ignore) IExchangeManageStore **OUTPUT(IExchangeManageStore *temp)

--- a/com/win32comext/mapi/src/PyIMsgServiceAdmin2.i
+++ b/com/win32comext/mapi/src/PyIMsgServiceAdmin2.i
@@ -9,7 +9,7 @@
 
 %{
 
-#include "mapiaux.h"
+#include "MAPIAux.h"
 #include "PyIMsgServiceAdmin.h"
 #include "PyIMsgServiceAdmin2.h"
 

--- a/com/win32comext/mapi/src/PyMAPIUtil.h
+++ b/com/win32comext/mapi/src/PyMAPIUtil.h
@@ -1,6 +1,6 @@
 // PyMAPIUtil.h
 
-#include "mapix.h"
+#include "MAPIX.h"
 
 // We should not be using this!
 #define OleSetOleError PyCom_BuildPyException

--- a/com/win32comext/mapi/src/exchange.i
+++ b/com/win32comext/mapi/src/exchange.i
@@ -30,7 +30,7 @@
 #include "EdkMdb.h"
 
 #define USES_IID_IExchangeManageStore
-#include <edkguid.h>
+#include <EdkGuid.h>
 
 #include "PyIExchangeManageStore.h"
 #include "IExchangeManageStoreEx.h"

--- a/com/win32comext/mapi/src/exchangeguids.cpp
+++ b/com/win32comext/mapi/src/exchangeguids.cpp
@@ -24,5 +24,5 @@ up by the MAPI module */
 
 #endif /* BUILD_FREEZE */
 #include "windows.h"
-#include "mapiguid.h"
-#include "edkguid.h"
+#include "MAPIGuid.h"
+#include "EdkGuid.h"

--- a/com/win32comext/mapi/src/mapi.i
+++ b/com/win32comext/mapi/src/mapi.i
@@ -25,11 +25,11 @@
 %include "mapilib.i"
 
 %{
-#include "mapiaux.h"
+#include "MAPIAux.h"
 
 #include "PythonCOMServer.h"
 #include "PythonCOMRegister.h"
-#include <mapiutil.h>
+#include <MAPIUtil.h>
 #include "PyIMAPIProp.h"
 #include "PyIMAPIStatus.h"
 #include "PyIMAPITable.h"
@@ -1052,7 +1052,7 @@ PyObject *PyOpenStreamOnFile(PyObject *self, PyObject *args)
 
 		{
 			PY_INTERFACE_PRECALL;
-			// mapiutil.h incorrectly declares OpenStreamOnFile taking type LPTSTR
+			// MAPIUtil.h incorrectly declares OpenStreamOnFile taking type LPTSTR
 			hRes = OpenStreamOnFile(MAPIAllocateBuffer, MAPIFreeBuffer, flags, (LPTSTR)filename, (LPTSTR)prefix, &pStream);
 			PY_INTERFACE_POSTCALL;
 		}

--- a/com/win32comext/mapi/src/mapiguids.cpp
+++ b/com/win32comext/mapi/src/mapiguids.cpp
@@ -30,7 +30,7 @@
 #define USES_PS_ROUTING_SEARCH_KEY
 
 #include "windows.h"
-#include "mapiguid.h"
+#include "MAPIGuid.h"
 #include "extraMAPIGuids.h"
 #define USES_IID_IMsgServiceAdmin2
-#include "mapiaux.h"
+#include "MAPIAux.h"

--- a/isapi/src/PyExtensionObjects.cpp
+++ b/isapi/src/PyExtensionObjects.cpp
@@ -24,7 +24,7 @@
  */
 
 // #define PY_SSIZE_T_CLEAN  // defined by isapi\src\StdAfx.h
-#include "stdafx.h"
+#include "StdAfx.h"
 #include "PyWinTypes.h"
 #include "Utils.h"
 #include "PyExtensionObjects.h"

--- a/isapi/src/PyFilterObjects.cpp
+++ b/isapi/src/PyFilterObjects.cpp
@@ -24,7 +24,7 @@
  */
 
 // #define PY_SSIZE_T_CLEAN  // defined by isapi\src\StdAfx.h
-#include "stdafx.h"
+#include "StdAfx.h"
 #include "PyWinTypes.h"
 #include "Utils.h"
 #include "PyFilterObjects.h"

--- a/isapi/src/PythonEng.cpp
+++ b/isapi/src/PythonEng.cpp
@@ -26,7 +26,7 @@
 // NOTE: This code used to host the thread-pool used by dispatch to Python
 // Some of the methods etc made alot more sense then.
 
-#include "stdafx.h"
+#include "StdAfx.h"
 #include "Utils.h"
 #include "PythonEng.h"
 #include "PyExtensionObjects.h"

--- a/isapi/src/StdAfx.cpp
+++ b/isapi/src/StdAfx.cpp
@@ -23,8 +23,8 @@
  ======================================================================
  */
 
-// stdafx.cpp : source file that includes just the standard includes
+// StdAfx.cpp : source file that includes just the standard includes
 //	pyISAPI.pch will be the pre-compiled header
-//	stdafx.obj will contain the pre-compiled type information
+//	StdAfx.obj will contain the pre-compiled type information
 
-#include "stdafx.h"
+#include "StdAfx.h"

--- a/isapi/src/Utils.cpp
+++ b/isapi/src/Utils.cpp
@@ -23,7 +23,7 @@
  ======================================================================
  */
 
-#include "stdafx.h"
+#include "StdAfx.h"
 #include "Utils.h"
 
 extern HINSTANCE g_hInstance;

--- a/isapi/src/pyISAPI.cpp
+++ b/isapi/src/pyISAPI.cpp
@@ -26,7 +26,7 @@
 // pyISAPI.cpp - Implementation file for your Internet Server
 //    Python ISAPI Extension
 
-#include "stdafx.h"
+#include "StdAfx.h"
 #include "pyISAPI.h"
 #include "PyExtensionObjects.h"
 #include "PyFilterObjects.h"

--- a/setup.py
+++ b/setup.py
@@ -1240,7 +1240,7 @@ com_extensions = [
     pythoncom,
     WinExt_win32com(
         "adsi",
-        libraries="ACTIVEDS ADSIID user32 advapi32",
+        libraries="activeds adsiid user32 advapi32",
         sources=(
             """
                         {adsi}/adsi.i                 {adsi}/adsi.cpp
@@ -1279,7 +1279,7 @@ com_extensions = [
         sources=(
             """
                         {axscript}/AXScript.cpp
-                        {axscript}/GUIDS.cpp                   {axscript}/PyGActiveScript.cpp
+                        {axscript}/GUIDs.cpp                   {axscript}/PyGActiveScript.cpp
                         {axscript}/PyGActiveScriptError.cpp    {axscript}/PyGActiveScriptParse.cpp
                         {axscript}/PyGActiveScriptSite.cpp     {axscript}/PyGObjectSafety.cpp
                         {axscript}/PyIActiveScript.cpp         {axscript}/PyIActiveScriptError.cpp
@@ -1369,7 +1369,7 @@ com_extensions = [
     WinExt_win32com(
         "mapi",
         libraries="advapi32",
-        include_dirs=["{mapi}/MapiStubLibrary/include".format(**dirs)],
+        include_dirs=["{mapi}/MAPIStubLibrary/include".format(**dirs)],
         sources=(
             """
                         {mapi}/mapi.i                 {mapi}/mapi.cpp
@@ -1403,7 +1403,7 @@ com_extensions = [
     WinExt_win32com_mapi(
         "exchange",
         libraries="advapi32 legacy_stdio_definitions",
-        include_dirs=["{mapi}/MapiStubLibrary/include".format(**dirs)],
+        include_dirs=["{mapi}/MAPIStubLibrary/include".format(**dirs)],
         sources=(
             """
                                   {mapi}/exchange.i         {mapi}/exchange.cpp
@@ -1542,7 +1542,7 @@ com_extensions = [
     ),
     WinExt_win32com(
         "bits",
-        libraries="Bits",
+        libraries="bits",
         sources=(
             """
                         {bits}/bits.cpp


### PR DESCRIPTION
Follow-up to https://github.com/mhammond/pywin32/pull/2735 now that I can actually fully build pywin32 on a case-sensitive filesystem/OS

Interesting bonus fact: I found that MAPI headers are actually included in MinGW, they differ slightly in incompatible manner. The difference in filename casing causes issues as MinGW system ones are picked-up instead of the vendored ones, but that's all fixed by this PR.