### PR TITLE
Fix first WM_CREATE message dispatch

### DIFF
--- a/win32/src/win32gui.i
+++ b/win32/src/win32gui.i
@@ -614,17 +614,7 @@ BOOL PyWndProc_Call(PyObject *obFuncOrMap, HWND hWnd, UINT uMsg, WPARAM wParam, 
 	return TRUE;
 }
 
-LRESULT CALLBACK PyWndProcClass(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
-{
-	PyObject *obFunc = (PyObject *)GetClassLongPtr( hWnd, 0);
-	LRESULT rc = 0;
-	CEnterLeavePython _celp;
-	if (!PyWndProc_Call(obFunc, hWnd, uMsg, wParam, lParam, &rc)) {
-		_celp.release();
-		rc = DefWindowProc(hWnd, uMsg, wParam, lParam);
-	}
-	return rc;
-}
+LRESULT CALLBACK PyWndProcClass(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
 LRESULT CALLBACK PyDlgProcClass(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -837,6 +827,29 @@ PyWNDCLASS::PyWNDCLASS()
 	m_WNDCLASS.cbClsExtra = sizeof(PyObject *);
 	m_WNDCLASS.lpfnWndProc = PyWndProcClass;
 	m_obMenuName = m_obClassName = m_obWndProc = NULL;
+}
+
+LRESULT CALLBACK PyWndProcClass(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+        CEnterLeavePython _celp;
+        PyObject *obFunc = (PyObject *)GetClassLongPtr(hWnd, 0);
+        if (obFunc == NULL) {
+                ATOM atom = (ATOM)GetClassLongPtr(hWnd, GCW_ATOM);
+                PyObject *obatom = PyLong_FromUnsignedLong(atom);
+                if (obatom != NULL) {
+                        PyObject *obwc = PyDict_GetItem(g_AtomMap, obatom);
+                        if (obwc != NULL)
+                                obFunc = ((PyWNDCLASS *)obwc)->m_obWndProc;
+
+                        Py_DECREF(obatom);
+                }
+        }
+        LRESULT rc = 0;
+        if (!PyWndProc_Call(obFunc, hWnd, uMsg, wParam, lParam, &rc)) {
+                _celp.release();
+                rc = DefWindowProc(hWnd, uMsg, wParam, lParam);
+        }
+        return rc;
 }
 
 PyWNDCLASS::~PyWNDCLASS(void)

--- a/win32/test/test_win32gui.py
+++ b/win32/test/test_win32gui.py
@@ -6,6 +6,7 @@ import unittest
 
 import pywintypes
 import win32api
+import win32con
 import win32gui
 
 
@@ -167,6 +168,43 @@ class TestEnumWindowsFamily(unittest.TestCase):
         for func in (self.enum_callback, self.enum_callback_sle):
             for data in self.type_data_set:
                 self.assertRaises(TypeError, win32gui.EnumDesktopWindows, 0, func, data)
+
+
+class TestCreateWindow(unittest.TestCase):
+    def test_wm_create(self):
+        messages = []
+
+        def wndproc(hwnd, msg, wparam, lparam):
+            if msg == win32con.WM_CREATE:
+                messages.append(msg)
+            return win32gui.DefWindowProc(hwnd, msg, wparam, lparam)
+
+        wc = win32gui.WNDCLASS()
+        wc.lpfnWndProc = wndproc
+        wc.lpszClassName = "PyWin32TestWMCreate"
+
+        atom = win32gui.RegisterClass(wc)
+        try:
+            hwnd = win32gui.CreateWindow(
+                atom,
+                "PyWin32 WM_CREATE test",
+                0,
+                0,
+                0,
+                100,
+                100,
+                0,
+                0,
+                wc.hInstance,
+                None,
+            )
+
+            try:
+                self.assertIn(win32con.WM_CREATE, messages)
+            finally:
+                win32gui.DestroyWindow(hwnd)
+        finally:
+            win32gui.UnregisterClass(atom, wc.hInstance)
 
 
 class TestWindowProperties(unittest.TestCase):


### PR DESCRIPTION
Fixes #2727

## Summary

The first `WM_CREATE` message is currently not delivered to Python
WNDPROC handlers registered through `win32gui.RegisterClass`.

The Python WNDPROC is normally stored in the window class extra bytes,
but `CreateWindow` sends `WM_CREATE` before the existing post-processing
code stores the Python callback there.

This change makes `PyWndProcClass` fall back to looking up the
registered `PyWNDCLASS` using the window class atom when the class extra
bytes are not yet populated.

## Testing

Added a regression test that verifies the first `WM_CREATE` message is
received by the Python WNDPROC.

Tested with:

- Python 3.14
- Windows
- `pytest win32/test/test_win32gui.py -k wm_create -v`

Result:

1 passed, 10 deselected