### PR TITLE
Fix documented return values of GetMessage/PeekMessage/GetMenuItemRect

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ As of build 305, installation .exe files have been deprecated; see
 
 Coming in build 313, as yet unreleased
 --------------------------------------
+* Fixed the documented return values of `win32gui.GetMessage`, `win32gui.PeekMessage` and `win32gui.GetMenuItemRect`, which all return the API status code alongside the output value rather than the output value alone (mhammond#2428, [@MohammedAlkindi][MohammedAlkindi])
 * Fixed `win32api.GetFullPathName` silently returning an empty string for paths of 260 characters or more (mhammond#2795, [@MohammedAlkindi][MohammedAlkindi])
 * Added `win32api.ToUnicodeEx` wrapper for translating virtual-key codes and keyboard state to Unicode characters (mhammond#2788, [@ravik453][ravik453])
 * Updated `MAPIStubLibrary` vendored sources (mhammond#2764, [@Avasam][Avasam]):

--- a/win32/src/win32gui.i
+++ b/win32/src/win32gui.i
@@ -3306,7 +3306,7 @@ static PyObject *PyPumpWaitingMessages(PyObject *self, PyObject *args)
 %native (PumpMessages) PyPumpMessages;
 %native (PumpWaitingMessages) PyPumpWaitingMessages;
 
-// @pyswig MSG|GetMessage|
+// @pyswig (int, <o PyMSG>)|GetMessage|
 BOOL GetMessage(MSG *OUTPUT,
                 HWND hwnd, // @pyparm int|hwnd||
                 UINT min, // @pyparm int|min||
@@ -3327,7 +3327,7 @@ int TranslateAccelerator(
     MSG *INPUT // @pyparm MSG|msg||
 );
 
-// @pyswig MSG|PeekMessage|
+// @pyswig (int, <o PyMSG>)|PeekMessage|
 BOOL PeekMessage(MSG *OUTPUT,
                  HWND hwnd, // @pyparm int|hwnd||
                  UINT min, // @pyparm int|filterMin||
@@ -4546,7 +4546,7 @@ static PyObject *PyGetMenuItemInfo(PyObject *self, PyObject *args)
 // @pyparm int|hMenu||Handle to the menu
 int GetMenuItemCount(HMENU hMenu);
 
-// @pyswig (int, int, int, int)|GetMenuItemRect|
+// @pyswig (int, (left, top, right, bottom))|GetMenuItemRect|
 // @pyparm int|hWnd||
 // @pyparm int|hMenu||Handle to the menu
 // @pyparm int|uItem||

--- a/win32/test/test_win32gui.py
+++ b/win32/test/test_win32gui.py
@@ -6,6 +6,7 @@ import unittest
 
 import pywintypes
 import win32api
+import win32con
 import win32gui
 
 
@@ -182,6 +183,35 @@ class TestWindowProperties(unittest.TestCase):
         wnd = win32gui.GetDesktopWindow()
         for func in self.class_functions:
             self.assertTrue(func(wnd))
+
+
+class TestMessageFunctions(unittest.TestCase):
+    # GetMessage and PeekMessage each return the API's status code alongside
+    # the MSG tuple, not the MSG tuple on its own.
+
+    def setUp(self):
+        # Force this thread's message queue to exist so PostThreadMessage
+        # can't fail with ERROR_INVALID_THREAD_ID, and start from empty.
+        while win32gui.PeekMessage(0, 0, 0, win32con.PM_REMOVE)[0]:
+            pass
+
+    def test_peekmessage(self):
+        win32api.PostThreadMessage(
+            win32api.GetCurrentThreadId(), win32con.WM_USER, 1, 2
+        )
+        rc, msg = win32gui.PeekMessage(0, 0, 0, win32con.PM_REMOVE)
+        self.assertEqual(rc, 1)
+        self.assertEqual(msg[1:4], (win32con.WM_USER, 1, 2))
+
+    def test_getmessage(self):
+        win32api.PostThreadMessage(
+            win32api.GetCurrentThreadId(), win32con.WM_USER, 3, 4
+        )
+        # Never block: only call GetMessage once something is queued.
+        self.assertTrue(win32gui.PeekMessage(0, 0, 0, win32con.PM_NOREMOVE)[0])
+        rc, msg = win32gui.GetMessage(0, 0, 0)
+        self.assertEqual(rc, 1)
+        self.assertEqual(msg[1:4], (win32con.WM_USER, 3, 4))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`win32gui.GetMessage`, `PeekMessage` and `GetMenuItemRect` each return the API status code alongside the output value, but their `@pyswig` doc tags describe only the output value. That is what #2428 reports for `GetMessage`.

`GetMessage` and `PeekMessage` were tagged `MSG|`; both return `(int, PyMSG)`. `GetMenuItemRect` was tagged `(int, int, int, int)`; it returns `(int, (left, top, right, bottom))`. Comment-only changes to `win32gui.i`, plus a test so the contract cannot drift silently again.

Verified against installed pywin32 build 312, Windows 11 x64, Python 3.13.13:

```
GetMessage      -> len=2  rc=1  msg[1:4]=(1024, 3, 4)
PeekMessage     -> len=2  [0, (0, 0, 0, 0, 0, (0, 0))]
GetMenuItemRect -> len=2  [1, (8, 31, 46, 50)]
```

**Not verified:** the in-tree suite. Building the extensions needs MSVC, absent on this machine, so `test_win32gui.py` was not run here. The new test's assertions were run against the installed build using the same calls.

Closes #2428.
