### PR TITLE
Update release skippable extensions + Fix `_why_cant_build_extension` for MinGW

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -365,15 +365,19 @@ class my_build_ext(build_ext):
         self.swig_opts.append("-c++")
 
     def _get_gcc_include_dirs(self) -> list[str]:
-        """Query gcc's built-in include search paths (needed for cross-compilation on Linux)."""
+        """Query gcc's built-in include search paths."""
         cc = getattr(self.compiler, "cc", "")
         if not cc:
             return []
-        output = subprocess.check_output(
-            [cc, "-xc", "-E", "-", "-v"],
-            input=b"",
-            stderr=subprocess.STDOUT,
-        ).decode(errors="replace")
+        try:
+            output = subprocess.check_output(
+                [cc, "-xc", "-E", "-", "-v"],
+                input=b"",
+                stderr=subprocess.STDOUT,
+            ).decode(errors="replace")
+        except subprocess.CalledProcessError:
+            return []  # probably wasn't gcc
+        # All lines between the start and end markers will be include directories
         dirs: Iterator[str] = dropwhile(
             lambda line: line != "#include <...> search starts here:",
             output.splitlines(),

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,11 @@ import logging
 import os
 import platform
 import shutil
+import subprocess
 import sys
 from abc import abstractmethod
-from collections.abc import Iterable
-from itertools import chain
+from collections.abc import Iterable, Iterator
+from itertools import chain, dropwhile, takewhile
 from pathlib import Path
 from setuptools import Extension, setup
 from setuptools.command.build import build
@@ -363,39 +364,61 @@ class my_build_ext(build_ext):
         """List of excluded extensions and their reason"""
         self.swig_opts.append("-c++")
 
+    def _get_gcc_include_dirs(self) -> list[str]:
+        """Query gcc's built-in include search paths (needed for cross-compilation on Linux)."""
+        cc = getattr(self.compiler, "cc", "")
+        if not cc:
+            return []
+        output = subprocess.check_output(
+            [cc, "-xc", "-E", "-", "-v"],
+            input=b"",
+            stderr=subprocess.STDOUT,
+        ).decode(errors="replace")
+        dirs: Iterator[str] = dropwhile(
+            lambda line: line != "#include <...> search starts here:",
+            output.splitlines(),
+        )
+        next(dirs)
+        dirs = takewhile(lambda line: line != "End of search list.", dirs)
+        return [os.path.normpath(line.strip()) for line in dirs]
+
     def _why_cant_build_extension(self, ext):
         """Return None, or a reason it can't be built."""
-        include_dirs = self.compiler.include_dirs + os.environ.get("INCLUDE", "").split(
-            os.pathsep
+        include_dirs = (
+            self.compiler.include_dirs
+            + os.environ.get("INCLUDE", "").split(os.pathsep)  # MSVC INCLUDE Env
+            + self._get_gcc_include_dirs()
         )
 
-        look_dirs = include_dirs
         for h in ext.optional_headers:
-            for d in look_dirs:
+            for d in include_dirs:
                 if os.path.isfile(os.path.join(d, h)):
                     break
             else:
-                logging.debug("Header '%s' not found  in %s", h, look_dirs)
+                logging.debug("Header '%s' not found in %s", h, include_dirs)
                 return f"The header '{h}' can not be located."
 
-        common_dirs = self.compiler.library_dirs[:]
-        common_dirs += os.environ.get("LIB", "").split(os.pathsep)
-        patched_libs = []
-        for lib in ext.libraries:
-            if lib.lower() in self.found_libraries:
-                found = self.found_libraries[lib.lower()]
-            else:
-                look_dirs = common_dirs + ext.library_dirs
-                found = self.compiler.find_library_file(look_dirs, lib, self.debug)
-                if not found:
-                    logging.debug("Lib '%s' not found in %s", lib, look_dirs)
-                    return "No library '%s'" % lib
-                self.found_libraries[lib.lower()] = found
-            patched_libs.append(os.path.splitext(os.path.basename(found))[0])
+        if not is_mingw:
+            look_dirs = (
+                self.compiler.library_dirs
+                + os.environ.get("LIB", "").split(os.pathsep)
+                + ext.library_dirs
+            )
+            patched_libs = []
+            for lib in ext.libraries:
+                if lib.lower() in self.found_libraries:
+                    found = self.found_libraries[lib.lower()]
+                else:
+                    found = self.compiler.find_library_file(look_dirs, lib, self.debug)
+                    if not found:
+                        logging.debug("Lib '%s' not found in %s", lib, look_dirs)
+                        return f"No library '{lib}'"
+                    self.found_libraries[lib.lower()] = found
+                patched_libs.append(os.path.splitext(os.path.basename(found))[0])
 
-        # We update the .libraries list with the resolved library name.
-        # This is really only so "_d" works.
-        ext.libraries = patched_libs
+            # We update the .libraries list with the resolved library name.
+            # This is really only so "_d" works.
+            ext.libraries = patched_libs
         return None  # no reason - it can be built!
 
     def _build_scintilla(self):
@@ -1694,7 +1717,7 @@ pythonwin_extensions = [
             "pythonwin/Win32uiHostGlue.h",
             "pythonwin/win32win.h",
         ],
-        optional_headers=["afxres.h"],
+        optional_headers=["afxwin.h"],
     ),
     WinExt_pythonwin(
         "win32uiole",
@@ -1711,7 +1734,7 @@ pythonwin_extensions = [
             "pythonwin/win32oleDlgs.h",
             "pythonwin/win32uioledoc.h",
         ],
-        optional_headers=["afxres.h"],
+        optional_headers=["afxwin.h"],
     ),
     WinExt_pythonwin(
         "dde",
@@ -1724,7 +1747,7 @@ pythonwin_extensions = [
             "pythonwin/ddeserver.cpp",
         ],
         depends=["win32/src/stddde.h", "pythonwin/ddemodule.h"],
-        optional_headers=["afxres.h"],
+        optional_headers=["afxwin.h"],
     ),
 ]
 
@@ -1779,7 +1802,7 @@ W32_exe_files: list[WinExt] = [
             "pythonwin/Win32uiHostGlue.h",
             "pythonwin/pythonwin.h",
         ],
-        optional_headers=["afxres.h"],
+        optional_headers=["afxwin.h"],
     ),
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -2089,7 +2089,15 @@ if "build_ext" in dist.command_obj:
     # Print the list of extension modules we skipped building.
     excluded_extensions = dist.command_obj["build_ext"].excluded_extensions
     if excluded_extensions:
-        skip_whitelist = {"axdebug"}
+        # Set of extension names that are acceptable to skip for a release build
+        skip_whitelist = set()
+        if is_mingw:
+            # On MinGW, allow excluded ext/exe due to missing ATL/MFC headers (typically PythonWin)
+            skip_whitelist |= {
+                ext.name
+                for ext in [*pythonwin_extensions, *W32_exe_files]
+                if "afxwin.h" in ext.optional_headers
+            }
         skipped_ex = []
         print(f"*** NOTE: The following extensions were NOT {what_string}:")
         for ext, why in excluded_extensions:

--- a/setup.py
+++ b/setup.py
@@ -406,14 +406,15 @@ class my_build_ext(build_ext):
             )
             patched_libs = []
             for lib in ext.libraries:
-                if lib.lower() in self.found_libraries:
-                    found = self.found_libraries[lib.lower()]
+                lib_lower = lib.lower()
+                if lib_lower in self.found_libraries:
+                    found = self.found_libraries[lib_lower]
                 else:
                     found = self.compiler.find_library_file(look_dirs, lib, self.debug)
                     if not found:
                         logging.debug("Lib '%s' not found in %s", lib, look_dirs)
                         return f"No library '{lib}'"
-                    self.found_libraries[lib.lower()] = found
+                    self.found_libraries[lib_lower] = found
                 patched_libs.append(os.path.splitext(os.path.basename(found))[0])
 
             # We update the .libraries list with the resolved library name.


### PR DESCRIPTION
- axdebug can now be built unconditionally, should always be included in release build. We want a loud error if it starts failing again.
- ATL/MFC headers can't be obtained without the Visual Studio Installer. Meaning they're effectively irrelevant for non-MSVC compiler-based builds. We don't ship MinGW-based builds, but other distributors are. Allow skipping some related extensions in their release builds.
- Add gcc include dirs to `_why_cant_build_extension`'s search locations
- Simplify rest of the code in `_why_cant_build_extension`
- Change `optional_headers` to one that's actually missing on MinGW