### PR TITLE
Small build speedup: Make `_get_gcc_include_dirs` a cached property

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ import subprocess
 import sys
 from abc import abstractmethod
 from collections.abc import Iterable, Iterator
+from functools import cached_property
 from itertools import chain, dropwhile, takewhile
 from pathlib import Path
 from setuptools import Extension, setup
@@ -364,8 +365,13 @@ class my_build_ext(build_ext):
         """List of excluded extensions and their reason"""
         self.swig_opts.append("-c++")
 
-    def _get_gcc_include_dirs(self) -> list[str]:
-        """Query gcc's built-in include search paths."""
+    @cached_property
+    def _gcc_include_dirs(self) -> list[str]:
+        """Query gcc's built-in include search paths.
+
+        Cached: the compiler doesn't change during a build,
+        this saves on process spawn, and parsing on non-MSVC, once per extension.
+        """
         cc = getattr(self.compiler, "cc", "")
         if not cc:
             return []
@@ -391,7 +397,7 @@ class my_build_ext(build_ext):
         include_dirs = (
             self.compiler.include_dirs
             + os.environ.get("INCLUDE", "").split(os.pathsep)  # MSVC INCLUDE Env
-            + self._get_gcc_include_dirs()
+            + self._gcc_include_dirs
         )
 
         for h in ext.optional_headers:


### PR DESCRIPTION
A small improvement that saves on ~56 unnecessary subprocess calls (and additional parsing on non-MSVC)

Cached: the compiler doesn't change during a build, this saves on process spawn, and parsing on non-MSVC, once per extension.

It's a micro-optimization, CI variance is bigger than this saves, but it *is* a free win.