### PR TITLE
Fix win32api.GetFullPathName returning an empty string for long paths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ As of build 305, installation .exe files have been deprecated; see
 
 Coming in build 313, as yet unreleased
 --------------------------------------
+* Fixed `win32api.GetFullPathName` silently returning an empty string for paths of 260 characters or more (mhammond#2790, [@MohammedAlkindi][MohammedAlkindi])
 * Added `win32api.ToUnicodeEx` wrapper for translating virtual-key codes and keyboard state to Unicode characters (mhammond#2788, [@ravik453][ravik453])
 * Updated `MAPIStubLibrary` vendored sources (mhammond#2764, [@Avasam][Avasam]):
   * Migrated from deprecated SAL v1 annotations to SAL v2
@@ -510,6 +511,7 @@ for them.
 [kxrob]: https://github.com/kxrob
 [markuskimius]: https://github.com/markuskimius
 [maxim-krikun]: https://github.com/maxim
+[MohammedAlkindi]: https://github.com/MohammedAlkindi
 [Mscht]: https://github.com/Mscht
 [nbbeatty]: https://github.com/nbbeatty
 [ravik453]: https://github.com/ravik453

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@ As of build 305, installation .exe files have been deprecated; see
 
 Coming in build 313, as yet unreleased
 --------------------------------------
-* Fixed `win32api.GetFullPathName` silently returning an empty string for paths of 260 characters or more (mhammond#2790, [@MohammedAlkindi][MohammedAlkindi])
+* Fixed `win32api.GetFullPathName` silently returning an empty string for paths of 260 characters or more (mhammond#2795, [@MohammedAlkindi][MohammedAlkindi])
 * Added `win32api.ToUnicodeEx` wrapper for translating virtual-key codes and keyboard state to Unicode characters (mhammond#2788, [@ravik453][ravik453])
 * Updated `MAPIStubLibrary` vendored sources (mhammond#2764, [@Avasam][Avasam]):
   * Migrated from deprecated SAL v1 annotations to SAL v2

--- a/win32/src/win32apimodule.cpp
+++ b/win32/src/win32apimodule.cpp
@@ -2630,13 +2630,36 @@ static PyObject *PyGetFullPathName(PyObject *self, PyObject *args)
     if (!PyWinObject_AsTCHAR(obfileName, &fileName, FALSE))
         return NULL;
     TCHAR *temp;
+    PyObject *obFullPathName = NULL;
     PyW32_BEGIN_ALLOW_THREADS;
-    BOOL ok = GetFullPathName(fileName, sizeof(pathBuf) / sizeof(pathBuf[0]), pathBuf, &temp);
+    DWORD length = GetFullPathName(fileName, sizeof(pathBuf) / sizeof(pathBuf[0]), pathBuf, &temp);
     PyW32_END_ALLOW_THREADS;
+    if (length) {
+        if (length < sizeof(pathBuf) / sizeof(pathBuf[0]))
+            obFullPathName = PyWinObject_FromTCHAR(pathBuf);
+        else {
+            // The buffer was too small.  The length is then the buffer needed,
+            // which includes the NULL, so retry with one that is big enough.
+            TCHAR *buf = PyMem_New(TCHAR, length);
+            if (buf == NULL)
+                PyErr_NoMemory();
+            else {
+                PyW32_BEGIN_ALLOW_THREADS;
+                DWORD length2 = GetFullPathName(fileName, length, buf, &temp);
+                PyW32_END_ALLOW_THREADS;
+                if (length2)
+                    obFullPathName = PyWinObject_FromTCHAR(buf);
+                // On success it is the number of chars copied *not* including
+                // the NULL.  Check this is true.
+                assert(length2 == 0 || length2 + 1 == length);
+                PyMem_Free(buf);
+            }
+        }
+    }
     PyWinObject_FreeTCHAR(fileName);
-    if (!ok)
+    if (obFullPathName == NULL && !PyErr_Occurred())
         return ReturnAPIError("GetFullPathName");
-    return PyWinObject_FromTCHAR(pathBuf);
+    return obFullPathName;
 }
 
 // @pymethod string|win32api|GetWindowsDirectory|Returns the path of the Windows directory.

--- a/win32/test/test_win32api.py
+++ b/win32/test/test_win32api.py
@@ -224,6 +224,28 @@ class FileNames(unittest.TestCase):
         finally:
             win32file.RemoveDirectory(fname)
 
+    def testGetFullPathNameLongPath(self):
+        # GetFullPathName used to return an empty string for any path of
+        # MAX_PATH characters or more. It resolved into a MAX_PATH buffer and
+        # assigned the DWORD "characters required" return into a BOOL, so a
+        # too-small buffer looked like success and the untouched buffer was
+        # returned. The path does not need to exist; this is string resolution.
+        import win32file
+
+        drive = os.path.splitdrive(os.path.abspath(os.sep))[0]
+        base = drive + "\\" + "a" * 40
+        for total in (259, 260, 300):
+            path = base + "\\" + "b" * (total - len(base) - 1)
+            self.assertEqual(len(path), total)
+            got = win32api.GetFullPathName(path)
+            self.assertEqual(
+                got,
+                path,
+                f"GetFullPathName of a {total} character path returned '{got}'",
+            )
+            # win32file's version has always handled these; keep them agreeing.
+            self.assertEqual(got, win32file.GetFullPathName(path))
+
 
 class FormatMessage(unittest.TestCase):
     def test_FromString(self):


### PR DESCRIPTION
Closes #2790.

## What broke

`win32api.GetFullPathName` returns an empty string for any path of 260 characters or more, and raises nothing, so a caller cannot tell "resolved to empty" from "failed".

Two things at `win32/src/win32apimodule.cpp` combine. The resolve target is a fixed `TCHAR pathBuf[MAX_PATH]`, and the `DWORD` return of the Win32 function is assigned into a `BOOL`. When the buffer is too small the API returns the size required rather than zero, so `ok` is true, `ReturnAPIError` never fires, and the untouched buffer is returned. The buffer size makes the answer wrong; the `BOOL` makes it silent.

`win32serviceutil.LocatePythonServiceExe` is an in-tree caller, so this is reachable from shipped pywin32 code, not only from user code.

## The change

The same two-call pattern `GetLongPathNameW` already uses a few hundred lines up in this file: keep the stack buffer for the common case, and when the returned length says it did not fit, allocate a buffer of that size and resolve again. `#905` was this same bug class on a sibling function here and was fixed the same way in 2017.

Deliberately unchanged: the `@comm` note pointing at `win32file.GetFullPathName` stays, the signature and return type stay, and every path under 260 characters takes the identical code path it did before.

## Verified

Windows 11 Home 26200, Python 3.13.13, MSVC 14.44.35207, built from this branch with `python setup.py build_ext`.

Before, against a freshly built unpatched `win32api.pyd`:

```
len(in)=259  len(out)=259  ok
len(in)=260  len(out)=  0  WRONG
len(in)=300  len(out)=  0  WRONG
50 over-length calls raised nothing
```

After, same probe, same build command:

```
len(in)=259  len(out)=259  ok
len(in)=260  len(out)=260  ok
len(in)=300  len(out)=300  ok
```

The new test in `FileNames` fails on unmodified source and passes with the fix. I checked that by reverting only `win32apimodule.cpp`, rebuilding, and re-running it, so the failure is the real one and not a stale binary:

```
AssertionError: '' != 'C:\\aaaa[...]bbbb' : GetFullPathName of a 260 character path returned ''
```

`test_win32api.py` in full on the patched build: `Ran 16 tests ... OK`, 0 failures, 0 errors, 0 skipped. The other three `FileNames` tests pass in both directions, so the new one is specific to this bug.

The compile produces no new warnings. The eight `C4311`/`C4302`/`C4244`/`C4996` warnings in this file are all pre-existing and at unrelated lines.

## What I could not check here

`Pythonwin` and `dde` do not build on this machine because MFC (`afxwin.h`) is not installed with these Build Tools, so the in-place copy step at the end of a full build fails. That is unrelated to this change, which touches only `win32api`. CI is the authority for the rest of the matrix.
