### PR TITLE
Add win32api.ToUnicodeEx wrapper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@ As of build 305, installation .exe files have been deprecated; see
 
 Coming in build 313, as yet unreleased
 --------------------------------------
-
+* Added `win32api.ToUnicodeEx` wrapper for translating virtual-key codes and keyboard state to Unicode characters (mhammond#2788, [@ravik453][ravik453])
 * Updated `MAPIStubLibrary` vendored sources (mhammond#2764, [@Avasam][Avasam]):
   * Migrated from deprecated SAL v1 annotations to SAL v2
   * New `win32comext.mapi.mapitags` symbols:
@@ -512,6 +512,7 @@ for them.
 [maxim-krikun]: https://github.com/maxim
 [Mscht]: https://github.com/Mscht
 [nbbeatty]: https://github.com/nbbeatty
+[ravik453]: https://github.com/ravik453
 [saaketp]: https://github.com/saaketp
 [the-snork]: https://github.com/the-snork
 [wkschwartz]: https://github.com/wkschwartz

--- a/win32/src/win32apimodule.cpp
+++ b/win32/src/win32apimodule.cpp
@@ -5792,7 +5792,8 @@ PyObject *PyToAsciiEx(PyObject *self, PyObject *args)
     return PyBytes_FromStringAndSize(result, nc);
 }
 
-// @pymethod string|win32api|ToUnicodeEx|Translates the specified virtual-key code and keyboard state to Unicode characters.
+// @pymethod string|win32api|ToUnicodeEx|Translates the specified virtual-key code and keyboard state to Unicode
+// characters.
 PyObject *PyToUnicodeEx(PyObject *self, PyObject *args)
 {
     UINT vk, sc, flags = 0;
@@ -5818,15 +5819,7 @@ PyObject *PyToUnicodeEx(PyObject *self, PyObject *args)
 
     WCHAR result[256];
 
-    int nc = ToUnicodeEx(
-        vk,
-        sc,
-        (const BYTE *)state,
-        result,
-        ARRAYSIZE(result),
-        flags,
-        layout
-    );
+    int nc = ToUnicodeEx(vk, sc, (const BYTE *)state, result, ARRAYSIZE(result), flags, layout);
 
     if (nc <= 0) {
         Py_INCREF(Py_None);
@@ -5835,7 +5828,6 @@ PyObject *PyToUnicodeEx(PyObject *self, PyObject *args)
 
     return PyUnicode_FromWideChar(result, nc);
 }
-
 
 // @pymethod int|win32api|MapVirtualKey|Translates (maps) a virtual-key code into a scan code or character value, or
 // translates a scan code into a virtual-key code.
@@ -6305,7 +6297,8 @@ static struct PyMethodDef win32api_functions[] = {
     {"TerminateProcess", PyTerminateProcess, 1},  // @pymeth TerminateProcess|Terminates a process.
     {"ToAsciiEx", PyToAsciiEx, 1},  // @pymeth ToAsciiEx|Translates the specified virtual-key code and keyboard state to
                                     // the corresponding character or characters.
-    {"ToUnicodeEx", PyToUnicodeEx, 1},  // @pymeth ToUnicodeEx|Translates the specified virtual-key code and keyboard state to Unicode characters.
+    {"ToUnicodeEx", PyToUnicodeEx,
+     1},  // @pymeth ToUnicodeEx|Translates the specified virtual-key code and keyboard state to Unicode characters.
     {"UpdateResource", PyUpdateResource, 1},  // @pymeth UpdateResource|Updates a resource in a PE file.
     {"VkKeyScan", PyVkKeyScan,
      1},  // @pymeth VkKeyScan|Translates a character to the corresponding virtual-key code and shift state.

--- a/win32/src/win32apimodule.cpp
+++ b/win32/src/win32apimodule.cpp
@@ -5792,6 +5792,51 @@ PyObject *PyToAsciiEx(PyObject *self, PyObject *args)
     return PyBytes_FromStringAndSize(result, nc);
 }
 
+// @pymethod string|win32api|ToUnicodeEx|Translates the specified virtual-key code and keyboard state to Unicode characters.
+PyObject *PyToUnicodeEx(PyObject *self, PyObject *args)
+{
+    UINT vk, sc, flags = 0;
+    const char *state;
+    Py_ssize_t statesize;
+    PyObject *obhlayout = NULL;
+    HKL layout = 0;
+
+    // @pyparm int|vk||The virtual key code.
+    // @pyparm int|scancode||The scan code.
+    // @pyparm bytes|keyboardstate||A string of exactly 256 characters.
+    // @pyparm int|flags|0|
+    // @pyparm handle|hlayout|None|The keyboard layout to use
+
+    if (!PyArg_ParseTuple(args, "iis#|iO", &vk, &sc, &state, &statesize, &flags, &obhlayout))
+        return NULL;
+
+    if (statesize != 256)
+        return PyErr_Format(PyExc_ValueError, "keyboard state string must be exactly 256 characters");
+
+    if (obhlayout && !PyWinObject_AsHANDLE(obhlayout, (HANDLE *)&layout))
+        return NULL;
+
+    WCHAR result[256];
+
+    int nc = ToUnicodeEx(
+        vk,
+        sc,
+        (const BYTE *)state,
+        result,
+        ARRAYSIZE(result),
+        flags,
+        layout
+    );
+
+    if (nc <= 0) {
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+
+    return PyUnicode_FromWideChar(result, nc);
+}
+
+
 // @pymethod int|win32api|MapVirtualKey|Translates (maps) a virtual-key code into a scan code or character value, or
 // translates a scan code into a virtual-key code.
 // @comm implemented by calling the unicode versions of the API (MapVirtualKeyW/MapVirtualKeyExW)
@@ -6260,6 +6305,7 @@ static struct PyMethodDef win32api_functions[] = {
     {"TerminateProcess", PyTerminateProcess, 1},  // @pymeth TerminateProcess|Terminates a process.
     {"ToAsciiEx", PyToAsciiEx, 1},  // @pymeth ToAsciiEx|Translates the specified virtual-key code and keyboard state to
                                     // the corresponding character or characters.
+    {"ToUnicodeEx", PyToUnicodeEx, 1},  // @pymeth ToUnicodeEx|Translates the specified virtual-key code and keyboard state to Unicode characters.
     {"UpdateResource", PyUpdateResource, 1},  // @pymeth UpdateResource|Updates a resource in a PE file.
     {"VkKeyScan", PyVkKeyScan,
      1},  // @pymeth VkKeyScan|Translates a character to the corresponding virtual-key code and shift state.

--- a/win32/test/test_win32api.py
+++ b/win32/test/test_win32api.py
@@ -249,6 +249,17 @@ class Misc(unittest.TestCase):
         # hopefully ' ' doesn't depend on the locale!
         self.assertEqual(win32api.VkKeyScan(" "), 32)
 
+    def testToUnicodeEx(self):
+        state = bytes(256)
+        vk = ord("A")
+        sc = win32api.MapVirtualKey(vk, 0)
+        self.assertEqual(win32api.ToUnicodeEx(vk, sc, state), "a")
+        self.assertIsNone(win32api.ToUnicodeEx(0, 0, state))
+        with self.assertRaisesRegex(
+            ValueError, "keyboard state string must be exactly 256 characters"
+        ):
+            win32api.ToUnicodeEx(vk, sc, b"")
+
     def testVkKeyScanEx(self):
         # hopefully ' ' doesn't depend on the locale!
         self.assertEqual(win32api.VkKeyScanEx(" ", 0), 32)


### PR DESCRIPTION
## Summary

Add a `win32api.ToUnicodeEx` wrapper for the Windows `ToUnicodeEx` API.

## Details

- Exposes `ToUnicodeEx` through `win32api`
- Supports virtual-key code, scan code, keyboard state, flags, and optional keyboard layout
- Returns the translated Unicode string or `None` when no translation is produced
- Adds a regression test covering normal translation, no-result behavior, and invalid keyboard-state length

## Testing

- `python -m unittest win32.test.test_win32api.Misc` — 6 passed
- `python -m unittest win32.test.test_win32api` — 15 passed
- `python win32\scripts\pywin32_testall.py -v -skip-adodbapi` — `ToUnicodeEx` tests passed; unrelated environment-dependent failures occurred in Security/EncryptFile tests
- `git diff --check` — passed