### PR TITLE
Minimal type-checkers matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -180,7 +180,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
+        # Only test the oldest and newest supported Python. This should cover new breaking changes and support drops.
+        # Drawback is a less obvious failure boundary, but worth due to https://gh.io/actions-limits
+        python-version: ["3.9", "3.15"]
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
Update Python versions in type-checkers matrix to only test oldest and newest supported Python version.

Normally this would be free parallelization, and the actions are very short (~30s) but now that we're above the parallel action limits, 30*5 = 2.5m of additional wait time for the main builds.