### PR TITLE
setuptools 84 compatibility: Fix build with unhashable setuptools extensions + Remove `MyCygwinCompiler.initialize` hack

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
-  "setuptools >=84.0.0" # required for compiler initialization compatibility
+  "setuptools >=77.0.3", # made PEP-639 license deprecations introduced by 77.0.0 into warnings rather than errors
+  "setuptools >=84.0.0; python_version >= '3.10'", # required for compiler initialization compatibility; setuptools 83 and msys2 dropped support for Python 3.9
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools >=77.0.3" # made PEP-639 license deprecations introduced by 77.0.0 into warnings rather than errors
+  "setuptools >=84.0.0" # required for compiler initialization compatibility
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -856,9 +856,6 @@ else:
 
 
 class MyCygwinCompiler(BaseCygwinCompiler):
-    # Workaround until pypa/distutils#399 is fixed
-    BaseCygwinCompiler.initialize = lambda *_: None
-
     # Work around python/cpython#80483 / python/cpython#86175
     # it sorts sources but this breaks support for building .mc files etc :(
     # See pypa/setuptools#4986 / pypa/distutils#370 for potential upstream fix.

--- a/setup.py
+++ b/setup.py
@@ -601,7 +601,7 @@ class my_build_ext(build_ext):
         # This is only available from the Visual Studio Installer.
         # Skip if Pythonwin was also skipped.
         win32ui_ext = pythonwin_extensions[0]
-        if win32ui_ext not in {ext for ext, why in self.excluded_extensions}:
+        if not any(win32ui_ext is ext for ext, why in self.excluded_extensions):
             vc_path = next(p for p in Path(self.compiler.cc).parents if p.name == "VC")
             msvc_version = next(
                 p for p in Path(self.compiler.cc).parents if p.parent.name == "MSVC"


### PR DESCRIPTION
## Problem

Building pywin32 with setuptools 84.0.0 fails with:

`TypeError: cannot use 'WinExt_pythonwin' as a set element (unhashable type: 'WinExt_pythonwin')`

The failure occurs in `my_build_ext.build_extensions()` when checking whether `win32ui_ext` is present in `self.excluded_extensions`.

## Cause

`self.excluded_extensions` is a list of `(WinExt, str)` tuples, but the current code constructs a set from the extension objects using `{ext for ext, why in self.excluded_extensions}`.

With setuptools 84.0.0, `Extension` instances are unhashable, so constructing this set raises `TypeError`.

## Fix

Use `any()` with identity comparison instead of constructing a set.

The original check was:

`if win32ui_ext not in {ext for ext, why in self.excluded_extensions}:`

It was changed to:

`if not any(win32ui_ext is ext for ext, why in self.excluded_extensions):`

The check only needs to determine whether this specific extension object was excluded, so constructing a set is unnecessary.

## Verification

Tested on Windows x64 with Python 3.14.5 and MSVC 14.44.

- setuptools 83.0.0 with the existing code: build succeeds
- setuptools 84.0.0 with the existing code: build fails at `setup.py:604`
- setuptools 84.0.0 with this change: build succeeds
- `import win32api, win32con, win32ui`: succeeds

The resulting wheel was successfully built and installed.