### PR TITLE
Fix goto crossing initialization of variables

### DIFF
--- a/com/win32com/src/PyRecord.cpp
+++ b/com/win32com/src/PyRecord.cpp
@@ -58,17 +58,17 @@ PyObject *PyObject_FromSAFEARRAYRecordInfo(SAFEARRAY *psa, long *arrayIndices)
     PyObject *ret = NULL, *ret_tuple = NULL;
     IRecordInfo *info = NULL;
     BYTE *source_data = NULL, *this_dest_data = NULL;
-    UINT dimNo = 0;
     long lbound, ubound, nelems, i;
     ULONG cb_elem;
     PyRecordBuffer *owner = NULL;
     HRESULT hr;
-    dimNo = SafeArrayGetDim(psa);
+    long *pMyArrayIndex;
+    UINT dimNo = SafeArrayGetDim(psa);
     if (dimNo == 0) {
         hr = E_UNEXPECTED;
         goto exit;
     }
-    long *pMyArrayIndex = arrayIndices + (dimNo - 1);
+    pMyArrayIndex = arrayIndices + (dimNo - 1);
     hr = SafeArrayGetRecordInfo(psa, &info);
     if (FAILED(hr))
         goto exit;
@@ -717,6 +717,7 @@ int PyRecord::setattro(PyObject *self, PyObject *obname, PyObject *v)
     HRESULT hr;
     WCHAR *wname;
     VARTYPE vt;
+    PyThreadState *_save;
 
     if (!PyWinObject_AsWCHAR(obname, &wname, FALSE))
         return -1;
@@ -794,7 +795,7 @@ int PyRecord::setattro(PyObject *self, PyObject *obname, PyObject *v)
         }
     }
 
-    PY_INTERFACE_PRECALL;
+    _save = PyEval_SaveThread();  // PY_INTERFACE_PRECALL;
     hr = pyrec->pri->PutField(INVOKE_PROPERTYPUT, pyrec->pdata, wname, &val);
     PY_INTERFACE_POSTCALL;
 
@@ -805,12 +806,13 @@ int PyRecord::setattro(PyObject *self, PyObject *obname, PyObject *v)
     }
 done:
     PyWinObject_FreeWCHAR(wname);
-    if (pta && pti)
-        pti->ReleaseTypeAttr(pta);
-    if (pVarDesc && pti)
-        pti->ReleaseVarDesc(pVarDesc);
-    if (pti)
+    if (pti) {
+        if (pta)
+            pti->ReleaseTypeAttr(pta);
+        if (pVarDesc)
+            pti->ReleaseVarDesc(pVarDesc);
         pti->Release();
+    }
     return ret;
 }
 

--- a/win32/src/PyWinTypesmodule.cpp
+++ b/win32/src/PyWinTypesmodule.cpp
@@ -1051,6 +1051,10 @@ PYWINTYPES_EXPORT WCHAR *GetPythonTraceback(PyObject *exc_type, PyObject *exc_va
     PyObject *argsTB = NULL;
     PyObject *obResult = NULL;
     TmpWCHAR resultPtr;
+    // Py3k has added an undocumented 'chain' argument which defaults to True
+    // and causes all kinds of exceptions while trying to print a traceback!
+    // This *could* be useful thought if we can tame it - later!
+    int chain = 0;
 
     // cStringIO is in "io"
     modStringIO = PyImport_ImportModule("io");
@@ -1073,10 +1077,6 @@ PYWINTYPES_EXPORT WCHAR *GetPythonTraceback(PyObject *exc_type, PyObject *exc_va
     obFuncTB = PyObject_GetAttrString(modTB, "print_exception");
     if (obFuncTB == NULL)
         GPEM_ERROR("can't find traceback.print_exception");
-    // Py3k has added an undocumented 'chain' argument which defaults to True
-    // and causes all kinds of exceptions while trying to print a traceback!
-    // This *could* be useful thought if we can tame it - later!
-    int chain = 0;
 
     argsTB = Py_BuildValue("OOOOOi", exc_type ? exc_type : Py_None, exc_value ? exc_value : Py_None,
                            exc_tb ? exc_tb : Py_None,

--- a/win32/src/win32file.i
+++ b/win32/src/win32file.i
@@ -3489,6 +3489,7 @@ py_RemoveUsersFromEncryptedFile(PyObject *self, PyObject *args)
 	// @pyparm ((<o PySID>,bytes,string),...)|pHashes||Sequence representing an ENCRYPTION_CERTIFICATE_HASH_LIST structure, as returned by QueryUsersOnEncryptedFile
 	PyObject *ret=NULL, *obfname=NULL, *obechl=NULL;
 	WCHAR *fname=NULL;
+    DWORD err=0;
 	ENCRYPTION_CERTIFICATE_HASH_LIST echl;
 	ZeroMemory(&echl,sizeof(ENCRYPTION_CERTIFICATE_HASH_LIST));
 	if (!PyArg_ParseTuple(args,"OO:RemoveUsersFromEncryptedFile", &obfname, &obechl))
@@ -3498,7 +3499,7 @@ py_RemoveUsersFromEncryptedFile(PyObject *self, PyObject *args)
 	if (!PyWinObject_AsPENCRYPTION_CERTIFICATE_HASH_LIST(obechl,&echl))
 		goto done;
 
-	DWORD err=RemoveUsersFromEncryptedFile(fname, &echl);
+	err=RemoveUsersFromEncryptedFile(fname, &echl);
 	if (err != ERROR_SUCCESS)
 		PyWin_SetAPIError("RemoveUsersFromEncryptedFile",err);
 	else


### PR DESCRIPTION
As title says: some `goto` statements cross initialization of variables, which is an unsilenceable error in non-MSVC compilers