### PR TITLE
Add missing import libs for i686 MSYS2 MinGW

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -426,6 +426,34 @@ class my_build_ext(build_ext):
             ext.libraries = patched_libs
         return None  # no reason - it can be built!
 
+    def _generate_missing_import_libs(self):
+        """Generate import libraries missing from some MinGW toolchains.
+
+        i686 MSYS2 MinGW ships headers but not all import .a files.
+        Generate them from bundled .def files using dlltool.
+        Only runs on win32 (i686) builds; x86_64 ships these already.
+        """
+        if not (is_mingw and self.plat_name == "win32"):
+            return
+        # (def_file, output_lib)
+        missing_libs = [
+            (
+                os.path.join("win32", "src", "PerfMon", "loadperf.def"),
+                os.path.join(self.build_temp, "libloadperf.a"),
+            ),
+            (
+                os.path.join("win32", "src", "sfc.def"),
+                os.path.join(self.build_temp, "libsfc.a"),
+            ),
+        ]
+        dlltool = os.environ.get("DLLTOOL", "dlltool")
+        for def_file, out_lib in missing_libs:
+            if os.path.exists(def_file) and not os.path.exists(out_lib):
+                self.mkpath(self.build_temp)
+                self.compiler.spawn(
+                    [dlltool, "--input-def", def_file, "--output-lib", out_lib]
+                )
+
     def _build_scintilla(self):
         scintilla_path = "pythonwin/Scintilla"
         makefile = "makefile_pythonwin"
@@ -551,6 +579,8 @@ class my_build_ext(build_ext):
             remove_manifest_flags(self.compiler.ldflags_exe_debug)
             remove_manifest_flags(self.compiler.ldflags_shared)
             remove_manifest_flags(self.compiler.ldflags_shared_debug)
+
+        self._generate_missing_import_libs()
 
         for ext in self.extensions:
             if not isinstance(ext, WinExt):

--- a/win32/src/PerfMon/loadperf.def
+++ b/win32/src/PerfMon/loadperf.def
@@ -1,0 +1,6 @@
+; Import definition for loadperf.dll (Windows Performance Counter API)
+; Used to generate libloadperf.a for i686 MinGW toolchains that don't ship it.
+LIBRARY "loadperf.dll"
+EXPORTS
+    LoadPerfCounterTextStringsA@8
+    UnloadPerfCounterTextStringsA@8

--- a/win32/src/sfc.def
+++ b/win32/src/sfc.def
@@ -1,0 +1,6 @@
+; Import definition for sfc.dll (Windows System File Checker API)
+; Used to generate libsfc.a for i686 MinGW toolchains that don't ship it.
+LIBRARY "sfc.dll"
+EXPORTS
+    SfcGetNextProtectedFile@8
+    SfcIsFileProtected@8


### PR DESCRIPTION
Split off from https://github.com/mhammond/pywin32/pull/2778