### PR TITLE
`.pyo` don't exist since Python 3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ __pycache__
 *.flg
 *.chm
 *.chw
-*.pyo
 *.pdb
 *.whl
 arm64libs/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ As of build 305, installation .exe files have been deprecated; see
 Coming in build 312, as yet unreleased
 --------------------------------------
 
+* Removed special-casing for `.pyo` files which haven't been a thing since [Python 3.5](https://peps.python.org/pep-0488/) (mhammond#2754, [@Avasam][Avasam])
 * Fixed `axdebug` build on Python 3.11+ using CPython's new opaque frame APIs, fixed 64-bit overflow in sourceContext and stack addresses, fixed incorrect step-over and step-out behavior, and fixed `ListEnumeratorGateway.Next()` returning lazy `map` iterator incompatible with C++ COM gateways that require a sequence (mhammond#2723, mhammond#2724, mhammond#2725, [@wxinix-2022][wxinix-2022])
 * Removed more leftover obsolete `UNICODE` constants since dropping Python 2 support in `win32ui`, `win32gui` and `win32clipboard` (mhammond#2717, [@Avasam][Avasam])
 * Implement COM Records as `[out]` method parameters (mhammond#2708, [@geppi][geppi], [@the-snork][the-snork])

--- a/com/win32com/client/makepy.py
+++ b/com/win32com/client/makepy.py
@@ -308,12 +308,8 @@ def GenerateFromTypeLibSpec(
                     os.unlink(full_name + ".pyc")
                 except OSError:
                     pass
-                try:
-                    os.unlink(full_name + ".pyo")
-                except OSError:
-                    pass
                 # Don't create the package folder yet, wait until the file's been generated.
-                # This avoids issues with other processes attemping to import the package
+                # This avoids issues with other processes attempting to import the package
                 # and getting a namespace package before the __init__.py file is written.
                 tempName = full_name + ".__init__.py"
                 outputName = os.path.join(full_name, "__init__.py")

--- a/com/win32com/server/register.py
+++ b/com/win32com/server/register.py
@@ -138,16 +138,12 @@ def _find_localserver_module():
         os.stat(pyfile)
     except OSError:
         # See if we have a compiled extension
-        if __debug__:
-            ext = ".pyc"
-        else:
-            ext = ".pyo"
-        pyfile = os.path.join(path, baseName + ext)
+        pyfile = os.path.join(path, baseName + ".pyc")
         try:
             os.stat(pyfile)
         except OSError:
             raise RuntimeError(
-                "Can not locate the Python module 'win32com.server.%s'" % baseName
+                f"Can not locate the Python module 'win32com.server.{baseName}'"
             )
     return pyfile
 

--- a/com/win32comext/axdebug/codecontainer.py
+++ b/com/win32comext/axdebug/codecontainer.py
@@ -207,10 +207,9 @@ class SourceCodeContainer:
 class SourceModuleContainer(SourceCodeContainer):
     def __init__(self, module):
         self.module = module
-        if hasattr(module, "__file__"):
-            fname = self.module.__file__
-            # Check for .pyc or .pyo or even .pys!
-            if fname[-1] in ["O", "o", "C", "c", "S", "s"]:
+        if fname := getattr(module, "__file__", ""):
+            # Check for .pyc or even .pys!
+            if fname.endswith(("C", "c", "S", "s")):
                 fname = fname[:-1]
             try:
                 fname = win32api.GetFullPathName(fname)

--- a/com/win32comext/shell/demos/servers/column_provider.py
+++ b/com/win32comext/shell/demos/servers/column_provider.py
@@ -7,7 +7,7 @@
 # * Execute this script to register the namespace.
 # * Open Windows Explorer
 # * Right-click an explorer column header - select "More"
-# * Locate column 'pyc size' or 'pyo size', and add it to the view.
+# * Locate column 'pyc size' and add it to the view.
 # This handler is providing that column data.
 import os
 import stat
@@ -45,15 +45,12 @@ class ColumnProvider:
         print("ColumnProvider initializing for file", name)
 
     def GetColumnInfo(self, index):
-        # We support exactly 2 columns - 'pyc size' and 'pyo size'
-        if index in [0, 1]:
+        # We used to support exactly 2 columns - 'pyc size' and 'pyo size'
+        # pyo isn't a thing since Python 3.5: https://peps.python.org/pep-0488/
+        if index == 0:
             # As per the MSDN sample, use our CLSID as the fmtid
-            if index == 0:
-                ext = ".pyc"
-            else:
-                ext = ".pyo"
-            title = ext + " size"
-            description = "Size of compiled %s file" % ext
+            title = ".pyc size"
+            description = "Size of compiled .pyc file"
             col_id = (self._reg_clsid_, index)  # fmtid  # pid
             col_info = (
                 col_id,  # scid
@@ -69,16 +66,12 @@ class ColumnProvider:
         return None  # Indicate no more columns.
 
     def GetItemData(self, colid, colData):
-        fmt_id, pid = colid
-        fmt_id == self._reg_clsid_
+        # colid[1] used to be the pid where 0==pyc or 1==pyo.
+        # But pyo isn't a thing since Python 3.5: https://peps.python.org/pep-0488/
         flags, attr, reserved, ext, name = colData
-        if ext.lower() not in [".py", ".pyw"]:
+        if ext.lower() not in {".py", ".pyw"}:
             return None
-        if pid == 0:
-            ext = ".pyc"
-        else:
-            ext = ".pyo"
-        check_file = os.path.splitext(name)[0] + ext
+        check_file = os.path.splitext(name)[0] + ".pyc"
         try:
             st = os.stat(check_file)
             return st[stat.ST_SIZE]

--- a/com/win32comext/shell/demos/servers/empty_volume_cache.py
+++ b/com/win32comext/shell/demos/servers/empty_volume_cache.py
@@ -68,7 +68,7 @@ class EmptyVolumeCache:
 
         return (
             "pywin32 compiled files",
-            "Removes all .pyc and .pyo files in the pywin32 directories",
+            "Removes all .pyc files in the pywin32 directories",
             "click me!",
             flags,
         )
@@ -90,7 +90,7 @@ class EmptyVolumeCache:
         callback, total_list = arg
         for file in files:
             fqn = os.path.join(directory, file).lower()
-            if file.endswith(".pyc") or file.endswith(".pyo"):
+            if file.endswith(".pyc"):
                 # See below - total_list is None means delete files,
                 # otherwise it is a list where the result is stored. It's a
                 # list simply due to the way os.walk works - only [0] is

--- a/pythonwin/pywin/framework/scriptutils.py
+++ b/pythonwin/pywin/framework/scriptutils.py
@@ -120,7 +120,6 @@ def GetPackageModuleName(fileName):
                 and (
                     os.path.exists(os.path.join(path, modBit, "__init__.py"))
                     or os.path.exists(os.path.join(path, modBit, "__init__.pyc"))
-                    or os.path.exists(os.path.join(path, modBit, "__init__.pyo"))
                 )
             ):
                 modBits.reverse()
@@ -439,12 +438,9 @@ def ImportFile():
     # meaning sys.modules can change as a side-effect of looking at
     # module.__file__ - so we must take a copy (ie, list(items()))
     for key, mod in sys.modules.items():
-        if getattr(mod, "__file__", None):
-            fname = mod.__file__
-            base, ext = os.path.splitext(fname)
-            if ext.lower() in (".pyo", ".pyc"):
-                ext = ".py"
-            fname = base + ext
+        if fname := getattr(mod, "__file__", ""):
+            if fname.endswith(".pyc"):
+                fname = fname[:-1]
             if win32ui.ComparePath(fname, pathName):
                 modName = key
                 break

--- a/setup.py
+++ b/setup.py
@@ -1889,8 +1889,8 @@ def convert_data_files(files: Iterable[str]):
             files_use = tuple(
                 str(path)
                 for path in Path(file).parent.rglob(os.path.basename(file))
-                # We never want CVS
-                if not ("\\CVS\\" in file or path.suffix in {".pyc", ".pyo"})
+                # Ignore pre-compiled bytecode
+                if path.suffix != ".pyc"
             )
             if not files_use:
                 raise RuntimeError("No files match '%s'" % file)


### PR DESCRIPTION
GitHub comments are currently broken, so I'll write here in stead of directly on the file:


setup.py:

Same comment as https://github.com/mhammond/pywin32/pull/2753/changes#r3191830125
Outdated checks:
- `.pyo` aren't a thing since Python 3.5
- `CVS` I assume is Concurrent Versions System which haven't been a thing in this project for a while

---

com/win32comext/shell/demos/servers/column_provider.py

I feel this reveals this demo may not be quite as useful. I still need to properly run this demo on a Windows machine to check.