### PR TITLE
`delay_load_libraries`/`/delayload` to avoid loading at runtime is no longer necessary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,17 +128,12 @@ class WinExt(Extension):
         export_symbols=None,
         export_symbol_file=None,
         is_regular_dll=False,  # regular Windows DLL?
-        # list of headers which may not be installed forcing us to
-        # skip this extension
+        # list of headers which may not be installed forcing us to skip this extension
         optional_headers=[],
         depends=None,
         implib_name=None,
-        delay_load_libraries="",
     ):
         include_dirs = ["com/win32com/src/include", "win32/src"] + include_dirs
-        libraries = libraries.split()
-        self.delay_load_libraries = delay_load_libraries.split()
-        libraries.extend(self.delay_load_libraries)
 
         extra_link_args = extra_link_args or []
         if export_symbol_file:
@@ -165,15 +160,14 @@ class WinExt(Extension):
         self.optional_headers = optional_headers
         self.is_regular_dll = is_regular_dll
         self.implib_name = implib_name
-        Extension.__init__(
-            self,
+        super().__init__(
             name,
             sources,
             include_dirs,
             define_macros,
             undef_macros,
             library_dirs,
-            libraries,
+            libraries.split(),
             runtime_library_dirs,
             extra_objects,
             extra_compile_args,
@@ -209,11 +203,6 @@ class WinExt(Extension):
 
             # silence: warning C4163: '__cpuidex' : not available as an intrinsic function
             self.extra_compile_args.append("/wd4163")
-
-            if self.delay_load_libraries:
-                self.libraries.append("delayimp")
-                for delay_lib in self.delay_load_libraries:
-                    self.extra_link_args.append("/delayload:%s.dll" % delay_lib)
 
             # If someone needs a specially named implib created, handle that
             if self.implib_name:
@@ -973,9 +962,8 @@ pywintypes = WinExt_system32(
     libraries="advapi32 user32 ole32 oleaut32",
 )
 
-win32_extensions: list[WinExt] = [pywintypes]
-
-win32_extensions.append(
+win32_extensions = [
+    pywintypes,
     WinExt_win32(
         "perfmondata",
         sources=[
@@ -984,13 +972,13 @@ win32_extensions.append(
         ],
         libraries="advapi32",
         export_symbol_file="win32/src/PerfMon/perfmondata.def",
-        is_regular_dll=1,
+        is_regular_dll=True,
         depends=[
             "win32/src/PerfMon/perfutil.h",
             "win32/src/PerfMon/PyPerfMonControl.h",
         ],
     ),
-)
+]
 
 for name, libraries, sources in (
     ("mmapfile", "", "win32/src/mmapfilemodule.cpp"),
@@ -1101,6 +1089,29 @@ for name, libraries, sources in (
     ("win32ts", "wtsapi32", "win32/src/win32tsmodule.cpp"),
     ("_win32sysloader", "", "win32/src/_win32sysloader.cpp"),
     ("win32transaction", "kernel32 ktmw32", "win32/src/win32transactionmodule.cpp"),
+    (
+        "win32evtlog",
+        "advapi32 oleaut32 wevtapi",
+        """
+        win32/src/win32evtlog_messages.mc
+        win32/src/win32evtlog.i
+        """,
+    ),
+    (
+        "win32api",
+        "user32 advapi32 shell32 version secur32 powrprof",
+        """
+        win32/src/win32apimodule.cpp
+        win32/src/win32api_display.cpp
+        win32/src/win32api_cputopo.cpp
+        """,
+    ),
+    (
+        "_winxptheme",
+        "gdi32 user32 comdlg32 comctl32 shell32 uxtheme",
+        "win32/src/_winxptheme.i",
+    ),
+    ("win32help", "htmlhelp user32 advapi32", "win32/src/win32helpmodule.cpp"),
 ):
     ext = WinExt_win32(
         name,
@@ -1113,50 +1124,16 @@ for name, libraries, sources in (
 # The few that need slightly special treatment
 win32_extensions += [
     WinExt_win32(
-        "win32evtlog",
-        sources="""
-                win32/src/win32evtlog_messages.mc win32/src/win32evtlog.i
-                """.split(),
-        libraries="advapi32 oleaut32",
-        delay_load_libraries="wevtapi",
-    ),
-    WinExt_win32(
-        "win32api",
-        sources="""
-                win32/src/win32apimodule.cpp win32/src/win32api_display.cpp win32/src/win32api_cputopo.cpp
-                """.split(),
-        libraries="user32 advapi32 shell32 version secur32",
-        delay_load_libraries="powrprof",
-    ),
-    WinExt_win32(
         "win32gui",
-        sources="""
-                win32/src/win32dynamicdialog.cpp
-                win32/src/win32gui.i
-               """.split(),
+        sources=["win32/src/win32dynamicdialog.cpp", "win32/src/win32gui.i"],
         libraries="gdi32 user32 comdlg32 comctl32 shell32 msimg32",
         define_macros=[("WIN32GUI", None)],
     ),
     WinExt_win32(
-        "_winxptheme",
-        sources=["win32/src/_winxptheme.i"],
-        libraries="gdi32 user32 comdlg32 comctl32 shell32 uxtheme",
-    ),
-]
-win32_extensions += [
-    WinExt_win32(
         "servicemanager",
         sources=["win32/src/PythonServiceMessages.mc", "win32/src/PythonService.cpp"],
-        define_macros=[("PYSERVICE_BUILD_DLL", None)],
         libraries="user32 ole32 advapi32 shell32",
-    ),
-]
-
-win32_extensions += [
-    WinExt_win32(
-        "win32help",
-        sources=["win32/src/win32helpmodule.cpp"],
-        libraries="htmlhelp user32 advapi32",
+        define_macros=[("PYSERVICE_BUILD_DLL", None)],
     ),
 ]
 
@@ -1514,31 +1491,28 @@ com_extensions = [
     ),
     WinExt_win32com(
         "propsys",
-        libraries="propsys",
-        delay_load_libraries="shell32",
-        sources=(
-            """
-                        {propsys}/propsys.cpp
-                        {propsys}/PyIInitializeWithFile.cpp
-                        {propsys}/PyIInitializeWithStream.cpp
-                        {propsys}/PyINamedPropertyStore.cpp
-                        {propsys}/PyIPropertyDescription.cpp
-                        {propsys}/PyIPropertyDescriptionAliasInfo.cpp
-                        {propsys}/PyIPropertyDescriptionList.cpp
-                        {propsys}/PyIPropertyDescriptionSearchInfo.cpp
-                        {propsys}/PyIPropertyEnumType.cpp
-                        {propsys}/PyIPropertyEnumTypeList.cpp
-                        {propsys}/PyIPropertyStore.cpp
-                        {propsys}/PyIPropertyStoreCache.cpp
-                        {propsys}/PyIPropertyStoreCapabilities.cpp
-                        {propsys}/PyIPropertySystem.cpp
-                        {propsys}/PyPROPVARIANT.cpp
-                        {propsys}/PyIPersistSerializedPropStorage.cpp
-                        {propsys}/PyIObjectWithPropertyKey.cpp
-                        {propsys}/PyIPropertyChange.cpp
-                        {propsys}/PyIPropertyChangeArray.cpp
-                        """.format(**dirs)
-        ).split(),
+        libraries="propsys shell32",
+        sources="""
+            {propsys}/propsys.cpp
+            {propsys}/PyIInitializeWithFile.cpp
+            {propsys}/PyIInitializeWithStream.cpp
+            {propsys}/PyINamedPropertyStore.cpp
+            {propsys}/PyIPropertyDescription.cpp
+            {propsys}/PyIPropertyDescriptionAliasInfo.cpp
+            {propsys}/PyIPropertyDescriptionList.cpp
+            {propsys}/PyIPropertyDescriptionSearchInfo.cpp
+            {propsys}/PyIPropertyEnumType.cpp
+            {propsys}/PyIPropertyEnumTypeList.cpp
+            {propsys}/PyIPropertyStore.cpp
+            {propsys}/PyIPropertyStoreCache.cpp
+            {propsys}/PyIPropertyStoreCapabilities.cpp
+            {propsys}/PyIPropertySystem.cpp
+            {propsys}/PyPROPVARIANT.cpp
+            {propsys}/PyIPersistSerializedPropStorage.cpp
+            {propsys}/PyIObjectWithPropertyKey.cpp
+            {propsys}/PyIPropertyChange.cpp
+            {propsys}/PyIPropertyChangeArray.cpp
+        """.format(**dirs).split(),
         implib_name="pypropsys",
     ),
     WinExt_win32com(
@@ -1776,7 +1750,7 @@ other_extensions = [
                   PythonEng.h StdAfx.h Utils.h
                """.split()
         ],
-        is_regular_dll=1,
+        is_regular_dll=True,
         export_symbols="""HttpExtensionProc GetExtensionVersion
                            TerminateExtension GetFilterVersion
                            HttpFilterProc TerminateFilter


### PR DESCRIPTION
Everything here should be available all the time. Removes special-casing with little-to-none benefits.
Further standardizes `setup.py`