### PR TITLE
Fix bare except clause in win32/Lib/win32serviceutil.py

### DIFF
--- a/win32/Lib/win32serviceutil.py
+++ b/win32/Lib/win32serviceutil.py
@@ -646,7 +646,7 @@ def QueryServiceStatus(serviceName, machine=None):
 def usage():
     try:
         fname = os.path.split(sys.argv[0])[1]
-    except:
+    except (IndexError, AttributeError):
         fname = sys.argv[0]
     print(
         "Usage: '%s [options] install|update|remove|start [...]|stop|restart [...]|debug [...]'"


### PR DESCRIPTION
Replace bare `except:` with `except (IndexError, AttributeError):` in the `usage()` function in `win32/Lib/win32serviceutil.py` (line 649).

The `try` block calls `os.path.split(sys.argv[0])[1]`, which can raise `IndexError` if `sys.argv` is empty or `AttributeError` if `sys.argv[0]` is not a string. Using a specific exception type avoids silently swallowing unexpected errors like `SystemExit` or `KeyboardInterrupt`.