### PR TITLE
Fix duplicated words in comments and docstrings

### DIFF
--- a/com/win32com/server/register.py
+++ b/com/win32com/server/register.py
@@ -335,7 +335,7 @@ def RegisterServer(
 
 
 def GetUnregisterServerKeys(clsid, progID=None, verProgID=None, customKeys=None):
-    """Given a server, return a list of of ("key", root), which are keys recursively
+    """Given a server, return a list of ("key", root), which are keys recursively
     and uncondtionally deleted at unregister or uninstall time.
     """
     # remove the main CLSID registration

--- a/com/win32comext/directsound/test/ds_test.py
+++ b/com/win32comext/directsound/test/ds_test.py
@@ -10,7 +10,7 @@ import win32com.directsound.directsound as ds
 import win32event
 from pywin32_testutil import find_test_fixture
 
-# next two lines are for for debugging:
+# next two lines are for debugging:
 # import win32com
 # import directsound as ds
 

--- a/com/win32comext/mapi/mapiutil.py
+++ b/com/win32comext/mapi/mapiutil.py
@@ -22,7 +22,7 @@ def GetPropTagName(pt):
                 # PR_BODY	= PROP_TAG( PT_TSTRING,	4096)
                 # PR_BODY_W	= PROP_TAG( PT_UNICODE, 4096)
                 # PR_BODY_A	= PROP_TAG( PT_STRING8, 4096)
-                # The following change ensures a lookup using only the the
+                # The following change ensures a lookup using only the
                 # property id returns the conditional default.
 
                 # PT_TSTRING is a conditional assignment for either PT_UNICODE or

--- a/pythonwin/pywin/scintilla/view.py
+++ b/pythonwin/pywin/scintilla/view.py
@@ -598,7 +598,7 @@ class CScintillaView(docview.CtrlView, control.CScintillaColorEditInterface):
                 self._UpdateWithClassMethods(dict, super)
 
     # Find which class definition caret is currently in and return
-    # indexes of the the first and the last lines of that class definition
+    # indexes of the first and the last lines of that class definition
     # Data is obtained from module browser (if enabled)
     def _GetClassInfoFromBrowser(self, pos=-1):
         minline = 0

--- a/win32/Lib/win32serviceutil.py
+++ b/win32/Lib/win32serviceutil.py
@@ -1,5 +1,5 @@
 # General purpose service utilities, both for standard Python scripts,
-# and for for Python programs which run as services...
+# and for Python programs which run as services...
 #
 # Note that most utility functions here will raise win32api.error's
 # (which is win32service.error, pywintypes.error, etc)

--- a/win32/test/test_win32file.py
+++ b/win32/test/test_win32file.py
@@ -800,7 +800,7 @@ class TestConnect(unittest.TestCase):
             win32file.ConnectEx(s2, self.addr, ol, b"some expected request")
         except win32file.error as exc:
             win32event.SetEvent(giveup_event)
-            raise  # some error error we don't expect.
+            raise  # some error we don't expect.
         # We occasionally see ERROR_CONNECTION_REFUSED in automation
         try:
             win32file.GetOverlappedResult(s2.fileno(), ol, 1)
@@ -835,7 +835,7 @@ class TestConnect(unittest.TestCase):
             win32file.ConnectEx(s2, self.addr, ol)
         except win32file.error as exc:
             win32event.SetEvent(giveup_event)
-            raise  # some error error we don't expect.
+            raise  # some error we don't expect.
         # We occasionally see ERROR_CONNECTION_REFUSED in automation
         try:
             win32file.GetOverlappedResult(s2.fileno(), ol, 1)


### PR DESCRIPTION
Removes accidental word repetitions in comments and one docstring. Each is a pure duplication — a single repeated word removed, with no wording or behaviour change:

- `com/win32com/server/register.py` — `GetUnregisterServerKeys` docstring: "a list **of of**" → "a list of"
- `com/win32comext/mapi/mapiutil.py` — "using only **the the**" → "using only the"
- `pythonwin/pywin/scintilla/view.py` — "indexes of **the the** first" → "indexes of the first"
- `win32/Lib/win32serviceutil.py` — "and **for for** Python programs" → "and for Python programs"
- `com/win32comext/directsound/test/ds_test.py` — "are **for for** debugging" → "are for debugging"
- `win32/test/test_win32file.py` (×2) — "some **error error** we don't expect" → "some error we don't expect"

Comments/docstrings only; no code behaviour changes.