### PR TITLE
Implement PEP 639 (Full SPDX license expression)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1995,7 +1995,21 @@ dist = setup(
         "Support Requests": "https://github.com/mhammond/pywin32/discussions",
         "Mailing List": "https://mail.python.org/mailman/listinfo/python-win32",
     },
-    license="PSF",
+    # `license` must contain all licenses for the *distribution*
+    # in the form of a SPDX license expression. See:
+    # https://packaging.python.org/en/latest/specifications/pyproject-toml/#license
+    # https://packaging.python.org/en/latest/specifications/core-metadata/#core-metadata-license-expression
+    # https://packaging.python.org/en/latest/specifications/license-expression/
+    license=" AND ".join(  # noqa: FLY002 # Entries broken by comment for readability and maintainability
+        (
+            "PSF-2.0",  # project root (explicit license file), https://github.com/mhammond/pywin32/issues/1127#issuecomment-393364022
+            "BSD-3-Clause",  # Pythonwin, com, win32, win32com, win32comext, pywin32_system32 (explicit license file), https://github.com/mhammond/pywin32/issues/1127#issuecomment-393364022
+            "(PSF-2.0 OR BSD-3-Clause)",  # isapi, https://github.com/mhammond/pywin32/issues/1744#issuecomment-917368167
+            "Python-2.0.1",  # IDLE (bundled with Pythonwin)
+            "MIT",  # MAPI
+            "LGPL-2.1-or-later",  # ADO DB-API
+        )
+    ),
     license_files=(
         "**/[Ll]icense.txt",
         "**/LICENSE*",


### PR DESCRIPTION
Implements https://peps.python.org/pep-0639/

Up-to-date documentation references (given that PEPs are historical documents):
- https://packaging.python.org/en/latest/specifications/pyproject-toml/#license
- https://packaging.python.org/en/latest/specifications/core-metadata/#core-metadata-license-expression
- https://packaging.python.org/en/latest/specifications/license-expression/

This doesn't change any existing licenses. https://github.com/mhammond/pywin32/pull/2590 already clarified missing licenses for individual parts of the distribution. This clarifies the combined license of the entire distribution in a (newly) standard way.

I am purposefully leaving in the deprecated `License :: OSI Approved :: Python Software Foundation License` license classifier despite setuptool's warnings. Until if/when it is refused by PyPI or if/when there's a dedicated way to indicate source code/non-distribution project metadata.