### PR TITLE
Skip tests that need features absent on Windows Home editions

### DIFF
--- a/win32/test/test_security.py
+++ b/win32/test/test_security.py
@@ -12,7 +12,16 @@ from pywin32_testutil import testmain
 
 class SecurityTests(unittest.TestCase):
     def setUp(self):
-        self.pwr_sid = win32security.LookupAccountName("", "Power Users")[0]
+        try:
+            self.pwr_sid = win32security.LookupAccountName("", "Power Users")[0]
+        except pywintypes.error as exc:
+            # 'Power Users' does not exist on every edition - it is absent on
+            # Windows Home (EditionID "Core") - and is localized on non-English
+            # installs. Every test in this class needs the SID, so skip rather
+            # than error out of setUp.
+            if exc.winerror != winerror.ERROR_NONE_MAPPED:
+                raise
+            raise unittest.SkipTest("No 'Power Users' group is available")
         try:
             self.admin_sid = win32security.LookupAccountName("", "Administrator")[0]
         except pywintypes.error as exc:

--- a/win32/test/test_security.py
+++ b/win32/test/test_security.py
@@ -1,4 +1,5 @@
 # Tests for the win32security module.
+import os
 import unittest
 
 import ntsecuritycon
@@ -19,7 +20,7 @@ class SecurityTests(unittest.TestCase):
             # Windows Home (EditionID "Core") - and is localized on non-English
             # installs. Every test in this class needs the SID, so skip rather
             # than error out of setUp.
-            if exc.winerror != winerror.ERROR_NONE_MAPPED:
+            if exc.winerror != winerror.ERROR_NONE_MAPPED or "CI" in os.environ:
                 raise
             raise unittest.SkipTest("No 'Power Users' group is available")
         try:

--- a/win32/test/test_win32file.py
+++ b/win32/test/test_win32file.py
@@ -737,7 +737,10 @@ class TestEncrypt(unittest.TestCase):
             try:
                 win32file.EncryptFile(fname)
             except win32file.error as details:
-                if details.winerror == winerror.ERROR_NOT_SUPPORTED and "CI" not in os.environ:
+                if (
+                    details.winerror == winerror.ERROR_NOT_SUPPORTED
+                    and "CI" not in os.environ
+                ):
                     # EFS is not available on every edition - Windows Home
                     # (EditionID "Core") returns ERROR_NOT_SUPPORTED here.
                     raise unittest.SkipTest(

--- a/win32/test/test_win32file.py
+++ b/win32/test/test_win32file.py
@@ -737,7 +737,7 @@ class TestEncrypt(unittest.TestCase):
             try:
                 win32file.EncryptFile(fname)
             except win32file.error as details:
-                if details.winerror == winerror.ERROR_NOT_SUPPORTED:
+                if details.winerror == winerror.ERROR_NOT_SUPPORTED and "CI" not in os.environ:
                     # EFS is not available on every edition - Windows Home
                     # (EditionID "Core") returns ERROR_NOT_SUPPORTED here.
                     raise unittest.SkipTest(

--- a/win32/test/test_win32file.py
+++ b/win32/test/test_win32file.py
@@ -737,6 +737,12 @@ class TestEncrypt(unittest.TestCase):
             try:
                 win32file.EncryptFile(fname)
             except win32file.error as details:
+                if details.winerror == winerror.ERROR_NOT_SUPPORTED:
+                    # EFS is not available on every edition - Windows Home
+                    # (EditionID "Core") returns ERROR_NOT_SUPPORTED here.
+                    raise unittest.SkipTest(
+                        "EFS is not supported on this edition of Windows"
+                    )
                 if details.winerror != winerror.ERROR_ACCESS_DENIED:
                     raise
                 print("It appears this is not NTFS - can't encrypt/decrypt")


### PR DESCRIPTION
## Summary

On a Windows **Home** edition (`EditionID` = `Core`), `win32/test/testall.py` reports **8 errors**. Seven of them are two environment facts that the test suite treats as failures rather than as "not available here":

- **The `Power Users` group does not exist on Home.** `SecurityTests.setUp` looks the SID up with no guard, so every test in the class errors out in `setUp`.
- **EFS is not available on Home.** `EncryptFile()` fails with `ERROR_NOT_SUPPORTED` (50), which `TestEncrypt` does not tolerate.

Both sites already have the right pattern one or two lines away — this PR just applies it consistently.

In `test_security.py`, the `Administrator` lookup immediately below already tolerates `ERROR_NONE_MAPPED` for precisely this reason, with a comment noting it is seen in automation. The `Power Users` lookup above it is unguarded.

In `test_win32file.py`, `TestEncrypt` already tolerates `ERROR_ACCESS_DENIED` for non-NTFS volumes; it just doesn't know about the "no EFS on this edition" errno.

## Changes

Two commits, independently revertable:

1. `win32/test/test_security.py` — guard the `Power Users` lookup and `SkipTest` when the group is unresolvable. Every test in the class needs `pwr_sid`, so skipping in `setUp` is the whole-class answer.
2. `win32/test/test_win32file.py` — `SkipTest` on `ERROR_NOT_SUPPORTED` from `EncryptFile()`.

Both messages say "Home" because that's what I can reproduce, but the `Power Users` change also covers **non-English installs**, where the group exists under a localized name and `LookupAccountName` returns the same `ERROR_NONE_MAPPED`.

## Testing

Windows 11 Home (`EditionID` `Core`, 10.0.26200), Python 3.13.13. Repo at `a992023`; `build_id` is `312.1` and I tested against the `312` wheel, so the extension modules are one patch build off the source tree — that skew doesn't touch these code paths, but it's worth stating.

`python win32/test/testall.py`, comparing the **set** of failing tests rather than the counts:

| | before | after |
|---|---|---|
| errors | **8** | **1** |

- **Fixed (7):** `testEqual`, `testNEOther`, `testNESID`, `testSIDInDict`, `testBuffer`, `testMemory` (all `SecurityTests`, all previously erroring in `setUp`), and `testEncrypt`.
- **Introduced: none.**

Verified individually afterwards: `test_security` reports `OK (skipped=14)`, and `TestEncrypt` reports `SKIPPED: 1 tests - EFS is not supported on this edition of Windows`.

## What is deliberately unchanged

**The remaining error is the `win32/Demos/OpenEncryptedFileRaw.py` demo**, which fails from the same missing EFS. I left it alone: `testall.py` has a `bad_demos` exclusion list, but that would disable the demo everywhere, and it is perfectly good on editions that have EFS. Making it exit cleanly would mean editing the demo itself to probe for EFS first — a bigger and more opinionated change than this PR, and I'd rather ask than assume. Happy to do it in a follow-up if you want it.

I also left `TestEncrypt`'s existing `ERROR_ACCESS_DENIED` branch as-is, though note it prints and then still calls `DecryptFile()` on a file that was never encrypted. That looked pre-existing and out of scope here.

No `CHANGES.md` entry: the "notable changes" list reads as user-facing API/build changes, and this is test-only. Say the word if you'd like one anyway.

## Note on AI assistance

I used an AI assistant while working on this. The reproduction, the before/after suite runs, the failing-set comparison, and the `EditionID`/`LookupAccountName` probes quoted above were all executed by me on the Windows Home machine described. I compared failing-test *sets* rather than counts deliberately — on other projects I've seen counts vary between runs of an identical commit, and a count delta alone would not have been evidence.
