### PR TITLE
Fix documentation code block wrapping + monospace

### DIFF
--- a/com/help/active_directory.html
+++ b/com/help/active_directory.html
@@ -88,7 +88,7 @@ A tool that can be of a great help is the ADSI Edit MMC snap-in, aka <b>ADSIEdit
 >Remote Server Administration Tools for Windows 10</a> for installation instructions.
 It gives you the raw ldap view of active directory.
 Note that it is not available for the Home edition of Windows.</p>
-<code>
+<pre><code>
 def discover():
     Here is a function that helps you determine the active directory ldap strings that you can actually use.
     #get base LDAP string
@@ -125,7 +125,7 @@ def discover():
     for i in win32com.client.GetObject('LDAP://'+ex_first_store):
         ex_stores.append('cn='+i.cn+','+ex_first_store)
     print("\tExchange stores:","',".join(ex_stores))
-</code>
+</code></pre>
 
 <h3><a name="opends">Making the object</a></h3>
 
@@ -145,7 +145,7 @@ or to get the groups fred is a member of
 <br>
 print("groups=",opends("fred").memberOf)
 
-<code>
+<pre><code>
 def opends(loc,server=''):
     '''automatically buoild ldap string and authenticate
     ldap=win32com.client.Dispatch('ADsNameSpaces').getobject("","LDAP:")
@@ -161,7 +161,7 @@ def opends(loc,server=''):
     if loc.find('LDAP://')==-1: loc='LDAP://'+loc
 
     return ldap.OpenDSObject(loc,Ad.ldap_auth,Ad.pw,1)
-</code>
+</code></pre>
 
 <h3><a name="what">What does the object have?</a></h3>
 
@@ -178,16 +178,16 @@ library.
 <p>
 You would use ad_dict like a normal python dictionary.
 <br>
-<code>
+<pre><code>
 for i in ad_dict('fred').items():
 	print(i)
-</code>
+</code></pre>
 <br>
 A lot of things convert to automatic python data types. For others, you'll get stuff like
 COMObject. You need to do specific processing, like the one done for
 pwdLastSet below, to extract data from them.
 
-<code>
+<pre><code>
 def ad_dict(ldapobj,attr_dict={},recurse=0,auth=1,filter=()):
     if ldapobj.find(',')==-1: ldapobj='cn='+ldapobj+','+Ad.ldap_main_loc
     if auth: #setup authenticated connections
@@ -233,7 +233,7 @@ def ad_dict(ldapobj,attr_dict={},recurse=0,auth=1,filter=()):
             except:
                 pass
     return attr_dict
-</code>
+</code></pre>
 
 
 <h3><a NAME="time">The time property</a></h3>
@@ -252,7 +252,7 @@ print("time in seconds",conv_time(user.pwdLastSet.lowpart,user.pwdLastSet.highpa
 
 user.pwdLastSet returns a com object, not a python data type.
 
-<code>
+<pre><code>
 def conv_time(l,h):
     #converts 64-bit integer specifying the number of 100-nanosecond
     #intervals which have passed since January 1, 1601.
@@ -261,7 +261,7 @@ def conv_time(l,h):
     d=116444736000000000L #diference between 1601 and 1970
     #we divide by 10million to convert to seconds
     return (((long(h)<< 32) + long(l))-d)/10000000
-</code>
+</code></pre>
 
 <hr>
 <h2><A name="users">Managing Users</a></h2>

--- a/com/help/adsi.html
+++ b/com/help/adsi.html
@@ -118,7 +118,7 @@ The ex_path in the above example specifies the resource you are trying to access
 <hr>
 <h2><A NAME="User">User Account Management</A></h2>
 <h3><a name="add">Adding a user to exchange</A></h3>
-<code>
+<pre><code>
 # Adding a new account to exchange is simple except for one thing.
 # You need to associate an NT account with an exchange account.
 # To do so at this point requires some c++ to produce some hex SID
@@ -143,11 +143,11 @@ newobj.put('NT-Security-Descriptor',assoc_nt)
 newobj.put('NT-Security-Descriptor',nt_security)
 
 newobj.SetInfo
-</code>
+</code></pre>
 
 <h3><a name="get">Getting/Modify user info</a></h3>
 
-<code>
+<pre><code>
 ex_path="LDAP://server/cn=fredflint,cn=Recipients,ou=rubble,o=bedrock"
 myDSObject = ldap.OpenDSObject(ex_path,logon_ex,password,0)
 myDSObject.Getinfo()
@@ -157,7 +157,7 @@ print(attribute)
 # To modify a user try:
 myDSObject.Put('Extension-Attribute-1','barney was here')
 myDSObject.Setinfo()
-</code>
+</code></pre>
 Comments
 
 <strong>Note</strong> -- To make any changes permanent setinfo is required.
@@ -165,7 +165,7 @@ Comments
 
 <h3><a name="delete">Deleting a user from exchange</a></h3>
 
-<code>
+<pre><code>
 #Here we connect to Recipients and then
 #delete a user
 #This is a more complete example.
@@ -190,18 +190,15 @@ try:
   dsobj.Setinfo()
 except:
   print("Error deleting "+login, sys.exc_type , sys.exc_value)
-</code>
+</code></pre>
 </p>
 <hr>
 <h2><a name="Distribution List">Distribution List</a></h2>
-<p>
-<pre>
 <hr>
-
 
 <h3><a name="dadd">Adding to a distribution list</a></h3>
 
-<code>
+<pre><code>
 # I used putex instead of put because it has more options
 # The '3' value means append. The SDK has specific info on it
 ex_list_path="LDAP://"+server+"/cn="+list+",cn=Recipients,ou="+ou+",o="+o
@@ -211,12 +208,11 @@ list_member='cn='+user+',cn=Recipients,ou='+ou+',o='+o
 append_list=[list_member]
 dsobj.putEx(3,'Member',append_list);
 dsobj.SetInfo()
-</code>
-
+</code></pre>
 
 <h3><a name="dlist"></A>Recursively listing all unique members of a distribution list</h3>
 
-<code>
+<pre><code>
 #This function looks for all Organizational persons to add to a dictionary
 #If it gets a groupOfNames, it needs to parse that and call the function again
 #to get the members of the groupOfNames
@@ -249,11 +245,9 @@ def getmembers(path=''):
       print("skipped",dsobj.Class,dsobj.uid)
   return user_dict
 
+</code></pre>
 
-</code>
-</p>
 <p>
-
 <hr>
 <h2><a name="Conclusion">In Conclusion</a></h2>
 Microsoft's ADSI allows one to manage exchange w/out having to resort to the lower-level APIs.

--- a/com/win32com/HTML/PythonCOM.html
+++ b/com/win32com/HTML/PythonCOM.html
@@ -52,17 +52,20 @@
 <H4>QueryInterface and Types </H4>
 <P>When the only support required by Python is IDispatch, everything is simple - every object returned from QueryInterface is a PyIDispatch object. But this does not extend to other types, such as ITypeLib, IConnectionPoint etc., which are required for full COM support. </P>
 <P>For example, consider the following C++ pseudo-code: </P>
-<CODE><P>IConnectionPoint *conPt;<BR>
-someIDispatch-&gt;QueryInterface(IID_IConnectionPoint, (void **)&amp;conPt);<BR>
-// Note the IID_ and type of the * could be anything!</CODE> </P>
+<PRE><CODE>IConnectionPoint *conPt;
+someIDispatch-&gt;QueryInterface(IID_IConnectionPoint, (void **)&amp;conPt);
+// Note the IID_ and type of the * could be anything!
+</CODE></PRE>
 <P>This cast, and knowledge of a specific IID_* to type must be simulated in Python. </P>
 <P>Python/COM will therefore maintain a map of UID's to Python type objects. Whenever QueryInterface is called, Python will lookup this map, to determine if the object type is supported. If the object is supported, then an object of that type will be returned. If the object is not supported, then a PyIUnknown object will be returned. </P>
 <P>Note that PyIDispatch will be supported by the core engine. Therefore: </P>
-<CODE><P>&gt;&gt;&gt; disp=someobj.QueryInterface(win32com.IID_Dispatch) </P>
-</CODE><P>will return a PyIDispatch object, whereas </P>
-<CODE><P>&gt;&gt;&gt; unk=someobj.QueryInterface(SomeUnknownIID) # returns PyIUnknown<BR>
-&gt;&gt;&gt; disp=unk.QueryInterface(win32com.IID_Dispatch) <BR>
-&gt;&gt;&gt; unk.Release() # Clean up now, rather than waiting for unk death.</CODE> </P>
+<PRE><CODE>&gt;&gt;&gt; disp=someobj.QueryInterface(win32com.IID_Dispatch)
+</CODE></PRE>
+<P>will return a PyIDispatch object, whereas </P>
+<PRE><CODE>&gt;&gt;&gt; unk=someobj.QueryInterface(SomeUnknownIID) # returns PyIUnknown
+&gt;&gt;&gt; disp=unk.QueryInterface(win32com.IID_Dispatch)
+&gt;&gt;&gt; unk.Release() # Clean up now, rather than waiting for unk death.
+</CODE></PRE>
 <P>Is needed to convert to an IDispatch object. </P>
 <H4>Core Support </H4>
 <P>The core COM support module will support the IUnknown, IDispatch, ITypeInfo, ITypeLib and IConnectionPointContainer and IConnectionPoint interfaces. This implies the core COM module supports 6 different OLE client object types, mapped to the 6 IID_*'s representing the objects. (The IConnection* objects allow for Python to respond to COM events) </P>
@@ -70,10 +73,11 @@ someIDispatch-&gt;QueryInterface(IID_IConnectionPoint, (void **)&amp;conPt);<BR>
 <H4>Extensibility </H4>
 <P>To provide the above functionality, a Python map is provided, which maps from a GUID to a Python type object. </P>
 <P>The advantage of this scheme is an external extension modules can hook into the core support. For example, imagine the following code: </P>
-<CODE><P>&gt;&gt;&gt; import myextracom # external .pyd supporting some interface.<BR>
-# myextracom.pyd will do the equivalent of</CODE> </P>
-<CODE><P># pythoncom.mapSupportedTypes(myextracom.IID_Extra, myextracom.ExtraType) <BR>
-&gt;&gt;&gt; someobj.QueryInterface(myextracom.IID_Extra)</CODE> </P>
+<PRE><CODE>&gt;&gt;&gt; import myextracom # external .pyd supporting some interface.
+# myextracom.pyd will do the equivalent of
+# pythoncom.mapSupportedTypes(myextracom.IID_Extra, myextracom.ExtraType)
+&gt;&gt;&gt; someobj.QueryInterface(myextracom.IID_Extra)
+</CODE></PRE>
 <P>Would correctly return an object defined in the extension module. </P>
 <H3>Server Framework </H3>
 <H4>General Framework </H4>

--- a/com/win32com/HTML/QuickStartClientCom.html
+++ b/com/win32com/HTML/QuickStartClientCom.html
@@ -22,16 +22,17 @@
 
 <H2>Quick Start</H2>
 <H3><A NAME="Using">To use a COM object from Python</A></H3>
-<CODE><P>import win32com.client<BR>
-o = win32com.client.Dispatch("Object.Name")<BR>
-o.Method()<BR>
-o.property = "New Value"<BR>
-print(o.property)</P>
-</CODE><P>Example</P>
-<CODE><P>o = win32com.client.Dispatch("Excel.Application")<BR>
-o.Visible = 1<BR>
-o.Workbooks.Add()<BR>
-o.Cells(1,1).Value = "Hello"</CODE> </P>
+<PRE><CODE>import win32com.client
+o = win32com.client.Dispatch("Object.Name")
+o.Method()
+o.property = "New Value"
+print(o.property)
+</CODE></PRE>
+<P>Example</P>
+<PRE><CODE>o = win32com.client.Dispatch("Excel.Application")
+o.Visible = 1
+o.Workbooks.Add()
+o.Cells(1,1).Value = "Hello"</CODE></PRE>
 <P>And we will see the word "Hello" appear in the top cell. </P>
 <H3><A NAME="WhatObjects">How do I know which methods and properties are available?</A></H3>
 <P>Good question. This is hard! You need to use the documentation with the products, or possibly a COM browser. Note however that COM browsers typically rely on these objects registering themselves in certain ways, and many objects to not do this. You are just expected to know.</P>
@@ -41,8 +42,8 @@ o.Cells(1,1).Value = "Hello"</CODE> </P>
 <P>To run the browser, simply select it from the Pythonwin <I>Tools</I> menu, or double-click on the file <I>win32com\client\combrowse.py</I></P>
 <H2><A NAME="StaticDispatch">Static Dispatch (or Type Safe) objects</A></H2>
 <P>In the above examples, if we printed the '<CODE>repr(o)</CODE>' object above, it would have resulted in</P>
-<CODE><P>&lt;COMObject Excel.Application&gt;</P>
-</CODE><P>This reflects that the object is a generic COM object that Python has no special knowledge of (other than the name you used to create it!). This is known as a "dynamic dispatch" object, as all knowledge is built dynamically. The win32com package also has the concept of <I>static dispatch</I> objects, which gives Python up-front knowledge about the objects that it is working with (including arguments, argument types, etc)</P>
+<PRE><CODE>&lt;COMObject Excel.Application&gt;</CODE></PRE>
+<P>This reflects that the object is a generic COM object that Python has no special knowledge of (other than the name you used to create it!). This is known as a "dynamic dispatch" object, as all knowledge is built dynamically. The win32com package also has the concept of <I>static dispatch</I> objects, which gives Python up-front knowledge about the objects that it is working with (including arguments, argument types, etc)</P>
 <P>In a nutshell, Static Dispatch involves the generation of a .py file that contains support for the specific object. For more overview information, please see the documentation references above.</P>
 <P>The generation and management of the .py files is somewhat automatic, and involves one of 2 steps:</P>
 
@@ -68,15 +69,17 @@ o.Cells(1,1).Value = "Hello"</CODE> </P>
 <LI>If you desire, you can also use explicit code to generate it just before you need to use it at runtime.  Run <CODE>'makepy.py -i "Microsoft Word 8.0 Object Library"</CODE>' (include the double quotes) to see how to do this.</LI></UL>
 
 <P>And that is it! Nothing more needed. No special import statements needed! Now, you simply need say</P>
-<CODE><P>&gt;&gt;&gt; import win32com.client</P>
-<P>&gt;&gt;&gt; w=win32com.client.Dispatch("Word.Application")</P>
-<P>&gt;&gt;&gt; w.Visible=1</P>
-<P>&gt;&gt;&gt; w</P>
-<P>&lt;win32com.gen_py.Microsoft Word 8.0 Object Library._Application&gt;</P>
-</CODE><P>Note that now Python knows the explicit type of the object.</P>
+<PRE><CODE>&gt;&gt;&gt; import win32com.client
+&gt;&gt;&gt; w=win32com.client.Dispatch("Word.Application")
+&gt;&gt;&gt; w.Visible=1
+&gt;&gt;&gt; w
+&lt;win32com.gen_py.Microsoft Word 8.0 Object Library._Application&gt;
+</CODE></PRE>
+<P>Note that now Python knows the explicit type of the object.</P>
 <H3><A NAME="UsingComConstants">Using COM Constants</A></H3>
-<P>Makepy automatically installs all generated constants from a type library in an object called <I>win32com.clients.constants</I>.  You do not need to do anything special to make these constants work, other than create the object itself (ie, in the example above, the constants relating to <I>Word</I> would automatically be available after the <CODE>w=win32com.client.Dispatch("Word.Application</CODE>") statement<CODE>.</P>
-</CODE><P>For example, immediately after executing the code above, you could execute the following:</P>
-<CODE><P>&gt;&gt;&gt; w.WindowState = win32com.client.constants.wdWindowStateMinimize</P>
-</CODE><P>and Word will Minimize.</P></BODY>
+<P>Makepy automatically installs all generated constants from a type library in an object called <I>win32com.clients.constants</I>.  You do not need to do anything special to make these constants work, other than create the object itself (ie, in the example above, the constants relating to <I>Word</I> would automatically be available after the<CODE>w=win32com.client.Dispatch("Word.Application")</CODE> statement.</P>
+<P>For example, immediately after executing the code above, you could execute the following:</P>
+<PRE><CODE>&gt;&gt;&gt; w.WindowState = win32com.client.constants.wdWindowStateMinimize</CODE></PRE>
+<P>and Word will Minimize.</P>
+</BODY>
 </HTML>

--- a/com/win32com/HTML/QuickStartServerCom.html
+++ b/com/win32com/HTML/QuickStartServerCom.html
@@ -17,40 +17,22 @@
 <P>In this document we discuss the <A HREF="#core">core functionality</A>, <A HREF="#Registering">registering the server</A>, <A HREF="#testing">testing the class</A>, <A HREF="#debugging">debugging the class</A>, <A HREF="#Exception">exception handling</A> and <A HREF="#Policies">server policies</A> (phew!)</P>
 <H2><A NAME="core">Implement the core functionality</A></H2>
 <H3><A NAME="Using">Implement a stand-alone Python class with your functionality</A></H3>
-<CODE><P>class HelloWorld:</P><DIR>
-<DIR>
+<PRE><CODE>class HelloWorld:
+    def __init__(self):
+        self.softspace = 1
+        self.noCalls = 0
 
-<P>def __init__(self):</P><DIR>
-<DIR>
-
-<P>self.softspace = 1</P>
-<P>self.noCalls = 0</P></DIR>
-</DIR>
-
-<P>def Hello(self, who):</P><DIR>
-<DIR>
-
-<P>self.noCalls = self.noCalls + 1</P>
-<P># insert "softspace" number of spaces</P>
-<P>return "Hello" + " " * self.softspace + who</P></DIR>
-</DIR>
-</DIR>
-</DIR>
-
-</CODE><P>This is obviously a very simple server. In particular, custom error handling would be needed for a production class server. In addition, there are some contrived properties just for demonstration purposes.</P>
+    def Hello(self, who):
+        self.noCalls = self.noCalls + 1
+        # insert "softspace" number of spaces
+        return "Hello" + " " * self.softspace + who
+</CODE></PRE>
+<P>This is obviously a very simple server. In particular, custom error handling would be needed for a production class server. In addition, there are some contrived properties just for demonstration purposes.</P>
 <H3>Make Unicode concessions</H3>
 <P>At this stage, Python and Unicode don't really work well together. All strings which come from COM will actually be Unicode objects rather than string objects.</P>
-<P>To make this code work in a COM environment, the last line of the "Hello" method must become:</P><DIR>
-<DIR>
-<DIR>
-<DIR>
-
-<CODE><P>return "Hello" + " " * self.softspace + str(who)</P></DIR>
-</DIR>
-</DIR>
-</DIR>
-
-</CODE><P>Note the conversion of the "who" to "str(who)". This forces the Unicode object into a native Python string object.</P>
+<P>To make this code work in a COM environment, the last line of the "Hello" method must become:</P>
+<PRE><CODE>        return "Hello" + " " * self.softspace + str(who)</CODE></PRE>
+<P>Note the conversion of the "who" to "str(who)". This forces the Unicode object into a native Python string object.</P>
 <P>For details on how to debug COM Servers to find this sort of error, please see <A HREF="#debugging">debugging the class</A></P>
 <H3>Annotate the class with win32com specific attributes</H3>
 <P>This is not a complete list of names, simply a list of properties used by this sample.</P>
@@ -78,24 +60,23 @@
 </TABLE>
 
 <P>We change the class header to become:</P>
-<CODE><P>class HelloWorld:</P><DIR>
-<DIR>
-
-<P>_public_methods_ = ['Hello']</P>
-<P>_public_attrs_ = ['softspace', 'noCalls']</P>
-<P>_readonly_attrs_ = ['noCalls']</P>
-<P>def __init__(self):</P>
-<P>[Same from here...]</P></DIR>
-</DIR>
-
-</CODE><H3><A NAME="Registering">Registering and assigning a CLSID for the object</A></H3>
+<PRE><CODE>class HelloWorld:
+    _public_methods_ = ['Hello']
+    _public_attrs_ = ['softspace', 'noCalls']
+    _readonly_attrs_ = ['noCalls']
+    def __init__(self):
+    [Same from here...]
+</CODE></PRE>
+<H3><A NAME="Registering">Registering and assigning a CLSID for the object</A></H3>
 <P>COM requires that all objects use a unique CLSID and be registered under a "user friendly" name. This documents the process.</P>
 <H4>Generating the CLSID</H4>
 <P>Microsoft Visual C++ comes with various tools for generating CLSID's, which are quite suitable. Alternatively, the pythoncom module exports the function CreateGuid() to generate these identifiers.</P>
-<CODE><P>&gt;&gt;&gt; import pythoncom<BR>
-&gt;&gt;&gt; print(pythoncom.CreateGuid())<BR>
-{7CC9F362-486D-11D1-BB48-0000E838A65F}</P>
-</CODE><P>Obviously the GUID that you get will be different than that displayed here.</P>
+<PRE><CODE>
+&gt;&gt;&gt; import pythoncom
+&gt;&gt;&gt; print(pythoncom.CreateGuid())
+{7CC9F362-486D-11D1-BB48-0000E838A65F}
+</CODE></PRE>
+<P>Obviously the GUID that you get will be different than that displayed here.</P>
 <H4>Preparing for registration of the Class</H4>
 <P>The win32com package allows yet more annotations to be applied to a class, allowing registration to be effected with 2 lines in your source file. The registration annotations used by this sample are:</P>
 <TABLE CELLSPACING=0 BORDER=0 CELLPADDING=7 WIDTH=636>
@@ -136,25 +117,23 @@
 
 <P>Note there are quite a few other keys available. Also note that these annotations are <I>not</I> required - they just make registration simple. Helper functions in the module <CODE>win32com.server.register</CODE> allow you to explicitly specify each of these attributes without attaching them to the class.</P>
 <P>The header of our class now becomes:</P>
-<CODE><P>class HelloWorld:</P><DIR>
-<DIR>
-
-<P>_reg_clsid_ = "{7CC9F362-486D-11D1-BB48-0000E838A65F}"</P>
-<P>_reg_desc_ = "Python Test COM Server"</P>
-<P>_reg_progid_ = "Python.TestServer"</P>
-<P>_public_methods_ = ['Hello']</P>
-<P>[same from here]</P></DIR>
-</DIR>
-
-</CODE><H4>Registering the Class</H4>
+<PRE><CODE>class HelloWorld:
+    _reg_clsid_ = "{7CC9F362-486D-11D1-BB48-0000E838A65F}"
+    _reg_desc_ = "Python Test COM Server"
+    _reg_progid_ = "Python.TestServer"
+    _public_methods_ = ['Hello']
+    [same from here]
+</CODE></PRE>
+<H4>Registering the Class</H4>
 <P>The idiom that most Python COM Servers use is that they register themselves when run as a script (ie, when executed from the command line.) Thus the standard "<CODE>if __name__=='__main___':</CODE>" technique works well.</P>
 <P>win32com.server.register contains a number of helper functions. The easiest to use is "<CODE>UseCommandLine</CODE>".</P>
 <P>Registration becomes as simple as:</P>
-<CODE><P>if __name__=='__main__':<BR>
-&#9;# ni only for 1.4!<BR>
-&#9;import ni, win32com.server.register <BR>
-&#9;win32com.server.register.UseCommandLine(HelloWorld)</P>
-</CODE><P>Running the script will register our test server.</P>
+<PRE><CODE>if __name__=='__main__':
+    # ni only for 1.4!
+    import ni, win32com.server.register 
+    win32com.server.register.UseCommandLine(HelloWorld)
+</CODE></PRE>
+<P>Running the script will register our test server.</P>
 <H2><A NAME="testing">Testing our Class</A></H2>
 <P>For the purposes of this demonstration, we will test the class using Visual Basic. This code should run under any version of Visual Basic, including VBA found in Microsoft Office. Any COM compliant package could be used alternatively. VB has been used just to prove there is no "smoke and mirrors. For information on how to test the server using Python, please see the <A HREF="QuickStartClientCom.html">Quick Start to Client side COM</A> documentation.</P>
 <P>This is not a tutorial in VB. The code is just presented! Run it, and it will work!</P>
@@ -167,11 +146,11 @@
 <P>Servers need to be able to provide exception information to their client. In some cases, it may be a simple return code (such as E_NOTIMPLEMENTED), but often it can contain much richer information, describing the error on detail, and even a help file and topic where more information can be found. </P>
 <P>We use Python class based exceptions to provide this information. The COM framework will examine the exception, and look for certain known attributes. These attributes will be copied across to the COM exception, and passed back to the client. </P>
 <P>The following attributes are supported, and correspond to the equivalent entry in the COM Exception structure:<BR>
-<CODE>scode, code, description, source, helpfile and helpcontext</P>
-</CODE><P>To make working with exceptions easier, there is a helper module "win32com.server.exception.py", which defines a single class. An example of its usage would be: </P>
-<CODE><P>raise COMException(desc="Must be a string",scode=winerror.E_INVALIDARG,helpfile="myhelp.hlp",...)</CODE> </P>
-<P>(Note the <CODE>COMException class supports (and translates) "desc" as a shortcut for "description", but the framework requires "description")</P>
-</CODE><H2><A NAME="Policies">Server Policies</A></H2>
+<CODE>scode, code, description, source, helpfile and helpcontext</CODE></P>
+<P>To make working with exceptions easier, there is a helper module "win32com.server.exception.py", which defines a single class. An example of its usage would be: </P>
+<PRE><CODE>raise COMException(desc="Must be a string",scode=winerror.E_INVALIDARG,helpfile="myhelp.hlp",...)</CODE></PRE>
+<P>(Note the<CODE>COMException</CODE> class supports (and translates) "desc" as a shortcut for "description", but the framework requires "description")</P>
+<H2><A NAME="Policies">Server Policies</A></H2>
 <P>This is information about how it all hangs together. The casual COM author need not know this. </P>
 <P>Whenever a Python Server needs to be created, the C++ framework first instantiates a "policy" object. This "policy" object is the gatekeeper for the COM Server - it is responsible for creating the underlying Python object that is the server (ie, your object), and also for translating the underlying COM requests for the object. </P>
 <P>This policy object handles all of the underlying COM functionality. For example, COM requires all methods and properties to have unique numeric ID's associated with them. The policy object manages the creation of these ID's for the underlying Python methods and attributes. Similarly, when the client whishes to call a method with ID 123, the policy object translates this back to the actual method, and makes the call. </P>

--- a/com/win32com/HTML/variant.html
+++ b/com/win32com/HTML/variant.html
@@ -43,7 +43,7 @@ possibly or'd together.
 <p>For example, to create a VARIANT object which defines a byref array of
 32bit integers, you could use:
 
-<pre>
+<pre><code>
 >>> from win32com.client import VARIANT
 >>> import pythoncom
 >>> v = VARIANT(pythoncom.VT_BYREF | pythoncom.VT_ARRAY | pythoncom.VT_I4,
@@ -51,7 +51,7 @@ possibly or'd together.
 >>> v
 win32com.client.VARIANT(24579, [1, 2, 3, 4])
 >>>
-</pre>
+</code></pre>
 
 This variable can then be used whereever a COM VARIANT is expected.
 
@@ -60,9 +60,9 @@ This variable can then be used whereever a COM VARIANT is expected.
 For this example we will use the COM object used for win32com testing,
 <code>PyCOMTest.PyCOMTest</code>.  This object defines a method which is
 defined in IDL as:
-<pre>
+<pre><code>
 HRESULT DoubleInOutString([in,out] BSTR *str);
-</pre>
+</code></pre>
 
 As you can see, it takes a single string parameter which is also used as
 an "out" parameter - the single parameter will be updated after the call.
@@ -71,24 +71,24 @@ The implementation of the method simply "doubles" the string.
 <p>If the object has a type-library, this method works fine with makepy
 generated support.  For example:
 
-<pre>
+<pre><code>
 >>> from win32com.client.gencache import EnsureDispatch
 >>> ob = EnsureDispatch("PyCOMTest.PyCOMTest")
 >>> ob.DoubleInOutString("Hello")
 u'HelloHello'
 >>>
-</pre>
+</code></pre>
 
 However, if makepy support is not available the method does not work as
 expected.  For the next example we will use <code>DumbDispatch</code> to
 simulate the object not having a type-library.
 
-<pre>
+<pre><code>
 >>> import win32com.client.dynamic
 >>> ob = win32com.client.dynamic.DumbDispatch("PyCOMTest.PyCOMTest")
 >>> ob.DoubleInOutString("Hello")
 >>>
-</pre>
+</code></pre>
 
 As you can see, no result came back from the function.  This is because
 win32com has no type information available to use, so doesn't know the
@@ -99,7 +99,7 @@ around this, we can use the <code>VARIANT</code> object.
 variant type of a byref string and a value 'Hello'.  After making the
 call with this VARIANT the value is updated.
 
-<pre>
+<pre><code>
 >>> import win32com.client.dynamic
 >>> from win32com.client import VARIANT
 >>> import pythoncom
@@ -111,7 +111,7 @@ call with this VARIANT the value is updated.
 >>> variant.value
 u'HelloHello'
 >>>
-</pre>
+</code></pre>
 
 <h2>Usage with generated objects</h2>
 
@@ -122,9 +122,9 @@ be useful.
 
 Imagine a poorly specified object with IDL like:
 
-<pre>
+<pre><code>
 HRESULT DoSomething([in] VARIANT value);
-</pre>
+</code></pre>
 
 But also imagine that the object has a limitation that if the parameter is an
 integer, it must be a 32bit unsigned value - any other integer representation
@@ -145,14 +145,14 @@ was a COM object which a method called <code>foo</code> and you wanted to
 override the type declaration for <code>foo</code> by passing a VARIANT.
 You could do something like:
 
-<pre>
+<pre><code>
 >>> import win32com.client.dynamic
 >>> from win32com.client import VARIANT
 >>> import pythoncom
 >>> dumbob = win32com.client.dynamic.DumbDispatch(ob)
 >>> variant = VARIANT(pythoncom.VT_BYREF | pythoncom.VT_BSTR, "Hello")
 >>> dumbob.foo(variant)
-</pre>
+</code></pre>
 
 The code above converts the makepy supported <code>ob</code> into a
 'dumb' (ie, non-makepy supported) version of the object, which will then

--- a/com/win32comext/axscript/demos/client/ie/demo_intro.htm
+++ b/com/win32comext/axscript/demos/client/ie/demo_intro.htm
@@ -22,7 +22,7 @@ host are different, but Python should work "correctly".
 the concept of a "local" namespace.  For example, in VB, you can
 code <code>text="Hi there"</code>, but in Python, you must code
 <code>MyForm.ThisButton.Text="Hi There"</code>.  See the <A HREF="foo2.htm">foo2</A> sample
-for futher details.
+for further details.
 
 <H3>Known bugs and problems</H3>
 <UL>

--- a/com/win32comext/mapi/src/PyIMAPISession.i
+++ b/com/win32comext/mapi/src/PyIMAPISession.i
@@ -310,7 +310,7 @@ HRESULT OpenAddressBook(
 	IAddrBook **OUTPUT
 );
 
-// @pyswig <o PyIProfSection>|OpenProfileSection|Opens a section of the current profile and returns an object for futher access
+// @pyswig <o PyIProfSection>|OpenProfileSection|Opens a section of the current profile and returns an object for further access
 HRESULT OpenProfileSection(
 	MAPIUID *INPUT, // @pyparm <o PyIID>|iidSection||The MAPIIID of the profile section
 	IID *INPUT_NULLOK, // @pyparm <o PyIID>|iid||The IID of the interface, or None.

--- a/pythonwin/doc/EmbeddingWin32ui.html
+++ b/pythonwin/doc/EmbeddingWin32ui.html
@@ -29,7 +29,7 @@
   classes, and at certain key points in your CWinApp derived class, call the appropriate methods. You may choose to
   provide your own glue class derived from Win32uiHostGlue in certain cases. </P>
 <P>Below is an example class, which overrides the "SetStatusText" method, so that status information displays in the applications status bar (this is only necessary if your application has a "non standard" status bar - normally you could omit this.). </P>
-<PRE>GameApp NEAR theApp; // My existing CWinApp derived class.
+<PRE><CODE>GameApp NEAR theApp; // My existing CWinApp derived class.
 // HostGlue class.
 
 class GameHostGlue : public Win32uiHostGlue
@@ -40,12 +40,12 @@ class GameHostGlue : public Win32uiHostGlue
 };
 
 // The one and only Glue object.
-GameHostGlue NEAR glue; </PRE>
+GameHostGlue NEAR glue; </CODE></PRE>
 <P>And now we are well on our way. </P>
 <H3>Delegating to win32uiHostGlue</H3>
 <P>You need to either implement, or modify, certain key methods of your Application object. Probably the most important is the call to initialise win32ui. You need to modify your CWinApp::InitInstance method (it is almost certain you already have one). The following code needs to be executed in this method: </P>
 <H4>InitInstance</H4>
-<PRE>BOOL GameApp::InitInstance()
+<PRE><CODE>BOOL GameApp::InitInstance()
 {
 ...
   if (!glue.DynamicApplicationInit("import initscore", csScripts)) {
@@ -53,7 +53,7 @@ GameHostGlue NEAR glue; </PRE>
     ReportError("Could not attach to the Python win32ui extensions");
     return FALSE;
   }
-... </PRE>
+... </CODE></PRE>
 <P>Note the following: </P>
 
 <UL>
@@ -63,7 +63,7 @@ GameHostGlue NEAR glue; </PRE>
 
 <H4>And the Rest</H4>
 <P>Below is the rest of the code you need to implement. You may need to create these methods, as the AppWizard generated MFC application does not have some. </P>
-<PRE>BOOL
+<PRE><CODE>BOOL
 GameApp::OnCmdMsg (UINT nID, int nCode,
 void* pExtra, AFX_CMDHANDLERINFO*pHandlerInfo)
 {
@@ -87,13 +87,13 @@ BOOL GameApp::OnIdle( LONG lCount )
   if (CWinApp::OnIdle(lCount))
     return TRUE;
   return glue.OnIdle(lCount);
-} </PRE>
+} </CODE></PRE>
 
 <UL>
 <H3><LI>initscore.py</LI></H3>
 <LI>Below is the code for initscore.py. Obviously your code will vary, depending on your requirements. </LI></UL>
 
-<PRE>import sys
+<PRE><CODE>import sys
 import win32ui
 # First step - redirect python output to the debugging device, until we
 # can create a window to capture it.
@@ -114,9 +114,9 @@ sys.stderr=sys.stdout=DebugOutput()
 # the Pythonwin Interactive Window, which handles this automatically.
 
 # Now here is the code that does the real work.
-import win32con </PRE>
-<FONT FACE="Courier New" SIZE=2><P>from pywin.framework import intpyapp, app</P>
-</FONT><PRE>
+import win32con
+from pywin.framework import intpyapp, app
+
 class ScoreApp(intpyapp.InteractivePythonApp):
   def InitInstance(self):
     # Call the base class (if you want)
@@ -130,6 +130,6 @@ class ScoreApp(intpyapp.InteractivePythonApp):
 #  def OnExitInstance(self):
 #    return 0
 
-app = ScoreApp()</PRE>
+app = ScoreApp()</CODE></PRE>
 <P>And we are done </P></BODY>
 </HTML>

--- a/pythonwin/doc/architecture.html
+++ b/pythonwin/doc/architecture.html
@@ -38,29 +38,30 @@
 <P>Each win32ui type supports being "attached" to a Python class instance. When a virtual function is called, the Python class instance associated with the object is checked to see if it has a method with the same name. If so, the method is called. </P>
 <P>More details on this can be found in the <A HREF="docview.html">document and view architecture documentation</A>. </P>
 <H3><A NAME="Example">Example of this in action</A> </H3>
-<CODE><P>&gt;&gt;&gt; import win32ui # import the base win32ui module. <BR>
-&gt;&gt;&gt; import dialog # import dialog.py<BR>
-&gt;&gt;&gt; d=dialog.Dialog(win32ui.IDD_SIMPLE_INPUT)<BR>
-&gt;&gt;&gt; d<BR>
-&lt;Dialog instance at 886c78&gt;</CODE> </P>
+<PRE><CODE>&gt;&gt;&gt; import win32ui # import the base win32ui module.
+&gt;&gt;&gt; import dialog # import dialog.py
+&gt;&gt;&gt; d=dialog.Dialog(win32ui.IDD_SIMPLE_INPUT)
+&gt;&gt;&gt; d
+&lt;Dialog instance at 886c78&gt;</CODE></PRE>
 <P>This creates an instance of class Dialog, defined in dialog.py. Dialog is derived from Object (via Wnd). To see the underlying win32ui type: </P>
-<CODE><P>&gt;&gt;&gt; d._obj_<BR>
-object 'PyCDialog' - assoc is 002F3278, vf=True, ch=0, mh=2, kh=0<BR>
-&gt;&gt;&gt; <BR>
-</CODE>This output shows the C++ CDialog object is at address<CODE> 0x002F3278</CODE>, that there is a virtual function handler (i.e., the class instance "d"), that 2 messages have hooks, and no command or keyboard handlers are installed. </P>
+<PRE><CODE><P>&gt;&gt;&gt; d._obj_
+object 'PyCDialog' - assoc is 002F3278, vf=True, ch=0, mh=2, kh=0
+&gt;&gt;&gt;
+</CODE></PRE>This output shows the C++ CDialog object is at address <CODE> 0x002F3278</CODE>, that there is a virtual function handler (i.e., the class instance "d"), that 2 messages have hooks, and no command or keyboard handlers are installed. </P>
 <P>Even though the DoModal() method is implemented in the underlying win32ui type, the class object can be used just like the win32ui object. Thus: </P>
-<CODE><P>&gt;&gt;&gt; d.DoModal()<BR>
-1<BR>
-&gt;&gt;&gt; </P>
-</CODE><P>To see virtual functions in action </P>
-<CODE><PRE>&gt;&gt;&gt; class MyDialog(dialog.Dialog):<BR>
-...   def OnInitDialog(self, msg): <BR>
-...     self.GetDlgItem(win32ui.IDC_PROMPT1).SetWindowText("Hello") <BR>
-...     return 1<BR>
-... <BR>
-&gt;&gt;&gt; d=MyDialog(win32ui.IDD_SIMPLE_INPUT)<BR>
-&gt;&gt;&gt; d.DoModal()<BR>
-1</CODE> </PRE>
-<P>Note the prompt on the dialog box is now "Hello".<BR>
-</P></BODY>
+<PRE><CODE>&gt;&gt;&gt; d.DoModal()
+1
+&gt;&gt;&gt;
+</CODE></PRE>
+<P>To see virtual functions in action </P>
+<PRE><CODE>&gt;&gt;&gt; class MyDialog(dialog.Dialog):
+...   def OnInitDialog(self, msg): 
+...     self.GetDlgItem(win32ui.IDC_PROMPT1).SetWindowText("Hello") 
+...     return 1
+... 
+&gt;&gt;&gt; d=MyDialog(win32ui.IDD_SIMPLE_INPUT)
+&gt;&gt;&gt; d.DoModal()
+1</CODE></PRE>
+<P>Note the prompt on the dialog box is now "Hello".</P>
+</BODY>
 </HTML>

--- a/pythonwin/doc/debugger/general.html
+++ b/pythonwin/doc/debugger/general.html
@@ -20,33 +20,33 @@
 <H2><A NAME="Debugger_Interface">Debugger Interface</A></H2>
 <P>The debugger is based on the standard Python debugging modules. It is suggested you read the documentation on the "<CODE>pdb</CODE>" and "<CODE>bdb</CODE>" modules. This documentation can be located in the standard Python documentation: </P>
 <P>The package exports the following functions: </P>
-<CODE><P>GetDebugger()</CODE> </P><DIR>
+<PRE><CODE>GetDebugger()</CODE></PRE><DIR>
 <DIR>
 
 <P>Returns a debugger object. If there is already a debugger, then this function returns it (re-creating its window, if necessary). If there is no current debugger, a debugger is created. </P></DIR>
 </DIR>
 
 <P>The following functions operate almost identically to those described in the <CODE>pdb</CODE> documentation </P>
-<CODE><P>set_trace()<BR>
-brk() # alternative name</CODE> </P><DIR>
+<PRE><CODE>set_trace()
+brk() # alternative name</CODE></PRE><DIR>
 <DIR>
 
 <P>Like a hard-coded break-point, this function creates a debugger if necessary, and stops at the following statement. Note - putting this statement as the last line of a function may cause you to stop at an unexpected place! </P></DIR>
 </DIR>
 
-<CODE><P>post_mortem(traceback, exception_type = None, exception_value = None)</CODE> </P><DIR>
+<PRE><CODE>post_mortem(traceback, exception_type = None, exception_value = None)</CODE></PRE><DIR>
 <DIR>
 
 <P>Perform post-mortem debugging of the passed traceback. This is useful for analysing the conditions that lead up to an exception. </P></DIR>
 </DIR>
 
-<CODE><P>run(cmd, globals=None, locals=None)</CODE> </P><DIR>
+<PRE><CODE>run(cmd, globals=None, locals=None)</CODE></PRE><DIR>
 <DIR>
 
 <P>Begin debugging the command, in the globals and locals context. </P></DIR>
 </DIR>
 
-<CODE><P>runeval(expression, globals=None, locals=None)</CODE> </P><DIR>
+<PRE><CODE>runeval(expression, globals=None, locals=None)</CODE></PRE><DIR>
 <DIR>
 
 <P>Like "<CODE>run</CODE>" but treats the string as an expression to be evaluated. </P></DIR>

--- a/pythonwin/doc/debugger/tutorial.html
+++ b/pythonwin/doc/debugger/tutorial.html
@@ -25,23 +25,23 @@
 <H2><A NAME="Starting_the_Debugger">Starting the Debugger</A> </H2>
 <H3>From Pythonwin or Python.exe</H3>
 <P>At the interactive window, type:</P>
-<PRE>import pywin.debugger.fail&lt;enter&gt;</PRE>
+<PRE><CODE>import pywin.debugger.fail&lt;enter&gt;</CODE></PRE>
 <P>&nbsp;</P>
 <H3>From Windows Explorer</H3>
 <P>Navigate to the pythonwin\pywin\debugger directory, and double-click on the file "fail.py"</P>
 <H3>From the MS-DOS Prompt</H3>
 <P>Change to the pythonwin\pywin\debugger directory.</P>
 <P>For Windows NT users, type:</P>
-<CODE><P>fail.py&lt;enter&gt;</CODE> </P>
+<PRE><CODE>fail.py&lt;enter&gt;</CODE></PRE>
 <P>or</P>
-<CODE><P>start fail.py</CODE> </P>
+<PRE><CODE>start fail.py</CODE></PRE>
 <H2>Using the Debugger</H2>
 <P>If all goes well, you should see the debugger appear in a full GUI frame, with a particular line in fail.py highlighted. Part of the screen should look something like: </P>
 <P><i>NOTE:</i> This screen capture is wrong - hopefully what you can see on
 your screen is better and more obvious than this old picture! </P>
 <P><IMG SRC="tut1.gif" WIDTH=551 HEIGHT=82></P>
 <P>In this case, the Python program has executed until it hit the statement: </P>
-<CODE><P>pywin.debugger.set_trace()</CODE> </P>
+<PRE><CODE>pywin.debugger.set_trace()</CODE></PRE>
 <P>This statement is effectively a hard-coded break-point, which creates a debugger, and causes it to stop at the statement following the set_trace(). </P>
 <P>The Debugger is showing the blue line as the "current" line - this is the next statement to be executed. </P>
 <H2><A NAME="Setting_a_Breakpoint">Setting a Break-point</A> </H2>

--- a/win32/help/process_info.html
+++ b/win32/help/process_info.html
@@ -99,7 +99,7 @@ We'll cover these points now in more depth.
 The MSDN describes the call as the following:
 </p>
 <p>
-<code>
+<pre><code>
 PDH_STATUS PdhEnumObjectItems(
   LPCTSTR szDataSource,
   LPCTSTR szMachineName,
@@ -111,7 +111,7 @@ PDH_STATUS PdhEnumObjectItems(
   DWORD dwDetailLevel,
   DWORD dwFlags
 );
-</code>
+</code></pre>
 </p>
 <p>
 The python call is similar though simpler. For example, you do not
@@ -121,14 +121,14 @@ components shown later.To call make with python would look like the
 following
 
 <p>
-<code>
+<pre><code>
     def proclist(self):
         try:
             junk, instances = win32pdh.EnumObjectItems(None,None,self.object, win32pdh.PERF_DETAIL_WIZARD)
             return instances
         except:
             raise COMException("Problem getting process list")
-</code>
+</code></pre>
 <p>
 The variable instances contains the list of processes, and you'll find the item or counter than we want
 'ID Process' present in the list of items.
@@ -139,13 +139,13 @@ python it is convenient to use a dictionary to store a list of
 processes and how many you found for each type.
 </p>
 <p>
-<pre>
+<pre><code>
     for instance in instances:
         if proc_dict.has_key(instance):
             proc_dict[instance] = proc_dict[instance] + 1
         else:
             proc_dict[instance]=0
-</pre>
+</code></pre>
 </p>
 
 <p>
@@ -160,7 +160,7 @@ Standard C++. The additional things you need to manage are:
 </ul>
 </p>
 <p>
-<code>
+<pre><code>
 HRESULT getinst (map &lt; string,int &gt; & m_inst) {
 
 	map&lt;string, int&gt;::iterator iter;
@@ -234,7 +234,7 @@ HRESULT getinst (map &lt; string,int &gt; & m_inst) {
 	return S_OK;
 
 }
-</code>
+</code></pre>
 </p>
 
 <hr>
@@ -254,7 +254,7 @@ As usual the python code matches this very cleanly (like pseudocode that actuall
 out the basic meanings and sequences of the win32 calls without having to deal with other details.
 
 <p>
-<code>
+<pre><code>
         for instance, max_instances in proc_dict.items():
             for inum in xrange(max_instances+1):
                 try:
@@ -267,7 +267,7 @@ out the basic meanings and sequences of the win32 calls without having to deal w
                     win32pdh.CloseQuery(hq)
                 except:
                     raise COMException("Problem getting process id")
-</code>
+</code></pre>
 
 <p>
 Again, the C++ code is more involved and makes use of Standard C++, vector, map, and string.
@@ -276,7 +276,7 @@ has tab-delimited process id entry. Also, the process id info is returned in the
 is converted to a string.
 </p>
 <p>
-<code>
+<pre><code>
 HRESULT getprocid (map&lt;string,int&gt;& m_inst, vector&lt;string&gt; &v_ids) {
 
 
@@ -347,20 +347,20 @@ HRESULT getprocid (map&lt;string,int&gt;& m_inst, vector&lt;string&gt; &v_ids) {
 	return S_OK;
 }
 
-</code>
+</code></pre>
 <p>
 <hr><h2><a name="client">The COM client.</a></h2>
 The Python COM client which will call the C++ COM object and Python COM object does the following:
 </p>
 <p>
-<code>
+<pre><code>
      import win32com.client
      a=win32com.client.Dispatch('NtPerf.process') # C++ com object
      print(a.procids())
 
      b=win32com.client.Dispatch('PyPerf.process') # python com object
      print(b.procids())
-</code>
+</code></pre>
 </p>
 <p>
 As far as it is concerned, there is no difference between the 2 objects. Both returns a list of processes and their
@@ -448,7 +448,7 @@ object and a line to register it.
 </p>
 
 <p>
-<code>
+<pre><code>
 import win32pdh, string, win32api
 from win32com.server.exception import COMException
 import win32com.server.util
@@ -504,7 +504,7 @@ class pyperf:
 if __name__=='__main__':
     import win32com.server.register
     win32com.server.register.UseCommandLine(pyperf)
-</code>
+</code></pre>
 </p>
 
 
@@ -524,7 +524,7 @@ you store the values in a Variant pointer.
 </p>
 
 <p>
-<code>
+<pre><code>
 
 Here is the relevant excerpt from the IDL:
 
@@ -819,7 +819,7 @@ STDMETHODIMP Cprocess::procids(VARIANT *pids)
 
 
 }
-</code>
+</code></pre>
 <p>
 
 <hr>

--- a/win32/help/security_directories.html
+++ b/win32/help/security_directories.html
@@ -152,7 +152,7 @@ for info about the various win32 calls made.
 <H2><A NAME="Extend_get">Extending Python for Directory Permissions</A></H2>
 The following Extension creates a dictionary of
 user or group plus the access mask. To Python it will look like:
-<pre>
+<pre><code>
 import fileperm
 all_perms=fileperm.get_perms(r'\\Simon\share\db\a.txt')
 
@@ -160,10 +160,10 @@ And if you print the perms you'll get something like:
 
 print(all_perms)
 {'\\Everyone': 2032127L, 'Domain\\fred': 1179817L, 'BUILTIN\\Users': 1179817L}
-</pre>
+</code></pre>
 
 <h3><A NAME="#Extend_Get_c">C code</a></h3>
-<pre>
+<pre><code>
 
 #include <Python.h>
 
@@ -249,13 +249,13 @@ static PyObject *get_perms(PyObject *self, PyObject *args)
 		acl_info(pDACL, aclSize.AceCount, fp );
 
 		//Dict
-		for (ULONG i=0;i<aclSize.AceCount;++i){
+		for (ULONG i=0;i&lt;aclSize.AceCount;++i){
 			PyDict_SetItem( py_perms, PyBytes_FromString(fp[i].user_domain) ,
 				PyLong_FromUnsignedLong ((unsigned long) fp[i].user_mask));
 		}
 
 		//List
-		for (i=0;i<aclSize.AceCount;++i){
+		for (i=0;i&lt;aclSize.AceCount;++i){
 			PyList_Append(py_perms,PyBytes_FromString(fp[i].user_domain));
 		}
 
@@ -282,9 +282,6 @@ Py_InitModule("fileperm",fileperm_methods);
 
 }
 
-</pre>
-
-
 
 
 //Boilerplate functions
@@ -306,9 +303,7 @@ void initfileperm()
 Py_InitModule("fileperm",fileperm_methods);
 
 }
-
-<p>
-</p>
+</code></pre>
 
 <h3><A NAME="#Extend_Get_py">Python code</a></h3>
 One thing the extension doesn't do is process the access mask into human
@@ -317,7 +312,7 @@ readable names. Python can easily do that as shown in the program below.
 This program looks down a directory tree, takes the access mask and the login/group information,
 processes the access mask to produce human readable names and prints out the
 permission structure for the tree.
-<pre>
+<pre><code>
 import os
 import sys
 import win32net
@@ -423,7 +418,7 @@ def get_perm(file):
             perm_list.append(sys_id+'\t\t'+mask_name)
     return perm_list
 def get_perms(arg, d, files):
-    a=2147483648L #1L<<31L
+    a=2147483648L #1L&lt;&lt;31L
     print("Now at ",d)
     for i in files:
         file=d+'\\'+i
@@ -505,7 +500,7 @@ else:
             print(i)
         end = time.clock()-init
 
-</pre>
+</code></pre>
 
 <HR>
 <H2><A NAME="Conclusion">In Conclusion</A></H2>

--- a/win32/help/win32net.html
+++ b/win32/help/win32net.html
@@ -83,12 +83,12 @@ r'\\rubble'.
 <p>
 And finally, python's exception handling makes it convenient to catch win32net errors.
 I use the following format:
-<code>
+<pre><code>
 try:
   #win32net calls
 except win32net.error:
   print(traceback.format_tb(sys.exc_info()[2]),'\n',sys.exc_type,'\n',sys.exc_value)
-</code>
+</code></pre>
 The traceback and sys modules are used to extract the error information.
 
 
@@ -103,7 +103,7 @@ The traceback and sys modules are used to extract the error information.
 need to use NetWkstaUserEnum api call.
 
 In c++ the call looks like this: |
-<code>
+<pre><code>
 NET_API_STATUS NetWkstaUserEnum(
   LPWSTR servername,
   DWORD level,
@@ -113,7 +113,7 @@ NET_API_STATUS NetWkstaUserEnum(
   LPDWORD totalentries,
   LPDWORD resumehandle
 );
-</code>
+</code></pre>
 The python documentation says this: | ([dict, ...], total, resumeHandle)
 = NetWkstaUserEnum( server, level , resumeHandle , prefLen )
 
@@ -128,7 +128,7 @@ returned which trivial to parse and if resumeHandle is true you make
 the win32 call again.
 
 Now for some code:
-<code>
+<pre><code>
 def getusers(server):
   res=1  #initially set it to true
   pref=win32netcon.MAX_PREFERRED_LENGTH
@@ -147,7 +147,7 @@ def getusers(server):
 print(getusers(r'\\betty'))
 
 
-</code>
+</code></pre>
 
 <H3><A NAME="accounts">Listing all user accounts</A></H3>
 
@@ -158,7 +158,7 @@ can look for. In this case, we use the constant in win32netcon to look
 for 'normal' accounts. Another win32net function, NetUserGetInfo
 described later gets the full_name for the login.
 
-<code>
+<pre><code>
 def getall_users(server):
    'This functions returns a list of id and full_names on an NT server'
    j=1
@@ -181,7 +181,7 @@ def getall_users(server):
 
 print(getall_users(r'\\dino'))
 
-</code>
+</code></pre>
 
 <H3><A NAME="machines">Listing all machines in Domain</A></H3> If you
 need to touch every machine in your domain, NetServerEnum can help you
@@ -190,7 +190,7 @@ for different classes of machines.  For example,
 win32netcon.SV_TYPE_DOMAIN_BAKCTRL, will single out backup domain
 controllers. Here we use SV_TYPE_ALL to get everything.
 
-<code>
+<pre><code>
 def getall_boxes(domain='',server=''):
     res=1
     wrk_lst=[]
@@ -208,7 +208,7 @@ def getall_boxes(domain='',server=''):
     return final_lst
 
 print(getall_boxes('bedrock',r'\\rubble'))
-</code>
+</code></pre>
 
 <H3><A NAME="share">Creating a share</A></H3>
 
@@ -224,7 +224,7 @@ structures; let's assume we want to use the PySHARE_INFO_2 structure.
 So do you create this PySHARE_INFO_2 Object? It is really quite simple:
 
 In c++, for example, the SHARE_INFO_2 structure looks like:
-<code>
+<pre><code>
 typedef struct _SHARE_INFO_2 {
 LPWSTR shi2_netname;
 DWORD shi2_type;
@@ -235,7 +235,7 @@ DWORD shi2_current_uses;
 LPWSTR shi2_path;
 LPWSTR shi2_passwd;
 } SHARE_INFO_2, *PSHARE_INFO_2, *LPSHARE_INFO_2;
-	</code>
+    </code></pre>
 What does that mean in python?
 
 
@@ -259,7 +259,7 @@ Example
 
 Given this knowledge, we could then write the following Python code to
 add a new share.
-<code>
+<pre><code>
 import win32net
 import win32netcon
 
@@ -283,7 +283,7 @@ try:
 except win32net.error:
   print(traceback.format_tb(sys.exc_info()[2]),'\n',sys.exc_type,'\n',sys.exc_value)
 
-</code>
+</code></pre>
 </p>
 <HR>
 <H2><A NAME="manage">Manage Users</A></H2>
@@ -298,7 +298,7 @@ use NetUserGetInfo and NetUserSetInfo, respectively.
 
 Example
 In c++ the setinfo call looks like this:
-<code>
+<pre><code>
 
 NET_API_STATUS NetUserSetInfo(
 
@@ -314,7 +314,7 @@ NET_API_STATUS NetUserSetInfo(
 
 );
 
-</code>
+</code></pre>
 It's reasonably self explanatory except for level. It turns out there
 are many levels. One of the most useful one is USER_INFO_3 this
 structure lets you change just about anything you want for a
@@ -326,7 +326,7 @@ using USER_INFO_1008 that has no corresponding NetUserGetInfo.
 
 The python call looks like this:
 
-<code>NetUserSetInfo( server , username ,level , data )</code>
+<pre><code>NetUserSetInfo( server , username ,level , data )</code></pre>
 
 For it the most interesting parts are server, level, and data.  Server
 is only interesting because the server name has to be prepended with
@@ -356,7 +356,7 @@ exception handling is a very powerful asset. The try block explicitly
 catches and win32net errors from your system calls. And, we can
 extract what happened with sys.exc_type and sys.exc_value.
 
-<code>
+<pre><code>
 import sys
 import win32net
 import win32netcon
@@ -377,7 +377,7 @@ try:
     print(info['full_name'])
 except win32net.error:
     print(traceback.format_tb(sys.exc_info()[2]),'\n',sys.exc_type,'\n',sys.exc_value)
-</code>
+</code></pre>
 
 <H3><A NAME="password"></A>Changing password expiration</H3>
 
@@ -403,7 +403,7 @@ Here is some code that turns on the
 
 UF_DONT_EXPIRE_PASSWD bit for a user.
 
-<code>
+<pre><code>
 import sys
 import win32net
 import win32netcon
@@ -428,7 +428,7 @@ try:
 except win32net.error:
     print(traceback.format_tb(sys.exc_info()[2]),'\n',sys.exc_type,'\n',sys.exc_value)
 
-</code>
+</code></pre>
 </p>
 <p>
 


### PR DESCRIPTION
Fixes https://github.com/mhammond/pywin32/issues/2784

- Wrap all multiline code block in `<pre><code> ... </code></pre>`.
  - `code` for monospace font, `pre` for respecting whitespace and newlines without CSS
- Fixed a handful of badly nested HTML and unclosed elements (like `<code><p></code></p>`)
- Removed a lot of deprecated `<dir>`
- Unblocks validating Python in HTML syntax and formatting (so I can tackle automatically discovering all issues similar to https://github.com/mhammond/pywin32/issues/1395)