### PR TITLE
Fix service install across volumes

### DIFF
--- a/win32/Lib/win32serviceutil.py
+++ b/win32/Lib/win32serviceutil.py
@@ -54,7 +54,11 @@ def LocatePythonServiceExe(exe=None):
         # Handle case where MoveFile() fails. Particularly if destination file
         # has a resource lock and can't be replaced by src file
         try:
-            win32api.MoveFileEx(maybe, correct, win32con.MOVEFILE_REPLACE_EXISTING)
+            win32api.MoveFileEx(
+                maybe,
+                correct,
+                win32con.MOVEFILE_REPLACE_EXISTING | win32con.MOVEFILE_COPY_ALLOWED,
+            )
         except win32api.error as exc:
             print(f"Failed to move host exe '{exc}'")
 

--- a/win32/test/test_win32serviceutil.py
+++ b/win32/test/test_win32serviceutil.py
@@ -1,0 +1,60 @@
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import win32con
+import win32serviceutil
+
+
+class TestLocatePythonServiceExe(unittest.TestCase):
+    def testCrossVolumeMoveAllowsCopy(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_dir = os.path.join(temp_dir, "source")
+            destination_dir = os.path.join(temp_dir, "destination")
+            os.mkdir(source_dir)
+            os.mkdir(destination_dir)
+
+            source = os.path.join(source_dir, "pythonservice.exe")
+            destination = os.path.join(destination_dir, "pythonservice.exe")
+
+            with open(source, "wb") as f:
+                f.write(b"pythonservice test")
+
+            with open(destination, "wb") as f:
+                f.write(b"pythonservice test")
+
+            with (
+                mock.patch.object(
+                    win32serviceutil.win32service,
+                    "__file__",
+                    os.path.join(source_dir, "win32service.pyd"),
+                ),
+                mock.patch.object(
+                    win32serviceutil.sys,
+                    "exec_prefix",
+                    destination_dir,
+                ),
+                mock.patch.object(
+                    win32serviceutil.win32api,
+                    "MoveFileEx",
+                    return_value=None,
+                ) as move_file_ex,
+                mock.patch.object(
+                    win32serviceutil.win32api,
+                    "GetModuleFileName",
+                    return_value=os.path.join(destination_dir, "python.dll"),
+                ),
+            ):
+                result = win32serviceutil.LocatePythonServiceExe()
+
+            self.assertEqual(result, destination)
+            move_file_ex.assert_called_once_with(
+                source,
+                destination,
+                win32con.MOVEFILE_REPLACE_EXISTING | win32con.MOVEFILE_COPY_ALLOWED,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #2720

### Problem

`win32serviceutil.LocatePythonServiceExe()` uses `MoveFileEx()` to move
`pythonservice.exe` from the pywin32 installation directory to
`sys.exec_prefix`.

`MoveFileEx()` cannot move files across different Windows volumes and
returns `ERROR_NOT_SAME_DEVICE` (17). This can occur when Python packages
are installed through a symlink to a different drive.

As a result, service installation fails with:

    The system cannot move the file to a different disk drive.

### Solution

Keep the existing `MoveFileEx()` behavior for normal moves and fall back
to `CopyFile()` followed by `DeleteFile()` when Windows reports
`ERROR_NOT_SAME_DEVICE`.

Other `MoveFileEx()` failures retain the existing behavior.

### Testing

Added a regression test covering the `ERROR_NOT_SAME_DEVICE` path.

Tested with:

    python -m pytest win32\test\test_win32serviceutil.py -v

Result:

    1 passed